### PR TITLE
fix(publisher): register per-org publisher app under the org's OU + self-heal platform profile

### DIFF
--- a/asdlc-service/clients/thundersvc/client.go
+++ b/asdlc-service/clients/thundersvc/client.go
@@ -52,7 +52,14 @@ type Client interface {
 	// it up in their secret store. When the secret was lost (e.g.
 	// OpenBao was wiped), use RegenerateClientSecret to issue a new
 	// one.
-	EnsurePublisherApp(ctx context.Context, orgHandle string) (clientID, clientSecret string, created bool, err error)
+	//
+	// orgOUID is the org's Thunder OU id (the JWT `ouId`). The app is
+	// registered under that OU so its client_credentials token carries
+	// `ouHandle == orgHandle` — the publisher-token verifier's cross-org
+	// check requires this. When orgOUID is empty the default OU is used
+	// (single-org / local dev), which only matches when the default OU
+	// is the org's OU.
+	EnsurePublisherApp(ctx context.Context, orgHandle, orgOUID string) (clientID, clientSecret string, created bool, err error)
 
 	// DeletePublisherApp deletes the publisher app for the given org.
 	// Returns true when the app existed and was deleted, false when it
@@ -279,7 +286,7 @@ func (c *client) getDefaultOUID(ctx context.Context, token string) (string, erro
 
 // -- EnsurePublisherApp ---------------------------------------------------
 
-func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle string) (string, string, bool, error) {
+func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle, orgOUID string) (string, string, bool, error) {
 	if orgHandle == "" {
 		return "", "", false, fmt.Errorf("orgHandle required")
 	}
@@ -300,9 +307,15 @@ func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle string) (stri
 		return existingClientID, "", false, nil
 	}
 
-	ouID, err := c.getDefaultOUID(ctx, token)
-	if err != nil {
-		return "", "", false, err
+	// Register the app under the org's own OU so the cc token's `ouHandle`
+	// resolves to the org handle (the verifier's cross-org check). Fall
+	// back to the default OU only when the org OU is unknown.
+	ouID := orgOUID
+	if ouID == "" {
+		ouID, err = c.getDefaultOUID(ctx, token)
+		if err != nil {
+			return "", "", false, err
+		}
 	}
 
 	id, secret, err := c.createApp(ctx, token, appName, ouID)

--- a/asdlc-service/clients/thundersvc/client.go
+++ b/asdlc-service/clients/thundersvc/client.go
@@ -296,15 +296,51 @@ func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle, orgOUID stri
 	}
 	appName := PublisherAppName(orgHandle)
 
-	_, existingClientID, err := c.findApp(ctx, token, appName)
+	internalID, existingClientID, err := c.findApp(ctx, token, appName)
 	if err != nil {
-		return "", "", false, err
+		return "", "", false, fmt.Errorf("findApp %q: %w", appName, err)
 	}
 	if existingClientID != "" {
-		// Already exists. Thunder doesn't expose secrets on read so
-		// the caller must already have it in OpenBao; we return only
-		// the clientId + created=false.
-		return existingClientID, "", false, nil
+		// The app exists. Self-heal its OU: an app created under the wrong
+		// OU (e.g. the default OU, before this code registered under the
+		// org OU) issues cc tokens whose `ouHandle` won't match the org, so
+		// the publisher-token verifier rejects the runner. When we know the
+		// org OU and the existing app sits under a different one, delete +
+		// recreate it under the org OU. The client_id is deterministic
+		// (= app name) so it's unchanged; only the secret rotates, which
+		// the caller re-mirrors on the created=true branch.
+		if orgOUID == "" {
+			slog.WarnContext(ctx, "publisher app OU not verified — org OU unknown (falling back), token ouHandle may not match",
+				"appName", appName)
+			return existingClientID, "", false, nil
+		}
+		currentOU, ouErr := c.appOUID(ctx, token, internalID)
+		if ouErr != nil {
+			// Don't take a destructive heal on an uncertain read; log and
+			// keep the existing app so dispatch isn't blocked.
+			slog.WarnContext(ctx, "publisher app OU read failed — skipping OU self-heal",
+				"appName", appName, "appID", internalID, "error", ouErr)
+			return existingClientID, "", false, nil
+		}
+		if currentOU == "" || currentOU == orgOUID {
+			slog.DebugContext(ctx, "publisher app already under correct OU",
+				"appName", appName, "ouID", currentOU)
+			return existingClientID, "", false, nil
+		}
+		slog.InfoContext(ctx, "publisher app under wrong OU — re-registering under org OU",
+			"appName", appName, "appID", internalID, "currentOU", currentOU, "orgOU", orgOUID)
+		if _, derr := c.deleteApp(ctx, token, internalID); derr != nil {
+			return "", "", false, fmt.Errorf("heal publisher OU: delete %q (id=%s): %w", appName, internalID, derr)
+		}
+		id, secret, cerr := c.createApp(ctx, token, appName, orgOUID)
+		if cerr != nil {
+			// The old app is gone; the next dispatch re-enters the create
+			// path below and provisions fresh. Surface the error loudly.
+			return "", "", false, fmt.Errorf("heal publisher OU: recreate %q under OU %s: %w", appName, orgOUID, cerr)
+		}
+		slog.InfoContext(ctx, "publisher app re-registered under org OU (secret rotated)",
+			"appName", appName, "orgOU", orgOUID)
+		return id, secret, true, nil
 	}
 
 	// Register the app under the org's own OU so the cc token's `ouHandle`
@@ -314,15 +350,35 @@ func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle, orgOUID stri
 	if ouID == "" {
 		ouID, err = c.getDefaultOUID(ctx, token)
 		if err != nil {
-			return "", "", false, err
+			return "", "", false, fmt.Errorf("getDefaultOUID: %w", err)
 		}
+		slog.WarnContext(ctx, "creating publisher app under DEFAULT OU — org OU unknown; token ouHandle may not match org",
+			"appName", appName, "defaultOU", ouID)
 	}
 
 	id, secret, err := c.createApp(ctx, token, appName, ouID)
 	if err != nil {
-		return "", "", false, err
+		return "", "", false, fmt.Errorf("createApp %q under OU %s: %w", appName, ouID, err)
 	}
+	slog.InfoContext(ctx, "publisher app created", "appName", appName, "ouID", ouID, "underOrgOU", orgOUID != "")
 	return id, secret, true, nil
+}
+
+// appOUID reads the OU id an existing Thunder application is registered
+// under, so EnsurePublisherApp can detect a wrong-OU app and heal it.
+// Returns "" (not an error) when the OU can't be determined from the app
+// body — callers treat that as "don't risk a destructive heal".
+func (c *client) appOUID(ctx context.Context, token, appID string) (string, error) {
+	app, err := c.getAppByID(ctx, token, appID)
+	if err != nil {
+		return "", err
+	}
+	for _, k := range []string{"ouId", "ou_id", "organizationUnitId"} {
+		if v, ok := app[k].(string); ok && v != "" {
+			return v, nil
+		}
+	}
+	return "", nil
 }
 
 func (c *client) DeletePublisherApp(ctx context.Context, orgHandle string) (bool, error) {

--- a/asdlc-service/clients/thundersvc/client_test.go
+++ b/asdlc-service/clients/thundersvc/client_test.go
@@ -1,0 +1,132 @@
+package thundersvc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// thunderMock is a minimal in-memory Thunder admin API for exercising
+// EnsurePublisherApp's OU self-heal without a live cluster.
+type thunderMock struct {
+	appID    string // internal id of the existing publisher app ("" = none)
+	appName  string
+	clientID string
+	ouID     string // OU the existing app is registered under
+
+	deleted     bool
+	createdOU   string // OU passed to the create call
+	createCount int
+}
+
+func (m *thunderMock) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/oauth2/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "expires_in": 3600})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/applications":
+			var apps []map[string]any
+			if m.appID != "" {
+				apps = append(apps, map[string]any{"id": m.appID, "name": m.appName, "clientId": m.clientID})
+			}
+			_ = json.NewEncoder(w).Encode(apps)
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/applications/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": m.appID, "name": m.appName, "ouId": m.ouID,
+			})
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/applications/"):
+			m.deleted = true
+			m.appID = "" // gone
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/applications":
+			var body struct {
+				OuID string `json:"ouId"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			m.createdOU = body.OuID
+			m.createCount++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clientId": m.appName, "clientSecret": "fresh-secret",
+			})
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+func newTestClient(base string) *client {
+	return New(Config{BaseURL: base, ClientID: "sys", ClientSecret: "sec"}).(*client)
+}
+
+// Wrong OU → delete + recreate under the org OU, created=true, secret rotated.
+func TestEnsurePublisherApp_HealsWrongOU(t *testing.T) {
+	m := &thunderMock{appID: "app-1", appName: "asdlc-publisher-org1", clientID: "asdlc-publisher-org1", ouID: "default-ou"}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	id, secret, created, err := c.EnsurePublisherApp(context.Background(), "org1", "org-ou-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.deleted {
+		t.Error("expected the wrong-OU app to be deleted")
+	}
+	if m.createdOU != "org-ou-1" {
+		t.Errorf("recreated under OU %q, want org-ou-1", m.createdOU)
+	}
+	if !created || secret != "fresh-secret" {
+		t.Errorf("want created=true with rotated secret, got created=%v secret=%q", created, secret)
+	}
+	if id != "asdlc-publisher-org1" {
+		t.Errorf("client_id changed: got %q", id)
+	}
+}
+
+// Correct OU → no delete, no recreate, created=false.
+func TestEnsurePublisherApp_CorrectOU_NoHeal(t *testing.T) {
+	m := &thunderMock{appID: "app-1", appName: "asdlc-publisher-org1", clientID: "asdlc-publisher-org1", ouID: "org-ou-1"}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	_, _, created, err := c.EnsurePublisherApp(context.Background(), "org1", "org-ou-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.deleted || m.createCount != 0 {
+		t.Errorf("must not heal when OU already matches (deleted=%v creates=%d)", m.deleted, m.createCount)
+	}
+	if created {
+		t.Error("want created=false for an existing correct-OU app")
+	}
+}
+
+// No existing app + org OU known → create under the org OU.
+func TestEnsurePublisherApp_CreatesUnderOrgOU(t *testing.T) {
+	m := &thunderMock{appName: "asdlc-publisher-org1"}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	_, _, created, err := c.EnsurePublisherApp(context.Background(), "org1", "org-ou-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created || m.createdOU != "org-ou-1" {
+		t.Errorf("want fresh create under org-ou-1, got created=%v ou=%q", created, m.createdOU)
+	}
+	if m.deleted {
+		t.Error("must not delete when no app existed")
+	}
+}

--- a/asdlc-service/services/idp_service.go
+++ b/asdlc-service/services/idp_service.go
@@ -88,10 +88,10 @@ type PlatformIDPConfig struct {
 }
 
 type idpService struct {
-	db        *gorm.DB
-	thunder   thundersvc.Client
-	platform  PlatformIDPConfig
-	smAPI     *SMAPIWriter
+	db       *gorm.DB
+	thunder  thundersvc.Client
+	platform PlatformIDPConfig
+	smAPI    *SMAPIWriter
 }
 
 // NewIDPService builds the service. `thunder` may be nil in unit tests
@@ -146,6 +146,26 @@ func (s *idpService) GetOrCreateProfile(ctx context.Context, orgID string) (*mod
 		return nil, err
 	}
 	if existing != nil {
+		// Self-heal the cluster-level platform fields. Issuer/JWKSURL are
+		// cluster config, not per-org data, but they were cached onto the
+		// row at creation. If the config changed since (e.g. the cluster
+		// moved from an in-cluster Thunder URL to the gateway URL), refresh
+		// the row so the derived per-org publisher token URL stays correct.
+		if s.platform.JWKSURL != "" &&
+			(existing.JWKSURL != s.platform.JWKSURL || existing.Issuer != s.platform.Issuer) {
+			if err := s.db.WithContext(ctx).Model(existing).Where("org_id = ?", orgID).
+				Updates(map[string]interface{}{
+					"jwks_url":   s.platform.JWKSURL,
+					"issuer":     s.platform.Issuer,
+					"updated_at": time.Now().UTC(),
+				}).Error; err != nil {
+				slog.WarnContext(ctx, "idp_service: platform field self-heal failed (continuing)",
+					"orgID", orgID, "error", err)
+			} else {
+				existing.JWKSURL = s.platform.JWKSURL
+				existing.Issuer = s.platform.Issuer
+			}
+		}
 		return existing, nil
 	}
 
@@ -168,6 +188,21 @@ func (s *idpService) GetOrCreateProfile(ctx context.Context, orgID string) (*mod
 	return &profile, nil
 }
 
+// lookupOrgOUID returns the org's Thunder OU id (the JWT `ouId`, stored as
+// Organization.ThunderOrgUUID) so the publisher app can be registered under
+// the org's OU. Returns "" when the org row or its Thunder UUID is missing —
+// the Thunder client then falls back to the default OU.
+func (s *idpService) lookupOrgOUID(ctx context.Context, orgHandle string) string {
+	var org models.Organization
+	if err := s.db.WithContext(ctx).Where("name = ?", orgHandle).First(&org).Error; err != nil {
+		return ""
+	}
+	if org.ThunderOrgUUID == nil {
+		return ""
+	}
+	return org.ThunderOrgUUID.String()
+}
+
 func (s *idpService) EnsureOrgPublisher(ctx context.Context, orgID, actor string) (string, string, bool, error) {
 	if orgID == "" {
 		return "", "", false, fmt.Errorf("orgID required")
@@ -183,7 +218,11 @@ func (s *idpService) EnsureOrgPublisher(ctx context.Context, orgID, actor string
 
 	beforeJSON, _ := json.Marshal(profileSummary(profile))
 
-	clientID, clientSecret, created, terr := s.thunder.EnsurePublisherApp(ctx, orgID)
+	// Resolve the org's Thunder OU id (JWT ouId) so the publisher app is
+	// registered under the org's OU — its cc token then carries
+	// ouHandle == orgHandle, which the publisher-token verifier requires.
+	// Empty (org UUID not yet backfilled) falls back to the default OU.
+	clientID, clientSecret, created, terr := s.thunder.EnsurePublisherApp(ctx, orgID, s.lookupOrgOUID(ctx, orgID))
 	if terr != nil {
 		s.audit(ctx, orgID, models.IDPAuditEnsurePublisher, actor, beforeJSON, nil, terr)
 		return "", "", false, fmt.Errorf("idp_service.EnsureOrgPublisher: %w", terr)
@@ -413,10 +452,10 @@ func (s *idpService) UpdateProfile(ctx context.Context, orgID, actor string, req
 // happened on Thunder / in the DB).
 func (s *idpService) audit(ctx context.Context, orgID, action, actor string, before, after []byte, opErr error) {
 	row := models.IDPAuditEvent{
-		OrgID:      orgID,
-		Action:     action,
-		Actor:      coalesceActor(actor),
-		OccurredAt: time.Now().UTC(),
+		OrgID:       orgID,
+		Action:      action,
+		Actor:       coalesceActor(actor),
+		OccurredAt:  time.Now().UTC(),
 		BeforeState: before,
 		AfterState:  after,
 	}

--- a/asdlc-service/services/idp_service.go
+++ b/asdlc-service/services/idp_service.go
@@ -222,7 +222,14 @@ func (s *idpService) EnsureOrgPublisher(ctx context.Context, orgID, actor string
 	// registered under the org's OU — its cc token then carries
 	// ouHandle == orgHandle, which the publisher-token verifier requires.
 	// Empty (org UUID not yet backfilled) falls back to the default OU.
-	clientID, clientSecret, created, terr := s.thunder.EnsurePublisherApp(ctx, orgID, s.lookupOrgOUID(ctx, orgID))
+	orgOUID := s.lookupOrgOUID(ctx, orgID)
+	if orgOUID == "" {
+		slog.WarnContext(ctx, "idp_service: org Thunder OU id unknown — publisher app will use the default OU; runner token ouHandle may not match the org. Ensure the org row has thunder_org_uuid (user must have logged in with an ouId claim).",
+			"orgID", orgID)
+	} else {
+		slog.DebugContext(ctx, "idp_service: provisioning publisher under org OU", "orgID", orgID, "orgOU", orgOUID)
+	}
+	clientID, clientSecret, created, terr := s.thunder.EnsurePublisherApp(ctx, orgID, orgOUID)
 	if terr != nil {
 		s.audit(ctx, orgID, models.IDPAuditEnsurePublisher, actor, beforeJSON, nil, terr)
 		return "", "", false, fmt.Errorf("idp_service.EnsureOrgPublisher: %w", terr)


### PR DESCRIPTION
## Problem

The coding-agent runner authenticates to the BFF with a per-org Thunder publisher `client_credentials` token (WS2.4). On dev cloud, with the system client + reachable token URL in place, the runner mints the token but the BFF's publisher-token verifier rejects it.

Root cause (verified on the dev cluster by minting + decoding real platform-idp cc tokens): **a client_credentials token's `ouHandle`/`ouId`/`ouName` claims reflect the OU the OAuth app is registered under.** `EnsurePublisherApp` always registered the publisher app under the **default OU**, so every org's publisher token carried the default OU's `ouHandle` — never the org's. The verifier requires `ouHandle == orgHandle` (its cross-org defense), so it rejected the token for any org whose handle isn't the default OU's. Single-org local testing couldn't surface this.

This matches how agent-manager does it: it registers the per-org publisher under the **org's** OU (`ouID := orgUUID`), default only as a fallback.

## Changes

**1. Publisher OU (`thundersvc` + `idp_service`)**
- `EnsurePublisherApp(ctx, orgHandle, orgOUID)` — new `orgOUID` param; registers the app under the org's OU, falling back to the default OU only when empty.
- `EnsureOrgPublisher` resolves the org's OU id (`Organization.ThunderOrgUUID` = JWT `ouId`) via `lookupOrgOUID` and passes it through.

**2. Self-heal an existing wrong-OU app (durable — no org deletion needed)**
- `EnsureOrgPublisher` is idempotent by app name, so an org that already has a publisher app under the wrong (default) OU would not self-correct. `EnsurePublisherApp` now reads the existing app's OU and, when it differs from the org's OU, **deletes + recreates** it under the org OU. `client_id` is deterministic (= app name) so it's unchanged; only the secret rotates, which the caller re-mirrors on the `created=true` branch. The next dispatch in that org self-corrects.

**3. Platform profile self-heal (`GetOrCreateProfile`)**
- The cluster-level `issuer`/`jwksURL` were cached onto the org row at creation and never refreshed, so a config change (e.g. moving `PLATFORM_IDP_JWKS_URL` from the in-cluster service to the public gateway) didn't reach already-provisioned orgs and the derived publisher **token URL** stayed stale. Now refreshed from config when they differ.

**4. Diagnostics**
- Logs on every branch for debuggability: org OU unknown (default-OU fallback), OU read failure (heal skipped), already-correct OU, wrong-OU re-registration (current → target OU), fresh create, and missing `thunder_org_uuid`.

## Tests / verification

- New httptest-backed unit tests for the three `EnsurePublisherApp` paths: wrong-OU heal (delete+recreate, secret rotated, client_id stable), correct-OU no-op, fresh create under the org OU.
- `go build ./...`, `go vet`, `go test ./clients/thundersvc/... ./services/...` pass; gofmt clean.
- Decoded real cloud platform-idp cc tokens (kubectl): confirmed `ouHandle` follows the app's OU, `iss=platform-idp`, no-scope `aud` = client_id.

## Companion

Deployment PR (wso2cloud-deployment #2391) sets `PLATFORM_IDP_JWKS_URL` + `PLATFORM_IDP_ISSUER`; both are required alongside this change. The runner image is unchanged — the fix is entirely BFF-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)