### PR TITLE
fix(build): provision the build git secret via OpenChoreo (unified local + cloud)

### DIFF
--- a/asdlc-service/clients/openchoreo/component_client.go
+++ b/asdlc-service/clients/openchoreo/component_client.go
@@ -89,12 +89,16 @@ type ComponentClient interface {
 	// empty the OC client auto-generates one via NewBuildRunName. Callers
 	// that need to know the name ahead of time (so they can stage a
 	// per-WorkflowRun build Secret) MUST pass it.
-	TriggerBuild(ctx context.Context, orgName, projectName, componentName, runName string) (*models.WorkflowRun, error)
+	// secretRef sets parameters.repository.secretRef so the dockerfile-builder
+	// workflow synthesises the git Secret from the org's SecretReference
+	// (provisioned by BuildCredentialsService). Empty leaves it blank — the
+	// build clones unauthenticated (public repos only).
+	TriggerBuild(ctx context.Context, orgName, projectName, componentName, secretRef, runName string) (*models.WorkflowRun, error)
 	// TriggerBuildAtCommit creates a WorkflowRun pinned to commitSHA via
 	// params.repository.revision.commit. Mirrors agent-manager's pattern at
 	// agent-manager-service/clients/openchoreosvc/client/builds.go:71-85.
-	// See TriggerBuild for the `runName` contract.
-	TriggerBuildAtCommit(ctx context.Context, orgName, projectName, componentName, commitSHA, runName string) (*models.WorkflowRun, error)
+	// See TriggerBuild for the `runName` + `secretRef` contracts.
+	TriggerBuildAtCommit(ctx context.Context, orgName, projectName, componentName, commitSHA, secretRef, runName string) (*models.WorkflowRun, error)
 	// TriggerCodingAgent creates a WorkflowRun of ClusterWorkflow
 	// `app-factory-coding-agent` for the per-task ephemeral pod that runs the
 	// Claude Agent SDK against the task's feature branch. Replaces the legacy
@@ -865,12 +869,12 @@ func (c *componentClient) ListDeployments(ctx context.Context, orgName, projectN
 
 // -- WorkflowRuns (builds + coding-agent) ------------------------------------
 
-func (c *componentClient) TriggerBuild(ctx context.Context, orgName, projectName, componentName, runName string) (*models.WorkflowRun, error) {
-	return c.triggerBuildInner(ctx, orgName, projectName, componentName, "", runName)
+func (c *componentClient) TriggerBuild(ctx context.Context, orgName, projectName, componentName, secretRef, runName string) (*models.WorkflowRun, error) {
+	return c.triggerBuildInner(ctx, orgName, projectName, componentName, "", secretRef, runName)
 }
 
-func (c *componentClient) TriggerBuildAtCommit(ctx context.Context, orgName, projectName, componentName, commitSHA, runName string) (*models.WorkflowRun, error) {
-	return c.triggerBuildInner(ctx, orgName, projectName, componentName, commitSHA, runName)
+func (c *componentClient) TriggerBuildAtCommit(ctx context.Context, orgName, projectName, componentName, commitSHA, secretRef, runName string) (*models.WorkflowRun, error) {
+	return c.triggerBuildInner(ctx, orgName, projectName, componentName, commitSHA, secretRef, runName)
 }
 
 // triggerBuildInner fetches the Component to grab its declared Workflow
@@ -884,7 +888,7 @@ func (c *componentClient) TriggerBuildAtCommit(ctx context.Context, orgName, pro
 // Production callers (dispatch path, console "Build" button) pass runName
 // because they staged the per-WorkflowRun build Secret with that name
 // upfront.
-func (c *componentClient) triggerBuildInner(ctx context.Context, orgName, projectName, componentName, commitSHA, runName string) (*models.WorkflowRun, error) {
+func (c *componentClient) triggerBuildInner(ctx context.Context, orgName, projectName, componentName, commitSHA, secretRef, runName string) (*models.WorkflowRun, error) {
 	scopedComp := ScopedComponentName(projectName, componentName)
 
 	compResp, err := c.oc.GetComponentWithResponse(ctx, orgName, scopedComp)
@@ -900,7 +904,7 @@ func (c *componentClient) triggerBuildInner(ctx context.Context, orgName, projec
 		})
 	}
 
-	wf := buildWorkflowFromComponent(compResp.JSON200, commitSHA)
+	wf := buildWorkflowFromComponent(compResp.JSON200, commitSHA, secretRef)
 	if wf.Name == "" {
 		return nil, fmt.Errorf("trigger build: component %s/%s has no workflow configured", projectName, componentName)
 	}
@@ -928,7 +932,7 @@ func (c *componentClient) triggerBuildInner(ctx context.Context, orgName, projec
 // Parameters is shaped as `map[string]interface{}` end-to-end on the gen
 // side; we deep-copy the slice keys we touch to avoid mutating shared maps
 // returned by the cache layer (which would race with concurrent triggers).
-func buildWorkflowFromComponent(comp *gen.Component, commitSHA string) gen.WorkflowRunConfig {
+func buildWorkflowFromComponent(comp *gen.Component, commitSHA, secretRef string) gen.WorkflowRunConfig {
 	if comp == nil || comp.Spec == nil || comp.Spec.Workflow == nil {
 		return gen.WorkflowRunConfig{}
 	}
@@ -950,30 +954,26 @@ func buildWorkflowFromComponent(comp *gen.Component, commitSHA string) gen.Workf
 	if commitSHA != "" {
 		injectCommitSHA(params, commitSHA)
 	}
-	// Force-blank repository.secretRef. App Factory delivers the per-build
-	// credential by pre-staging a K8s Secret named
-	// `<workflowRunName>-git-secret` in workflows-<orgID> (see
-	// docs/design/build-credential-injection.md); the upstream
-	// dockerfile-builder workflow's externalRefs lookup is skipped when
-	// secretRef is empty (openchoreo internal/controller/workflowrun/
-	// externalref.go:41-44) and its git-secret ExternalSecret resource is
-	// gated on `secretRef != ""`. Legacy Components may still have a
-	// non-empty secretRef stored from the SecretReference-era flow — wipe
-	// it at trigger time so the workflow never tries to resolve it.
-	blankRepoSecretRef(params)
+	// Set repository.secretRef explicitly at trigger time. When non-empty
+	// (the BFF provisioned the per-org GitSecret), the dockerfile-builder
+	// workflow synthesises the git ExternalSecret from that SecretReference;
+	// when empty it clones unauthenticated (public repos). Setting it here —
+	// rather than trusting whatever the Component stored — keeps the build's
+	// credential a property of the dispatch (which provisioned the secret),
+	// and overwrites any stale value left by an earlier flow.
+	setRepoSecretRef(params, secretRef)
 	out.Parameters = &params
 	return out
 }
 
-// blankRepoSecretRef sets params["repository"]["secretRef"] = "", creating
-// the nested map if needed. No-op for components that never had a
-// repository block.
-func blankRepoSecretRef(params map[string]interface{}) {
+// setRepoSecretRef sets params["repository"]["secretRef"] = secretRef.
+// No-op for components that never had a repository block.
+func setRepoSecretRef(params map[string]interface{}, secretRef string) {
 	repo, ok := params["repository"].(map[string]interface{})
 	if !ok {
 		return
 	}
-	repo["secretRef"] = ""
+	repo["secretRef"] = secretRef
 }
 
 // injectCommitSHA stamps params["repository"]["revision"]["commit"] = sha,
@@ -1170,4 +1170,3 @@ func (c *componentClient) GetWorkflowRun(ctx context.Context, orgName, runName s
 	run := workflowRunToModel(*resp.JSON200)
 	return &run, nil
 }
-

--- a/asdlc-service/clients/openchoreo/mocks/component_client_mock.go
+++ b/asdlc-service/clients/openchoreo/mocks/component_client_mock.go
@@ -42,10 +42,10 @@ var _ openchoreo.ComponentClient = &ComponentClientMock{}
 //			ListWorkflowRunsFunc: func(ctx context.Context, orgName string, projectName string, componentName string, limit int, cursor string) (*models.WorkflowRunList, error) {
 //				panic("mock out the ListWorkflowRuns method")
 //			},
-//			TriggerBuildFunc: func(ctx context.Context, orgName string, projectName string, componentName string, runName string) (*models.WorkflowRun, error) {
+//			TriggerBuildFunc: func(ctx context.Context, orgName string, projectName string, componentName string, secretRef string, runName string) (*models.WorkflowRun, error) {
 //				panic("mock out the TriggerBuild method")
 //			},
-//			TriggerBuildAtCommitFunc: func(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, runName string) (*models.WorkflowRun, error) {
+//			TriggerBuildAtCommitFunc: func(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, secretRef string, runName string) (*models.WorkflowRun, error) {
 //				panic("mock out the TriggerBuildAtCommit method")
 //			},
 //			TriggerCodingAgentFunc: func(ctx context.Context, params openchoreo.CodingAgentParams) (*models.WorkflowRun, error) {
@@ -92,10 +92,10 @@ type ComponentClientMock struct {
 	ListWorkflowRunsFunc func(ctx context.Context, orgName string, projectName string, componentName string, limit int, cursor string) (*models.WorkflowRunList, error)
 
 	// TriggerBuildFunc mocks the TriggerBuild method.
-	TriggerBuildFunc func(ctx context.Context, orgName string, projectName string, componentName string, runName string) (*models.WorkflowRun, error)
+	TriggerBuildFunc func(ctx context.Context, orgName string, projectName string, componentName string, secretRef string, runName string) (*models.WorkflowRun, error)
 
 	// TriggerBuildAtCommitFunc mocks the TriggerBuildAtCommit method.
-	TriggerBuildAtCommitFunc func(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, runName string) (*models.WorkflowRun, error)
+	TriggerBuildAtCommitFunc func(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, secretRef string, runName string) (*models.WorkflowRun, error)
 
 	// TriggerCodingAgentFunc mocks the TriggerCodingAgent method.
 	TriggerCodingAgentFunc func(ctx context.Context, params openchoreo.CodingAgentParams) (*models.WorkflowRun, error)
@@ -205,6 +205,8 @@ type ComponentClientMock struct {
 			ProjectName string
 			// ComponentName is the componentName argument value.
 			ComponentName string
+			// SecretRef is the secretRef argument value.
+			SecretRef string
 			// RunName is the runName argument value.
 			RunName string
 		}
@@ -220,6 +222,8 @@ type ComponentClientMock struct {
 			ComponentName string
 			// CommitSHA is the commitSHA argument value.
 			CommitSHA string
+			// SecretRef is the secretRef argument value.
+			SecretRef string
 			// RunName is the runName argument value.
 			RunName string
 		}
@@ -616,7 +620,7 @@ func (mock *ComponentClientMock) ListWorkflowRunsCalls() []struct {
 }
 
 // TriggerBuild calls TriggerBuildFunc.
-func (mock *ComponentClientMock) TriggerBuild(ctx context.Context, orgName string, projectName string, componentName string, runName string) (*models.WorkflowRun, error) {
+func (mock *ComponentClientMock) TriggerBuild(ctx context.Context, orgName string, projectName string, componentName string, secretRef string, runName string) (*models.WorkflowRun, error) {
 	if mock.TriggerBuildFunc == nil {
 		panic("ComponentClientMock.TriggerBuildFunc: method is nil but ComponentClient.TriggerBuild was just called")
 	}
@@ -625,18 +629,20 @@ func (mock *ComponentClientMock) TriggerBuild(ctx context.Context, orgName strin
 		OrgName       string
 		ProjectName   string
 		ComponentName string
+		SecretRef     string
 		RunName       string
 	}{
 		Ctx:           ctx,
 		OrgName:       orgName,
 		ProjectName:   projectName,
 		ComponentName: componentName,
+		SecretRef:     secretRef,
 		RunName:       runName,
 	}
 	mock.lockTriggerBuild.Lock()
 	mock.calls.TriggerBuild = append(mock.calls.TriggerBuild, callInfo)
 	mock.lockTriggerBuild.Unlock()
-	return mock.TriggerBuildFunc(ctx, orgName, projectName, componentName, runName)
+	return mock.TriggerBuildFunc(ctx, orgName, projectName, componentName, secretRef, runName)
 }
 
 // TriggerBuildCalls gets all the calls that were made to TriggerBuild.
@@ -648,6 +654,7 @@ func (mock *ComponentClientMock) TriggerBuildCalls() []struct {
 	OrgName       string
 	ProjectName   string
 	ComponentName string
+	SecretRef     string
 	RunName       string
 } {
 	var calls []struct {
@@ -655,6 +662,7 @@ func (mock *ComponentClientMock) TriggerBuildCalls() []struct {
 		OrgName       string
 		ProjectName   string
 		ComponentName string
+		SecretRef     string
 		RunName       string
 	}
 	mock.lockTriggerBuild.RLock()
@@ -664,7 +672,7 @@ func (mock *ComponentClientMock) TriggerBuildCalls() []struct {
 }
 
 // TriggerBuildAtCommit calls TriggerBuildAtCommitFunc.
-func (mock *ComponentClientMock) TriggerBuildAtCommit(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, runName string) (*models.WorkflowRun, error) {
+func (mock *ComponentClientMock) TriggerBuildAtCommit(ctx context.Context, orgName string, projectName string, componentName string, commitSHA string, secretRef string, runName string) (*models.WorkflowRun, error) {
 	if mock.TriggerBuildAtCommitFunc == nil {
 		panic("ComponentClientMock.TriggerBuildAtCommitFunc: method is nil but ComponentClient.TriggerBuildAtCommit was just called")
 	}
@@ -674,6 +682,7 @@ func (mock *ComponentClientMock) TriggerBuildAtCommit(ctx context.Context, orgNa
 		ProjectName   string
 		ComponentName string
 		CommitSHA     string
+		SecretRef     string
 		RunName       string
 	}{
 		Ctx:           ctx,
@@ -681,12 +690,13 @@ func (mock *ComponentClientMock) TriggerBuildAtCommit(ctx context.Context, orgNa
 		ProjectName:   projectName,
 		ComponentName: componentName,
 		CommitSHA:     commitSHA,
+		SecretRef:     secretRef,
 		RunName:       runName,
 	}
 	mock.lockTriggerBuildAtCommit.Lock()
 	mock.calls.TriggerBuildAtCommit = append(mock.calls.TriggerBuildAtCommit, callInfo)
 	mock.lockTriggerBuildAtCommit.Unlock()
-	return mock.TriggerBuildAtCommitFunc(ctx, orgName, projectName, componentName, commitSHA, runName)
+	return mock.TriggerBuildAtCommitFunc(ctx, orgName, projectName, componentName, commitSHA, secretRef, runName)
 }
 
 // TriggerBuildAtCommitCalls gets all the calls that were made to TriggerBuildAtCommit.
@@ -699,6 +709,7 @@ func (mock *ComponentClientMock) TriggerBuildAtCommitCalls() []struct {
 	ProjectName   string
 	ComponentName string
 	CommitSHA     string
+	SecretRef     string
 	RunName       string
 } {
 	var calls []struct {
@@ -707,6 +718,7 @@ func (mock *ComponentClientMock) TriggerBuildAtCommitCalls() []struct {
 		ProjectName   string
 		ComponentName string
 		CommitSHA     string
+		SecretRef     string
 		RunName       string
 	}
 	mock.lockTriggerBuildAtCommit.RLock()

--- a/asdlc-service/cmd/asdlc-api/main.go
+++ b/asdlc-service/cmd/asdlc-api/main.go
@@ -321,6 +321,10 @@ func main() {
 	projectClient := openchoreo.NewProjectClient(ocConfig)
 	namespaceClient := openchoreo.NewNamespaceClient(ocConfig)
 	componentClient := openchoreo.NewComponentClient(ocConfig)
+	// GitSecret client lands the per-org build git credential on the workflow
+	// plane (via OC → OpenBao → SecretReference). Used by BuildCredentialsService
+	// for both cloud (CP/WP split) and local k3d — one unified path.
+	gitSecretClient := openchoreo.NewGitSecretClient(ocConfig)
 
 	// Observability client (optional — build logs disabled when URL not set)
 	var observClient observability.Client
@@ -530,7 +534,7 @@ func main() {
 	webhookRegService := services.NewWebhookService(repoRepo, githubClient, repoService, issueService, cfg.WebhookDeliveryURL, cfg.WebhookHMACSecret)
 	credRefreshService := services.NewCredentialsRefreshService(credResolver)
 	credService := services.NewCredentialService(db, credStore, minter, cfg.WebhookHMACSecret, cfg.GitHubAppClientID, appClientSecret, githubClient)
-	buildCredService := services.NewBuildCredentialsService(repoRepo, credResolver, wpClient)
+	buildCredService := services.NewBuildCredentialsService(repoRepo, credResolver, gitSecretClient)
 	credService.WithBuildSecretCleaner(buildCredService)
 	anthropicInvalidator := services.HTTPAgentsCacheInvalidator(cfg.AgentsServiceURL, "")
 	anthropicCredService := services.NewAnthropicCredentialService(db, credStore, wpClient, cfg.AnthropicPlatformKey, anthropicInvalidator)

--- a/asdlc-service/models/repository_test.go
+++ b/asdlc-service/models/repository_test.go
@@ -23,22 +23,6 @@ func TestSlugForURL(t *testing.T) {
 	}
 }
 
-func TestBuildSecretNameFor(t *testing.T) {
-	// The Secret name must match what the upstream dockerfile-builder
-	// ClusterWorkflow templates from `${metadata.workflowRunName}-git-secret`.
-	cases := []struct {
-		runName, want string
-	}{
-		{"default-greeting-api-1731538100123", "default-greeting-api-1731538100123-git-secret"},
-		{"x", "x-git-secret"},
-	}
-	for _, c := range cases {
-		if got := BuildSecretNameFor(c.runName); got != c.want {
-			t.Errorf("BuildSecretNameFor(%q) = %q; want %q", c.runName, got, c.want)
-		}
-	}
-}
-
 func TestWorkflowPlaneNamespace(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/asdlc-service/models/wp_naming.go
+++ b/asdlc-service/models/wp_naming.go
@@ -27,31 +27,10 @@ func WorkflowPlaneNamespace(ocOrgID string) string {
 	return boundedDNSName("workflows-", ocOrgID)
 }
 
-// BuildSecretNameFor returns the K8s Secret name git-service writes
-// (kubernetes.io/basic-auth) into WorkflowPlaneNamespace(ocOrgID) for one
-// WorkflowRun. The name matches the upstream `dockerfile-builder`
-// ClusterWorkflow's expected default for `workflow.parameters.git-secret`
-// — `${metadata.workflowRunName}-git-secret` (line 144 of the workflow).
-//
-// Per-WorkflowRun (NOT per-org) because the upstream workflow templates
-// the Secret name from the WorkflowRun's metadata.name; using that exact
-// shape lets us keep the shared workflow byte-identical to upstream while
-// pre-staging the Secret from git-service before the build pod runs.
-//
-// We intentionally do NOT length-bound here. The workflow itself fails
-// the Argo Workflow creation if `<workflowRunName>-git-secret` exceeds
-// DNS-1123 subdomain length, so the WorkflowRun would already be invalid
-// upstream — bounding here would produce a name that doesn't match what
-// the workflow templates and silently break the mount.
-func BuildSecretNameFor(workflowRunName string) string {
-	return workflowRunName + "-git-secret"
-}
-
 // AnthropicSecretName is the fixed K8s Secret name git-service writes
 // into WorkflowPlaneNamespace(ocOrgID). The Secret is unique within its
 // namespace (one per WP namespace, one WP namespace per org), so no
-// org-id encoding in the name is needed — different from BuildSecretName
-// which retains its legacy `git-<orgID>` shape. The coding-agent pod
+// org-id encoding in the name is needed. The coding-agent pod
 // mounts this Secret's ANTHROPIC_API_KEY key via secretKeyRef. Each
 // dispatch SSA-overwrites the same Secret with the freshest value from
 // `org_secrets`.

--- a/asdlc-service/services/build_credentials_service.go
+++ b/asdlc-service/services/build_credentials_service.go
@@ -1,21 +1,28 @@
 // Package services — build credentials.
 //
-// StageBuildSecret is the BFF entry point for provisioning a per-build GitHub
-// credential. The BFF generates the WorkflowRun name upfront and asks
-// git-service to materialise a per-WorkflowRun `kubernetes.io/basic-auth`
-// Secret named `<workflowRunName>-git-secret` in the org's workflow-plane
-// namespace `workflows-<ocOrgID>`. The build pod's checkout-source step then
-// mounts that Secret as a regular volume.secret.secretName — same name the
-// upstream `dockerfile-builder` ClusterWorkflow templates from
-// `${metadata.workflowRunName}-git-secret` (line 144 of the workflow).
+// StageBuildSecret is the BFF entry point for provisioning the git credential
+// a component build's checkout step uses to clone the repo. It mints a fresh
+// token and lands it on the workflow plane via OpenChoreo's GitSecret API
+// (`CreateGitSecret`), which stores the value in OpenBao and creates a
+// per-org SecretReference. The build is then triggered with
+// `repository.secretRef = <BuildGitSecretName>`; the upstream
+// `dockerfile-builder` ClusterWorkflow synthesises the
+// `<workflowRunName>-git-secret` ExternalSecret from that SecretReference and
+// ESO materialises the Secret the checkout step mounts.
 //
-// This sidesteps the SecretReference / per-run ExternalSecret synth entirely
-// because the BFF POSTs the WorkflowRun with `parameters.repository.secretRef
-// == ""` — OC's externalRefs resolver explicitly skips empty refs
-// (openchoreo internal/controller/workflowrun/externalref.go:41-44) and the
-// workflow's `git-secret` resource has `includeWhen: secretRef != ""`.
+// Why OC and not a direct K8s write: the BFF runs on the control plane and the
+// build runs on a separate workflow plane (CP/WP split in cloud). A direct
+// in-cluster client can't reach the WP. OC owns the cross-plane write, and the
+// same call works on local k3d (single cluster) where OpenBao + ESO + the
+// Vault-backed `default` ClusterSecretStore are also present — so this is one
+// unified path for both environments, no env flag.
 //
-// Design doc: docs/design/build-credential-injection.md.
+// The git token is a short-lived GitHub App installation token, so the value
+// is refreshed (delete + create — OC has no update) on every build dispatch.
+// The SecretReference is per-org (BuildGitSecretName, isolated by OC's org
+// namespace) and reused across builds; concurrent builds clobber the value
+// benignly because installation tokens are account-scoped and any valid one
+// clones any of the org's repos.
 package services
 
 import (
@@ -24,93 +31,79 @@ import (
 	"fmt"
 	"log/slog"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/wso2/asdlc/asdlc-service/clients/k8s"
-	"github.com/wso2/asdlc/asdlc-service/models"
+	"github.com/wso2/asdlc/asdlc-service/clients/openchoreo"
 	"github.com/wso2/asdlc/asdlc-service/internal/credentials"
 	"github.com/wso2/asdlc/asdlc-service/repositories"
 )
 
-// StageResult is the response shape returned to the BFF. The token itself
-// never crosses the boundary; only the K8s Secret name the workflow will
-// mount.
+// BuildGitSecretName is the OC GitSecret / SecretReference name carrying the
+// org's git credential for component builds. Per-org and deterministic: OC
+// scopes it by the org namespace, so the same name is safe across orgs, and
+// both the refresh (delete+create) and the disconnect cleanup target it by
+// name. Passed to the build WorkflowRun as `repository.secretRef`.
+const BuildGitSecretName = "app-factory-component-build-git-secret"
+
+// StageResult is returned to the BFF. The token never crosses the boundary;
+// only the SecretRef the build WorkflowRun should reference.
 type StageResult struct {
-	SecretName string `json:"secretName"`
+	// SecretRef is the OC GitSecret name to set as repository.secretRef on
+	// the build. Empty when the git-secret client is unavailable (degraded:
+	// the build falls back to an unauthenticated clone).
+	SecretRef string `json:"secretRef"`
 }
 
 // Errors with stable codes the API layer maps to phase2.md §5.2 status codes:
 //
 //   - ErrRepoNotInOrg    → 404 (the (ocOrgId, repoSlug) tuple doesn't match
-//                          an active repo — server-side ownership fence)
+//     an active repo — server-side ownership fence)
 //   - ErrOrgDisconnected → 409 (credential row is suspended or disconnected)
 //
-// Transient K8s SSA / credential-store failures fall through as 500-class.
+// Transient OC / credential-store failures fall through as 500-class.
 var (
 	ErrRepoNotInOrg    = errors.New("stage-build-secret: repo not in org")
 	ErrOrgDisconnected = errors.New("stage-build-secret: org disconnected")
 )
 
-// Labels stamped on every per-WorkflowRun build Secret. Used by
-// DeleteBuildSecretsForOrg and the (future) sweep loop to find Secrets to
-// clean up. The `build-secret` value is the discriminator from
-// AnthropicSecretName / other things git-service writes into WP namespaces.
-const (
-	LabelManagedBy   = "app.kubernetes.io/managed-by"
-	LabelOrgID       = "app-factory.openchoreo.dev/oc-org-id"
-	LabelSecretType  = "app-factory.openchoreo.dev/secret-type"
-	BuildSecretLabel = "build-credentials"
-)
-
-// BuildCredentialsService stages per-WorkflowRun build Secrets in
-// workflows-<ocOrgID>. It reads the credential from the resolver (which
-// reads from `org_secrets` in postgres for PAT mode), packages it as a
-// kubernetes.io/basic-auth Secret, and SSAs it into the WP namespace.
+// BuildCredentialsService provisions the per-org build git secret on the
+// workflow plane via OpenChoreo. It reads the org credential from the
+// resolver, mints a token, and upserts the OC GitSecret.
 //
-// wpClient may be nil in tests or when running outside a cluster — in
-// that case Secret writes are skipped (with a loud warning) and the build
-// will fail at clone time with a clearer NotFound error than a silent
-// misroute. Production startup logs the configured state.
+// gitSecrets may be nil in tests or when the OC client isn't configured — in
+// that case provisioning is skipped (with a loud warning) and StageBuildSecret
+// returns an empty SecretRef so the build runs unauthenticated and fails at
+// clone with a clearer signal than a silent misroute.
 type BuildCredentialsService struct {
-	repos    repositories.RepoRepository
-	resolver credentials.Resolver
-	wpClient client.Client
+	repos      repositories.RepoRepository
+	resolver   credentials.Resolver
+	gitSecrets openchoreo.GitSecretClient
 }
 
 func NewBuildCredentialsService(
 	repos repositories.RepoRepository,
 	resolver credentials.Resolver,
-	wpClient client.Client,
+	gitSecrets openchoreo.GitSecretClient,
 ) *BuildCredentialsService {
 	return &BuildCredentialsService{
-		repos:    repos,
-		resolver: resolver,
-		wpClient: wpClient,
+		repos:      repos,
+		resolver:   resolver,
+		gitSecrets: gitSecrets,
 	}
 }
 
-// StageBuildSecret materialises a per-WorkflowRun K8s Secret carrying the
-// org's GitHub credential, named to match the upstream
-// `dockerfile-builder` workflow's expected default
-// (`${metadata.workflowRunName}-git-secret`).
+// StageBuildSecret provisions the org's build git secret on the workflow plane
+// and returns the SecretRef the caller passes to the build WorkflowRun.
 //
 // Flow:
 //
-//  1. Validate (ocOrgId, repoSlug) maps to an active git_repositories row
-//     — server-side ownership fence, identical to the prior MintBuildToken
-//     surface.
+//  1. Validate (ocOrgId, repoSlug) maps to an active git_repositories row —
+//     server-side ownership fence.
 //  2. Resolve the org's credential. Refuses if status != active.
 //  3. cred.Token(ctx) → fresh token (App: per-installation mint, cached;
-//     PAT: postgres read via `userPATCred`).
-//  4. SSA `<workflowRunName>-git-secret` into workflows-<ocOrgID>:
-//     - type: kubernetes.io/basic-auth
-//     - data: {username, password}
-//     - labels: managed-by + oc-org-id + secret-type=build-credentials
+//     PAT: postgres read).
+//  4. Refresh the per-org OC GitSecret (delete + create) with the fresh token.
 //
-// Idempotent on retry (SSA with stable FieldOwner).
+// workflowRunName is retained for log correlation only — the OC GitSecret is
+// per-org, not per-run.
 func (s *BuildCredentialsService) StageBuildSecret(
 	ctx context.Context, ocOrgID, repoSlug, workflowRunName string,
 ) (*StageResult, error) {
@@ -141,94 +134,58 @@ func (s *BuildCredentialsService) StageBuildSecret(
 		return nil, classifyMintErr(err)
 	}
 
-	secretName := models.BuildSecretNameFor(workflowRunName)
-	if err := s.applyBuildSecret(ctx, ocOrgID, secretName, cred, token); err != nil {
-		return nil, fmt.Errorf("stage-build-secret: write WP secret: %w", err)
+	if s.gitSecrets == nil {
+		slog.WarnContext(ctx, "stage-build-secret: git-secret client not configured — provisioning skipped (build will fail at clone)",
+			"ocOrgId", ocOrgID, "workflowRunName", workflowRunName)
+		return &StageResult{SecretRef: ""}, nil
 	}
 
-	slog.InfoContext(ctx, "stage-build-secret",
-		"ocOrgId", ocOrgID, "repoSlug", repoSlug,
-		"workflowRunName", workflowRunName,
-		"secretName", secretName,
-		"wpNamespace", models.WorkflowPlaneNamespace(ocOrgID))
+	if err := s.provisionGitSecret(ctx, ocOrgID, usernameForCredential(cred), token); err != nil {
+		return nil, fmt.Errorf("stage-build-secret: provision git secret: %w", err)
+	}
 
-	return &StageResult{SecretName: secretName}, nil
+	slog.InfoContext(ctx, "stage-build-secret: git secret provisioned",
+		"ocOrgId", ocOrgID, "repoSlug", repoSlug,
+		"workflowRunName", workflowRunName, "secretRef", BuildGitSecretName)
+
+	return &StageResult{SecretRef: BuildGitSecretName}, nil
 }
 
-// applyBuildSecret SSAs the per-WorkflowRun build Secret into the WP
-// namespace. No-op (with warn) when wpClient is nil.
-func (s *BuildCredentialsService) applyBuildSecret(
-	ctx context.Context,
-	ocOrgID, secretName string,
-	cred credentials.Credential,
-	token string,
-) error {
-	if s.wpClient == nil {
-		slog.WarnContext(ctx, "stage-build-secret: wp k8s client not configured — Secret write skipped (build will fail at clone)",
-			"ocOrgId", ocOrgID, "secretName", secretName)
-		return nil
+// provisionGitSecret refreshes the per-org build GitSecret with the current
+// token. OC has no update verb and Create 409s on a duplicate name, so we
+// delete (tolerating not-found) then create. The brief delete window is safe
+// for in-flight builds: each build has its own ExternalSecret/target Secret,
+// ESO defaults to deletionPolicy=Retain, and installation tokens are
+// interchangeable.
+func (s *BuildCredentialsService) provisionGitSecret(ctx context.Context, ocOrgID, username, token string) error {
+	if err := s.gitSecrets.DeleteGitSecret(ctx, ocOrgID, BuildGitSecretName); err != nil && !errors.Is(err, openchoreo.ErrNotFound) {
+		return fmt.Errorf("refresh (delete) git secret: %w", err)
 	}
-
-	ns := models.WorkflowPlaneNamespace(ocOrgID)
-	// The WP namespace is pre-provisioned by OC's project-onboarding flow.
-	// If absent, the SSA below surfaces a clear NotFound to the operator.
-
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: ns,
-			Labels: map[string]string{
-				LabelManagedBy:  k8s.FieldOwner,
-				LabelOrgID:      ocOrgID,
-				LabelSecretType: BuildSecretLabel,
-			},
-		},
-		Type: corev1.SecretTypeBasicAuth,
-		StringData: map[string]string{
-			"username": usernameForCredential(cred),
-			"password": token,
-		},
-	}
-
-	if err := s.wpClient.Patch(
-		ctx, secret,
-		client.Apply,
-		client.ForceOwnership,
-		client.FieldOwner(k8s.FieldOwner),
-	); err != nil {
-		return fmt.Errorf("ssa secret: %w", err)
+	if _, err := s.gitSecrets.CreateGitSecret(ctx, ocOrgID, openchoreo.CreateGitSecretRequest{
+		Name:       BuildGitSecretName,
+		SecretType: openchoreo.GitSecretBasicAuth,
+		Username:   username,
+		Token:      token,
+		// WorkflowPlaneKind/Name left zero — the client defaults them to
+		// ClusterWorkflowPlane/default.
+	}); err != nil {
+		return fmt.Errorf("create git secret: %w", err)
 	}
 	return nil
 }
 
-// DeleteBuildSecretsForOrg removes every per-WorkflowRun build Secret in
-// the org's WP namespace. Called from the org.disconnected cascade so
-// staged tokens for that org don't linger after the credential row is
-// wiped. Idempotent — NotFound list / delete errors are returned as nil.
-//
-// Selector: managed-by=<FieldOwner> + secret-type=build-credentials. The
-// org-id label is implicit in the WP namespace name; we don't filter on
-// it (the namespace is per-org).
+// DeleteBuildSecretsForOrg removes the org's build GitSecret. Called from the
+// org.disconnected cascade so a staged token doesn't linger after the
+// credential row is wiped. Idempotent — a not-found delete is a no-op.
 func (s *BuildCredentialsService) DeleteBuildSecretsForOrg(ctx context.Context, ocOrgID string) error {
-	if s.wpClient == nil {
+	if s.gitSecrets == nil {
 		return nil
 	}
-	ns := models.WorkflowPlaneNamespace(ocOrgID)
-	if err := s.wpClient.DeleteAllOf(ctx, &corev1.Secret{},
-		client.InNamespace(ns),
-		client.MatchingLabels{
-			LabelManagedBy:  k8s.FieldOwner,
-			LabelSecretType: BuildSecretLabel,
-		},
-	); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("delete build secrets in %s: %w", ns, err)
+	if err := s.gitSecrets.DeleteGitSecret(ctx, ocOrgID, BuildGitSecretName); err != nil && !errors.Is(err, openchoreo.ErrNotFound) {
+		return fmt.Errorf("delete build git secret for org %s: %w", ocOrgID, err)
 	}
-	slog.InfoContext(ctx, "stage-build-secret: deleted org build secrets on disconnect",
-		"ocOrgId", ocOrgID, "namespace", ns)
+	slog.InfoContext(ctx, "stage-build-secret: deleted org build git secret on disconnect",
+		"ocOrgId", ocOrgID, "secretRef", BuildGitSecretName)
 	return nil
 }
 

--- a/asdlc-service/services/build_credentials_service_test.go
+++ b/asdlc-service/services/build_credentials_service_test.go
@@ -6,9 +6,33 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wso2/asdlc/asdlc-service/models"
+	"github.com/wso2/asdlc/asdlc-service/clients/openchoreo"
 	"github.com/wso2/asdlc/asdlc-service/internal/credentials"
+	"github.com/wso2/asdlc/asdlc-service/models"
 )
+
+// fakeGitSecretClient records CreateGitSecret/DeleteGitSecret calls.
+type fakeGitSecretClient struct {
+	created   []openchoreo.CreateGitSecretRequest
+	deleted   []string
+	deleteErr error
+	createErr error
+}
+
+func (f *fakeGitSecretClient) CreateGitSecret(ctx context.Context, orgNS string, req openchoreo.CreateGitSecretRequest) (*openchoreo.GitSecretInfo, error) {
+	f.created = append(f.created, req)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &openchoreo.GitSecretInfo{Name: req.Name, Namespace: orgNS}, nil
+}
+func (f *fakeGitSecretClient) DeleteGitSecret(ctx context.Context, orgNS, name string) error {
+	f.deleted = append(f.deleted, name)
+	return f.deleteErr
+}
+func (f *fakeGitSecretClient) ListGitSecrets(ctx context.Context, orgNS string) ([]*openchoreo.GitSecretInfo, error) {
+	return nil, nil
+}
 
 // fakeRepoRepo is a minimal in-memory RepoRepository for the
 // stage-build-secret tests.
@@ -72,18 +96,66 @@ func TestStageBuildSecret_Happy(t *testing.T) {
 	}
 	repos := &fakeRepoRepo{rows: map[string]*models.GitRepository{"default/asdlc-repos-myrepo": repo}}
 	res := &fakeResolver{cred: &fakeCred{token: "ghs_abc123", exp: time.Now().Add(time.Hour)}}
+	gs := &fakeGitSecretClient{}
 
-	// wpClient=nil: SSA is skipped (with a warn) but the method should still
-	// return the expected name. Production wires a real controller-runtime
-	// client via NewInClusterClient.
-	svc := NewBuildCredentialsService(repos, res, nil)
+	svc := NewBuildCredentialsService(repos, res, gs)
 	got, err := svc.StageBuildSecret(context.Background(), "default", "asdlc-repos-myrepo", testRunName)
 	if err != nil {
 		t.Fatalf("StageBuildSecret: %v", err)
 	}
-	want := models.BuildSecretNameFor(testRunName)
-	if got.SecretName != want {
-		t.Errorf("SecretName = %q; want %q", got.SecretName, want)
+	if got.SecretRef != BuildGitSecretName {
+		t.Errorf("SecretRef = %q; want %q", got.SecretRef, BuildGitSecretName)
+	}
+	// Refresh = delete then create with the fresh token.
+	if len(gs.deleted) != 1 || gs.deleted[0] != BuildGitSecretName {
+		t.Errorf("delete calls = %v; want [%s]", gs.deleted, BuildGitSecretName)
+	}
+	if len(gs.created) != 1 {
+		t.Fatalf("create calls = %d; want 1", len(gs.created))
+	}
+	c := gs.created[0]
+	if c.Name != BuildGitSecretName || c.Token != "ghs_abc123" || c.SecretType != openchoreo.GitSecretBasicAuth {
+		t.Errorf("create req = %+v; want name=%s token=ghs_abc123 type=basic-auth", c, BuildGitSecretName)
+	}
+	if c.Username != "git" { // WebhookPerRepo + empty identity → "git"
+		t.Errorf("username = %q; want git", c.Username)
+	}
+}
+
+// A 404 on the delete leg (first-ever build for the org) must be tolerated —
+// the create still proceeds.
+func TestStageBuildSecret_DeleteNotFoundTolerated(t *testing.T) {
+	repos := &fakeRepoRepo{rows: map[string]*models.GitRepository{
+		"default/slug": {OrgID: "default", RepoSlug: "slug"},
+	}}
+	res := &fakeResolver{cred: &fakeCred{token: "t", exp: time.Now().Add(time.Hour)}}
+	gs := &fakeGitSecretClient{deleteErr: openchoreo.ErrNotFound}
+
+	svc := NewBuildCredentialsService(repos, res, gs)
+	got, err := svc.StageBuildSecret(context.Background(), "default", "slug", testRunName)
+	if err != nil {
+		t.Fatalf("StageBuildSecret: %v", err)
+	}
+	if got.SecretRef != BuildGitSecretName || len(gs.created) != 1 {
+		t.Errorf("want create after tolerated 404; SecretRef=%q creates=%d", got.SecretRef, len(gs.created))
+	}
+}
+
+// With no git-secret client wired (degraded), provisioning is skipped and an
+// empty SecretRef is returned so the build clones unauthenticated.
+func TestStageBuildSecret_NilClientDegraded(t *testing.T) {
+	repos := &fakeRepoRepo{rows: map[string]*models.GitRepository{
+		"default/slug": {OrgID: "default", RepoSlug: "slug"},
+	}}
+	res := &fakeResolver{cred: &fakeCred{token: "t", exp: time.Now().Add(time.Hour)}}
+
+	svc := NewBuildCredentialsService(repos, res, nil)
+	got, err := svc.StageBuildSecret(context.Background(), "default", "slug", testRunName)
+	if err != nil {
+		t.Fatalf("StageBuildSecret: %v", err)
+	}
+	if got.SecretRef != "" {
+		t.Errorf("SecretRef = %q; want empty (degraded)", got.SecretRef)
 	}
 }
 

--- a/asdlc-service/services/component_service.go
+++ b/asdlc-service/services/component_service.go
@@ -56,8 +56,8 @@ type componentService struct {
 	// repoSvc + buildCredSvc are used by TriggerBuild to pre-stage the
 	// per-WorkflowRun build Secret. Optional — nil means "no staging"
 	// (tests / unit-only flows).
-	repoSvc       RepoService
-	buildCredSvc  *BuildCredentialsService
+	repoSvc      RepoService
+	buildCredSvc *BuildCredentialsService
 }
 
 // NewComponentService builds the component service. repoSvc + buildCredSvc
@@ -167,22 +167,27 @@ func (s *componentService) TriggerBuild(ctx context.Context, orgName, projectNam
 	// Manual triggers from the console go through this path; the
 	// webhook-driven dispatch path uses workflowRunService.dispatchBuild.
 	runName := openchoreo.NewBuildRunName(projectName, componentName)
+	buildSecretRef := ""
 	if s.repoSvc != nil && s.buildCredSvc != nil {
 		repo, err := s.repoSvc.GetRepo(ctx, projectName)
 		switch {
 		case err != nil:
-			slog.WarnContext(ctx, "trigger-build: GetRepo failed; proceeding without staged Secret (build will fail at clone)",
+			slog.WarnContext(ctx, "trigger-build: GetRepo failed; proceeding without git secret (build will fail at clone)",
 				"orgName", orgName, "projectName", projectName, "error", err)
 		case repo == nil || repo.RepoSlug == "":
-			slog.WarnContext(ctx, "trigger-build: no repo / repoSlug; proceeding without staged Secret",
+			slog.WarnContext(ctx, "trigger-build: no repo / repoSlug; proceeding without git secret",
 				"orgName", orgName, "projectName", projectName)
 		default:
-			if _, sErr := s.buildCredSvc.StageBuildSecret(ctx, orgName, repo.RepoSlug, runName); sErr != nil {
+			res, sErr := s.buildCredSvc.StageBuildSecret(ctx, orgName, repo.RepoSlug, runName)
+			if sErr != nil {
 				return nil, fmt.Errorf("trigger-build: stage-build-secret: %w", sErr)
+			}
+			if res != nil {
+				buildSecretRef = res.SecretRef
 			}
 		}
 	}
-	run, err := s.client.TriggerBuild(ctx, orgName, projectName, componentName, runName)
+	run, err := s.client.TriggerBuild(ctx, orgName, projectName, componentName, buildSecretRef, runName)
 	if err != nil {
 		return nil, translateComponentHTTPError(err)
 	}

--- a/asdlc-service/services/workflowrun_service.go
+++ b/asdlc-service/services/workflowrun_service.go
@@ -171,11 +171,14 @@ func (s *workflowRunService) dispatchBuild(
 	// per-build K8s Secret before the WorkflowRun spawns the Argo pod.
 	runName := openchoreo.NewBuildRunName(projectID, task.ComponentName)
 
-	// Stage the per-WorkflowRun build Secret in workflows-<orgID> with the
-	// org's GitHub credential. Errors classify identically to the previous
-	// mint-build surface (404 → skip, 409 → skip, 5xx → log + retry).
+	// Provision the org's build git secret on the workflow plane (OC
+	// GitSecret) and capture the secretRef to pass to the build. Errors
+	// classify identically to the previous mint-build surface (404 → skip,
+	// 409 → skip, 5xx → log + retry).
+	var buildSecretRef string
 	if s.repoSvc != nil && s.buildCredSvc != nil && repoSlug != "" {
-		if _, err := s.buildCredSvc.StageBuildSecret(ctx, orgID, repoSlug, runName); err != nil {
+		res, err := s.buildCredSvc.StageBuildSecret(ctx, orgID, repoSlug, runName)
+		if err != nil {
 			switch {
 			case errors.Is(err, ErrRepoNotInOrg):
 				slog.WarnContext(ctx, "stage-build-secret refused: repo/org mismatch",
@@ -191,9 +194,12 @@ func (s *workflowRunService) dispatchBuild(
 				return "", err
 			}
 		}
+		if res != nil {
+			buildSecretRef = res.SecretRef
+		}
 	}
 
-	run, err := s.ocClient.TriggerBuildAtCommit(ctx, orgID, projectID, task.ComponentName, sha, runName)
+	run, err := s.ocClient.TriggerBuildAtCommit(ctx, orgID, projectID, task.ComponentName, sha, buildSecretRef, runName)
 	if err != nil {
 		slog.ErrorContext(ctx, "trigger build failed",
 			"component", task.ComponentName, "sha", sha, "error", err)
@@ -286,7 +292,8 @@ func (s *workflowRunService) RetryAuthFailedBuild(ctx context.Context, task *mod
 		return "", fmt.Errorf("retry-auth-failed: project %s has no repo slug", task.ProjectID)
 	}
 	runName := openchoreo.NewBuildRunName(task.ProjectID, task.ComponentName)
-	if _, err := s.buildCredSvc.StageBuildSecret(ctx, task.OrgID, repo.RepoSlug, runName); err != nil {
+	res, err := s.buildCredSvc.StageBuildSecret(ctx, task.OrgID, repo.RepoSlug, runName)
+	if err != nil {
 		switch {
 		case errors.Is(err, ErrRepoNotInOrg), errors.Is(err, ErrOrgDisconnected):
 			return "", err
@@ -294,7 +301,11 @@ func (s *workflowRunService) RetryAuthFailedBuild(ctx context.Context, task *mod
 			return "", fmt.Errorf("retry-auth-failed: stage-build-secret: %w", err)
 		}
 	}
-	run, err := s.ocClient.TriggerBuildAtCommit(ctx, task.OrgID, task.ProjectID, task.ComponentName, task.LastBuildSHA, runName)
+	buildSecretRef := ""
+	if res != nil {
+		buildSecretRef = res.SecretRef
+	}
+	run, err := s.ocClient.TriggerBuildAtCommit(ctx, task.OrgID, task.ProjectID, task.ComponentName, task.LastBuildSHA, buildSecretRef, runName)
 	if err != nil {
 		return "", fmt.Errorf("retry-auth-failed: trigger build: %w", err)
 	}


### PR DESCRIPTION
## Problem

Component builds fail at **git clone** in the cloud dev env (task → `building → failed`). The BFF wrote the `<runName>-git-secret` `kubernetes.io/basic-auth` Secret with an **in-cluster k8s client**, but the BFF runs on the **control plane** while the build runs on a separate **workflow plane** (CP/WP split in cloud). The in-cluster client can't reach the WP cluster, so the Secret never landed in the build namespace and the private-repo clone died:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: exit status 128
```

The direct write only worked on local k3d (single cluster). The `BUILD_GIT_SECRET_VIA_OC`-style "two paths, one per environment" approach was rejected for maintainability.

## Fix — one unified path via OpenChoreo's GitSecret API

Use the same mechanism agent-manager uses; OpenChoreo owns the cross-plane write, and it works identically on local k3d (which also has OpenBao + ESO + the Vault-backed `default` ClusterSecretStore). **No env flag.**

- `BuildCredentialsService` mints the token and lands it on the workflow plane via **OC `CreateGitSecret`** (stores it in OpenBao + creates a per-org `SecretReference`). The in-cluster SSA write + `wpClient` dependency are removed.
- The build is triggered with `repository.secretRef = app-factory-component-build-git-secret`; the upstream `dockerfile-builder` workflow synthesises the `<runName>-git-secret` ExternalSecret from that SecretReference and ESO materialises the mounted Secret. `TriggerBuild`/`TriggerBuildAtCommit` gain a `secretRef` arg (threaded from `StageBuildSecret`), replacing the force-blank.
- The GitHub App installation token is **short-lived**, so the per-org SecretReference is **refreshed** (delete + create — OC has no update verb) on every build dispatch.
- The disconnect cleaner now deletes the OC GitSecret.

### Concurrency / in-flight builds (per-org shared secret)
Safe: each build has its **own** target Secret, ESO defaults to `deletionPolicy: Retain` (the sub-second delete window can't wipe an in-flight build's Secret), GitHub **installation** tokens are account-scoped so any valid one clones any of the org's repos, and **clone is the first build step** (reads a fresh token seconds after the pod starts). Per-org refresh is in fact *more* robust against queue delays than a per-build secret.

## Scope / not touched
- The **anthropic** per-org secret still uses the in-cluster client — separate concern, intentionally left for a follow-up.
- The **coding-agent runner** is unaffected: it fetches a fresh token over HTTP (`/credentials/refresh`) at clone time — a different path from the build secret (shares only the credential resolver).
- Removed the now-dead `BuildSecretNameFor` helper + its test.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass; gofmt clean.
- New unit tests: refresh = delete+create with the fresh token + `secretRef` returned; delete-404 tolerated (first build); nil-client degraded (empty secretRef → unauthenticated clone).
- Mechanism verified against the live cloud WP (`dockerfile-builder` `secretRef`→ExternalSecret synthesis, OpenBao-backed `${workflowplane.secretStore}`) and the local k3d setup (same OpenBao + ESO + `default` store + workflow block).

## Follow-up before relying on it in dev
- Local k3d smoke test that an OC-provisioned git secret materialises the build Secret end-to-end.
- Confirm the dev cloud `dockerfile-builder` workflow matches the `secretRef`-synthesis block verified on wso2cloud-deployment `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)