### PR TITLE
fix(asdlc-api): forward user JWT to platform-api (drop M2M-first priority)

### DIFF
--- a/asdlc-service/clients/openchoreo/transport.go
+++ b/asdlc-service/clients/openchoreo/transport.go
@@ -101,17 +101,24 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 	return c, nil
 }
 
-// authToken prefers the cached service token (client_credentials) over any
-// user token in ctx — OC authorises by the service subject. Falls back to
-// the inbound user token when the service token is unobtainable so calls
-// don't silently lose auth during a Thunder outage.
+// authToken prefers the inbound user JWT over the M2M service token.
+// Reason: platform-api-service derives the target OC namespace from the
+// JWT's `ouId` claim (see backend/core/internal/cpapi/handler.go), so a
+// service-credentials token routes every call to the namespace of the
+// M2M client's owning OU (Admin) instead of the caller's tenant.
+// Falls back to the M2M token only when no user token is present —
+// preserves auth for async paths that explicitly inject a service token
+// via middleware.WithAuthToken (e.g. MCP-triggered deploys).
 func authToken(ctx context.Context, ap AuthProvider) string {
+	if tok := middleware.GetAuthToken(ctx); tok != "" {
+		return tok
+	}
 	if ap != nil {
 		if tok, err := ap.Token(); err == nil {
 			return tok
 		} else {
-			slog.ErrorContext(ctx, "openchoreo: service token fetch failed, falling back to user token", "error", err)
+			slog.ErrorContext(ctx, "openchoreo: no user token in ctx and service token fetch failed", "error", err)
 		}
 	}
-	return middleware.GetAuthToken(ctx)
+	return ""
 }


### PR DESCRIPTION
## Summary
- Re-applies the priority flip from internal PR `wso2-enterprise/lab-app-factory#38` (commit d40fad1, merged 2026-05-14) that was lost during the OSS migration.
- `asdlc-service/clients/openchoreo/transport.go` now prefers the inbound user JWT over the M2M (`APP_FACTORY_BFF_TO_PLATFORM_API`) service token when calling platform-api-service. M2M is only used as a fallback when no user token is in context.

## Why
`platform-api-service` derives the target OC namespace from the JWT's `ouId` claim. With the M2M-first priority, every authenticated request resolved to the namespace of the M2M client's owning OU (Admin / `a5000000-...`) instead of the caller's tenant, so:
- `GET /api/v1/organizations` returns `{"items":[]}` (lists admin's namespaces).
- `POST /api/v1/organizations/{handle}/projects` falls back to the admin namespace, entitlement quota = 0, platform-api returns 402, BFF translates to 500.

Confirmed against deployed dev (`development-wso2cloud.gateway.dev.cloud.wso2.com`):
- agent-manager-service has no M2M wired (`IDP_CLIENT_SECRET=dummy-secret`) and uses user-JWT pass-through — project creation works.
- asdlc-api has M2M wired and the old priority — every call routes to admin.

The fallback to M2M is preserved for async paths that inject a service token via `middleware.WithAuthToken` (e.g. MCP-triggered deploys), so we don't regress those.

## Test plan
- [ ] `go build ./...` in `asdlc-service/` (passes locally)
- [ ] Build new image and bump `pin.env` in the `lab-app-factory` overlay
- [ ] In dev: `GET /asdlc-api-service/api/v1/organizations` returns the caller's actual namespace (`wc-<...>`)
- [ ] In dev: project creation under that namespace succeeds (no 402/500 from platform-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)