### PR TITLE
feat(dispatch): provision per-org publisher cc at dispatch (runner gateway-auth for every component)

### DIFF
--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -730,6 +730,14 @@ func main() {
 	if hook, ok := dispatchSvc.(services.DispatchServiceWithTraitSync); ok {
 		hook.SetTraitSync(traitSyncService)
 	}
+	// WS2.4 — let the proxy dispatch pre-flight provision the per-org publisher
+	// cc on demand (decoupled from API security), so the runner can auth to the
+	// BFF through the gateway for every component, not just protected ones.
+	if idpSetter, ok := dispatchSvc.(interface {
+		SetIDPService(services.IDPService)
+	}); ok {
+		idpSetter.SetIDPService(idpService)
+	}
 	// WS2.3 — wire the proxy-based dispatcher. nil dispatcher → the
 	// legacy ClusterWorkflow path stays the only dispatch flow.
 	if codingAgentDispatcher != nil {

--- a/asdlc-service/services/dispatch_service.go
+++ b/asdlc-service/services/dispatch_service.go
@@ -108,6 +108,14 @@ type dispatchService struct {
 	// populated before any React module runs — no rebuild needed when
 	// per-env values change. Wired via SetRuntimeConfig.
 	runtimeConfig *RuntimeConfigService
+
+	// idp, when non-nil, provisions the per-org Thunder publisher
+	// client_credentials on demand so the coding-agent runner can
+	// authenticate to the BFF through the IdP-authed gateway (WS2.4).
+	// Decoupled from API security: trait_sync only provisions it on the
+	// first protected deploy, but the runner needs it for every component,
+	// so the dispatch pre-flight ensures it too. Wired via SetIDPService.
+	idp IDPService
 }
 
 // WithCodingAgentDispatcher wires the WS2.3 proxy-based dispatch path.
@@ -128,6 +136,14 @@ func (s *dispatchService) WithCodingAgentDispatcher(d *codingagent.Dispatcher, d
 type DispatchServiceWithTraitSync interface {
 	DispatchService
 	SetTraitSync(traitSync *TraitSyncService)
+}
+
+// SetIDPService wires the per-org Thunder publisher provisioning hook used
+// by the proxy dispatch pre-flight (WS2.4 runner-auth). Optional — when
+// unset (e.g. local k3d without Thunder), the dispatch path falls back to
+// the per-task RS256 JWT.
+func (s *dispatchService) SetIDPService(idp IDPService) {
+	s.idp = idp
 }
 
 // SetRuntimeConfig installs the env-config.js emitter that writes
@@ -481,17 +497,24 @@ func (s *dispatchService) tryDispatchViaProxy(
 		return false, "", nil
 	}
 
-	// WS2.4 — optional publisher cc creds. When the IDP profile carries
-	// the SM-API triplet, the dispatcher emits a third per-run
-	// ExternalSecret materialising PUBLISHER_CLIENT_ID +
-	// PUBLISHER_CLIENT_SECRET into the runner pod (TS runner then prefers
-	// cc → /credentials/refresh and falls back to ASDLC_BEARER when
-	// PUBLISHER_TOKEN_URL is absent). Missing row is fine — the runner
-	// keeps using ASDLC_BEARER.
+	// WS2.4 — publisher cc creds. The runner authenticates to the BFF through
+	// the IdP-authed gateway with a Thunder publisher client_credentials token
+	// (a real platform-idp JWT). trait_sync only provisions that publisher on
+	// the first *protected* deploy, but the coding-agent runs for every
+	// component, so ensure it here too (idempotent get-or-create + SM-API
+	// mirror). When the IDP profile carries the SM-API triplet, the dispatcher
+	// emits a third per-run ExternalSecret materialising PUBLISHER_CLIENT_ID +
+	// PUBLISHER_CLIENT_SECRET into the runner pod.
 	var (
 		publisherSR       *codingagent.SecretRef
 		publisherTokenURL string
 	)
+	if s.idp != nil {
+		if _, _, _, perr := s.idp.EnsureOrgPublisher(ctx, task.OrgID, "dispatch"); perr != nil {
+			slog.WarnContext(ctx, "proxy dispatch: EnsureOrgPublisher failed; publisher cc may be unavailable",
+				"task", task.ID, "org", task.OrgID, "error", perr)
+		}
+	}
 	var idpRow models.OrganizationIDPProfile
 	if err := s.db.WithContext(ctx).Where("org_id = ?", task.OrgID).First(&idpRow).Error; err == nil {
 		if idpRow.SMAPIKVPath != nil && idpRow.SMAPISecretRefName != nil {
@@ -507,6 +530,19 @@ func (s *dispatchService) tryDispatchViaProxy(
 				publisherSR = nil
 			}
 		}
+	}
+
+	// In cloud the runner reaches the BFF through the IdP-authed gateway, so a
+	// per-task RS256 JWT is rejected there (401) — the publisher cc is
+	// mandatory. Fail the dispatch loudly rather than launch a runner that
+	// cannot authenticate (which would surface as an opaque
+	// "git-service returned 401" deep in the runner). Local k3d (http platform
+	// URL, no gateway) keeps using the per-task bearer fallback.
+	if publisherSR != nil {
+		slog.InfoContext(ctx, "proxy dispatch: publisher cc path active",
+			"task", task.ID, "org", task.OrgID)
+	} else if isGatewayPlatformURL(s.platformURL) {
+		return false, "", fmt.Errorf("publisher cc not provisioned for org %q: the coding-agent runner cannot authenticate to the BFF through the gateway (a per-task JWT is rejected). Ensure Thunder + SM-API are healthy so the publisher can be provisioned and mirrored", task.OrgID)
 	}
 
 	// OrgUUID lookup. The BFF Organization row carries the UUID the
@@ -604,6 +640,14 @@ func derefStr(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// isGatewayPlatformURL reports whether the runner reaches the BFF through the
+// IdP-authed cloud gateway (https) rather than an internal http URL (local
+// k3d). On the gateway path a per-task JWT is rejected, so the publisher cc is
+// required; off it (http) the bearer fallback still works.
+func isGatewayPlatformURL(u string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(u)), "https://")
 }
 
 // deriveTokenURLFromJWKS swaps the trailing `/oauth2/jwks` path on the


### PR DESCRIPTION
## Problem

WS2.4 (#26) gave the runner a publisher `client_credentials` path to auth to the BFF — a real platform-idp token that passes the gateway's `jwtAuth`. But the per-org publisher is provisioned **only by `trait_sync`, only on the first deploy of an API-secured component**.

The coding-agent runs for **every** component. For a plain (non-protected) service — e.g. test-dev-13's `hello-api` (`apiSecurityEnabled:false`) — the publisher is never provisioned:
- dispatcher sets no `PUBLISHER_*` envs (verified on the worker pod: only `ASDLC_BEARER`),
- the runner falls back to the per-task RS256 JWT,
- the IdP-authed gateway **401s it before it reaches the BFF**,
- surfacing as the opaque `workspace_provisioning: git-service returned 401` deep in the runner.

(The cleanup deleting `ca-…-publisher-es` → 404 confirmed the publisher ExternalSecret was never created.)

## Fix

Decouple publisher provisioning from API security. The proxy dispatch pre-flight (`tryDispatchViaProxy`) now:
1. calls `idp.EnsureOrgPublisher` (idempotent get-or-create + SM-API mirror) when an `IDPService` is wired,
2. loads `PublisherSR` from `organization_idp_profiles`,
3. in **cloud** (https platform URL = IdP-authed gateway), where the per-task JWT can't work, **fails the dispatch loudly** with a clear message if the publisher still can't be resolved — instead of launching a runner that can't authenticate. **Local k3d** (http platform URL, no gateway) keeps the per-task bearer fallback.

`idpService` is wired into `dispatchService` via `SetIDPService` in `main.go` (same pattern as `trait_sync`). Adds an INFO log when the publisher cc path activates.

## Scope
`lab-app-factory` (BFF) only — no deployment/gateway change. The WS2.4 endpoint (#26), `AGENT_CLUSTER_SECRET_STORE=secretstore-read` (#2372), and the gateway already in place; the publisher cc token passes the existing `jwtAuth`.

## Test
`go build ./...`, `go vet`, `gofmt`, `services` tests all pass.

## Verification after deploy
Re-trigger dispatch for a non-API service → BFF logs `proxy dispatch: publisher cc path active`; the worker pod gets `PUBLISHER_CLIENT_ID/SECRET/TOKEN_URL`; runner mints a cc token, calls `POST /api/v1/tasks/{id}/credentials/refresh` → 200 with PAT; `provisionWorkspace` clones; agent runs. If the publisher can't be provisioned, the task fails with an explicit message rather than the opaque runner 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)