### PR TITLE
feat(db): self-grant on startup to recover from managed-DB REVOKE

### DIFF
--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -67,6 +67,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Bootstrap — self-grant full privileges on owned schema objects so
+	// FK-creating migrations don't trip over a managed-DB REVOKE that
+	// stripped REFERENCES/TRIGGER from the owner role. Owner can always
+	// self-grant; non-fatal on failure.
+	{
+		c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = migrations.RunBootstrapGrants(c, db)
+		cancel()
+	}
+
 	// Phase 2 PR A migration — DROP TABLE org_credentials (relocated to
 	// git-service) and TRUNCATE the dev tables that held legacy
 	// 'platform' references. Idempotent and dev-only.

--- a/asdlc-service/database/migrations/bootstrap_grants.go
+++ b/asdlc-service/database/migrations/bootstrap_grants.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	"context"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+// RunBootstrapGrants restores the connecting role's full privilege set on
+// objects it owns in the public schema. Runs before any other migration.
+//
+// Some managed-DB setups provision the app role via an out-of-band
+// hardening step that REVOKEs everything and re-grants only DML
+// (INSERT/SELECT/UPDATE/DELETE). The owner retains ALTER (an owner-only
+// check that bypasses the ACL) so column-level migrations keep working,
+// but raw `CREATE TABLE … REFERENCES <owned-table>` fails with
+// `permission denied for table <owned-table>` because REFERENCES is an
+// ACL bit that was stripped.
+//
+// Owners can always GRANT to themselves, so this is a safe self-heal:
+// no-op when fine, recovery when an out-of-band REVOKE has run.
+// Errors are logged and swallowed so a more locked-down environment
+// can still reach the diagnostic specific migration errors that follow.
+func RunBootstrapGrants(ctx context.Context, db *gorm.DB) error {
+	stmts := []string{
+		`GRANT ALL ON ALL TABLES IN SCHEMA public TO CURRENT_USER`,
+		`GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO CURRENT_USER`,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO CURRENT_USER`,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO CURRENT_USER`,
+	}
+	for _, s := range stmts {
+		if err := db.WithContext(ctx).Exec(s).Error; err != nil {
+			slog.Warn("bootstrap_grants: statement failed (continuing)", "stmt", s, "error", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Add a bootstrap step in `asdlc-service` that, on every startup, runs the
following before any other migration:

```sql
GRANT ALL ON ALL TABLES    IN SCHEMA public TO CURRENT_USER;
GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO CURRENT_USER;
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES    TO CURRENT_USER;
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO CURRENT_USER;
```

Owners can always GRANT to themselves, so this is a safe no-op on a
healthy DB and a recovery path when an out-of-band hardening step has
stripped privileges from the owner role.

## Why this is needed

Some managed-DB provisioning pipelines REVOKE everything from the app
role after creating the DB and re-grant only DML
(`INSERT`/`SELECT`/`UPDATE`/`DELETE`). The owner keeps `ALTER` (an
owner-only check that bypasses the ACL) so column-level migrations keep
working, but raw SQL like:

```sql
CREATE TABLE coding_agent_logs (
  task_id UUID NOT NULL REFERENCES component_tasks(id) ON DELETE CASCADE,
  ...
);
```

fails with `permission denied for table component_tasks (SQLSTATE 42501)`
because the `REFERENCES` privilege bit was stripped from the owner ACL.

This surfaced today in WSO2 cloud's dev environment: after a fresh image
roll, `phase3_coding_agent_logs` crashed the pod on startup. The
`component_tasks` table's `relacl` was `{user=arwd/user}` —
INSERT/SELECT/UPDATE/DELETE only, no `x` (REFERENCES) or `t` (TRIGGER).

GORM `AutoMigrate` doesn't hit this because:
1. Original tables were created back when the owner had full privileges
   (the REVOKE happened later).
2. AutoMigrate adds columns via `ALTER TABLE` (owner-only check, no ACL
   lookup).
3. New raw-SQL migrations that issue `CREATE TABLE … REFERENCES` do hit
   the ACL.

## Behaviour

- **Healthy DB**: GRANTs are no-ops (owner already has everything).
- **Hardened DB**: ACL bits get restored before the FK-creating
  migrations run. Pod boots clean.
- **Errors**: logged at `WARN` and swallowed. A more locked-down env
  (where even self-grant is blocked) still reaches the more specific
  migration errors downstream rather than hiding behind a generic
  permission error here.

## Files

- `asdlc-service/database/migrations/bootstrap_grants.go` (new)
- `asdlc-service/cmd/asdlc-api/main.go` — invoke once after
  `database.Open`, before any other migration.

## Test plan

- [ ] Local stack (`deployments/`): pod boots normally — bootstrap step
      logs no warnings (healthy DB).
- [ ] WSO2 cloud dev: previously-failing `phase3_coding_agent_logs`
      runs to completion on next image roll; manual `REVOKE` test to
      confirm self-heal.