### PR TITLE
chore(observability): logs for CGW dispatch + OC impersonation

### DIFF
--- a/asdlc-service/clients/clustergatewayproxy/client.go
+++ b/asdlc-service/clients/clustergatewayproxy/client.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -348,6 +349,8 @@ func (c *Client) StreamPodLog(ctx context.Context, namespace, podName string, op
 	if err != nil {
 		return nil, fmt.Errorf("clustergatewayproxy: GET %s: %w", url, err)
 	}
+	slog.DebugContext(ctx, "cluster-gateway-proxy stream",
+		"url", url, "status", resp.StatusCode)
 	if resp.StatusCode == http.StatusNotFound {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
@@ -465,10 +468,14 @@ func (c *Client) do(ctx context.Context, method, k8sPath string, body any) (*htt
 	req.Header.Set("X-Correlation-ID", middleware.GetCorrelationID(ctx))
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		slog.DebugContext(ctx, "cluster-gateway-proxy request failed",
+			"method", method, "url", url, "error", err)
 		return nil, nil, fmt.Errorf("clustergatewayproxy: %s %s: %w", method, url, err)
 	}
 	defer resp.Body.Close()
 	out, _ := io.ReadAll(resp.Body)
+	slog.DebugContext(ctx, "cluster-gateway-proxy request",
+		"method", method, "url", url, "status", resp.StatusCode)
 	return resp, out, nil
 }
 

--- a/asdlc-service/clients/openchoreo/transport.go
+++ b/asdlc-service/clients/openchoreo/transport.go
@@ -99,6 +99,8 @@ func newGenClient(cfg Config) (*gen.ClientWithResponses, error) {
 				}
 				if orgUUID != "" {
 					req.Header.Set("X-Impersonate-Org", orgUUID)
+					slog.DebugContext(ctx, "openchoreo: impersonating org on M2M call",
+						"namespace", ns, "orgUUID", orgUUID, "method", req.Method, "path", req.URL.Path)
 				}
 			}
 		}

--- a/asdlc-service/services/codingagent/dispatcher.go
+++ b/asdlc-service/services/codingagent/dispatcher.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/wso2/asdlc/asdlc-service/clients/clustergatewayproxy"
 )
@@ -114,6 +115,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, in Inputs) (string, error) {
 		return "", err
 	}
 
+	slog.InfoContext(ctx, "coding-agent proxy dispatch: start",
+		"orgUUID", in.OrgUUID, "namespace", ns, "runName", in.Job.RunName)
+
 	// 1) Namespace.
 	if err := d.proxy.EnsureNamespace(ctx, clustergatewayproxy.NamespaceMeta{
 		Name: ns,
@@ -169,6 +173,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, in Inputs) (string, error) {
 	if err := d.proxy.ApplyJob(ctx, ns, manifest); err != nil {
 		return "", fmt.Errorf("dispatcher: apply Job: %w", err)
 	}
+	slog.InfoContext(ctx, "coding-agent proxy dispatch: complete",
+		"namespace", ns, "runName", runName)
 	return runName, nil
 }
 


### PR DESCRIPTION
## Why

We're about to verify the impersonation + cluster-gateway-proxy dispatch path in deployed **dev**. Today the most important moments in that path are silent, so a 402 or a mis-routed write means guessing. This adds the few log lines that make `docker compose logs -f asdlc-api` (and the dev pod logs) tell the story directly.

## What

Three additive log points — no behaviour change:

1. **`clients/clustergatewayproxy/client.go`** — `do()` emits one `Debug` line per proxy call (`method`, `url`, `status`) and a failure line on transport error; `StreamPodLog` emits a stream-open line. Every CGW request (namespace / SA / ExternalSecret / Job / pod-log) is now visible.
2. **`services/codingagent/dispatcher.go`** — `Info` `start` / `complete` bracketing the four-step apply chain (`orgUUID`, `namespace`, `runName`), so a partial dispatch is obvious and the per-call Debug lines in between pinpoint the failing step.
3. **`clients/openchoreo/transport.go`** — `Debug` line whenever `X-Impersonate-Org` is set on an M2M call (`namespace -> orgUUID`, `method`, `path`). This is the line that confirms async writes (PR-merge build, cascade) route to the **user org** rather than Admin — the root cause of the dev 402.

**No token value is ever logged.** BFF logs at DEBUG by default, so all lines are visible in dev without config changes.

## Test

`go build ./...`, `go vet`, and the touched-package tests (`openchoreo`, `clustergatewayproxy`, `codingagent`) all pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)