### PR TITLE
[DIAGNOSTIC] Log M2M JWT claims + OC client request URL/status

### DIFF
--- a/asdlc-service/clients/oauth/token_provider.go
+++ b/asdlc-service/clients/oauth/token_provider.go
@@ -1,9 +1,11 @@
 package oauth
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -92,5 +94,48 @@ func (p *TokenProvider) fetchLocked() (string, error) {
 	p.token = tokenResp.AccessToken
 	p.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
+	// DIAGNOSTIC (revert in Plan A PR) — decode the minted JWT and log the
+	// claims that drive platform-api's namespace routing (ouId, ouHandle, sub,
+	// client_id, iss). Logged once per token mint (~1/hour) so log volume is
+	// negligible. Confirms the M2M token actually carries `ouId` for the BFF
+	// client (the open contradiction at the bottom of
+	// `docs/superpowers/plans/2026-05-29-bff-oc-rest-direct.md`).
+	if claims := decodeJWTClaims(p.token); claims != nil {
+		slog.Info("oauth: m2m token minted",
+			"tokenURL", p.tokenURL,
+			"clientID", p.clientID,
+			"jwt.iss", claims["iss"],
+			"jwt.sub", claims["sub"],
+			"jwt.client_id", claims["client_id"],
+			"jwt.ouId", claims["ouId"],
+			"jwt.ouHandle", claims["ouHandle"],
+			"jwt.ouName", claims["ouName"],
+			"jwt.exp", claims["exp"],
+		)
+	} else {
+		slog.Warn("oauth: m2m token minted but could not decode claims",
+			"clientID", p.clientID,
+		)
+	}
+
 	return p.token, nil
+}
+
+// decodeJWTClaims is a DIAGNOSTIC helper (revert in Plan A PR). Decodes the
+// JWT payload without signature verification — used only for logging the
+// claim values that drive downstream namespace routing.
+func decodeJWTClaims(token string) map[string]any {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil
+	}
+	return claims
 }

--- a/asdlc-service/clients/openchoreo/transport.go
+++ b/asdlc-service/clients/openchoreo/transport.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"time"
 
 	"github.com/wso2/asdlc/asdlc-service/clients/httpx"
 	"github.com/wso2/asdlc/asdlc-service/clients/openchoreo/gen"
@@ -76,7 +77,10 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 		}
 	}
 
-	inner := &http.Client{Transport: httpx.WrapTransport(nil)}
+	// DIAGNOSTIC (revert in Plan A PR) — wrap with logging RoundTripper to
+	// capture method/URL/status/elapsed per OC client call. Confirms which
+	// requests 402 and the exact URL surface BFF is hitting on platform-api.
+	inner := &http.Client{Transport: &diagnosticTransport{base: httpx.WrapTransport(nil)}}
 	outer := requests.NewRetryableHTTPClient(inner, retryCfg)
 
 	authEditor := func(ctx context.Context, req *http.Request) error {
@@ -84,9 +88,14 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 			req.Host = cfg.HostHeader
 		}
 		req.Header.Set("X-Use-OpenAPI", "true")
-		if tok := authToken(ctx, cfg.AuthProvider); tok != "" {
+		tok, src := authTokenWithSource(ctx, cfg.AuthProvider)
+		if tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
 		}
+		// DIAGNOSTIC (revert in Plan A PR) — tag the request context so the
+		// logging RoundTripper can correlate the auth source with the eventual
+		// status code.
+		*req = *req.WithContext(contextWithAuthSource(req.Context(), src))
 		return nil
 	}
 
