### PR TITLE
docs(codingagent): correct per-org secret-store guidance (secretstore-read)

### DIFF
--- a/asdlc-service/services/codingagent/dispatcher.go
+++ b/asdlc-service/services/codingagent/dispatcher.go
@@ -53,10 +53,13 @@ type Inputs struct {
 	ThunderClientSR *SecretRef
 
 	// ClusterSecretStoreName is the ESO CSS that backs reads. On
-	// cloud-dp-oc-dp this MUST be `application-secrets-read` (AppRole
-	// `approle-creds-application-read-permission` — the only one
-	// scoped to `user-app-secrets/*` on the DP). `secretstore-read`
-	// will silently no-op. Local k3d reuses `default`.
+	// cloud-dp-oc-dp this MUST be `secretstore-read` (AppRole
+	// `approle-creds-read-permission`), whose Vault policy grants read on
+	// `user-app-secrets/*` — the per-org paths the worker's anthropic/github
+	// ExternalSecrets resolve. This is the same store every per-org reader on
+	// the DP uses. Do NOT use `application-secrets-read`: its AppRole policy is
+	// scoped to `cloud-dp-secrets/data/application` only, so `user-app-secrets`
+	// reads 403. Local k3d reuses `default`.
 	ClusterSecretStoreName string
 }
 


### PR DESCRIPTION
Comment-only fix. The `ClusterSecretStoreName` doc in the coding-agent dispatcher steered toward the wrong ESO ClusterSecretStore, which is how the worker ended up unable to read its per-org secrets.

It claimed `application-secrets-read` was "the only one scoped to `user-app-secrets/*`" and that `secretstore-read` "will silently no-op". The live DP shows the opposite:
- `application-secrets-read` (AppRole `approle-creds-application-read-permission`) → policy grants only `cloud-dp-secrets/data/application` → reading `user-app-secrets/<org>/cred-*` returns **403**, leaving worker ExternalSecrets in `SecretSyncedError` and the pod in `CreateContainerConfigError`.
- `secretstore-read` (AppRole `approle-creds-read-permission`) → policy grants `user-app-secrets/*` → this is the store every per-org reader on the DP uses, READY=True.

The store is chosen at deploy time via `AGENT_CLUSTER_SECRET_STORE` (paired wso2cloud-deployment change flips dev from `application-secrets-read` to `secretstore-read`). This just stops the comment from steering the next person back to the broken store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)