### PR TITLE
fix(org): resolve impersonation org by handle (JWT ouId + handle-keyed side-car)

### DIFF
--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/wso2/asdlc/asdlc-service/internal/credentials"
 	"github.com/wso2/asdlc/asdlc-service/internal/seed"
 	"github.com/wso2/asdlc/asdlc-service/middleware"
+	"github.com/wso2/asdlc/asdlc-service/middleware/jwt"
 	"github.com/wso2/asdlc/asdlc-service/middleware/jwtassertion"
 	"github.com/wso2/asdlc/asdlc-service/middleware/logger"
 	"github.com/wso2/asdlc/asdlc-service/models"
@@ -271,6 +272,17 @@ func main() {
 	// OC calls. Reads the local organizations side-car; prefers the
 	// Thunder-issued ouId.
 	orgUUIDResolver := func(ctx context.Context, namespace string) (string, error) {
+		// Authoritative path: a user-initiated request carries the caller's
+		// Thunder org UUID in the JWT (ouId). When the JWT's handle matches the
+		// namespace we're about to impersonate, use ouId directly — no DB
+		// dependency, and it's the same value Thunder embeds. Async paths
+		// (webhooks, watchers) have no JWT and fall through to the side-car.
+		if claims := jwt.ClaimsFromContext(ctx); claims != nil && claims.OuId != "" && jwt.ResolveOuHandle(claims) == namespace {
+			return claims.OuId, nil
+		}
+		// Side-car path: the organizations row is keyed by the org handle (the
+		// same value the BFF puts in OC URLs). orgensure backfills it with the
+		// Thunder UUID on the first authed request from the org.
 		var org models.Organization
 		if err := db.WithContext(ctx).Where("name = ?", namespace).First(&org).Error; err != nil {
 			return "", fmt.Errorf("resolve impersonation org for namespace %q: %w", namespace, err)

--- a/asdlc-service/services/organization_service.go
+++ b/asdlc-service/services/organization_service.go
@@ -113,7 +113,7 @@ func (s *organizationService) List(ctx context.Context) (*models.OrganizationLis
 	for i, v := range views {
 		row, ok := byName[v.Name]
 		if !ok {
-			row = s.backfillRow(ctx, v, "")
+			row = s.backfillRow(ctx, v.Name, v, "")
 			if row.UUID == uuid.Nil {
 				continue
 			}
@@ -200,7 +200,13 @@ func (s *organizationService) verifyForOuHandle(ctx context.Context, ouHandle, t
 		return translateHTTPError(err)
 	}
 
-	s.backfillRow(ctx, *view, thunderOrgUUID)
+	// Key the row by the handle, not view.Name: platform-api returns the
+	// canonical namespace name (e.g. "wc-<uuid8>-<hash8>") in metadata.name,
+	// but every per-org lookup — this verify path, ensureThunderUUID, the
+	// dispatch org-UUID lookup, and the OC-client impersonation resolver — keys
+	// by the handle the BFF puts in OC URLs. Storing view.Name made those
+	// lookups miss forever (and re-backfill on every request).
+	s.backfillRow(ctx, ouHandle, *view, thunderOrgUUID)
 	return nil
 }
 
@@ -233,20 +239,22 @@ func (s *organizationService) ensureThunderUUID(ctx context.Context, ouHandle, t
 	}
 }
 
-// backfillRow inserts a local row for an OC namespace we just discovered.
-// Returns the resulting (possibly racing) row; on hard failure returns a
-// zero row and logs.
-func (s *organizationService) backfillRow(ctx context.Context, view models.OrganizationView, thunderOrgUUID string) models.Organization {
+// backfillRow inserts a local row for an org we just discovered, keyed by
+// `name`. Callers choose the key deliberately: the verify/ensure path keys by
+// the org handle (the identifier the BFF puts in OC URLs and every per-org
+// lookup), while List keys by the OC namespace name it enumerated. Returns the
+// resulting (possibly racing) row; on hard failure returns a zero row and logs.
+func (s *organizationService) backfillRow(ctx context.Context, name string, view models.OrganizationView, thunderOrgUUID string) models.Organization {
 	row := models.Organization{
 		UUID:        uuid.New(),
-		Name:        view.Name,
+		Name:        name,
 		DisplayName: view.DisplayName,
 	}
 	if thunderOrgUUID != "" {
 		if parsed, perr := uuid.Parse(thunderOrgUUID); perr == nil {
 			row.ThunderOrgUUID = &parsed
 		} else {
-			slog.WarnContext(ctx, "backfillRow: invalid Thunder UUID in JWT — leaving column NULL", "name", view.Name, "thunderOrgUUID", thunderOrgUUID, "error", perr)
+			slog.WarnContext(ctx, "backfillRow: invalid Thunder UUID in JWT — leaving column NULL", "name", name, "thunderOrgUUID", thunderOrgUUID, "error", perr)
 		}
 	}
 	err := s.db.WithContext(ctx).Create(&row).Error
@@ -255,11 +263,11 @@ func (s *organizationService) backfillRow(ctx context.Context, view models.Organ
 	}
 	if isUniqueViolation(err) {
 		// Lost the race with a concurrent caller; re-read.
-		if rerr := s.db.WithContext(ctx).Where("name = ?", view.Name).First(&row).Error; rerr == nil {
+		if rerr := s.db.WithContext(ctx).Where("name = ?", name).First(&row).Error; rerr == nil {
 			return row
 		}
 	}
-	slog.WarnContext(ctx, "backfill organization row failed", "name", view.Name, "error", err)
+	slog.WarnContext(ctx, "backfill organization row failed", "name", name, "error", err)
 	return models.Organization{}
 }
 


### PR DESCRIPTION
## Why

After PR #21 deployed, **Implement via remote agents** still failed — but no longer with a 402. The resolver is now on the dispatch path and surfaced a **pre-existing org-identity bug**:

```
ERROR dispatch step failed
  error="...create component: openchoreo: resolve impersonation org for namespace \"kajeorg\": record not found"
```

`trait_sync` was hitting the same error, and the recurring `idx_organizations_name` dup-key warnings were the same root cause.

## Root cause

The BFF uses the org **handle** (`kajeorg`) as the namespace in every OC URL and every per-org DB lookup — `verifyForOuHandle`, `ensureThunderUUID`, dispatch `lookupOrgUUID`, and the OC-client impersonation `orgUUIDResolver`.

But `backfillRow` stored the row under `view.Name = metadata.name` — platform-api's **canonical** namespace (`wc-019e6d83-e23ec424`, where `019e6d83` is kajeorg's Thunder UUID). So rows were **stored as `wc-…` but always searched as the handle** → every handle lookup missed forever, and re-backfill tripped the unique-name index.

This was latent before #21 because the resolver was never load-bearing on the dispatch path (the old `tokenInject` path suppressed impersonation).

## Fix (Option A — BFF only, no deployment changes)

1. **`orgUUIDResolver` prefers the JWT's `ouId`** when the JWT handle matches the request namespace — authoritative (same value Thunder embeds), no DB dependency. Fixes the user-initiated dispatch directly. Async paths (webhooks/watchers; no JWT) fall through to the side-car.
2. **`backfillRow` now stores under an explicit key.** `verifyForOuHandle` keys by the **handle** (so the side-car is findable by every per-org lookup, carrying the Thunder UUID orgensure already supplies); `List()` keeps keying by the OC namespace name it enumerates.

**No migration needed:** orgensure recreates the handle-keyed row (with `ThunderOrgUUID`) on the next authed request after rollout; the orphaned `wc-…` row is harmless.

## Scope

Entirely within `asdlc-service` (BFF). No `wso2cloud-deployment` changes — #2359 (impersonation policy) and the debug-log overrides are already deployed and correct.

## Test

`go build ./...`, `go vet`, `gofmt`, and the `services` / `clients/openchoreo` / `middleware` test packages all pass.

## Verification after deploy

Trigger a dispatch and confirm in the BFF logs:
- `openchoreo: service-identity call — impersonating org namespace=kajeorg orgUUID=019e6d83-…` (no more `record not found`),
- platform-api `m2m_impersonation / success` for `APP_FACTORY_BFF_TO_PLATFORM_API`,
- Component lands in the user org + billing increments,
- `trait_sync` stops erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)