@@ -110,15 +119,68 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 // preserves auth for async paths that explicitly inject a service token
 // via middleware.WithAuthToken (e.g. MCP-triggered deploys).
 func authToken(ctx context.Context, ap AuthProvider) string {
+	tok, _ := authTokenWithSource(ctx, ap)
+	return tok
+}
+
+// authTokenWithSource is a DIAGNOSTIC variant (revert in Plan A PR) that
+// also returns which auth source supplied the token: "user", "m2m", or "none".
+// Used to correlate request status codes with the auth path taken.
+func authTokenWithSource(ctx context.Context, ap AuthProvider) (string, string) {
 	if tok := middleware.GetAuthToken(ctx); tok != "" {
-		return tok
+		return tok, "user"
 	}
 	if ap != nil {
 		if tok, err := ap.Token(); err == nil {
-			return tok
+			return tok, "m2m"
 		} else {
 			slog.ErrorContext(ctx, "openchoreo: no user token in ctx and service token fetch failed", "error", err)
 		}
 	}
+	return "", "none"
+}
+
+// authSourceCtxKey is the context key for the auth source tag (DIAGNOSTIC).
+type authSourceCtxKey struct{}
+
+func contextWithAuthSource(ctx context.Context, src string) context.Context {
+	return context.WithValue(ctx, authSourceCtxKey{}, src)
+}
+
+func authSourceFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(authSourceCtxKey{}).(string); ok {
+		return v
+	}
 	return ""
+}
+
+// diagnosticTransport is a DIAGNOSTIC RoundTripper (revert in Plan A PR) that
+// logs the method, URL, status, and elapsed time of every OC client request
+// alongside the auth source tag set in authEditor. Surfaces exactly which
+// URLs 402 and which auth path was used.
+type diagnosticTransport struct {
+	base http.RoundTripper
+}
+
+func (t *diagnosticTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	elapsed := time.Since(start)
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	slog.InfoContext(req.Context(), "openchoreo: request",
+		"method", req.Method,
+		"url", req.URL.String(),
+		"status", status,
+		"elapsed_ms", elapsed.Milliseconds(),
+		"auth_source", authSourceFromContext(req.Context()),
+		"error", errStr,
+	)
+	return resp, err
 }


### PR DESCRIPTION
## Summary

Pre-rollout diagnostic for the BFF→platform-api 402 mystery. Two surgical log additions, both clearly marked `DIAGNOSTIC (revert in Plan A PR)`:

- **`clients/oauth/token_provider.go`** — after a successful M2M token mint, decode the JWT payload (no signature verification) and log the claim values that drive platform-api's namespace routing: `ouId`, `ouHandle`, `ouName`, `sub`, `client_id`, `iss`, `exp`. Fires ~1×/hour per provider — negligible log volume.

- **`clients/openchoreo/transport.go`** — wrap the inner `http.Client` with a `diagnosticTransport` that logs `method`, `url`, `status`, `elapsed_ms`, and the auth source (`user` | `m2m` | `none`) for every OC client request. The auth source is set in `authEditor` via a context tag and read back in the RoundTripper so we can correlate which auth path was taken with the eventual HTTP status code.

## Why

Confirms whether the seeded BFF M2M client's cc tokens carry `ouId = a5000000-…` (the value declared in `thunder-idp.yaml:1062`'s `ou_id` field). Phase 0 probe showed API-created cc apps do NOT carry `ouId`, but platform-api logs for the failing dispatch show `resolved namespace: wc-a5000000-9b9f461e` — only possible if the BFF token has `ouId=a5000000-…`. In-prod decode settles the contradiction before Plan A lands.

## Lifecycle

This is **diagnostic-only**. Reverted as the first step of the Plan A PR that switches BFF→OC REST direct. Merging this lets us bump the enterprise `pin.env` and observe the actual auth chain in dev before touching deployment configs.

## Test plan

- [x] \`go build ./...\` clean
- [x] No new test files needed (purely additive log lines)
- [ ] After merge: bump enterprise \`pin.env\` + \`Dockerfile ARG OSS_REF\` → CI builds → image rolls to dev → tail \`app-factory-api\` logs → trigger one task → confirm:
  - \`oauth: m2m token minted\` line with \`jwt.ouId\` populated (or absent)
  - \`openchoreo: request\` lines showing the failing URL + \`auth_source=m2m\` + \`status=402\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)