### PR TITLE
fix(webhook): scope PR/issue→task resolution by org_id (cross-org project-slug collision)

### DIFF
--- a/asdlc-service/services/webhook/handlers.go
+++ b/asdlc-service/services/webhook/handlers.go
@@ -245,13 +245,13 @@ func (h *Handler) PullRequestClosed(ctx context.Context, event, action string, b
 	if mergeSHA == "" {
 		return nil
 	}
-	projectID, err := lookupProjectByRepo(h.db.WithContext(ctx), p.Repository.FullName)
+	orgID, projectID, err := lookupProjectByRepo(h.db.WithContext(ctx), p.Repository.FullName)
 	if err != nil || projectID == "" {
 		return nil
 	}
 	var task models.ComponentTask
 	if err := h.db.WithContext(ctx).
-		Where("project_id = ? AND pull_request_number = ?", projectID, p.PullRequest.Number).
+		Where("org_id = ? AND project_id = ? AND pull_request_number = ?", orgID, projectID, p.PullRequest.Number).
 		First(&task).Error; err != nil {
 		return nil // already handled above
 	}
@@ -304,23 +304,31 @@ func (h *Handler) IssueComment(ctx context.Context, event, action string, body [
 	return nil
 }
 
-// lookupProjectByRepo translates a GitHub repo full_name to an ASDLC project
-// ID via the git_repositories table. Pass either a request-scoped *gorm.DB
+// lookupProjectByRepo translates a GitHub repo full_name to its owning ASDLC
+// (orgID, projectID) via the git_repositories table. The repo row is the
+// authority: repo URLs are globally unique, so the matched row disambiguates
+// the project. Callers MUST scope task lookups by BOTH org_id and project_id —
+// project_id is only a per-org slug and is reused across orgs, so a
+// project_id-only filter collides across orgs that share a slug and can absorb
+// a webhook into the wrong org's task. Pass a request-scoped *gorm.DB
 // (db.WithContext(ctx)) or an open transaction.
-func lookupProjectByRepo(db *gorm.DB, repoFullName string) (string, error) {
+func lookupProjectByRepo(db *gorm.DB, repoFullName string) (orgID, projectID string, err error) {
 	if repoFullName == "" {
-		return "", nil
+		return "", "", nil
 	}
-	var r struct{ ProjectID string }
-	err := db.Raw(`
-		SELECT project_id
+	var r struct {
+		OrgID     string
+		ProjectID string
+	}
+	err = db.Raw(`
+		SELECT org_id, project_id
 		FROM git_repositories
 		WHERE repo_url ILIKE ? OR repo_url ILIKE ?
 		LIMIT 1
 	`, "%"+repoFullName, "%"+repoFullName+".git").Scan(&r).Error
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return r.ProjectID, nil
+	return r.OrgID, r.ProjectID, nil
 }
 

--- a/asdlc-service/services/webhook/installation_handlers.go
+++ b/asdlc-service/services/webhook/installation_handlers.go
@@ -251,19 +251,20 @@ func (h *installationHandler) handleReposRemoved(ctx context.Context, _ string, 
 		return nil
 	}
 
-	// Resolve removed repo full_names → project IDs via git_repositories.
-	projectIDs := make([]string, 0, len(confirmed))
-	repoByProject := make(map[string]string, len(confirmed))
+	// Resolve removed repo full_names → (orgID, projectID) via git_repositories.
+	// We key by the (org, project) tuple, not project_id alone: project_id is a
+	// per-org slug reused across orgs, so a project_id-only match would cascade
+	// the abandon onto another org's tasks that share the slug.
+	orgProjectPairs := make([][]any, 0, len(confirmed))
 	for _, r := range confirmed {
-		pid, err := lookupProjectByRepo(h.db.WithContext(ctx), r)
+		orgID, pid, err := lookupProjectByRepo(h.db.WithContext(ctx), r)
 		if err != nil || pid == "" {
 			// No project for this repo on our side — nothing to cascade.
 			continue
 		}
-		projectIDs = append(projectIDs, pid)
-		repoByProject[pid] = r
+		orgProjectPairs = append(orgProjectPairs, []any{orgID, pid})
 	}
-	if len(projectIDs) == 0 {
+	if len(orgProjectPairs) == 0 {
 		slog.InfoContext(ctx, "webhook: reach reconciliation Phase B confirmed but no matching projects",
 			"installationId", p.Installation.ID, "confirmed", confirmed)
 		return nil
@@ -279,7 +280,7 @@ func (h *installationHandler) handleReposRemoved(ctx context.Context, _ string, 
 		string(models.TaskStatusAbandoned),
 	}
 	if err := h.db.WithContext(ctx).
-		Where("project_id IN ? AND status NOT IN ?", projectIDs, terminal).
+		Where("(org_id, project_id) IN ? AND status NOT IN ?", orgProjectPairs, terminal).
 		Find(&tasks).Error; err != nil {
 		slog.ErrorContext(ctx, "webhook: reach reconciliation Phase B list tasks failed",
 			"installationId", p.Installation.ID, "error", err)

--- a/asdlc-service/services/webhook/projector.go
+++ b/asdlc-service/services/webhook/projector.go
@@ -82,7 +82,7 @@ func (p *Projector) ApplyToTaskByPR(
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Resolve repo_full_name → project_id via git_repositories. The repo
 		// row is the authority here; without it the PR number is ambiguous.
-		projectID, err := lookupProjectByRepo(tx, repoFullName)
+		orgID, projectID, err := lookupProjectByRepo(tx, repoFullName)
 		if err != nil {
 			return fmt.Errorf("resolve project for repo %q: %w", repoFullName, err)
 		}
@@ -90,11 +90,13 @@ func (p *Projector) ApplyToTaskByPR(
 			return errTaskNotFound{prNumber: prNumber, repoFullName: repoFullName}
 		}
 
-		// Find the task scoped to (project, PR number). We use FOR UPDATE in
-		// case this is called concurrently against the same task; combined
-		// with the advisory lock below this is belt-and-suspenders.
+		// Find the task scoped to (org, project, PR number). org_id is required:
+		// project_id is a per-org slug reused across orgs, so a (project, PR)
+		// filter alone can resolve to another org's task that shares the slug.
+		// We use FOR UPDATE in case this is called concurrently against the same
+		// task; combined with the advisory lock below this is belt-and-suspenders.
 		var task models.ComponentTask
-		err = tx.Where("project_id = ? AND pull_request_number = ?", projectID, prNumber).
+		err = tx.Where("org_id = ? AND project_id = ? AND pull_request_number = ?", orgID, projectID, prNumber).
 			Clauses().
 			First(&task).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -271,7 +273,7 @@ func (p *Projector) LinkTaskByIssue(
 		return fmt.Errorf("repoFullName is required")
 	}
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		projectID, err := lookupProjectByRepo(tx, repoFullName)
+		orgID, projectID, err := lookupProjectByRepo(tx, repoFullName)
 		if err != nil {
 			return fmt.Errorf("resolve project for repo %q: %w", repoFullName, err)
 		}
@@ -279,8 +281,11 @@ func (p *Projector) LinkTaskByIssue(
 			return errTaskNotFound{issueNumber: issueNumber, repoFullName: repoFullName}
 		}
 
+		// Scope by (org, project, issue): project_id is a per-org slug reused
+		// across orgs, so an issue lookup without org_id can link the PR to a
+		// different org's task that shares the slug and issue number.
 		var task models.ComponentTask
-		err = tx.Where("project_id = ? AND issue_number = ?", projectID, issueNumber).
+		err = tx.Where("org_id = ? AND project_id = ? AND issue_number = ?", orgID, projectID, issueNumber).
 			First(&task).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return errTaskNotFound{issueNumber: issueNumber, repoFullName: repoFullName}


### PR DESCRIPTION
## Why

A coding-agent task could get stuck (e.g. `in_progress` after the agent raised its PR) because the webhook that should advance it resolved to the **wrong org's task**.

`project_id` is a **per-org slug** and is reused across orgs (e.g. `test-dev-5` existed in three orgs). But the webhook PR/issue→task lookups filtered by the slug alone:
- `ApplyToTaskByPR` → `Where(project_id = ? AND pull_request_number = ?)`
- `LinkTaskByIssue` → `Where(project_id = ? AND issue_number = ?)`
- merge-dispatch → `Where(project_id = ? AND pull_request_number = ?)`

`lookupProjectByRepo` resolved the repo to a `project_id` only, dropping `org_id`. So a PR for org A's task matched a row in org B sharing the slug; `First()` returned the older/colliding row. When that row wasn't in a state the event applied to, the projector dropped it as a "late event" and org A's task never transitioned.

## What

- `lookupProjectByRepo` now returns the owning **`(orgID, projectID)`** from the globally-unique `git_repositories` row.
- All webhook task resolvers scope by **`org_id` AND `project_id`**:
  - `ApplyToTaskByPR` and the merge/build-dispatch lookup (`+ pull_request_number`)
  - `LinkTaskByIssue` (`+ issue_number`)
  - the `installation_repositories.removed` cascade now matches on the `(org_id, project_id)` tuple (and drops a dead `repoByProject` map).

This closes the collision across the whole webhook chain: link → `ready_for_review` → reject → merge/build-dispatch → installation cleanup.

## Testing

`go build ./...`, `go vet`, and the `services` / `services/webhook` test suites pass. The projector queries run against real Postgres (transactions + advisory locks), so behavioural coverage lives in the integration suite; live validation is re-delivering the PR webhook on dev after deploy, which then routes to the correct org's task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
