### PR TITLE
fix(deploy): use per-org namespaced ComponentType so workloads get the ECR pull secret

### DIFF
--- a/asdlc-service/clients/openchoreo/component_client.go
+++ b/asdlc-service/clients/openchoreo/component_client.go
@@ -689,7 +689,26 @@ func buildCreateComponentBody(projectName string, req *models.CreateComponentReq
 		AnnotationKeyDisplayName: req.DisplayName,
 		AnnotationKeyDescription: req.Description,
 	}
-	ctKind := gen.ComponentSpecComponentTypeKindClusterComponentType
+	// Reference the per-org NAMESPACED ComponentType (not the cluster-scoped
+	// ClusterComponentType). Why: in dev cloud the `deployment/service`
+	// ClusterComponentType is the OpenChoreo built-in, whose render template has
+	// NO `registry-pull-secret` / `imagePullSecrets` — so the deployed workload
+	// can't pull its image from the per-org ECR repo and the Release sits at
+	// ResourcesProgressing (ImagePullBackOff) forever. The platform provisions a
+	// per-org namespaced ComponentType (named `service`/`web-application`, via
+	// platform-api ProvisionOrgUnit) that DOES carry the registry-pull-secret +
+	// imagePullSecrets AND still allows the dockerfile-builder ClusterWorkflow.
+	// Devant and agent-manager both reference the namespaced `ComponentType`
+	// (kind=ComponentType) for the same reason; app-factory was the outlier.
+	//
+	// NOTE — must verify locally before relying on this unconditionally: the
+	// local stack (deployments/scripts/setup-asdlc.sh) currently ships
+	// `service`/`web-application` ONLY as cluster-scoped ClusterComponentTypes
+	// and does not provision per-org namespaced ComponentTypes, so this kind may
+	// need to become env-conditional (ComponentType in cloud, ClusterComponentType
+	// locally) — or local setup updated to provision the namespaced types. The
+	// type NAME (`deployment/service` etc.) is identical for both kinds.
+	ctKind := gen.ComponentSpecComponentTypeKindComponentType
 	body := gen.Component{
 		Metadata: gen.ObjectMeta{
 			Name:        ScopedComponentName(projectName, req.Name),


### PR DESCRIPTION
## Why

User components were stuck at OpenChoreo Release status `ResourcesProgressing` forever — the workload pod couldn't pull its image from the per-org ECR repo (`ImagePullBackOff`, "no basic auth credentials").

Root cause: `buildCreateComponentBody` hardcoded `kind: ClusterComponentType`. In dev cloud, `deployment/service` resolves to the **OpenChoreo built-in** ClusterComponentType, whose render template has **no `registry-pull-secret` / `imagePullSecrets`**. The platform-provisioned **per-org namespaced `ComponentType`** (`service`/`web-application`, applied to every org by platform-api `ProvisionOrgUnit`) **does** carry the `registry-pull-secret` ExternalSecret + `imagePullSecrets`, **and** still lists `dockerfile-builder` in `allowedWorkflows`. Devant and agent-manager both reference `kind: ComponentType` for exactly this reason — app-factory was the outlier.

Verified on the cluster: app-factory orgs (`testkaje4`, `kajeorg3`) have the namespaced `service` type with the pull secret + builder pairing + the `replicas`/HTTPRoute schema defaults app-factory's empty-config deploy relies on. (OpenChoreo itself has no pull-secret render path — it comes only from this per-org type.)

## What

`buildCreateComponentBody`: `kind` → `ComponentType` (name unchanged, e.g. `deployment/service`). Applied **unconditionally** (cloud + local) for now to validate behaviour end-to-end.

## ⚠️ Needs local verification (may become env-conditional)

The local stack (`deployments/scripts/setup-asdlc.sh`) ships `service`/`web-application` only as **cluster-scoped ClusterComponentTypes** and does not provision per-org namespaced ComponentTypes (no platform-api OU provisioning locally). So this change **may break local component creation** ("type not found"). Plan: verify locally; if it breaks, make the kind env-conditional (`ComponentType` cloud / `ClusterComponentType` local) or update local setup to provision the namespaced types. This caveat is documented inline in the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
