### PR TITLE
fix(publisher): tolerate Thunder 5xx-on-delete during OU self-heal

### DIFF
--- a/asdlc-service/clients/thundersvc/client.go
+++ b/asdlc-service/clients/thundersvc/client.go
@@ -330,7 +330,17 @@ func (c *client) EnsurePublisherApp(ctx context.Context, orgHandle, orgOUID stri
 		slog.InfoContext(ctx, "publisher app under wrong OU — re-registering under org OU",
 			"appName", appName, "appID", internalID, "currentOU", currentOU, "orgOU", orgOUID)
 		if _, derr := c.deleteApp(ctx, token, internalID); derr != nil {
-			return "", "", false, fmt.Errorf("heal publisher OU: delete %q (id=%s): %w", appName, internalID, derr)
+			// Thunder has been observed to return 5xx (SSE-5000) on delete
+			// even when the app was actually removed server-side. Don't abort
+			// the heal on that — re-check by name and, if the app is gone,
+			// continue to recreate so the heal completes in a single dispatch
+			// (otherwise the org is left with no publisher app until the next
+			// run). Only a genuinely-still-present app is a hard failure.
+			if _, stillID, ferr := c.findApp(ctx, token, appName); ferr != nil || stillID != "" {
+				return "", "", false, fmt.Errorf("heal publisher OU: delete %q (id=%s): %w", appName, internalID, derr)
+			}
+			slog.WarnContext(ctx, "publisher app delete returned an error but the app is gone — continuing to recreate",
+				"appName", appName, "appID", internalID, "deleteErr", derr)
 		}
 		id, secret, cerr := c.createApp(ctx, token, appName, orgOUID)
 		if cerr != nil {

--- a/asdlc-service/clients/thundersvc/client_test.go
+++ b/asdlc-service/clients/thundersvc/client_test.go
@@ -17,9 +17,10 @@ type thunderMock struct {
 	clientID string
 	ouID     string // OU the existing app is registered under
 
-	deleted     bool
-	createdOU   string // OU passed to the create call
-	createCount int
+	deleted      bool
+	deleteStatus int    // override delete response code (0 = 204); app is removed regardless
+	createdOU    string // OU passed to the create call
+	createCount  int
 }
 
 func (m *thunderMock) server(t *testing.T) *httptest.Server {
@@ -43,7 +44,11 @@ func (m *thunderMock) server(t *testing.T) *httptest.Server {
 
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/applications/"):
 			m.deleted = true
-			m.appID = "" // gone
+			m.appID = "" // removed server-side regardless of the response code
+			if m.deleteStatus != 0 {
+				w.WriteHeader(m.deleteStatus)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodPost && r.URL.Path == "/applications":
@@ -90,6 +95,23 @@ func TestEnsurePublisherApp_HealsWrongOU(t *testing.T) {
 	}
 	if id != "asdlc-publisher-org1" {
 		t.Errorf("client_id changed: got %q", id)
+	}
+}
+
+// Wrong OU + Thunder returns 500 on delete but the app is actually gone →
+// the heal must still recreate under the org OU (one-pass durability).
+func TestEnsurePublisherApp_HealsWrongOU_DeleteReturns500ButGone(t *testing.T) {
+	m := &thunderMock{appID: "app-1", appName: "asdlc-publisher-org1", clientID: "asdlc-publisher-org1", ouID: "default-ou", deleteStatus: 500}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	_, secret, created, err := c.EnsurePublisherApp(context.Background(), "org1", "org-ou-1")
+	if err != nil {
+		t.Fatalf("heal must tolerate a 500-but-deleted delete, got error: %v", err)
+	}
+	if m.createdOU != "org-ou-1" || !created || secret != "fresh-secret" {
+		t.Errorf("want recreate under org-ou-1 (created+secret), got ou=%q created=%v secret=%q", m.createdOU, created, secret)
 	}
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #29. On dev cloud, the publisher-OU self-heal fired correctly for an org whose publisher app was under the wrong (default) OU, but the **Thunder DELETE returned HTTP 500** (`SSE-5000` internal error) — even though it removed the app server-side. The heal aborted before recreating, so:

- the org was left with **no** publisher app, and
- the dispatcher still handed the runner the pre-existing SM-API creds, which now point at a deleted client → the runner's token mint fails with `invalid_client`.

Observed log:
```
INFO publisher app under wrong OU — re-registering under org OU currentOU=<default> orgOU=<org>
WARN EnsureOrgPublisher failed ... heal publisher OU: delete "asdlc-publisher-<org>" ... thunder delete app returned 500: SSE-5000 Internal server error
```

## Fix

Treat a delete error as non-fatal **when the app is actually gone**: after a delete error, re-check by name via `findApp`; if it's absent, continue to recreate under the org OU so the heal completes in a single dispatch. A genuinely still-present app stays a hard error. The tolerated case is logged.

This makes the heal idempotent/one-pass against Thunder's 500-but-succeeded delete, instead of failing the first dispatch and relying on a second.

## Tests

- New `TestEnsurePublisherApp_HealsWrongOU_DeleteReturns500ButGone`: delete returns 500 but the app is gone → heal still recreates under the org OU (`created=true`, secret rotated).
- Existing heal/no-op/create tests still pass. `go build`/`vet`/`test` green, gofmt clean.

## Note

The org that hit this (kajeorg3) is already past it — its app was deleted by the 500'd delete, so its next dispatch takes the clean create path and provisions fresh under the org OU. This PR prevents the confusing one-dispatch failure for any other org still on a default-OU app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)