### PR TITLE
Rewrite README to lead with platform intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,64 @@
-# WSO2 Labs Agentic Engineer
+# WSO2 Labs: Agentic Engineer
 
-> ⚠️ ** EXPERIMENTAL — PROOF OF CONCEPT**
->
-> This repository is a research/PoC effort. It is **not production-ready**, APIs and
-> data models change without notice, and entire subsystems may be ripped out between
-> commits. There are no stability guarantees. Do not deploy this as-is.
+> 🧪 **Early lab project** — APIs, data models, and features are still evolving,
+> and subsystems may change shape between commits. Try it, break it, tell us what
+> you think — just don't build on it as a stable surface yet.
 
 Repository: [`wso2/labs-agentic-engineer`](https://github.com/wso2/labs-agentic-engineer)
 
-An AI-driven, spec-driven engineering platform built on top of
-[OpenChoreo](https://github.com/openchoreo/openchoreo). It explores what an
-end-to-end "describe a project in markdown, get a deployed system" workflow could
-look like, with AI agents driving every stage:
+An experimental, open-source platform that explores what **agent-driven software
+engineering** looks like when the agents work inside an enterprise platform instead
+of a blank editor. It's an early WSO2 lab project, built on top of
+[OpenChoreo](https://github.com/openchoreo/openchoreo) and shared in the spirit of
+"let's see what works."
 
-```
-Specification → Design → Implementation → Build → Deploy → Manage
-```
+## The premise
 
-## Trying it out
+Agentic coding tools have made greenfield code generation fast and accessible. But
+enterprise software isn't bottlenecked on typing — it's bottlenecked on requirements,
+integrations, identity, deployment, and architectural conformance. The bet behind
+this project is that to push productivity further, agents need to operate **inside a
+platform that already understands those concerns**, so they can produce systems that
+slot into the existing ecosystem rather than ignore it.
 
-Today, the only way to try this is **locally** — clone the repo and follow the
-[Running it locally](#running-it-locally) section below. We're actively looking for
-feedback: bug reports, ideas, "this is confusing," "this is broken" — all welcome
-via GitHub issues on the repo.
+OpenChoreo already handles API management, identity, deployments, observability, and
+policy enforcement. The agents in this repo build on that foundation, so what they
+produce lands in an environment that enforces enterprise concerns automatically.
 
-A hosted version is planned: this will eventually be **deployed on WSO2 Cloud** so
-anyone interested can try it without standing up the local stack. Until then,
-local is the only path. Watch this section for the hosted URL once it lands.
+## What the platform does
 
-## What's in here
+It treats the SDLC as a chain of stages — **Specification → Design → Implementation
+→ Build → Deploy → Manage** — and gives each stage a specialized agent with only the
+tools and skills it needs. The flow:
+
+- A **business owner** describes the solution they want; a chat agent guides
+  requirements elicitation.
+- A **shared workspace** lets BAs, designers, and engineers collaborate on the same
+  artifacts, each with a view suited to them.
+- Everything is captured as **spec files in a Git repository** (`specs/requirements/`,
+  `specs/design/`, wireframes, domain models). Those specs become the contract
+  downstream agents work against.
+- Coding agents pick up tasks from those specs, work via **GitHub issues + branches
+  + PRs** (no merge without human review), and the platform watches webhooks to drive
+  each task through `pending → in_progress → ready_for_review → merged → building → deployed`.
+- Because agents share context across artifacts, the system stays internally
+  consistent — change a requirement and the wireframes, design, and tasks move with it.
+
+## Design principles worth calling out
+
+- **Spec-driven, Git-native.** Specs live in the project's Git repo, not a
+  proprietary database. Engineers can drop into the code at any stage without
+  leaving familiar tools.
+- **Human-in-the-loop is explicit.** Agents open PRs; they don't merge. State
+  transitions are driven by GitHub events.
+- **Skills are the customization surface.** Organizations encode their own
+  conventions — naming, architecture patterns, security baselines, the approved
+  service catalog — as skills, so standards become something the agents actually
+  apply.
+- **Model-agnostic.** You can pick the LLM behind each agent and mix providers
+  across the lifecycle.
+
+## What's in the repo
 
 | Path | Role |
 |---|---|
@@ -54,11 +84,17 @@ local is the only path. Watch this section for the hosted URL once it lands.
 contributors. The root `README.md` you're reading is the on-ramp; `AGENTS.md` is the
 detailed manual.
 
-## Running it locally
+## Trying it out
 
-Everything starts from [`deployments/`](./deployments) — that's the local
-setup. It brings up a k3d cluster (OpenChoreo + Thunder + OpenBao + ESO + kgateway)
-and a Docker Compose stack for the long-lived services.
+You can try it out locally — clone the repo and run the scripts under
+[`deployments/`](./deployments). The setup brings up a k3d cluster (OpenChoreo +
+Thunder + OpenBao + ESO + kgateway) and a Docker Compose stack for the long-lived
+services (BFF, agents, git-service, console, database, smee relay). Once it's up,
+you sign in to the console at http://localhost:8090 and drive a project end-to-end
+through the agents.
+
+A hosted version on **WSO2 Cloud** is planned so people can try it without standing
+up the local stack — watch this section for the URL once it lands.
 
 ### Prerequisites
 
@@ -178,8 +214,14 @@ See [`tests/README.md`](./tests/README.md) for details.
 - **Agent protocol** — GitHub issue + branch + PR, driven by webhooks
 - **Infra** — k3d (cluster) + Docker Compose (long-lived services)
 
+## Status and feedback
+
+This is an **early lab project**, and the whole point of putting it out now is to
+learn from people working through similar problems: where agent boundaries should
+sit, how skills map to your conventions, what felt natural, what got in the way.
+Feedback goes via GitHub issues on
+[`wso2/labs-agentic-engineer`](https://github.com/wso2/labs-agentic-engineer).
+
 ## License
 
 Apache 2.0 — see [`LICENSE`](./LICENSE).
-
-Again: this is a **proof of concept**. Don't ship it.


### PR DESCRIPTION
## Summary

- Reframes the top of the README around the platform's **premise**, **what it does**, and **design principles** (drawn from the announcement blog post) instead of jumping straight into the directory layout.
- Softens the experimental warning into a friendlier "early lab project" note.
- Rewords *Trying it out* so local setup reads as the current path rather than the only path, and mentions the planned WSO2 Cloud hosted version.

All the practical sections (repo layout, prerequisites, three-command bring-up, scripts table, ports, daily cycle, architecture diagram, testing, tech stack, license) are unchanged.

## Test plan

- [ ] Render the README on GitHub and confirm headings, tables, and code fences look right.
- [ ] Spot-check the links to `deployments/`, `docs/design/architecture.md`, `tests/README.md`, and the `wso2/labs-agentic-engineer` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)