### PR TITLE
WS2.4: per-org publisher cc runner-auth (additive, behind triplet)

### DIFF
--- a/asdlc-service/api/app.go
+++ b/asdlc-service/api/app.go
@@ -164,6 +164,11 @@ func NewHandler(params AppParams) http.Handler {
 		// JWT path, authenticated inside the handler with the per-task
 		// RS256 bearer the runner already holds.
 		mux.HandleFunc("GET /api/v1/tasks/{taskId}/skills", params.TaskController.Skills)
+		// WS2.4 — path-scoped credentials refresh that accepts both
+		// TaskJWT and Thunder publisher cc tokens. Legacy
+		// POST /api/v1/credentials/refresh stays mounted below for
+		// pre-WS2.4 runner images.
+		mux.HandleFunc("POST /api/v1/tasks/{taskId}/credentials/refresh", params.TaskController.RefreshCredentials)
 	}
 
 	// App-mode connect callback — outside JWT. The signed connect-state JWT

--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -236,6 +236,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	{
+		// Phase 8 — SM-API triplet on organization_idp_profiles (WS2.4).
+		// Mirrors phase3 sm_api_columns shape; populated by
+		// SMAPIWriter.WritePublisher after EnsureOrgPublisher provisions
+		// the Thunder cc app.
+		c, cancel := migCtx(30 * time.Second)
+		if err := migrations.RunPhase8IDPSMAPIColumns(c, db); err != nil {
+			cancel()
+			slog.Error("phase8_idp_sm_api_columns migration failed", "error", err)
+			os.Exit(1)
+		}
+		cancel()
+	}
+
 	// Skill bootstrap — UPSERT the four bundled built-in skills into
 	// the `skills` table, prune any built-ins removed between releases.
 	// Best-effort: log + warn on failure rather than refusing to start
@@ -382,6 +396,11 @@ func main() {
 	}
 	_ = smClient // wired into dispatch + connect controllers in WS2.
 
+	// WS2.2 — SM-API mirror writer. Hoisted ahead of the credential / IDP
+	// service constructors so all consumers can attach via WithSMAPIWriter
+	// (the no-op case when smClient is nil is fine).
+	smWriter := services.NewSMAPIWriter(smClient, db)
+
 	// --- Phase 1 — cluster-gateway-proxy client (WS1.4) ----------------
 	// Same shape as wso2cloud/backend/core/internal/ou's cpapi: no
 	// Authorization header, X-Correlation-ID-only tracing. When the URL
@@ -411,6 +430,7 @@ func main() {
 	}
 
 	// --- Credentials + in-process services (folded in after WS0.1.i) ---
+	// --- Git-service services + controllers (folded in after WS0.1.i) ---
 	credKey, err := base64.StdEncoding.DecodeString(cfg.CredentialEncryptionKey)
 	if err != nil || len(credKey) != 32 {
 		slog.Error("CREDENTIAL_ENCRYPTION_KEY must be a base64-encoded 32-byte key", "error", err)
@@ -516,9 +536,8 @@ func main() {
 	anthropicCredService := services.NewAnthropicCredentialService(db, credStore, wpClient, cfg.AnthropicPlatformKey, anthropicInvalidator)
 
 	// WS2.2 — SM-API mirror writer wired into both credential services.
-	// nil-safe: smClient is nil when SECRET_MANAGER_API_URL is unset,
-	// and WithSMAPIWriter accepts the no-op writer cleanly.
-	smWriter := services.NewSMAPIWriter(smClient, db)
+	// The writer itself was hoisted ahead of the IDP service constructor
+	// (WS2.4) so it's already built; nil-safe via Enabled() check.
 	credService.WithSMAPIWriter(smWriter)
 	anthropicCredService.WithSMAPIWriter(smWriter)
 	validatorProbes := services.NewValidatorProbes(credService, githubClient, credResolver, minter)
@@ -625,10 +644,14 @@ func main() {
 	} else {
 		slog.Warn("Thunder admin client disabled — set THUNDER_ADMIN_URL + THUNDER_SYSTEM_CLIENT_ID + THUNDER_SYSTEM_CLIENT_SECRET")
 	}
+	// WS2.4 — WithSMAPIWriter mirrors per-org publisher client_secret to
+	// SM-API on EnsureOrgPublisher / RegenerateClientSecret so the
+	// dispatcher's PUBLISHER_CLIENT_SECRET ExternalSecret can materialise
+	// it into runner pods without the BFF holding the plaintext.
 	idpService := services.NewIDPService(db, thunderAdminClient, services.PlatformIDPConfig{
 		Issuer:  cfg.PlatformIDP.Issuer,
 		JWKSURL: cfg.PlatformIDP.JWKSURL,
-	})
+	}).WithSMAPIWriter(smWriter)
 	// Make idpService available to trait_sync so first-protected-deploy
 	// provisions the publisher app lazily.
 	traitSyncService.SetIDPService(idpService)
@@ -834,6 +857,22 @@ func main() {
 				SetSkillsService(*services.TaskSkillsService)
 			}); ok {
 				setter.SetSkillsService(taskSkillsSvc)
+			}
+			// WS2.4 — wire publisher cc token verifier (Thunder JWKS,
+			// audience prefix "asdlc-publisher-"). When ThunderJWKS is
+			// nil (local dev without platform IDP), verifier is nil and
+			// runner callbacks accept TaskJWT only.
+			if pv := services.NewPublisherTokenVerifier(thunderJWKS, cfg.PlatformIDP.Issuer, "asdlc-publisher-"); pv != nil {
+				if setter, ok := tc.(interface {
+					SetPublisherVerifier(*services.PublisherTokenVerifier)
+				}); ok {
+					setter.SetPublisherVerifier(pv)
+				}
+			}
+			if setter, ok := tc.(interface {
+				SetCredentialsRefreshService(services.CredentialsRefreshService)
+			}); ok {
+				setter.SetCredentialsRefreshService(credRefreshService)
 			}
 			return tc
 		}(),

