### PR TITLE
feat(openchoreo): impersonate target org on M2M calls (X-Impersonate-Org)

### DIFF
--- a/asdlc-service/clients/openchoreo/transport.go
+++ b/asdlc-service/clients/openchoreo/transport.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/wso2/asdlc/asdlc-service/clients/httpx"
 	"github.com/wso2/asdlc/asdlc-service/clients/openchoreo/gen"
@@ -29,16 +30,25 @@ type Config struct {
 	HostHeader   string
 	AuthProvider AuthProvider
 	RetryConfig  requests.RequestRetryConfig
+
+	// ImpersonateOrgResolver, when set, maps the namespace in a request URL
+	// (".../namespaces/{namespace}/...") to the org UUID sent as the
+	// X-Impersonate-Org header on M2M (service-token) requests, so platform-api
+	// routes and bills the target org rather than the service identity's own.
+	// Only consulted when no inbound user JWT is being forwarded. nil disables
+	// the header (e.g. local k3d, which talks to OpenChoreo directly and reads
+	// the namespace from the URL path).
+	ImpersonateOrgResolver func(ctx context.Context, namespace string) (string, error)
 }
 
 // newGenClient builds a *gen.ClientWithResponses with the three-layer
 // transport stack:
 //
-//	1. httpx.WrapTransport (innermost) — stamps X-Correlation-ID for tracing
-//	2. RetryableHTTPClient (middle) — jittered exponential backoff on
-//	   transient codes; 401 invalidates the cached service token and retries
-//	3. RequestEditorFn (outermost, oapi-codegen hook) — sets Authorization,
-//	   Host, and X-Use-OpenAPI on every request
+//  1. httpx.WrapTransport (innermost) — stamps X-Correlation-ID for tracing
+//  2. RetryableHTTPClient (middle) — jittered exponential backoff on
+//     transient codes; 401 invalidates the cached service token and retries
+//  3. RequestEditorFn (outermost, oapi-codegen hook) — sets Authorization,
+//     Host, and X-Use-OpenAPI on every request
 //
 // Auth lives in the editor (not a RoundTripper) so the retry middleware sees
 // a fresh token after invalidation: the editor runs on every attempt and
@@ -75,6 +85,23 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 			req.Host = cfg.HostHeader
 		}
 		req.Header.Set("X-Use-OpenAPI", "true")
+		// On the M2M path (no inbound user JWT) the service token's own org is
+		// not the caller's, so impersonate the target org — taken from the
+		// namespace in the request URL — and platform-api routes and bills that
+		// org. User-initiated requests forward the user JWT instead (see
+		// authToken), where platform-api derives the org from the JWT's ouId, so
+		// no impersonation header is set.
+		if cfg.ImpersonateOrgResolver != nil && middleware.GetAuthToken(ctx) == "" {
+			if ns := namespaceFromPath(req.URL.Path); ns != "" {
+				orgUUID, err := cfg.ImpersonateOrgResolver(ctx, ns)
+				if err != nil {
+					return fmt.Errorf("openchoreo: resolve impersonation org for namespace %q: %w", ns, err)
+				}
+				if orgUUID != "" {
+					req.Header.Set("X-Impersonate-Org", orgUUID)
+				}
+			}
+		}
 		tok, err := authToken(ctx, cfg.AuthProvider)
 		if err != nil {
 			return err
@@ -125,4 +152,18 @@ func authToken(ctx context.Context, ap AuthProvider) (string, error) {
 		return "", fmt.Errorf("openchoreo: service token fetch failed: %w", err)
 	}
 	return tok, nil
+}
+
+// namespaceFromPath extracts the {namespace} segment from an OpenChoreo REST
+// path of the form ".../namespaces/{namespace}/...". Returns "" when the path
+// has no namespace segment (e.g. the namespaces collection endpoint), where no
+// single org applies.
+func namespaceFromPath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		if s == "namespaces" && i+1 < len(segs) && segs[i+1] != "" {
+			return segs[i+1]
+		}
+	}
+	return ""
 }

