### PR TITLE
fix(webhook): also serve the GitHub webhook receiver at /api/v1/webhooks/github

### DIFF
--- a/asdlc-service/api/webhook_routes.go
+++ b/asdlc-service/api/webhook_routes.go
@@ -6,9 +6,19 @@ import (
 	"github.com/wso2/asdlc/asdlc-service/controllers"
 )
 
-// registerWebhookRoutes mounts the inbound GitHub webhook receiver. The route
-// lives outside the JWT middleware (same pattern the now-removed /mcp/ mount
-// used) — webhooks authenticate via HMAC, not JWT.
+// registerWebhookRoutes mounts the inbound GitHub webhook receiver. The routes
+// live outside the JWT middleware (same pattern the now-removed /mcp/ mount
+// used) — webhooks authenticate via HMAC, not JWT. Both patterns are more
+// specific than the JWT-gated "/api/" subtree, so net/http's ServeMux routes
+// them here rather than into the auth middleware.
+//
+// Two paths are registered for the same handler:
+//   - /webhooks/github         — local/dev (smee delivers here).
+//   - /api/v1/webhooks/github  — cloud. The gateway's webhook endpoint is
+//     scoped to base path /api/v1/webhooks and forwards to the BFF verbatim,
+//     so GitHub deliveries arrive here. (jwtAuth is disabled on that gateway
+//     endpoint; the per-repo webhook URL is GITHUB_WEBHOOK_DELIVERY_URL.)
 func registerWebhookRoutes(mux *http.ServeMux, c controllers.WebhookController) {
 	mux.HandleFunc("POST /webhooks/github", c.Receive)
+	mux.HandleFunc("POST /api/v1/webhooks/github", c.Receive)
 }


### PR DESCRIPTION
## Problem

In the cloud deployment, coding-agent tasks get stuck `in_progress` and never advance to `ready_for_review`. The agent implements + raises the PR + marks it ready, but the `pull_request.ready_for_review` webhook (which drives the transition) never reaches the BFF.

Root cause (verified on the dev cluster, gateway access log): the BFF's webhook gateway endpoint is scoped to base path `/api/v1/webhooks`, jwtAuth **disabled** (RestApi `policies: [cors]`), and forwards GitHub deliveries to the BFF verbatim as **`/api/v1/webhooks/github`**. But the BFF only registered `POST /webhooks/github`. With no handler at `/api/v1/webhooks/github`, net/http's ServeMux falls back to the JWT-gated `/api/` subtree → `401 missing Authorization header` (from the BFF, not the gateway). So GitHub's deliveries were rejected and the task never advanced.

## Fix

Register the same `WebhookController.Receive` handler at `/api/v1/webhooks/github` in addition to the existing `/webhooks/github` (local/smee). Both patterns are more specific than `/api/`, so ServeMux routes them outside the JWT middleware (webhooks authenticate via HMAC `X-Hub-Signature-256`, not JWT).

This aligns the BFF with the already-working gateway route — no gateway/auth change needed.

## Companion / follow-up

- Deployment: a wso2cloud-deployment change sets `GITHUB_WEBHOOK_DELIVERY_URL` to the public webhook URL (`https://<env>-wso2cloud.gateway.<domain>/app-factory-api-app-factory-webhook-api-endpoint/api/v1/webhooks/github`) — without it the BFF logs `failed to register webhook on repo` and never installs the repo webhook. Both changes are required together.
- Webhook registration happens at repo-creation time, so existing repos (e.g. test-dev-3298) won't get a webhook retroactively — verify on a freshly created project after both land.

## Tests

`go build ./...`, `go vet ./api/...`, `go test ./api/...` pass (no ServeMux pattern conflict); gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)