--- a/asdlc-service/controllers/task_controller.go
+++ b/asdlc-service/controllers/task_controller.go
@@ -41,18 +41,26 @@ type TaskController interface {
 	// per-task JWT.
 	Skills(w http.ResponseWriter, r *http.Request)
 
+	// RefreshCredentials (WS2.4) is the path-scoped equivalent of the
+	// legacy /api/v1/credentials/refresh endpoint. Accepts both the
+	// legacy BFF-signed TaskJWT and Thunder-issued publisher cc tokens
+	// via authorizeRunnerCallback. Used by the runner's credhelper.
+	RefreshCredentials(w http.ResponseWriter, r *http.Request)
+
 	// Progress endpoints — task-execution-progress.md §5.2.
 	GetTaskAgentProgress(w http.ResponseWriter, r *http.Request)
 	GetTaskBuildProgress(w http.ResponseWriter, r *http.Request)
 }
 
 type taskController struct {
-	service     services.TaskService
-	dispatchSvc services.DispatchService
-	progressSvc services.ProgressService
-	ocClient    openchoreo.ComponentClient
-	taskTokens  *services.TaskTokenManager
-	skillsSvc   *services.TaskSkillsService
+	service           services.TaskService
+	dispatchSvc       services.DispatchService
+	progressSvc       services.ProgressService
+	ocClient          openchoreo.ComponentClient
+	taskTokens        *services.TaskTokenManager
+	publisherVerifier *services.PublisherTokenVerifier
+	skillsSvc         *services.TaskSkillsService
+	credsRefreshSvc   services.CredentialsRefreshService
 }
 
 func NewTaskController(
@@ -75,6 +83,74 @@ func NewTaskController(
 // when nil, the handler returns 503.
 func (c *taskController) SetSkillsService(s *services.TaskSkillsService) {
 	c.skillsSvc = s
+}
+
+// SetPublisherVerifier wires WS2.4's publisher cc token verifier so the
+// runner-callback handlers accept Thunder-issued cc tokens alongside the
+// legacy BFF-signed TaskJWTs. Optional — when nil, only TaskJWTs work.
+func (c *taskController) SetPublisherVerifier(v *services.PublisherTokenVerifier) {
+	c.publisherVerifier = v
+}
+
+// SetCredentialsRefreshService wires the credentials-refresh service so
+// the WS2.4 path-scoped /api/v1/tasks/{taskId}/credentials/refresh
+// endpoint can delegate. Optional — when nil, the handler returns 503
+// and the runner must fall back to the legacy /api/v1/credentials/refresh
+// route (TaskJWT path).
+func (c *taskController) SetCredentialsRefreshService(s services.CredentialsRefreshService) {
+	c.credsRefreshSvc = s
+}
+
+// authorizeRunnerCallback validates the inbound Authorization header for
+// runner-facing routes (Skills, VerificationFailed, the WS2.4
+// per-task /credentials/refresh). Tries the BFF TaskJWT first; on
+// failure tries the publisher cc verifier (WS2.4). Returns the canonical
+// org handle the caller may need for downstream lookups.
+//
+// On error, writes the HTTP error response and returns ok=false.
+func (c *taskController) authorizeRunnerCallback(w http.ResponseWriter, r *http.Request, taskID string) (orgHandle string, ok bool) {
+	authz := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(authz) <= len(prefix) || authz[:len(prefix)] != prefix {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "bearer token required")
+		return "", false
+	}
+	tok := authz[len(prefix):]
+
+	if c.taskTokens != nil {
+		if claims, err := c.taskTokens.Verify(tok); err == nil {
+			if claims.TaskID != taskID {
+				slog.WarnContext(r.Context(), "runner callback: task bearer subject mismatch",
+					"task", taskID, "claimTaskId", claims.TaskID)
+				utils.WriteErrorResponse(w, http.StatusForbidden, "task bearer does not match path")
+				return "", false
+			}
+			return claims.OcOrgID, true
+		}
+	}
+
+	if c.publisherVerifier != nil {
+		if claims, err := c.publisherVerifier.Verify(tok); err == nil {
+			task, terr := c.service.GetTask(r.Context(), taskID)
+			if terr != nil || task == nil {
+				slog.WarnContext(r.Context(), "runner callback: task lookup failed",
+					"task", taskID, "error", terr)
+				utils.WriteErrorResponse(w, http.StatusForbidden, "task not found")
+				return "", false
+			}
+			if task.OrgID != claims.OrgHandle {
+				slog.WarnContext(r.Context(), "runner callback: publisher org mismatch",
+					"task", taskID, "taskOrg", task.OrgID, "publisherOrg", claims.OrgHandle)
+				utils.WriteErrorResponse(w, http.StatusForbidden, "publisher token does not match task org")
+				return "", false
+			}
+			return claims.OrgHandle, true
+		}
+	}
+
+	slog.WarnContext(r.Context(), "runner callback: bearer rejected by all verifiers", "task", taskID)
+	utils.WriteErrorResponse(w, http.StatusUnauthorized, "invalid bearer")
+	return "", false
 }
 
 func (c *taskController) ListTasks(w http.ResponseWriter, r *http.Request) {
@@ -379,22 +455,7 @@ func (c *taskController) VerificationFailed(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	authz := r.Header.Get("Authorization")
-	const prefix = "Bearer "
-	if len(authz) <= len(prefix) || authz[:len(prefix)] != prefix {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "bearer token required")
-		return
-	}
-	claims, err := c.taskTokens.Verify(authz[len(prefix):])
-	if err != nil {
-		slog.WarnContext(r.Context(), "verification-failed: invalid bearer", "task", taskID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "invalid task bearer")
-		return
-	}
-	if claims.TaskID != taskID {
-		slog.WarnContext(r.Context(), "verification-failed: bearer subject mismatch",
-			"task", taskID, "claimTaskId", claims.TaskID)
-		utils.WriteErrorResponse(w, http.StatusForbidden, "task bearer does not match path")
+	if _, ok := c.authorizeRunnerCallback(w, r, taskID); !ok {
 		return
 	}
 
@@ -469,22 +530,7 @@ func (c *taskController) Skills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authz := r.Header.Get("Authorization")
-	const prefix = "Bearer "
-	if len(authz) <= len(prefix) || authz[:len(prefix)] != prefix {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "bearer token required")
-		return
-	}
-	claims, err := c.taskTokens.Verify(authz[len(prefix):])
-	if err != nil {
-		slog.WarnContext(r.Context(), "skills: invalid bearer", "task", taskID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "invalid task bearer")
-		return
-	}
-	if claims.TaskID != taskID {
-		slog.WarnContext(r.Context(), "skills: bearer subject mismatch",
-			"task", taskID, "claimTaskId", claims.TaskID)
-		utils.WriteErrorResponse(w, http.StatusForbidden, "task bearer does not match path")
+	if _, ok := c.authorizeRunnerCallback(w, r, taskID); !ok {
 		return
 	}
 
@@ -499,5 +545,34 @@ func (c *taskController) Skills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	utils.WriteSuccessResponse(w, http.StatusOK, resp)
+}
+
+// RefreshCredentials (WS2.4) is the path-scoped credential refresh
+// endpoint that accepts either a legacy TaskJWT or a Thunder-issued
+// publisher cc token. The runner's credhelper.sh hits this after WS2.4
+// so the same auth-mode the runner uses for everything else also covers
+// /credentials/refresh. Legacy route `POST /api/v1/credentials/refresh`
+// still exists (TaskJWT only) and is deleted in WS2.6.
+func (c *taskController) RefreshCredentials(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("taskId")
+	if !requireTaskID(w, taskID) {
+		return
+	}
+	if c.credsRefreshSvc == nil {
+		utils.WriteErrorResponse(w, http.StatusServiceUnavailable, "credentials refresh not configured")
+		return
+	}
+	orgHandle, ok := c.authorizeRunnerCallback(w, r, taskID)
+	if !ok {
+		return
+	}
+	resp, err := c.credsRefreshSvc.Refresh(r.Context(), taskID, orgHandle)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "refresh credentials failed",
+			"taskId", taskID, "ocOrgId", orgHandle, "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "failed to refresh credentials")
+		return
+	}
 	utils.WriteSuccessResponse(w, http.StatusOK, resp)
 }

--- a/asdlc-service/database/migrations/phase8_idp_sm_api_columns.go
+++ b/asdlc-service/database/migrations/phase8_idp_sm_api_columns.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// RunPhase8IDPSMAPIColumns adds the SM-API triplet columns to
+// organization_idp_profiles (WS2.4). The publisher cc client_secret is
+// mirrored to SM-API and materialised into the runner pod via a per-run
+// ExternalSecret; the triplet here is read by the dispatcher to build that
+// ExternalSecret without a label-selector lookup. Mirrors the per-row
+// semantics in RunPhase3SMAPIColumns.
+func RunPhase8IDPSMAPIColumns(ctx context.Context, db *gorm.DB) error {
+	stmt := `DO $$ BEGIN
+	   IF EXISTS (SELECT FROM information_schema.tables
+	              WHERE table_schema='public' AND table_name='organization_idp_profiles') THEN
+	     ALTER TABLE organization_idp_profiles
+	       ADD COLUMN IF NOT EXISTS sm_api_secret_ref_name TEXT,
+	       ADD COLUMN IF NOT EXISTS sm_api_kv_path         TEXT,
+	       ADD COLUMN IF NOT EXISTS sm_api_property        TEXT,
+	       ADD COLUMN IF NOT EXISTS sm_api_written_at      TIMESTAMPTZ;
+	   END IF;
+	 END $$`
+	if err := db.WithContext(ctx).Exec(stmt).Error; err != nil {
+		return fmt.Errorf("phase8_idp_sm_api_columns: %w", err)
+	}
+	return nil
+}

--- a/asdlc-service/models/idp_profile.go
+++ b/asdlc-service/models/idp_profile.go
@@ -32,6 +32,14 @@ type OrganizationIDPProfile struct {
 	// purpose-built endpoint to fetch it.
 	PublisherClientSecret string    `gorm:"column:publisher_client_secret" json:"-"`
 	PublisherSecretRef    string    `gorm:"column:publisher_secret_ref" json:"publisherSecretRef,omitempty"`
+	// SM-API triplet (WS2.4) — populated by SMAPIWriter.WritePublisher
+	// after EnsureOrgPublisher provisions the Thunder cc app. Nullable
+	// rows pre-date WS2.4; the dispatcher short-circuits the per-run
+	// runner-auth ExternalSecret when missing.
+	SMAPISecretRefName *string    `gorm:"type:text;column:sm_api_secret_ref_name" json:"-"`
+	SMAPIKVPath        *string    `gorm:"type:text;column:sm_api_kv_path" json:"-"`
+	SMAPIProperty      *string    `gorm:"type:text;column:sm_api_property" json:"-"`
+	SMAPIWrittenAt     *time.Time `gorm:"column:sm_api_written_at" json:"-"`
 	CreatedAt           time.Time `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt           time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }

--- a/asdlc-service/services/codingagent/dispatcher.go
+++ b/asdlc-service/services/codingagent/dispatcher.go
@@ -36,7 +36,7 @@ type Inputs struct {
 	// Job is the fully-resolved Job manifest inputs. The orchestrator
 	// passes it straight to Build; callers fill in everything except
 	// `OrgNS`, `AnthropicSecretName`, `GitHubSecretName`, and
-	// `ThunderClientSecretName`, which the orchestrator computes from
+	// `PublisherSecretName`, which the orchestrator computes from
 	// the run name and overwrites.
 	Job JobInputs
 
@@ -47,10 +47,14 @@ type Inputs struct {
 	AnthropicSR SecretRef
 	GitHubSR    SecretRef
 
-	// ThunderClientSR is WS2.4's third per-run ExternalSecret carrying
-	// the per-org Thunder client_credentials. Optional today; required
-	// once WS2.4 lands.
-	ThunderClientSR *SecretRef
+	// PublisherSR is WS2.4's per-org publisher cc credentials triplet
+	// (`organization_idp_profiles`). When present, the orchestrator
+	// emits a third per-run ExternalSecret materialising both
+	// client_id + client_secret into a K8s Secret that the runner
+	// mounts via envFrom (PUBLISHER_CLIENT_ID + PUBLISHER_CLIENT_SECRET).
+	// Optional during the WS2.4 rollout — when absent the runner falls
+	// back to ASDLC_BEARER.
+	PublisherSR *SecretRef
 
 	// ClusterSecretStoreName is the ESO CSS that backs reads. On
 	// cloud-dp-oc-dp this MUST be `application-secrets-read` (AppRole
@@ -140,9 +144,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, in Inputs) (string, error) {
 	runName := in.Job.RunName
 	anthropicSecret := runName + "-anthropic"
 	githubSecret := runName + "-github"
-	thunderSecret := ""
-	if in.ThunderClientSR != nil {
-		thunderSecret = runName + "-runner-auth"
+	publisherSecret := ""
+	if in.PublisherSR != nil {
+		publisherSecret = runName + "-publisher"
 	}
 
 	// 3) ExternalSecrets.
@@ -152,9 +156,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, in Inputs) (string, error) {
 	if err := d.applyExternalSecret(ctx, in, ns, runName+"-github-es", githubSecret, "GITHUB_TOKEN", in.GitHubSR); err != nil {
 		return "", fmt.Errorf("dispatcher: apply github-pat ExternalSecret: %w", err)
 	}
-	if in.ThunderClientSR != nil {
-		if err := d.applyExternalSecret(ctx, in, ns, runName+"-runner-auth-es", thunderSecret, "RUNNER_CLIENT_SECRET", *in.ThunderClientSR); err != nil {
-			return "", fmt.Errorf("dispatcher: apply runner-auth ExternalSecret: %w", err)
+	if in.PublisherSR != nil {
+		if err := d.applyPublisherExternalSecret(ctx, in, ns, runName+"-publisher-es", publisherSecret, *in.PublisherSR); err != nil {
+			return "", fmt.Errorf("dispatcher: apply publisher ExternalSecret: %w", err)
 		}
 	}
 
@@ -165,7 +169,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, in Inputs) (string, error) {
 	job.ServiceAccountName = d.serviceAccount
 	job.AnthropicSecretName = anthropicSecret
 	job.GitHubSecretName = githubSecret
-	job.ThunderClientSecretName = thunderSecret
+	job.PublisherSecretName = publisherSecret
 	manifest, err := Build(job)
 	if err != nil {
 		return "", fmt.Errorf("dispatcher: build Job manifest: %w", err)
@@ -187,6 +191,29 @@ func (d *Dispatcher) applyExternalSecret(ctx context.Context, in Inputs, ns, esN
 		RemoteRefKey:           ref.KVPath,
 		RemoteRefProperty:      ref.Property,
 		LocalKey:               localKey,
+	})
+	if err != nil {
+		return err
+	}
+	return d.proxy.ApplyExternalSecret(ctx, ns, manifest)
+}
+
+// applyPublisherExternalSecret emits one ExternalSecret with two data
+// entries — client_id and client_secret share the SM-API secret at
+// ref.KVPath but materialise into distinct K8s Secret keys (PUBLISHER_
+// CLIENT_ID + PUBLISHER_CLIENT_SECRET) for envFrom in the Job pod.
+// Token URL is non-secret and rides as a plain env from the Job template.
+func (d *Dispatcher) applyPublisherExternalSecret(ctx context.Context, in Inputs, ns, esName, secretName string, ref SecretRef) error {
+	manifest, err := BuildExternalSecret(ExternalSecretInputs{
+		Name:                   esName,
+		Namespace:              ns,
+		TargetSecretName:       secretName,
+		ClusterSecretStoreName: in.ClusterSecretStoreName,
+		RemoteRefKey:           ref.KVPath,
+		DataEntries: []ExternalSecretDataEntry{
+			{LocalKey: "PUBLISHER_CLIENT_ID", RemoteRefProperty: "client_id"},
+			{LocalKey: "PUBLISHER_CLIENT_SECRET", RemoteRefProperty: "client_secret"},
+		},
 	})
 	if err != nil {
 		return err

--- a/asdlc-service/services/codingagent/externalsecret_template.go
+++ b/asdlc-service/services/codingagent/externalsecret_template.go
@@ -35,14 +35,24 @@ type ExternalSecretInputs struct {
 
 	// RemoteRefKey + RemoteRefProperty point at the SM-API-managed
 	// SecretReference (key=KV path, property=field name). Persisted on
-	// the per-org credential row by WS2.2's Connect flow.
+	// the per-org credential row by WS2.2's Connect flow. Single-field
+	// shape; for multi-field secrets (WS2.4 publisher) populate
+	// DataEntries instead and leave these empty.
 	RemoteRefKey      string
 	RemoteRefProperty string
 
 	// LocalKey is the env var name the runner reads (e.g.
 	// "ANTHROPIC_API_KEY" or "GITHUB_TOKEN"). The K8s Secret data map
-	// is keyed by this string.
+	// is keyed by this string. Single-field shape; for multi-field
+	// secrets populate DataEntries.
 	LocalKey string
+
+	// DataEntries is the multi-field shape. When non-empty, RemoteRefKey
+	// is used as the single shared KV path and one ES data entry is
+	// emitted per element. Used by WS2.4 publisher (client_id +
+	// client_secret in one SM-API secret → one ES → one K8s Secret with
+	// two keys). Empty falls back to the single-field shape above.
+	DataEntries []ExternalSecretDataEntry
 
 	// RefreshInterval — ESO reconcile cadence. Empty defaults to 5m,
 	// which is plenty for a short-lived Job. Set to "0" to disable
@@ -57,6 +67,14 @@ type ExternalSecretInputs struct {
 	OwnerRunUID  string
 }
 
+// ExternalSecretDataEntry is one {localKey, remoteProperty} pair in a
+// multi-field ExternalSecret. All entries share the parent inputs'
+// RemoteRefKey (the KV path).
+type ExternalSecretDataEntry struct {
+	LocalKey          string
+	RemoteRefProperty string
+}
+
 // BuildExternalSecret returns the ESO ExternalSecret manifest as a
 // `map[string]any` ready for clustergatewayproxy.ApplyExternalSecret.
 func BuildExternalSecret(in ExternalSecretInputs) (map[string]any, error) {
@@ -66,6 +84,30 @@ func BuildExternalSecret(in ExternalSecretInputs) (map[string]any, error) {
 	refresh := in.RefreshInterval
 	if refresh == "" {
 		refresh = "5m"
+	}
+
+	var data []map[string]any
+	if len(in.DataEntries) > 0 {
+		data = make([]map[string]any, 0, len(in.DataEntries))
+		for _, e := range in.DataEntries {
+			data = append(data, map[string]any{
+				"secretKey": e.LocalKey,
+				"remoteRef": map[string]any{
+					"key":      in.RemoteRefKey,
+					"property": e.RemoteRefProperty,
+				},
+			})
+		}
+	} else {
+		data = []map[string]any{
+			{
+				"secretKey": in.LocalKey,
+				"remoteRef": map[string]any{
+					"key":      in.RemoteRefKey,
+					"property": in.RemoteRefProperty,
+				},
+			},
+		}
 	}
 
 	manifest := map[string]any{
@@ -85,15 +127,7 @@ func BuildExternalSecret(in ExternalSecretInputs) (map[string]any, error) {
 				"name":           in.TargetSecretName,
 				"creationPolicy": "Owner",
 			},
-			"data": []map[string]any{
-				{
-					"secretKey": in.LocalKey,
-					"remoteRef": map[string]any{
-						"key":      in.RemoteRefKey,
-						"property": in.RemoteRefProperty,
-					},
-				},
-			},
+			"data": data,
 		},
 	}
 
@@ -126,8 +160,15 @@ func validateES(in ExternalSecretInputs) error {
 	check("TargetSecretName", in.TargetSecretName)
 	check("ClusterSecretStoreName", in.ClusterSecretStoreName)
 	check("RemoteRefKey", in.RemoteRefKey)
-	check("RemoteRefProperty", in.RemoteRefProperty)
-	check("LocalKey", in.LocalKey)
+	if len(in.DataEntries) > 0 {
+		for i, e := range in.DataEntries {
+			check(fmt.Sprintf("DataEntries[%d].LocalKey", i), e.LocalKey)
+			check(fmt.Sprintf("DataEntries[%d].RemoteRefProperty", i), e.RemoteRefProperty)
+		}
+	} else {
+		check("RemoteRefProperty", in.RemoteRefProperty)
+		check("LocalKey", in.LocalKey)
+	}
 	if len(in.Name) > 253 {
 		return errors.New("codingagent: ExternalSecret name exceeds 253-char DNS subdomain limit")
 	}

--- a/asdlc-service/services/codingagent/job_template.go
+++ b/asdlc-service/services/codingagent/job_template.go
@@ -11,7 +11,7 @@
 //                   ComponentTask. The watcher (WS2.5) keys on this.
 //   - orgNS       — per-org remote-worker namespace
 //                   (`wc-<orgUUID8>-<orgHash8>-remote-worker`).
-//   - anthropicSecretName / githubSecretName / thunderClientSecretName
+//   - anthropicSecretName / githubSecretName / publisherSecretName
 //                   — K8s Secret names materialized by per-run
 //                   ExternalSecrets just before the Job is applied.
 //                   Mounted as envFrom so a leaked process listing
@@ -37,7 +37,6 @@
 package codingagent
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -67,7 +66,15 @@ type JobInputs struct {
 	// secret is in place by the time the kubelet pulls the image.
 	AnthropicSecretName       string
 	GitHubSecretName          string
-	ThunderClientSecretName   string // optional — empty disables WS2.4 runner-auth
+	// PublisherSecretName is the K8s Secret holding the per-org publisher
+	// cc creds (client_id + client_secret) materialised by a per-run ES
+	// from SM-API. Empty disables the WS2.4 runner-auth path; the runner
+	// then falls back to ASDLC_BEARER for /credentials/refresh calls.
+	PublisherSecretName       string
+	// PublisherTokenURL is the Thunder /oauth2/token endpoint used by the
+	// runner's cc helper. Non-secret; rides as a plain env. Set in lockstep
+	// with PublisherSecretName.
+	PublisherTokenURL         string
 
 	// Dispatch payload — passed verbatim into the runner via ASDLC_* env vars.
 	RepoURL        string
@@ -80,7 +87,7 @@ type JobInputs struct {
 	CorrelationID  string // optional; runner synthesizes one if absent
 
 	// Bearer is the bespoke ASDLC_BEARER param. Deprecated by WS2.4 —
-	// when ThunderClientSecretName is set this field MUST be empty so
+	// when PublisherSecretName is set this field MUST be empty so
 	// the runner uses the Thunder client_credentials flow instead.
 	Bearer string
 
@@ -126,10 +133,15 @@ func Build(in JobInputs) (map[string]any, error) {
 		{"secretRef": map[string]any{"name": in.AnthropicSecretName}},
 		{"secretRef": map[string]any{"name": in.GitHubSecretName}},
 	}
-	if in.ThunderClientSecretName != "" {
+	if in.PublisherSecretName != "" {
 		envFrom = append(envFrom, map[string]any{
-			"secretRef": map[string]any{"name": in.ThunderClientSecretName},
+			"secretRef": map[string]any{"name": in.PublisherSecretName},
 		})
+		if in.PublisherTokenURL != "" {
+			envVars = append(envVars, map[string]any{
+				"name": "PUBLISHER_TOKEN_URL", "value": in.PublisherTokenURL,
+			})
+		}
 	}
 
 	labels := map[string]string{
@@ -208,9 +220,6 @@ func validate(in JobInputs) error {
 
 	if len(in.RunName) > 63 {
 		return fmt.Errorf("codingagent: RunName %q exceeds K8s 63-char DNS label limit", in.RunName)
-	}
-	if in.Bearer != "" && in.ThunderClientSecretName != "" {
-		return errors.New("codingagent: Bearer + ThunderClientSecretName both set; WS2.4 expects one or the other")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("codingagent: missing required field(s): %s", strings.Join(missing, ", "))

--- a/asdlc-service/services/codingagent/job_template_test.go
+++ b/asdlc-service/services/codingagent/job_template_test.go
@@ -17,7 +17,7 @@ func validInputs() JobInputs {
 		ServiceAccountName:      "remote-worker-runner",
 		AnthropicSecretName:     "run-abc12345-anthropic",
 		GitHubSecretName:        "run-abc12345-github",
-		ThunderClientSecretName: "",
+		PublisherSecretName:     "",
 		RepoURL:                 "https://github.com/wso2/demo.git",
 		Prompt:                  "implement /healthz",
 		IdentityName:            "ASDLC Bot",
@@ -60,19 +60,22 @@ func TestBuild_MissingField(t *testing.T) {
 	}
 }
 
-func TestBuild_BearerAndThunderConflict(t *testing.T) {
+func TestBuild_BearerAndPublisherCoexist(t *testing.T) {
+	// During the WS2.4 cutover Bearer + PublisherSecretName both ride on
+	// the same dispatch; the runner prefers cc and falls back to Bearer.
+	// Build must accept both being set.
 	in := validInputs()
-	in.ThunderClientSecretName = "run-abc12345-runner-auth"
-	// Bearer is still set from validInputs — this is the forbidden case.
-	if _, err := Build(in); err == nil {
-		t.Fatal("expected error when Bearer + ThunderClientSecretName both set")
+	in.PublisherSecretName = "run-abc12345-publisher"
+	in.PublisherTokenURL = "https://thunder.example.com/oauth2/token"
+	if _, err := Build(in); err != nil {
+		t.Fatalf("Bearer + PublisherSecretName must coexist during WS2.4 cutover: %v", err)
 	}
 }
 
-func TestBuild_ThunderOnlyAddsEnvFrom(t *testing.T) {
+func TestBuild_PublisherAddsEnvFrom(t *testing.T) {
 	in := validInputs()
-	in.Bearer = ""
-	in.ThunderClientSecretName = "run-abc12345-runner-auth"
+	in.PublisherSecretName = "run-abc12345-publisher"
+	in.PublisherTokenURL = "https://thunder.example.com/oauth2/token"
 	job, err := Build(in)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -81,7 +84,17 @@ func TestBuild_ThunderOnlyAddsEnvFrom(t *testing.T) {
 	containers := tmpl["spec"].(map[string]any)["containers"].([]map[string]any)
 	envFrom := containers[0]["envFrom"].([]map[string]any)
 	if len(envFrom) != 3 {
-		t.Fatalf("envFrom should include anthropic + github + thunder (3 entries); got %d", len(envFrom))
+		t.Fatalf("envFrom should include anthropic + github + publisher (3 entries); got %d", len(envFrom))
+	}
+	env := containers[0]["env"].([]map[string]any)
+	var sawTokenURL bool
+	for _, e := range env {
+		if e["name"] == "PUBLISHER_TOKEN_URL" {
+			sawTokenURL = true
+		}
+	}
+	if !sawTokenURL {
+		t.Fatal("PUBLISHER_TOKEN_URL env missing")
 	}
 }
 

--- a/asdlc-service/services/codingagent/watcher.go
+++ b/asdlc-service/services/codingagent/watcher.go
@@ -182,7 +182,7 @@ func (w *JobWatcher) checkOne(ctx context.Context, task *models.ComponentTask) {
 
 // cleanupPerRunExternalSecrets deletes the per-run ExternalSecrets
 // applied by codingagent.Dispatcher (anthropic + github, plus the
-// optional WS2.4 runner-auth). Owner-ref-based GC isn't possible
+// optional WS2.4 publisher). Owner-ref-based GC isn't possible
 // because the Job UID doesn't exist when the ESes are created
 // (chicken-and-egg: the Job needs the materialized Secrets to start),
 // so the watcher does explicit cleanup on terminal phase. Best-effort:
@@ -196,7 +196,7 @@ func (w *JobWatcher) cleanupPerRunExternalSecrets(ctx context.Context, task *mod
 	names := []string{
 		task.LastCodingAgentRunName + "-anthropic-es",
 		task.LastCodingAgentRunName + "-github-es",
-		task.LastCodingAgentRunName + "-runner-auth-es", // WS2.4 — no-op when absent (404 tolerated)
+		task.LastCodingAgentRunName + "-publisher-es", // WS2.4 — no-op when absent (404 tolerated)
 	}
 	for _, name := range names {
 		if err := w.proxy.DeleteExternalSecret(ctx, ns, name); err != nil {

--- a/asdlc-service/services/dispatch_service.go
+++ b/asdlc-service/services/dispatch_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -480,6 +481,34 @@ func (s *dispatchService) tryDispatchViaProxy(
 		return false, "", nil
 	}
 
+	// WS2.4 — optional publisher cc creds. When the IDP profile carries
+	// the SM-API triplet, the dispatcher emits a third per-run
+	// ExternalSecret materialising PUBLISHER_CLIENT_ID +
+	// PUBLISHER_CLIENT_SECRET into the runner pod (TS runner then prefers
+	// cc → /credentials/refresh and falls back to ASDLC_BEARER when
+	// PUBLISHER_TOKEN_URL is absent). Missing row is fine — the runner
+	// keeps using ASDLC_BEARER.
+	var (
+		publisherSR       *codingagent.SecretRef
+		publisherTokenURL string
+	)
+	var idpRow models.OrganizationIDPProfile
+	if err := s.db.WithContext(ctx).Where("org_id = ?", task.OrgID).First(&idpRow).Error; err == nil {
+		if idpRow.SMAPIKVPath != nil && idpRow.SMAPISecretRefName != nil {
+			publisherSR = &codingagent.SecretRef{
+				SecretRefName: derefStr(idpRow.SMAPISecretRefName),
+				KVPath:        derefStr(idpRow.SMAPIKVPath),
+				Property:      derefStr(idpRow.SMAPIProperty),
+			}
+			publisherTokenURL = deriveTokenURLFromJWKS(idpRow.JWKSURL)
+			if publisherTokenURL == "" {
+				slog.WarnContext(ctx, "proxy dispatch: publisher creds present but JWKS URL malformed; falling back to bearer only",
+					"task", task.ID, "jwksURL", idpRow.JWKSURL)
+				publisherSR = nil
+			}
+		}
+	}
+
 	// OrgUUID lookup. The BFF Organization row carries the UUID the
 	// NS derivation needs (`wc-<orgUUID8>-<orgHash8>-remote-worker`).
 	orgUUID, err := s.lookupOrgUUID(ctx, task.OrgID)
@@ -507,12 +536,13 @@ func (s *dispatchService) tryDispatchViaProxy(
 		// `ASDLC_BEARER` keeps the legacy per-task RS256 JWT path alive
 		// on the new dispatcher. The runner's `oneshot.ts` validates
 		// the env var at startup and uses it for /credentials/refresh
-		// callbacks. WS2.4's eventual switch to Thunder
-		// `client_credentials` (third per-run ExternalSecret =
-		// ThunderClientSR) lets us drop this; for now both paths are
-		// load-bearing and we mint the bearer here just like the
-		// legacy `wfRunService.TriggerCodingAgent` call does above.
-		Bearer: bearer,
+		// callbacks. WS2.4 adds the publisher cc path alongside —
+		// PublisherSR (below) populates a 3rd per-run ExternalSecret;
+		// the TS runner prefers cc when PUBLISHER_CLIENT_ID is present
+		// and falls back to Bearer otherwise. Drop Bearer here once
+		// the TS runner is fully migrated.
+		Bearer:            bearer,
+		PublisherTokenURL: publisherTokenURL,
 	}
 
 	rn, err := s.codingAgentDispatcher.Dispatch(ctx, codingagent.Inputs{
@@ -520,6 +550,7 @@ func (s *dispatchService) tryDispatchViaProxy(
 		Job:                    job,
 		AnthropicSR:            codingagent.SecretRef{SecretRefName: derefStr(anthropicRow.SMAPISecretRefName), KVPath: derefStr(anthropicRow.SMAPIKVPath), Property: derefStr(anthropicRow.SMAPIProperty)},
 		GitHubSR:               codingagent.SecretRef{SecretRefName: derefStr(githubRow.SMAPISecretRefName), KVPath: derefStr(githubRow.SMAPIKVPath), Property: derefStr(githubRow.SMAPIProperty)},
+		PublisherSR:            publisherSR,
 		ClusterSecretStoreName: s.clusterSecretStore,
 	})
 	if err != nil {
@@ -573,6 +604,18 @@ func derefStr(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// deriveTokenURLFromJWKS swaps the trailing `/oauth2/jwks` path on the
+// org's JWKS URL for `/oauth2/token`. The two endpoints live on the same
+// Thunder host so this is safe; returns "" on shapes we don't recognise
+// (caller skips the publisher path in that case).
+func deriveTokenURLFromJWKS(jwksURL string) string {
+	const suffix = "/oauth2/jwks"
+	if !strings.HasSuffix(jwksURL, suffix) {
+		return ""
+	}
+	return jwksURL[:len(jwksURL)-len(suffix)] + "/oauth2/token"
 }
 
 func failResult(r DispatchResult, msg string) DispatchResult {

--- a/asdlc-service/services/idp_service.go
+++ b/asdlc-service/services/idp_service.go
@@ -91,14 +91,28 @@ type idpService struct {
 	db        *gorm.DB
 	thunder   thundersvc.Client
 	platform  PlatformIDPConfig
+	smAPI     *SMAPIWriter
 }
 
 // NewIDPService builds the service. `thunder` may be nil in unit tests
 // — the service rejects EnsureOrgPublisher / RevokeOrgPublisher /
 // RegenerateClientSecret with ErrIDPThunderUnavailable when so. Read
-// methods (GetProfile, GetOrCreateProfile) keep working.
-func NewIDPService(db *gorm.DB, thunder thundersvc.Client, platform PlatformIDPConfig) IDPService {
+// methods (GetProfile, GetOrCreateProfile) keep working. Returns the
+// concrete type so WithSMAPIWriter (WS2.4) can chain at the composition
+// root; the concrete value still satisfies the IDPService interface for
+// consumers that store it as such.
+func NewIDPService(db *gorm.DB, thunder thundersvc.Client, platform PlatformIDPConfig) *idpService {
 	return &idpService{db: db, thunder: thunder, platform: platform}
+}
+
+// WithSMAPIWriter attaches the SM-API writer so EnsureOrgPublisher /
+// RegenerateClientSecret mirror the publisher cc credentials to SM-API
+// (WS2.4 — runner pods consume them via per-run ExternalSecret). nil
+// writer or one with Enabled()==false is a no-op; publisher provisioning
+// still works but dispatcher's runner-auth path stays disabled.
+func (s *idpService) WithSMAPIWriter(w *SMAPIWriter) *idpService {
+	s.smAPI = w
+	return s
 }
 
 // ErrIDPThunderUnavailable means the Thunder admin client isn't wired
@@ -192,6 +206,19 @@ func (s *idpService) EnsureOrgPublisher(ctx context.Context, orgID, actor string
 		return "", "", false, fmt.Errorf("idp_service.EnsureOrgPublisher persist: %w", err)
 	}
 
+	// WS2.4 — mirror publisher creds to SM-API so the dispatcher can mint
+	// a per-run ExternalSecret for the runner's cc flow. Only on fresh
+	// create (Thunder doesn't return the secret on subsequent reads); pre-
+	// existing apps without SM-API mirroring recover via an explicit
+	// RegenerateClientSecret. Best-effort: SM-API outage doesn't fail
+	// publisher provisioning.
+	if created && clientSecret != "" && s.smAPI != nil && s.smAPI.Enabled() {
+		if _, smerr := s.smAPI.WritePublisher(ctx, orgID, clientID, clientSecret); smerr != nil {
+			slog.WarnContext(ctx, "idp_service: SM-API publisher write failed (continuing)",
+				"orgID", orgID, "error", smerr)
+		}
+	}
+
 	// Re-read for the audit "after" snapshot.
 	after, _ := s.GetProfile(ctx, orgID)
 	afterJSON, _ := json.Marshal(profileSummary(after))
@@ -239,6 +266,16 @@ func (s *idpService) RevokeOrgPublisher(ctx context.Context, orgID, actor string
 		s.audit(ctx, orgID, models.IDPAuditRevokePublisher, actor, beforeJSON, nil, err)
 		return deleted, fmt.Errorf("idp_service.RevokeOrgPublisher persist: %w", err)
 	}
+
+	// WS2.4 — drop the SM-API publisher secret + clear the triplet. Best-
+	// effort so a missing SM-API doesn't strand the Thunder revoke.
+	if s.smAPI != nil && s.smAPI.Enabled() {
+		if smerr := s.smAPI.DeletePublisher(ctx, orgID); smerr != nil {
+			slog.WarnContext(ctx, "idp_service: SM-API publisher delete failed (continuing)",
+				"orgID", orgID, "error", smerr)
+		}
+	}
+
 	after, _ := s.GetProfile(ctx, orgID)
 	afterJSON, _ := json.Marshal(profileSummary(after))
 	s.audit(ctx, orgID, models.IDPAuditRevokePublisher, actor, beforeJSON, afterJSON, nil)
@@ -279,6 +316,17 @@ func (s *idpService) RegenerateClientSecret(ctx context.Context, orgID, actor st
 		s.audit(ctx, orgID, models.IDPAuditRegenerateSecret, actor, beforeJSON, nil, err)
 		return "", fmt.Errorf("idp_service.RegenerateClientSecret persist: %w", err)
 	}
+
+	// WS2.4 — mirror the rotated secret to SM-API; runner pods picking up
+	// from the next dispatch will receive the new secret via ExternalSecret
+	// refresh. Best-effort.
+	if s.smAPI != nil && s.smAPI.Enabled() {
+		if _, smerr := s.smAPI.WritePublisher(ctx, orgID, profile.PublisherClientID, newSecret); smerr != nil {
+			slog.WarnContext(ctx, "idp_service: SM-API publisher rewrite failed (continuing)",
+				"orgID", orgID, "error", smerr)
+		}
+	}
+
 	after, _ := s.GetProfile(ctx, orgID)
 	afterJSON, _ := json.Marshal(profileSummary(after))
 	s.audit(ctx, orgID, models.IDPAuditRegenerateSecret, actor, beforeJSON, afterJSON, nil)

--- a/asdlc-service/services/publisher_token_verifier.go
+++ b/asdlc-service/services/publisher_token_verifier.go
@@ -1,0 +1,126 @@
+package services
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/wso2/asdlc/asdlc-service/middleware/jwtassertion"
+)
+
+// PublisherTokenVerifier validates Thunder-issued client_credentials
+// access tokens whose audience identifies a per-org publisher OAuth app
+// ("asdlc-publisher-{orgHandle}"). Mirrors agent-manager's
+// PublisherClientAuthMiddleware at
+// agent-manager-service/middleware/jwtassertion/auth.go:106 — same
+// regex shape, same cross-org defense (subject's embedded org handle
+// MUST match the ouHandle claim).
+//
+// Used by the runner-callback handlers (Skills, VerificationFailed,
+// Refresh) to accept WS2.4's per-org publisher cc tokens alongside the
+// legacy BFF-signed TaskJWT.
+type PublisherTokenVerifier struct {
+	jwks           *jwtassertion.JWKSCache
+	expectedIssuer string
+	audiencePrefix string
+	subjectPattern *regexp.Regexp
+}
+
+// PublisherClaims is the projection of a verified publisher cc token.
+// OrgHandle is the canonical OC org handle (extracted from subject +
+// cross-checked against the ouHandle claim).
+type PublisherClaims struct {
+	jwt.RegisteredClaims
+	OuId      string `json:"ouId"`
+	OuName    string `json:"ouName"`
+	OuHandle  string `json:"ouHandle"`
+	OrgHandle string `json:"-"`
+}
+
+// NewPublisherTokenVerifier returns a verifier. audiencePrefix is the
+// shared prefix on every per-org publisher client (e.g. "asdlc-publisher-").
+// jwks must be a populated cache pointed at the platform IDP's JWKS
+// endpoint; expectedIssuer is the iss claim Thunder stamps (e.g.
+// "platform-idp"). Returns nil when any input is empty — composition root
+// uses this to disable WS2.4 cc verification cleanly in dev.
+func NewPublisherTokenVerifier(jwks *jwtassertion.JWKSCache, expectedIssuer, audiencePrefix string) *PublisherTokenVerifier {
+	if jwks == nil || strings.TrimSpace(expectedIssuer) == "" || strings.TrimSpace(audiencePrefix) == "" {
+		return nil
+	}
+	escaped := regexp.QuoteMeta(audiencePrefix)
+	pat := regexp.MustCompile("^" + escaped + `[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	return &PublisherTokenVerifier{
+		jwks:           jwks,
+		expectedIssuer: expectedIssuer,
+		audiencePrefix: audiencePrefix,
+		subjectPattern: pat,
+	}
+}
+
+// Verify parses + validates the publisher cc token. Returns canonical
+// claims on success; rejects with a descriptive error otherwise. Caller
+// is responsible for the in-handler scope check (e.g. validating that
+// the runner-presented taskID belongs to claims.OrgHandle).
+func (v *PublisherTokenVerifier) Verify(tokenString string) (*PublisherClaims, error) {
+	if v == nil {
+		return nil, fmt.Errorf("publisher verifier not configured")
+	}
+	if tokenString == "" {
+		return nil, fmt.Errorf("empty token")
+	}
+	tok, err := jwt.ParseWithClaims(tokenString, &PublisherClaims{}, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, fmt.Errorf("kid missing from token header")
+		}
+		return v.jwks.PublicKeyForKid(kid)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("parse publisher token: %w", err)
+	}
+	if !tok.Valid {
+		return nil, fmt.Errorf("publisher token not valid")
+	}
+	claims, ok := tok.Claims.(*PublisherClaims)
+	if !ok {
+		return nil, fmt.Errorf("claims not PublisherClaims")
+	}
+	if claims.Issuer != v.expectedIssuer {
+		return nil, fmt.Errorf("unexpected issuer %q", claims.Issuer)
+	}
+
+	// Identify the publisher app via the audience claim (Thunder stamps
+	// the cc client_id as aud per the agent-manager pattern at
+	// agent-manager/agent-manager-service/middleware/jwtassertion/auth.go:93).
+	// Subject is a Thunder-generated UUID, not the client_id.
+	var publisherAud string
+	for _, a := range claims.Audience {
+		if v.subjectPattern.MatchString(a) {
+			publisherAud = a
+			break
+		}
+	}
+	if publisherAud == "" {
+		return nil, fmt.Errorf("no publisher audience present (expected %s*)", v.audiencePrefix)
+	}
+	orgHandle := strings.TrimPrefix(publisherAud, v.audiencePrefix)
+
+	// Cross-org defense: the org handle embedded in the audience MUST
+	// match the ouHandle claim. Defends against an attacker who steals
+	// org A's publisher cc token and tries to act on org B's data by
+	// hand-rolling a token with a mismatched ouHandle (which would fail
+	// signature verification, but layered defense).
+	if claims.OuHandle == "" {
+		return nil, fmt.Errorf("ouHandle claim missing")
+	}
+	if claims.OuHandle != orgHandle {
+		return nil, fmt.Errorf("ouHandle %q does not match audience org %q", claims.OuHandle, orgHandle)
+	}
+	claims.OrgHandle = orgHandle
+	return claims, nil
+}

--- a/asdlc-service/services/sm_api_writer.go
+++ b/asdlc-service/services/sm_api_writer.go
@@ -207,6 +207,108 @@ func (w *SMAPIWriter) DeleteAnthropic(ctx context.Context, ocOrgID string) error
 		}).Error
 }
 
