### PR TITLE
fix(build): default to public repos + make build git-secret provisioning fault-tolerant

### DIFF
--- a/asdlc-service/config/config_loader.go
+++ b/asdlc-service/config/config_loader.go
@@ -88,7 +88,7 @@ func Load() (Config, error) {
 		// env-var names the standalone git-service used so existing local
 		// .env files / release-bindings keep working.
 		RepoBasePath:                r.readOptionalString("REPO_BASE_PATH", "/tmp/asdlc-repos"),
-		GitHubRepoVisibility:        r.readOptionalString("GITHUB_REPO_VISIBILITY", "private"),
+		GitHubRepoVisibility:        r.readOptionalString("GITHUB_REPO_VISIBILITY", "public"),
 		GitHubCommitterName:         r.readOptionalString("GIT_COMMITTER_NAME", "ASDLC Bot"),
 		GitHubCommitterEmail:        r.readOptionalString("GIT_COMMITTER_EMAIL", "bot@asdlc.dev"),
 		WebhookDeliveryURL:          r.readOptionalString("GITHUB_WEBHOOK_DELIVERY_URL", ""),

--- a/asdlc-service/services/build_credentials_service.go
+++ b/asdlc-service/services/build_credentials_service.go
@@ -141,7 +141,20 @@ func (s *BuildCredentialsService) StageBuildSecret(
 	}
 
 	if err := s.provisionGitSecret(ctx, ocOrgID, usernameForCredential(cred), token); err != nil {
-		return nil, fmt.Errorf("stage-build-secret: provision git secret: %w", err)
+		// Degrade gracefully instead of blocking the build. On dev cloud the
+		// OpenChoreo GitSecret API is unreachable — the platform-api does not
+		// route /api/v1alpha1/gitsecrets, so CreateGitSecret 404s (cross-plane
+		// private-repo secret delivery is tracked by wso2-enterprise/wso2cloud#319).
+		// Returning an empty SecretRef lets the build dispatch and clone
+		// unauthenticated, which is correct for the public repos app-factory
+		// creates by default; a private repo would fail later at checkout with a
+		// clear git error rather than a stuck task. Where provisioning DOES work
+		// (local k3d, single cluster), this branch is not taken and the real
+		// SecretRef is returned below.
+		slog.WarnContext(ctx, "stage-build-secret: git secret provisioning failed — dispatching build without a git secret (clones public repos only; see wso2cloud#319)",
+			"ocOrgId", ocOrgID, "repoSlug", repoSlug,
+			"workflowRunName", workflowRunName, "error", err)
+		return &StageResult{SecretRef: ""}, nil
 	}
 
 	slog.InfoContext(ctx, "stage-build-secret: git secret provisioned",

--- a/asdlc-service/services/build_credentials_service.go
+++ b/asdlc-service/services/build_credentials_service.go
@@ -153,14 +153,19 @@ func (s *BuildCredentialsService) StageBuildSecret(
 
 // provisionGitSecret refreshes the per-org build GitSecret with the current
 // token. OC has no update verb and Create 409s on a duplicate name, so we
-// delete (tolerating not-found) then create. The brief delete window is safe
-// for in-flight builds: each build has its own ExternalSecret/target Secret,
-// ESO defaults to deletionPolicy=Retain, and installation tokens are
-// interchangeable.
+// delete (tolerating not-found) then create. Both legs tolerate the benign
+// concurrent state: a not-found delete and a conflicting create both mean
+// another same-org build raced us. The delete window and a conflicting create
+// are safe for in-flight builds — each build has its own ExternalSecret/target
+// Secret, ESO defaults to deletionPolicy=Retain, and installation tokens are
+// account-scoped/interchangeable (the racing build's token clones our repo too).
 func (s *BuildCredentialsService) provisionGitSecret(ctx context.Context, ocOrgID, username, token string) error {
 	if err := s.gitSecrets.DeleteGitSecret(ctx, ocOrgID, BuildGitSecretName); err != nil && !errors.Is(err, openchoreo.ErrNotFound) {
 		return fmt.Errorf("refresh (delete) git secret: %w", err)
 	}
+	// Tolerate ErrConflict (409): a concurrent build re-created the secret
+	// between our delete and create. The secret exists with a valid token, so
+	// the build can proceed — don't fail it on the race.
 	if _, err := s.gitSecrets.CreateGitSecret(ctx, ocOrgID, openchoreo.CreateGitSecretRequest{
 		Name:       BuildGitSecretName,
 		SecretType: openchoreo.GitSecretBasicAuth,
@@ -168,7 +173,7 @@ func (s *BuildCredentialsService) provisionGitSecret(ctx context.Context, ocOrgI
 		Token:      token,
 		// WorkflowPlaneKind/Name left zero — the client defaults them to
 		// ClusterWorkflowPlane/default.
-	}); err != nil {
+	}); err != nil && !errors.Is(err, openchoreo.ErrConflict) {
 		return fmt.Errorf("create git secret: %w", err)
 	}
 	return nil

--- a/asdlc-service/services/build_credentials_service_test.go
+++ b/asdlc-service/services/build_credentials_service_test.go
@@ -161,6 +161,28 @@ func TestStageBuildSecret_CreateConflictTolerated(t *testing.T) {
 	}
 }
 
+// A non-tolerated provisioning failure (e.g. the dev-cloud platform-api 404 on
+// CreateGitSecret, surfaced as ErrNotFound) must NOT block the build — it
+// degrades to an empty SecretRef so the build dispatches and clones the
+// (public) repo unauthenticated. Private-repo support is tracked by
+// wso2-enterprise/wso2cloud#319.
+func TestStageBuildSecret_ProvisionFailureDegrades(t *testing.T) {
+	repos := &fakeRepoRepo{rows: map[string]*models.GitRepository{
+		"default/slug": {OrgID: "default", RepoSlug: "slug"},
+	}}
+	res := &fakeResolver{cred: &fakeCred{token: "t", exp: time.Now().Add(time.Hour)}}
+	gs := &fakeGitSecretClient{createErr: openchoreo.ErrNotFound}
+
+	svc := NewBuildCredentialsService(repos, res, gs)
+	got, err := svc.StageBuildSecret(context.Background(), "default", "slug", testRunName)
+	if err != nil {
+		t.Fatalf("StageBuildSecret should degrade on provision failure, got: %v", err)
+	}
+	if got.SecretRef != "" {
+		t.Errorf("SecretRef = %q; want empty (degraded)", got.SecretRef)
+	}
+}
+
 // With no git-secret client wired (degraded), provisioning is skipped and an
 // empty SecretRef is returned so the build clones unauthenticated.
 func TestStageBuildSecret_NilClientDegraded(t *testing.T) {

--- a/asdlc-service/services/build_credentials_service_test.go
+++ b/asdlc-service/services/build_credentials_service_test.go
@@ -141,6 +141,26 @@ func TestStageBuildSecret_DeleteNotFoundTolerated(t *testing.T) {
 	}
 }
 
+// A 409 on the create leg (a concurrent same-org build re-created the secret
+// between our delete and create) must be tolerated — the secret exists with a
+// valid token, so the build proceeds.
+func TestStageBuildSecret_CreateConflictTolerated(t *testing.T) {
+	repos := &fakeRepoRepo{rows: map[string]*models.GitRepository{
+		"default/slug": {OrgID: "default", RepoSlug: "slug"},
+	}}
+	res := &fakeResolver{cred: &fakeCred{token: "t", exp: time.Now().Add(time.Hour)}}
+	gs := &fakeGitSecretClient{createErr: openchoreo.ErrConflict}
+
+	svc := NewBuildCredentialsService(repos, res, gs)
+	got, err := svc.StageBuildSecret(context.Background(), "default", "slug", testRunName)
+	if err != nil {
+		t.Fatalf("StageBuildSecret should tolerate create-409, got: %v", err)
+	}
+	if got.SecretRef != BuildGitSecretName {
+		t.Errorf("SecretRef = %q; want %q", got.SecretRef, BuildGitSecretName)
+	}
+}
+
 // With no git-secret client wired (degraded), provisioning is skipped and an
 // empty SecretRef is returned so the build clones unauthenticated.
 func TestStageBuildSecret_NilClientDegraded(t *testing.T) {

--- a/asdlc-service/services/workflowrun_service.go
+++ b/asdlc-service/services/workflowrun_service.go
@@ -172,9 +172,12 @@ func (s *workflowRunService) dispatchBuild(
 	runName := openchoreo.NewBuildRunName(projectID, task.ComponentName)
 
 	// Provision the org's build git secret on the workflow plane (OC
-	// GitSecret) and capture the secretRef to pass to the build. Errors
-	// classify identically to the previous mint-build surface (404 → skip,
-	// 409 → skip, 5xx → log + retry).
+	// GitSecret) and capture the secretRef to pass to the build. Failing to
+	// provision the secret is non-fatal — StageBuildSecret degrades to an empty
+	// secretRef so the build still dispatches and clones unauthenticated (correct
+	// for the public repos app-factory creates by default; private-repo support
+	// is tracked by wso2-enterprise/wso2cloud#319). Only an ownership/credential
+	// refusal (repo not in org, org disconnected) blocks the build here.
 	var buildSecretRef string
 	if s.repoSvc != nil && s.buildCredSvc != nil && repoSlug != "" {
 		res, err := s.buildCredSvc.StageBuildSecret(ctx, orgID, repoSlug, runName)


### PR DESCRIPTION
## Why

Component builds were stuck: after a coding-agent PR merged, the task moved to `merged` but never reached `building`. On dev cloud the BFF's build-dispatch calls OpenChoreo `CreateGitSecret`, but the wso2cloud platform-api does not route `/api/v1alpha1/gitsecrets`, so the call 404s and `DispatchTaskBuild` errors out before triggering the build. Cross-plane private-repo secret delivery is a platform capability tracked by wso2-enterprise/wso2cloud#319.

Until #319 lands, app-factory should build **public** repos end-to-end and not be blocked by the unreachable git-secret path.

## What

- **Public repos by default** — `GITHUB_REPO_VISIBILITY` default flips `private` → `public` (`config_loader.go`). Repo creation lives in app-factory-api, whose cloud binding sets no override, so it inherits `public`; local overlays keep an explicit `private`, so local behaviour is unchanged. No wso2cloud-deployment change required.
- **Non-fatal git-secret provisioning** — `StageBuildSecret` now degrades to an empty `secretRef` (with a warning) when provisioning fails, so the build dispatches and clones unauthenticated (correct for public repos). Ownership/disconnect refusals stay fatal. Where provisioning works (local k3d, single cluster), the real `secretRef` is still used.
- **Tolerate OC 409 on create** (original #34 commit) — a concurrent same-org build that re-creates the per-org git secret between our delete and create returns 409; tolerating it keeps provisioning successful. This is what makes the local concurrent-build path correct: without it, a benign 409 would now hit the degrade path and wrongly return an empty `secretRef`, breaking a private-repo build.

## Behaviour

- **Cloud**: creates public repos; builds dispatch and clone unauthenticated; a private repo would fail at checkout with a clear git error (deferred to #319) rather than a stuck task.
- **Local k3d**: unchanged — private repos, OC `CreateGitSecret` works (including concurrent builds via the 409 tolerance).

## Testing

`go build ./...`, `go vet`, and the full `services`/`config` suites pass. Added `TestStageBuildSecret_ProvisionFailureDegrades` (provisioning 404 → empty `secretRef`, no error); retains `TestStageBuildSecret_CreateConflictTolerated` (409 → success).

This PR folds in the original #34 (OC 409 tolerance) commit alongside the new changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
