### PR TITLE
fix(remote-worker): use https transport when the git-service/BFF URL is https

### DIFF
--- a/remote-worker/src/lib/workspace.ts
+++ b/remote-worker/src/lib/workspace.ts
@@ -27,6 +27,7 @@ import { exec } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
 import http from "node:http";
+import https from "node:https";
 import { config } from "../config.js";
 import { credHelperScript, ghWrapperScript } from "./credhelper.js";
 
@@ -94,8 +95,14 @@ async function resolvePATForClone(
     headers["X-Correlation-ID"] = req.correlationId;
   }
 
+  // Pick the transport by URL scheme: in cloud the BFF/git endpoint is https
+  // (gateway), locally it's http. Node's http.request rejects https URLs with
+  // "Protocol \"https:\" not supported", so this must branch on the scheme
+  // (mirrors skills_pull.ts).
+  const lib = url.protocol === "https:" ? https : http;
+
   return new Promise((resolve, reject) => {
-    const hReq = http.request(
+    const hReq = lib.request(
       url,
       { method: "POST", headers, timeout: 10000 },
       (res) => {


### PR DESCRIPTION
## Problem

With the worker pod finally starting in dev (secrets resolve now), it dies immediately at workspace provisioning:

```
{"kind":"phase","phase":"workspace_provisioning"}
{"kind":"result","status":"failure","error":"workspace_provisioning: Protocol \"https:\" not supported. Expected \"http:\""}
[oneshot] provisionWorkspace failed: Protocol "https:" not supported. Expected "http:"
```

`provisionWorkspace` (→ credentials/refresh call) in `remote-worker/src/lib/workspace.ts` used `node:http`'s `http.request` **unconditionally**. In cloud, `ASDLC_GIT_SERVICE_URL` is the gateway **https** URL, and `http.request` rejects an https URL with exactly that error — so the worker never gets to clone.

## Fix

Branch the transport on `url.protocol` (`https:` → `node:https`, else `node:http`), mirroring `skills_pull.ts`, which already does this. Local k3d (http URL) is unchanged. `tsc --noEmit` passes.

## ⚠️ Requires a runner-image rebuild

The coding-agent runner image (`docker.io/xlight05/app-factory-coding-agent-runner:latest`, `imagePullPolicy: Always`) is built/pushed separately from the OSS-pin ECR pipeline. After merge, that image must be rebuilt + pushed for the fix to reach dev:
```
cd remote-worker && docker buildx build --platform linux/amd64 \
  -t docker.io/xlight05/app-factory-coding-agent-runner:latest --push .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)