+// PublisherSecretFieldClientID and PublisherSecretFieldClientSecret are the
+// JSON field names inside the SM-API "publisher" secret. The dispatcher
+// (WS2.4) materialises both into the per-run Job as PUBLISHER_CLIENT_ID
+// and PUBLISHER_CLIENT_SECRET via a single 2-entry ExternalSecret. Token
+// URL is non-secret and rides as a plain Job env from BFF config.
+const (
+	PublisherSecretFieldClientID     = "client_id"
+	PublisherSecretFieldClientSecret = "client_secret"
+)
+
+// WritePublisher uploads the per-org Thunder publisher cc credentials to
+// SM-API as a single 2-field secret and stamps the triplet onto
+// `organization_idp_profiles`. Called from idp_service.EnsureOrgPublisher
+// (on create) and RegenerateClientSecret (on rotation). The triplet is
+// read at dispatch time to mint the per-run ExternalSecret that hands
+// the runner pod its cc credentials (WS2.4 replaces ASDLC_BEARER).
+//
+// Same semantics as WriteAnthropic: best-effort, errors returned, ctx
+// must carry the user JWT.
+func (w *SMAPIWriter) WritePublisher(ctx context.Context, ocOrgID, clientID, clientSecret string) (string, error) {
+	if !w.Enabled() {
+		return "", nil
+	}
+	if strings.TrimSpace(ocOrgID) == "" {
+		return "", errors.New("sm-api writer: ocOrgID required")
+	}
+	if strings.TrimSpace(clientID) == "" {
+		return "", errors.New("sm-api writer: clientID required")
+	}
+	if strings.TrimSpace(clientSecret) == "" {
+		return "", errors.New("sm-api writer: clientSecret required")
+	}
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:    ocOrgID,
+		EntityName: "publisher",
+	}
+	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
+		PublisherSecretFieldClientID:     clientID,
+		PublisherSecretFieldClientSecret: clientSecret,
+	})
+	if err != nil {
+		return "", fmt.Errorf("sm-api writer: publisher upload: %w", err)
+	}
+	vaultKey, err := w.resolveVaultKey(ctx, secretRefName)
+	if err != nil {
+		return secretRefName, fmt.Errorf("sm-api writer: resolve publisher vault key: %w", err)
+	}
+	now := time.Now().UTC()
+	if err := w.db.WithContext(ctx).
+		Model(&models.OrganizationIDPProfile{}).
+		Where("org_id = ?", ocOrgID).
+		Updates(map[string]any{
+			"sm_api_secret_ref_name": secretRefName,
+			"sm_api_kv_path":         vaultKey,
+			"sm_api_property":        "publisher",
+			"sm_api_written_at":      now,
+		}).Error; err != nil {
+		return secretRefName, fmt.Errorf("sm-api writer: stamp publisher triplet: %w", err)
+	}
+	slog.InfoContext(ctx, "sm-api writer: publisher creds uploaded",
+		"ocOrgId", ocOrgID,
+		"secretRefName", secretRefName,
+		"vaultKey", vaultKey)
+	return secretRefName, nil
+}
+
+// DeletePublisher best-effort removes the SM-API publisher secret + clears
+// the triplet on `organization_idp_profiles`. Called by
+// idp_service.RevokeOrgPublisher.
+func (w *SMAPIWriter) DeletePublisher(ctx context.Context, ocOrgID string) error {
+	if !w.Enabled() {
+		return nil
+	}
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:    ocOrgID,
+		EntityName: "publisher",
+	}
+	var row models.OrganizationIDPProfile
+	if err := w.db.WithContext(ctx).Where("org_id = ?", ocOrgID).First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return fmt.Errorf("sm-api writer: load idp profile row: %w", err)
+	}
+	refName := ""
+	if row.SMAPISecretRefName != nil {
+		refName = *row.SMAPISecretRefName
+	}
+	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
+		return fmt.Errorf("sm-api writer: delete publisher secret: %w", err)
+	}
+	return w.db.WithContext(ctx).
+		Model(&models.OrganizationIDPProfile{}).
+		Where("org_id = ?", ocOrgID).
+		Updates(map[string]any{
+			"sm_api_secret_ref_name": nil,
+			"sm_api_kv_path":         nil,
+			"sm_api_property":        nil,
+			"sm_api_written_at":      nil,
+		}).Error
+}
+
 // DeleteGitHubPAT mirrors DeleteAnthropic on the GitHub side.
 func (w *SMAPIWriter) DeleteGitHubPAT(ctx context.Context, ocOrgID string) error {
 	if !w.Enabled() {

--- a/remote-worker/src/lib/credhelper.ts
+++ b/remote-worker/src/lib/credhelper.ts
@@ -31,9 +31,13 @@ export function credHelperScript(params: CredHelperParams): string {
   const { taskId, workspaceDir } = params;
   return `#!/usr/bin/env bash
 # Git credential helper for ASDLC platform-managed repos.
-# Reads the per-task bearer from $ASDLC_BEARER_FILE and asks
-# git-service for a fresh GitHub token. Stays silent on errors so git's
-# own error message reaches the user.
+# Two auth modes (WS2.4):
+#   (a) publisher cc — when PUBLISHER_CLIENT_ID/SECRET/TOKEN_URL are set,
+#       mint a Thunder access token via client_credentials and call the
+#       path-scoped endpoint POST /api/v1/tasks/{taskId}/credentials/refresh.
+#   (b) legacy TaskJWT — read the per-task bearer from \$ASDLC_BEARER_FILE
+#       and call POST /api/v1/credentials/refresh.
+# Stays silent on errors so git's own error message reaches the user.
 #
 # Phase 2 PR D §6.6 anti-misroute: refuses if the refresh response's
 # taskId doesn't match this script's bound task — defends against a
@@ -49,20 +53,43 @@ set -e
 expected_task_id=${shellSingleQuote(taskId)}
 workspace_dir=${shellSingleQuote(workspaceDir)}
 
-bearer="$(cat "$ASDLC_BEARER_FILE" 2>/dev/null || true)"
-if [ -z "$bearer" ]; then
-  exit 1
-fi
 corr_header=()
 if [ -n "$ASDLC_CORRELATION_ID" ]; then
   corr_header=(-H "X-Correlation-ID: $ASDLC_CORRELATION_ID")
 fi
+
+bearer=""
+refresh_url=""
+if [ -n "$PUBLISHER_CLIENT_ID" ] && [ -n "$PUBLISHER_CLIENT_SECRET" ] && [ -n "$PUBLISHER_TOKEN_URL" ]; then
+  # WS2.4 — mint cc token via Basic auth, call path-scoped endpoint.
+  cc_resp="$(curl -fsS -X POST \\
+    -u "$PUBLISHER_CLIENT_ID:$PUBLISHER_CLIENT_SECRET" \\
+    -H "Content-Type: application/x-www-form-urlencoded" \\
+    -d 'grant_type=client_credentials' \\
+    "$PUBLISHER_TOKEN_URL" 2>/dev/null || true)"
+  if [ -n "$cc_resp" ] && command -v python3 >/dev/null 2>&1; then
+    bearer="$(printf '%s' "$cc_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+  elif [ -n "$cc_resp" ]; then
+    bearer="$(echo "$cc_resp" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')"
+  fi
+  if [ -n "$bearer" ]; then
+    refresh_url="\${ASDLC_PLATFORM_URL:-$ASDLC_GIT_SERVICE_URL}/api/v1/tasks/$expected_task_id/credentials/refresh"
+  fi
+fi
+if [ -z "$bearer" ]; then
+  bearer="$(cat "$ASDLC_BEARER_FILE" 2>/dev/null || true)"
+  refresh_url="$ASDLC_GIT_SERVICE_URL/api/v1/credentials/refresh"
+fi
+if [ -z "$bearer" ]; then
+  exit 1
+fi
+
 resp="$(curl -fsS -X POST \\
   -H "Authorization: Bearer $bearer" \\
   -H "Content-Type: application/json" \\
   "\${corr_header[@]}" \\
   -d '{}' \\
-  "$ASDLC_GIT_SERVICE_URL/api/v1/credentials/refresh" 2>/dev/null || true)"
+  "$refresh_url" 2>/dev/null || true)"
 if [ -z "$resp" ]; then
   exit 1
 fi

--- a/remote-worker/src/lib/oauth.ts
+++ b/remote-worker/src/lib/oauth.ts
@@ -1,0 +1,127 @@
+// OAuth2 client_credentials token helper. Mirrors the canonical Go shape
+// at wso2cloud/backend/core/pkg/thunder/auth/token_provider.go: cache
+// the token, refresh on a 5-minute renewal buffer, honour `expires_in`,
+// HTTP Basic auth (client_secret_basic).
+//
+// WS2.4 runner-auth: the runner pod gets per-org Thunder publisher cc
+// credentials via per-run ExternalSecret (PUBLISHER_CLIENT_ID +
+// PUBLISHER_CLIENT_SECRET) and the token URL via plain env
+// (PUBLISHER_TOKEN_URL). This helper mints + caches access tokens that
+// authenticate the runner's callbacks to asdlc-api.
+
+import http from "node:http";
+import https from "node:https";
+import { URL } from "node:url";
+
+export interface ClientCredentialsConfig {
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  // renewalBufferMs — how long before expiry to refresh. Default 5 min.
+  renewalBufferMs?: number;
+  // fallbackTtlMs — token lifetime when the server omits expires_in.
+  // Default 50 min (matches the upstream Go helper's fallback).
+  fallbackTtlMs?: number;
+}
+
+const DEFAULT_RENEWAL_BUFFER_MS = 5 * 60 * 1000;
+const DEFAULT_FALLBACK_TTL_MS = 50 * 60 * 1000;
+
+export class ClientCredentialsTokenProvider {
+  private readonly tokenUrl: URL;
+  private readonly basicAuth: string;
+  private readonly renewalBufferMs: number;
+  private readonly fallbackTtlMs: number;
+
+  private cachedToken: string | undefined;
+  private expiresAtMs = 0;
+  private inflight: Promise<string> | undefined;
+
+  constructor(config: ClientCredentialsConfig) {
+    if (!config.tokenUrl) throw new Error("ClientCredentialsTokenProvider: tokenUrl required");
+    if (!config.clientId) throw new Error("ClientCredentialsTokenProvider: clientId required");
+    if (!config.clientSecret) throw new Error("ClientCredentialsTokenProvider: clientSecret required");
+    this.tokenUrl = new URL(config.tokenUrl);
+    this.basicAuth =
+      "Basic " +
+      Buffer.from(`${config.clientId}:${config.clientSecret}`, "utf8").toString("base64");
+    this.renewalBufferMs = config.renewalBufferMs ?? DEFAULT_RENEWAL_BUFFER_MS;
+    this.fallbackTtlMs = config.fallbackTtlMs ?? DEFAULT_FALLBACK_TTL_MS;
+  }
+
+  async getToken(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.expiresAtMs - this.renewalBufferMs) {
+      return this.cachedToken;
+    }
+    if (this.inflight) {
+      return this.inflight;
+    }
+    this.inflight = this.fetchToken().finally(() => {
+      this.inflight = undefined;
+    });
+    return this.inflight;
+  }
+
+  private fetchToken(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const body = "grant_type=client_credentials";
+      const lib = this.tokenUrl.protocol === "https:" ? https : http;
+      const req = lib.request(
+        this.tokenUrl,
+        {
+          method: "POST",
+          headers: {
+            Authorization: this.basicAuth,
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": Buffer.byteLength(body).toString(),
+            Accept: "application/json",
+          },
+          timeout: 10000,
+        },
+        (res) => {
+          let chunks = "";
+          res.on("data", (c: Buffer) => {
+            chunks += c.toString();
+          });
+          res.on("end", () => {
+            if ((res.statusCode ?? 0) < 200 || (res.statusCode ?? 0) >= 300) {
+              return reject(
+                new Error(
+                  `cc token endpoint returned ${res.statusCode}: ${chunks.slice(0, 200)}`,
+                ),
+              );
+            }
+            try {
+              const parsed = JSON.parse(chunks);
+              const accessToken: unknown = parsed?.access_token;
+              if (typeof accessToken !== "string" || accessToken === "") {
+                return reject(new Error("cc token response missing access_token"));
+              }
+              const expiresIn: unknown = parsed?.expires_in;
+              const ttlMs =
+                typeof expiresIn === "number" && expiresIn > 0
+                  ? expiresIn * 1000
+                  : this.fallbackTtlMs;
+              this.cachedToken = accessToken;
+              this.expiresAtMs = Date.now() + ttlMs;
+              resolve(accessToken);
+            } catch (err) {
+              reject(
+                new Error(
+                  `invalid cc token response: ${err instanceof Error ? err.message : String(err)}`,
+                ),
+              );
+            }
+          });
+        },
+      );
+      req.on("error", (err) => reject(err));
+      req.on("timeout", () => {
+        req.destroy();
+        reject(new Error("cc token request timed out"));
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+}

--- a/remote-worker/src/lib/types.ts
+++ b/remote-worker/src/lib/types.ts
@@ -22,4 +22,12 @@ export interface DispatchRequest {
   prompt: string;
   /** Optional correlation ID for distributed tracing. Forwarded to git-service via credhelper. */
   correlationId?: string;
+  /**
+   * WS2.4 — full URL for the credentials/refresh endpoint used during
+   * workspace bootstrap. Defaults to the legacy
+   * `${gitServiceUrl}/api/v1/credentials/refresh`; oneshot.ts overrides
+   * to the path-scoped `${platformUrl}/api/v1/tasks/{taskId}/credentials/refresh`
+   * when publisher cc creds are present.
+   */
+  refreshUrl?: string;
 }

--- a/remote-worker/src/lib/workspace.ts
+++ b/remote-worker/src/lib/workspace.ts
@@ -51,6 +51,11 @@ export interface ProvisionRequest {
   identity: { name: string; email: string; login?: string };
   gitServiceUrl: string;
   correlationId?: string;
+  // WS2.4 — full refresh URL override (defaults to
+  // `${gitServiceUrl}/api/v1/credentials/refresh`). oneshot.ts sets this
+  // to the path-scoped `${platformUrl}/api/v1/tasks/{taskId}/credentials/refresh`
+  // when publisher cc creds drive auth.
+  refreshUrl?: string;
 }
 
 // computeLayout names every path the dispatch flow touches. Pure function
@@ -83,9 +88,16 @@ async function resolvePATForClone(
     throw new Error("bearer file is empty");
   }
 
-  const url = new URL(req.gitServiceUrl);
-  if (!url.pathname.endsWith("/")) url.pathname += "/";
-  url.pathname += "api/v1/credentials/refresh";
+  // WS2.4 — refreshUrl overrides the legacy git-service path when
+  // publisher cc creds drive auth (oneshot.ts sets it).
+  let url: URL;
+  if (req.refreshUrl && req.refreshUrl !== "") {
+    url = new URL(req.refreshUrl);
+  } else {
+    url = new URL(req.gitServiceUrl);
+    if (!url.pathname.endsWith("/")) url.pathname += "/";
+    url.pathname += "api/v1/credentials/refresh";
+  }
 
   const headers: Record<string, string> = {
     "Authorization": `Bearer ${bearer.trim()}`,

--- a/remote-worker/src/oneshot.ts
+++ b/remote-worker/src/oneshot.ts
@@ -22,6 +22,7 @@ import type { DispatchRequest } from "./lib/types.js";
 import { emit, primeScrubber } from "./lib/progress/emitter.js";
 import { pullTaskSkills } from "./lib/skills_pull.js";
 import { materializeSkills } from "./lib/skills_materializer.js";
+import { ClientCredentialsTokenProvider } from "./lib/oauth.js";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -37,13 +38,26 @@ function readDispatchFromEnv(): DispatchRequest {
   const projectId = requireEnv("ASDLC_PROJECT_ID");
   const componentName = requireEnv("ASDLC_COMPONENT_NAME");
   const repoUrl = requireEnv("ASDLC_REPO_URL");
-  const bearer = requireEnv("ASDLC_BEARER");
+  // WS2.4 — Bearer is optional when publisher cc creds are present;
+  // required otherwise. Validated below after we peek at publisher envs.
+  const bearer = process.env.ASDLC_BEARER ?? "";
   const gitServiceUrl = requireEnv("ASDLC_GIT_SERVICE_URL");
   const prompt = requireEnv("ASDLC_PROMPT");
   const identityName = requireEnv("ASDLC_IDENTITY_NAME");
   const identityEmail = requireEnv("ASDLC_IDENTITY_EMAIL");
   const identityLogin = process.env.ASDLC_IDENTITY_LOGIN || "";
   const correlationId = process.env.ASDLC_CORRELATION_ID || randomUUID();
+
+  const publisherClientId = process.env.PUBLISHER_CLIENT_ID ?? "";
+  const publisherClientSecret = process.env.PUBLISHER_CLIENT_SECRET ?? "";
+  const publisherTokenUrl = process.env.PUBLISHER_TOKEN_URL ?? "";
+  const hasPublisher =
+    publisherClientId !== "" && publisherClientSecret !== "" && publisherTokenUrl !== "";
+  if (!hasPublisher && bearer === "") {
+    throw new Error(
+      "neither ASDLC_BEARER nor PUBLISHER_CLIENT_ID/SECRET/TOKEN_URL set — runner has no auth material",
+    );
+  }
 
   if (!isUUID(taskId)) throw new Error(`ASDLC_TASK_ID is not a valid UUID: ${taskId}`);
   if (!isSlug(orgId)) throw new Error(`ASDLC_ORG_ID is not a valid slug: ${orgId}`);
@@ -77,7 +91,44 @@ async function main(): Promise<number> {
     return 2;
   }
 
-  primeScrubber([process.env.ANTHROPIC_API_KEY, req.bearer]);
+  // WS2.4 — when publisher cc envs are set, mint a token via the cc helper
+  // and prefer it for runner→BFF callbacks. Falls back to ASDLC_BEARER
+  // (legacy TaskJWT) when cc envs are absent.
+  const publisherClientId = process.env.PUBLISHER_CLIENT_ID ?? "";
+  const publisherClientSecret = process.env.PUBLISHER_CLIENT_SECRET ?? "";
+  const publisherTokenUrl = process.env.PUBLISHER_TOKEN_URL ?? "";
+  let ccProvider: ClientCredentialsTokenProvider | undefined;
+  if (publisherClientId !== "" && publisherClientSecret !== "" && publisherTokenUrl !== "") {
+    ccProvider = new ClientCredentialsTokenProvider({
+      tokenUrl: publisherTokenUrl,
+      clientId: publisherClientId,
+      clientSecret: publisherClientSecret,
+    });
+    console.log("[oneshot] publisher cc creds present — using client_credentials for runner callbacks");
+  }
+
+  // When publisher cc is in play, pre-mint a token and stuff it into
+  // req.bearer + retarget the workspace-bootstrap refresh URL at the
+  // path-scoped WS2.4 endpoint. provisionWorkspace doesn't otherwise
+  // need to know which auth mode is active.
+  const platformURL = process.env.ASDLC_PLATFORM_URL ?? "";
+  if (ccProvider) {
+    try {
+      const ccToken = await ccProvider.getToken();
+      req.bearer = ccToken;
+      primeScrubber([ccToken]);
+      if (platformURL) {
+        const base = platformURL.endsWith("/") ? platformURL.slice(0, -1) : platformURL;
+        req.refreshUrl = `${base}/api/v1/tasks/${encodeURIComponent(req.taskId)}/credentials/refresh`;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("[oneshot] cc token mint failed:", msg);
+      return 2;
+    }
+  }
+
+  primeScrubber([process.env.ANTHROPIC_API_KEY, req.bearer, publisherClientSecret]);
 
   emit({
     kind: "phase",
@@ -103,13 +154,13 @@ async function main(): Promise<number> {
   // See docs/design/skills-system.md > "Coding agent".
   let preloadBuiltinNames: string[] = [];
   let skillsPluginDir: string | undefined;
-  const platformURL = process.env.ASDLC_PLATFORM_URL ?? "";
   if (platformURL) {
     try {
+      const skillsBearer = ccProvider ? await ccProvider.getToken() : req.bearer;
       const skills = await pullTaskSkills({
         platformURL,
         taskId: req.taskId,
-        bearer: req.bearer,
+        bearer: skillsBearer,
         correlationId: req.correlationId,
       });
       const result = await materializeSkills(layout.workspace, skills.skills);


### PR DESCRIPTION
## Summary
- Cross-language path so the coding-agent runner authenticates to the BFF via Thunder `client_credentials` instead of the BFF-minted RS256 TaskJWT.
- Reuses the existing per-org Thunder publisher OAuth app (no new app type) provisioned by `idp_service`. `SMAPIWriter.WritePublisher` mirrors the cc client_secret to SM-API; the dispatcher emits a per-run ExternalSecret materialising `PUBLISHER_CLIENT_ID + PUBLISHER_CLIENT_SECRET` into the runner pod; `remote-worker/lib/oauth.ts` mints + caches tokens (5-min renewal buffer, basic-auth grant, expires_in honored) and prefers cc for runner→BFF callbacks. `credhelper.sh` does the same in bash.
- Additive: legacy `ASDLC_BEARER` + `/credentials/refresh` stays mounted; runner falls back to bearer when publisher envs absent. New route `POST /api/v1/tasks/{taskId}/credentials/refresh` accepts both token types via in-handler dual-mode verify (TaskJWT first, then publisher cc with cross-org defense). WS2.6 will drop the legacy paths after the new path is proven on dev cloud.

Migration `phase8_idp_sm_api_columns` adds 4 nullable triplet cols on `organization_idp_profiles`; nullable so the dispatcher short-circuits the publisher path on pre-existing rows and the runner keeps using `ASDLC_BEARER`.

## Notes for reviewers
- Supersedes #12, which was opened against the pre-in-process-refactor `main`. This branch is freshly ported onto post-refactor `main` (smWriter already hoisted, Phase 8 migration call site stays in the same idiomatic block). Closing #12 after this lands.
- BFF half verified locally: `go build ./... && go vet ./... && go test ./services/...` all green.
- Runner image already pushed by @xlight05 in the #12 thread — no new image needed.

## Test plan
- [ ] Local k3d smoke: Connect → create project with a protected service component → trigger task → dispatcher emits publisher ES + envs → runner pod mints cc token → `/api/v1/tasks/{id}/credentials/refresh` returns 200 → agent commits/pushes/PR-ready
- [ ] Verify legacy path still works for orgs without the SM-API triplet (Phase 8 cols NULL): runner falls back to `ASDLC_BEARER`, legacy `/credentials/refresh` route still serves
- [ ] Cross-org defense: forge a publisher cc token from org A, call `/tasks/{taskId}/credentials/refresh` where taskId belongs to org B → expect 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)