--- a/asdlc-service/clients/openchoreo/transport_test.go
+++ b/asdlc-service/clients/openchoreo/transport_test.go
@@ -1,0 +1,134 @@
+package openchoreo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2/asdlc/asdlc-service/middleware"
+)
+
+type fakeAuthProvider struct{ tok string }
+
+func (f fakeAuthProvider) Token() (string, error) { return f.tok, nil }
+func (f fakeAuthProvider) Invalidate()            {}
+
+func TestNamespaceFromPath(t *testing.T) {
+	cases := map[string]string{
+		"/api/v1/namespaces/wc-abc/components":   "wc-abc",
+		"/api/v1/namespaces/wc-abc/components/x": "wc-abc",
+		"/api/v1/namespaces/wc-abc":              "wc-abc",
+		"/api/v1/namespaces":                     "",
+		"/api/v1/namespaces/":                    "",
+		"/healthz":                               "",
+		"":                                       "",
+	}
+	for path, want := range cases {
+		if got := namespaceFromPath(path); got != want {
+			t.Errorf("namespaceFromPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// captureServer records the impersonation + auth headers of the last request.
+func captureServer(t *testing.T, impersonate, auth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*impersonate = r.Header.Get("X-Impersonate-Org")
+		*auth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+}
+
+func TestImpersonateOrgHeader_M2MPath_SetsHeader(t *testing.T) {
+	var impersonate, auth string
+	srv := captureServer(t, &impersonate, &auth)
+	defer srv.Close()
+
+	c, err := newGenClient(Config{
+		BaseURL:      srv.URL,
+		AuthProvider: fakeAuthProvider{tok: "m2m-token"},
+		ImpersonateOrgResolver: func(_ context.Context, ns string) (string, error) {
+			if ns == "wc-abc" {
+				return "org-uuid-123", nil
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No user JWT in context -> M2M path -> impersonation header set from the
+	// resolved namespace, M2M token attached.
+	if _, err := c.GetNamespaceWithResponse(context.Background(), "wc-abc"); err != nil {
+		t.Fatal(err)
+	}
+	if impersonate != "org-uuid-123" {
+		t.Errorf("X-Impersonate-Org = %q, want org-uuid-123", impersonate)
+	}
+	if auth != "Bearer m2m-token" {
+		t.Errorf("Authorization = %q, want Bearer m2m-token", auth)
+	}
+}
+
+func TestImpersonateOrgHeader_UserJWTPath_NoHeader(t *testing.T) {
+	var impersonate, auth string
+	srv := captureServer(t, &impersonate, &auth)
+	defer srv.Close()
+
+	resolverCalled := false
+	c, err := newGenClient(Config{
+		BaseURL:      srv.URL,
+		AuthProvider: fakeAuthProvider{tok: "m2m-token"},
+		ImpersonateOrgResolver: func(_ context.Context, _ string) (string, error) {
+			resolverCalled = true
+			return "org-uuid-123", nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// User JWT in context -> forwarded; impersonation header is NOT set and the
+	// resolver is not consulted (platform-api routes by the JWT's ouId).
+	ctx := middleware.WithAuthToken(context.Background(), "user-jwt")
+	if _, err := c.GetNamespaceWithResponse(ctx, "wc-abc"); err != nil {
+		t.Fatal(err)
+	}
+	if impersonate != "" {
+		t.Errorf("user-JWT path must not set X-Impersonate-Org, got %q", impersonate)
+	}
+	if auth != "Bearer user-jwt" {
+		t.Errorf("Authorization = %q, want Bearer user-jwt", auth)
+	}
+	if resolverCalled {
+		t.Error("resolver must not be called on the user-JWT path")
+	}
+}
+
+func TestImpersonateOrgHeader_ResolverError_AbortsRequest(t *testing.T) {
+	var impersonate, auth string
+	srv := captureServer(t, &impersonate, &auth)
+	defer srv.Close()
+
+	c, err := newGenClient(Config{
+		BaseURL:      srv.URL,
+		AuthProvider: fakeAuthProvider{tok: "m2m-token"},
+		ImpersonateOrgResolver: func(_ context.Context, _ string) (string, error) {
+			return "", context.DeadlineExceeded
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A resolver error must abort the call (never silently mis-route to the
+	// service identity's own org).
+	if _, err := c.GetNamespaceWithResponse(context.Background(), "wc-abc"); err == nil {
+		t.Fatal("expected error when resolver fails, got nil")
+	}
+}

--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -256,15 +256,31 @@ func main() {
 		slog.Info("Service auth configured", "tokenURL", cfg.ServiceAuth.TokenURL, "clientID", cfg.ServiceAuth.ClientID)
 	}
 
+	// orgUUIDResolver maps an OC namespace (the org handle the BFF puts in the
+	// request URL) to the org's UUID, for the X-Impersonate-Org header on M2M
+	// OC calls. Reads the local organizations side-car; prefers the
+	// Thunder-issued ouId.
+	orgUUIDResolver := func(ctx context.Context, namespace string) (string, error) {
+		var org models.Organization
+		if err := db.WithContext(ctx).Where("name = ?", namespace).First(&org).Error; err != nil {
+			return "", fmt.Errorf("resolve impersonation org for namespace %q: %w", namespace, err)
+		}
+		if org.ThunderOrgUUID != nil {
+			return org.ThunderOrgUUID.String(), nil
+		}
+		return org.UUID.String(), nil
+	}
+
 	// OpenChoreo clients. Each one resolves the OC namespace as the OC
 	// org handle directly (== ouHandle); there is no override map. Migrated
 	// clients (namespace, project) take an openchoreo.Config; the still-hand-
 	// rolled clients (component, secretref) keep the legacy positional args
 	// until they migrate too.
 	ocConfig := openchoreo.Config{
-		BaseURL:      cfg.PlatformAPI.BaseURL,
-		HostHeader:   cfg.PlatformAPI.HostHeader,
-		AuthProvider: tokenProvider,
+		BaseURL:                cfg.PlatformAPI.BaseURL,
+		HostHeader:             cfg.PlatformAPI.HostHeader,
+		AuthProvider:           tokenProvider,
+		ImpersonateOrgResolver: orgUUIDResolver,
 	}
 	projectClient := openchoreo.NewProjectClient(ocConfig)
 	namespaceClient := openchoreo.NewNamespaceClient(ocConfig)
@@ -771,13 +787,13 @@ func main() {
 
 	// Controllers
 	params := api.AppParams{
-		Config:                 cfg,
-		ProjectController:      controllers.NewProjectController(projectService),
-		OrganizationController: controllers.NewOrganizationController(organizationService),
-		ComponentController:    controllers.NewComponentController(componentService, taskService),
+		Config:                     cfg,
+		ProjectController:          controllers.NewProjectController(projectService),
+		OrganizationController:     controllers.NewOrganizationController(organizationService),
+		ComponentController:        controllers.NewComponentController(componentService, taskService),
 		RequirementsController:     controllers.NewRequirementsController(requirementsService),
 		RequirementsChatController: controllers.NewRequirementsChatController(requirementsChatService),
-		DesignController:       controllers.NewDesignController(designService),
+		DesignController:           controllers.NewDesignController(designService),
 		TaskController: func() controllers.TaskController {
 			tc := controllers.NewTaskController(
 				taskService,


### PR DESCRIPTION
## Why

The app-factory BFF creates OpenChoreo resources (project / component / release-binding / build WorkflowRun) in each user's org namespace through platform-api. On the **async paths** (webhook handlers, status watchers, on-hold / cascade re-dispatch) there's no user JWT, so the BFF uses its **M2M service token** — and platform-api derives the namespace from *that token's* `ouId` (the Admin OU), mis-routing every async write to the Admin tenant and 402-ing on its (empty) billing entitlement.

This sets `X-Impersonate-Org` on M2M calls so platform-api routes **and bills the target org** instead. Combined with the impersonation policy on platform-api (wso2cloud-deployment#2359), the BFF acts on behalf of the user's org while keeping per-org component quotas enforced (app-factory is a configured billing product).

## What

- `clients/openchoreo/transport.go` — on the M2M path (no inbound user JWT), set `X-Impersonate-Org` to the org UUID resolved from the namespace in the request URL via an injected `ImpersonateOrgResolver`. A resolver error aborts the call (never silently mis-routes). `nil` resolver disables the header (local k3d talks to OpenChoreo directly).
- `cmd/asdlc-api/main.go` — wire the resolver: look up the local `organizations` side-car by namespace, prefer the Thunder-issued `ouId`.
- `clients/openchoreo/transport_test.go` — cover `namespaceFromPath`, the M2M-sets-header / user-JWT-skips-header split, and resolver-error-aborts.

User-initiated requests are unchanged — they forward the user JWT (per #18), where platform-api derives the org from the JWT's `ouId`, so no header is set.

## Depends on / stacking

- **Stacked on #18** (`fix/oc-client-restore-user-jwt`, which restores user-JWT forwarding). Based on its branch for a clean diff; retarget to `main` once #18 merges.
- Activation also requires (separate, sequenced): wso2cloud-deployment#2359 (impersonation policy on platform-api) deployed → then an app-factory release-binding repoint (`SERVICE_AUTH` → platform-idp, base URL → platform-api) + image bump.

`go build ./...`, `go vet`, and `go test ./...` pass.
