### PR TITLE
Fix local repo clone permissions and surface provisioning failures in the console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ deployments/.poc-api-platform-client.env
 # start; teardown wipes it.
 deployments/.kube/
 
+# Project git clones — bind-mounted into asdlc-api at ./data/repos
+deployments/data/repos/*
+!deployments/data/repos/.gitkeep
+
 # Test artifacts
 test-results/
 coverage/

--- a/asdlc-service/models/project.go
+++ b/asdlc-service/models/project.go
@@ -40,12 +40,13 @@ type CreateProjectRequest struct {
 
 // ProjectStatus represents the computed SDLC phase and artifact states.
 type ProjectStatus struct {
-	Phase        string `json:"phase"`        // "no-repo", "repo-cloning", "prompt", "spec", "architecture", "tasks", "components"
-	RepoStatus   string `json:"repoStatus"`   // "", "pending", "cloning", "ready", "error"
-	RepoURL      string `json:"repoUrl"`
-	HasSpec      bool   `json:"hasSpec"`
-	HasDesign    bool   `json:"hasDesign"`
-	HasTasks     bool   `json:"hasTasks"`
-	SpecStatus   string `json:"specStatus"`   // "", "draft", "approved"
-	DesignStatus string `json:"designStatus"` // "", "draft", "approved"
+	Phase            string `json:"phase"`      // "no-repo", "repo-cloning", "repo-error", "prompt", "spec", "architecture", "tasks", "components"
+	RepoStatus       string `json:"repoStatus"` // "", "pending", "cloning", "ready", "error"
+	RepoURL          string `json:"repoUrl"`
+	RepoErrorMessage string `json:"repoErrorMessage,omitempty"` // set when phase is "repo-error"
+	HasSpec          bool   `json:"hasSpec"`
+	HasDesign        bool   `json:"hasDesign"`
+	HasTasks         bool   `json:"hasTasks"`
+	SpecStatus       string `json:"specStatus"`   // "", "draft", "approved"
+	DesignStatus     string `json:"designStatus"` // "", "draft", "approved"
 }

--- a/asdlc-service/services/project_service.go
+++ b/asdlc-service/services/project_service.go
@@ -165,16 +165,7 @@ func (s *projectService) GetProjectStatus(ctx context.Context, orgName, projectN
 		return status, nil
 	}
 
-	status.RepoStatus = repo.Status
-	status.RepoURL = repo.RepoURL
-
-	if repo.Status == "pending" || repo.Status == "cloning" {
-		status.Phase = "repo-cloning"
-		return status, nil
-	}
-
-	if repo.Status == "error" {
-		status.Phase = "no-repo"
+	if done := applyRepoToProjectStatus(status, repo); done {
 		return status, nil
 	}
 
@@ -230,6 +221,30 @@ func (s *projectService) GetProjectStatus(ctx context.Context, orgName, projectN
 
 	status.Phase = "components"
 	return status, nil
+}
+
+// applyRepoToProjectStatus maps a provisioned git_repositories row onto the
+// status fields that depend on repo lifecycle. Returns true when phase is
+// fully determined (no-repo, cloning, or error) and artifact checks can stop.
+func applyRepoToProjectStatus(status *models.ProjectStatus, repo *models.GitRepository) bool {
+	if repo == nil {
+		status.Phase = "no-repo"
+		return true
+	}
+
+	status.RepoStatus = repo.Status
+	status.RepoURL = repo.RepoURL
+
+	switch repo.Status {
+	case "pending", "cloning":
+		status.Phase = "repo-cloning"
+		return true
+	case "error":
+		status.Phase = "repo-error"
+		status.RepoErrorMessage = repo.ErrorMessage
+		return true
+	}
+	return false
 }
 
 // translateHTTPError lifts OC-level sentinel errors (openchoreo.ErrNotFound

--- a/asdlc-service/services/project_status_test.go
+++ b/asdlc-service/services/project_status_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/wso2/asdlc/asdlc-service/models"
+)
+
+func TestApplyRepoToProjectStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		repo       *models.GitRepository
+		wantPhase  string
+		wantDone   bool
+		wantErrMsg string
+	}{
+		{
+			name:      "nil repo",
+			repo:      nil,
+			wantPhase: "no-repo",
+			wantDone:  true,
+		},
+		{
+			name:      "pending",
+			repo:      &models.GitRepository{Status: "pending", RepoURL: "https://github.com/o/r"},
+			wantPhase: "repo-cloning",
+			wantDone:  true,
+		},
+		{
+			name:      "cloning",
+			repo:      &models.GitRepository{Status: "cloning", RepoURL: "https://github.com/o/r"},
+			wantPhase: "repo-cloning",
+			wantDone:  true,
+		},
+		{
+			name:       "error",
+			repo:       &models.GitRepository{Status: "error", RepoURL: "https://github.com/o/r", ErrorMessage: "create directory: permission denied"},
+			wantPhase:  "repo-error",
+			wantDone:   true,
+			wantErrMsg: "create directory: permission denied",
+		},
+		{
+			name:      "ready continues",
+			repo:      &models.GitRepository{Status: "ready", RepoURL: "https://github.com/o/r"},
+			wantPhase: "",
+			wantDone:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			status := &models.ProjectStatus{}
+			done := applyRepoToProjectStatus(status, c.repo)
+			if done != c.wantDone {
+				t.Fatalf("done: got %v want %v", done, c.wantDone)
+			}
+			if c.wantPhase != "" && status.Phase != c.wantPhase {
+				t.Fatalf("phase: got %q want %q", status.Phase, c.wantPhase)
+			}
+			if c.repo != nil && status.RepoStatus != c.repo.Status {
+				t.Fatalf("repoStatus: got %q want %q", status.RepoStatus, c.repo.Status)
+			}
+			if status.RepoErrorMessage != c.wantErrMsg {
+				t.Fatalf("repoErrorMessage: got %q want %q", status.RepoErrorMessage, c.wantErrMsg)
+			}
+		})
+	}
+}

--- a/console/src/pages/ProjectOverviewPage.tsx
+++ b/console/src/pages/ProjectOverviewPage.tsx
@@ -147,6 +147,10 @@ export default function ProjectOverviewPage() {
     return <AuthExpiredState />;
   }
 
+  if (phase === 'repo-error') {
+    return <RepoErrorState repoUrl={status?.repoUrl} errorMessage={status?.repoErrorMessage} />;
+  }
+
   if (phase === 'no-repo') {
     return (
       <PageContent>
@@ -177,6 +181,82 @@ export default function ProjectOverviewPage() {
 // access token expired while the SPA was open. Re-signing in is the only
 // path back; the in-memory React state otherwise still looks "signed in"
 // because asgardeo hasn't observed the failure.
+function RepoErrorState({ repoUrl, errorMessage }: { repoUrl?: string; errorMessage?: string }) {
+  const { orgId } = useParams();
+  const navigate = useNavigate();
+  const routeOrgId = orgId ?? 'default';
+  const { summary, action, showGitHubSettings } = describeRepoError(errorMessage);
+
+  return (
+    <PageContent>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 12, gap: 1.5, maxWidth: 520 }}>
+        <Typography variant="h6" color="text.secondary">
+          We couldn&apos;t set up your repository
+        </Typography>
+        {repoUrl ? (
+          <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+            {repoUrl}
+          </Typography>
+        ) : null}
+        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+          {summary}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+          {action}
+        </Typography>
+        {showGitHubSettings ? (
+          <Button
+            variant="outlined"
+            size="small"
+            sx={{ mt: 1 }}
+            onClick={() => navigate(`/organizations/${routeOrgId}/settings/github`)}
+          >
+            Open GitHub settings
+          </Button>
+        ) : null}
+      </Box>
+    </PageContent>
+  );
+}
+
+function describeRepoError(errorMessage?: string): {
+  summary: string;
+  action: string;
+  showGitHubSettings: boolean;
+} {
+  const raw = errorMessage?.trim() ?? '';
+
+  if (/authentication failed|could not read Username|resolve credential|^token:/i.test(raw)) {
+    return {
+      summary: 'GitHub access for your organization could not be verified.',
+      action: 'Check your GitHub connection, then delete this project and create it again.',
+      showGitHubSettings: true,
+    };
+  }
+
+  if (/clone failed/i.test(raw)) {
+    return {
+      summary: 'The repository could not be cloned from GitHub.',
+      action: 'Confirm the repository exists and your GitHub connection has the required access, then try again.',
+      showGitHubSettings: true,
+    };
+  }
+
+  if (/permission denied/i.test(raw)) {
+    return {
+      summary: 'The platform could not prepare storage for this project.',
+      action: 'Please try again shortly. If this keeps happening, contact your administrator.',
+      showGitHubSettings: false,
+    };
+  }
+
+  return {
+    summary: 'An unexpected error occurred while provisioning the repository.',
+    action: 'Delete this project and try creating it again. Contact your administrator if the problem continues.',
+    showGitHubSettings: false,
+  };
+}
+
 function AuthExpiredState() {
   const { signIn } = useAuth();
   return (

--- a/console/src/services/api/types.ts
+++ b/console/src/services/api/types.ts
@@ -20,10 +20,15 @@
 // Domain types for the ASDLC platform
 // ---------------------------------------------------------------------------
 
-export type ProjectPhase = 'spec' | 'design' | 'components' | 'implementing' | 'done';
-export type SpecStatus = 'draft' | 'approved';
-export type DesignStatus = 'none' | 'generating' | 'draft' | 'approved';
-export type ComponentStatus = 'created' | 'implementing' | 'done';
+export type ProjectPhase =
+  | "spec"
+  | "design"
+  | "components"
+  | "implementing"
+  | "done";
+export type SpecStatus = "draft" | "approved";
+export type DesignStatus = "none" | "generating" | "draft" | "approved";
+export type ComponentStatus = "created" | "implementing" | "done";
 
 export interface ArtifactVersion {
   version: number;
@@ -62,11 +67,11 @@ export interface CollabSession {
 
 export interface DesignComponent {
   name: string;
-  componentType: 'service' | 'web-app';
+  componentType: "service" | "web-app";
   language: string;
   dependsOn: string[];
-  entrypoint: 'deployment/service';
-  buildpack: 'docker';
+  entrypoint: "deployment/service";
+  buildpack: "docker";
   appPath: string;
   // Optional: during streaming, the component card appears (with shape
   // metadata) before its OpenAPI YAML is set. Final design.json from the
@@ -85,14 +90,14 @@ export interface DesignComponent {
 }
 
 export interface APISecurity {
-  security: 'required' | 'none';
+  security: "required" | "none";
 }
 
 export interface DependentApi {
   name: string;
   url: string;
   description?: string;
-  authentication?: 'none' | 'bearer' | 'api-key';
+  authentication?: "none" | "bearer" | "api-key";
 }
 
 export interface Design {
@@ -110,7 +115,7 @@ export interface Design {
 
 export interface ComponentOpenAPI {
   componentName: string;
-  componentType: 'service' | 'web-app';
+  componentType: "service" | "web-app";
   // Raw OpenAPI 3.0 YAML, canonicalised by the BFF. Always present on a 200
   // response. On a 409 (non-service component) the BFF returns the same
   // envelope without a spec — the UI can render a typed empty state.
@@ -165,8 +170,15 @@ export interface Organization {
 
 // -- Build (WorkflowRun) ----------------------------------------------------
 
-export type BuildStatus = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Completed'
-  | 'WorkflowPending' | 'WorkflowSucceeded' | 'WorkflowFailed';
+export type BuildStatus =
+  | "Pending"
+  | "Running"
+  | "Succeeded"
+  | "Failed"
+  | "Completed"
+  | "WorkflowPending"
+  | "WorkflowSucceeded"
+  | "WorkflowFailed";
 
 export interface Build {
   name: string;
@@ -197,17 +209,17 @@ export interface BuildLogs {
 // OC) drive transitions; see asdlc-service/services/task_state.go for the
 // transition table.
 export type TaskStatus =
-  | 'pending'
-  | 'on_hold'
-  | 'in_progress'
-  | 'verification_failed'
-  | 'ready_for_review'
-  | 'merged'
-  | 'building'
-  | 'deployed'
-  | 'rejected'
-  | 'failed'
-  | 'abandoned';
+  | "pending"
+  | "on_hold"
+  | "in_progress"
+  | "verification_failed"
+  | "ready_for_review"
+  | "merged"
+  | "building"
+  | "deployed"
+  | "rejected"
+  | "failed"
+  | "abandoned";
 
 export interface ComponentTask {
   id: string;
@@ -266,14 +278,14 @@ export interface ComponentTask {
 export const TASK_PROGRESS_SCHEMA_VERSION = 1;
 
 export type TaskProgressKind =
-  | 'phase'
-  | 'tool_use'
-  | 'git_commit'
-  | 'git_push'
-  | 'gh_action'
-  | 'log'
-  | 'result'
-  | 'build_step';
+  | "phase"
+  | "tool_use"
+  | "git_commit"
+  | "git_push"
+  | "gh_action"
+  | "log"
+  | "result"
+  | "build_step";
 
 export interface TaskProgressEvent {
   schemaVersion: number;
@@ -287,8 +299,8 @@ export interface TaskProgressEvent {
   branch?: string;
   files?: number;
   command?: string;
-  level?: 'info' | 'warn' | 'error';
-  status?: 'success' | 'failure';
+  level?: "info" | "warn" | "error";
+  status?: "success" | "failure";
   summary?: string;
   error?: string;
   step?: string;
@@ -325,7 +337,7 @@ export interface TaskStatusResponse {
 export interface Tasks {
   projectId: string;
   tasks: ComponentTask[];
-  status: 'approved';
+  status: "approved";
 }
 
 // -- Project Board (sourced from GitHub Project Board) -----------------------
@@ -335,7 +347,11 @@ export interface LabelInfo {
   color: string; // hex without #, e.g. "0075ca"
 }
 
-export type TaskLifecycleStatus = 'gh_issue_waiting' | 'gh_issue_syncing' | 'gh_issue_created' | 'gh_issue_failed';
+export type TaskLifecycleStatus =
+  | "gh_issue_waiting"
+  | "gh_issue_syncing"
+  | "gh_issue_created"
+  | "gh_issue_failed";
 
 export interface Task {
   id: string;
@@ -358,7 +374,7 @@ export interface Task {
   // can dispatch — "WORKER" (coding-agent) tasks must go through the batch
   // dispatch path ("Execute all → Remote Agents"). Used by TaskDetailPanel
   // to gate the "Execute Now" button.
-  execType?: 'SYSTEM' | 'WORKER';
+  execType?: "SYSTEM" | "WORKER";
   // Component name this task targets — used by the Pending Deps column to
   // map this task back to the dep graph.
   componentName?: string;
@@ -398,12 +414,21 @@ export interface ComponentConfig {
 
 // -- Project Status (computed SDLC phase) -------------------------------------
 
-export type ProjectSdlcPhase = 'no-repo' | 'repo-cloning' | 'prompt' | 'spec' | 'architecture' | 'tasks' | 'components';
+export type ProjectSdlcPhase =
+  | "no-repo"
+  | "repo-cloning"
+  | "repo-error"
+  | "prompt"
+  | "spec"
+  | "architecture"
+  | "tasks"
+  | "components";
 
 export interface ProjectStatus {
   phase: ProjectSdlcPhase;
   repoStatus: string;
   repoUrl: string;
+  repoErrorMessage?: string;
   hasSpec: boolean;
   hasDesign: boolean;
   hasTasks: boolean;

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -173,8 +173,9 @@ services:
       OBSERVER_OAUTH_HOST_HEADER: "${OBSERVER_OAUTH_HOST_HEADER:-thunder.openchoreo.localhost}"
     volumes:
       - ./keys/task-signing.pem:/app/keys/task-signing.pem:ro
-      # Folded-in git-service volumes (after WS0.1).
-      - ${HOME}/specs/repos:/data/repos
+      # Folded-in git-service volumes (after WS0.1). Host path is prepared by
+      # start.sh (ensure_repo_storage) so appuser (uid 1000) can mkdir clones.
+      - ./data/repos:/data/repos
       - ./github-app-private-key.pem:/etc/github-app/private-key.pem:ro
       - ./.kube/config:/app/.kube/config:ro
     networks:
@@ -294,7 +295,13 @@ services:
     container_name: asdlc-smee-client
     depends_on:
       - asdlc-api
-    command: ["--url", "${GITHUB_WEBHOOK_PROXY_URL}", "--target", "http://asdlc-api:9090/webhooks/github"]
+    command:
+      [
+        "--url",
+        "${GITHUB_WEBHOOK_PROXY_URL}",
+        "--target",
+        "http://asdlc-api:9090/webhooks/github",
+      ]
     networks:
       - asdlc
     restart: unless-stopped

--- a/deployments/scripts/start.sh
+++ b/deployments/scripts/start.sh
@@ -155,7 +155,14 @@ else
     [ -f "$INTERNAL_KUBECONFIG" ] || touch "$INTERNAL_KUBECONFIG"
 fi
 
-# 4. BFF Task JWT signing key — bind-mounted into asdlc-api as
+# 4. Repo workspace bind mount — asdlc-api clones project repos here
+#    (REPO_BASE_PATH=/data/repos). Must exist and be writable by appuser
+#    (uid 1000) before compose creates the mount as root.
+echo ""
+echo "📁 Ensuring repo storage at $DEPLOY_DIR/data/repos..."
+ensure_repo_storage "$DEPLOY_DIR/data/repos"
+
+# 5. BFF Task JWT signing key — bind-mounted into asdlc-api as
 #    /app/keys/task-signing.pem (docker-compose volume). The BFF reads
 #    the PEM from BFF_TASK_SIGNING_KEY_PATH; mounting beats env-passing
 #    a multi-line value through compose's `${VAR}` substitution.
@@ -167,7 +174,7 @@ else
     chmod 644 "$TASK_KEY_PATH"
 fi
 
-# 5. Sync public URLs (.env → cluster). Touches Thunder ConfigMap, OIDC
+# 6. Sync public URLs (.env → cluster). Touches Thunder ConfigMap, OIDC
 #    issuer, HTTPRoute, redirect_uris. Idempotent — fast no-op if nothing
 #    changed.
 echo ""
@@ -178,7 +185,7 @@ else
     echo "⚠️  k3d cluster not accessible — skipping public-URL sync"
 fi
 
-# 6. Bring up the compose stack. The coding-agent runner is no longer a
+# 7. Bring up the compose stack. The coding-agent runner is no longer a
 #    long-lived service — it's dispatched as a one-shot pod via the
 #    `app-factory-coding-agent` ClusterWorkflow in the cluster (installed
 #    by setup-asdlc.sh). No host-mode toggle here.
@@ -188,7 +195,7 @@ echo "🐳 Starting Docker services..."
 docker compose up --build -d
 echo "✅ Docker services started"
 
-# 7. Repair per-org secrets in OpenBao. When the local cluster (or just the
+# 8. Repair per-org secrets in OpenBao. When the local cluster (or just the
 #    OpenBao volume) has been torn down since the last credential connect,
 #    the SM-API metadata rows still point at OpenBao paths that no longer
 #    exist. Without this stage every coding-agent dispatch hangs in

--- a/deployments/scripts/start.sh
+++ b/deployments/scripts/start.sh
@@ -148,7 +148,8 @@ if kubectl cluster-info --context "${CLUSTER_CONTEXT}" --request-timeout=5s &>/d
         rm -f "$INTERNAL_KUBECONFIG.bak"
         echo "✅ Wrote rewritten kubeconfig → $INTERNAL_KUBECONFIG"
     fi
-    chmod 600 "$INTERNAL_KUBECONFIG"
+    # 644 so non-root compose containers (appuser uid 1000) can read the bind mount.
+    chmod 644 "$INTERNAL_KUBECONFIG"
 else
     echo "⚠️  Cluster unreachable — leaving existing $INTERNAL_KUBECONFIG (may be stale)"
     [ -f "$INTERNAL_KUBECONFIG" ] || touch "$INTERNAL_KUBECONFIG"
@@ -162,6 +163,8 @@ TASK_KEY_PATH="$DEPLOY_DIR/keys/task-signing.pem"
 if [ ! -f "$TASK_KEY_PATH" ]; then
     echo "⚠️  BFF Task JWT signing key missing at $TASK_KEY_PATH — coding-agent dispatch will fail."
     echo "   Run setup-asdlc.sh to generate it."
+else
+    chmod 644 "$TASK_KEY_PATH"
 fi
 
 # 5. Sync public URLs (.env → cluster). Touches Thunder ConfigMap, OIDC

--- a/deployments/scripts/teardown.sh
+++ b/deployments/scripts/teardown.sh
@@ -72,17 +72,13 @@ echo "4️⃣  Clean generated artifacts"
 rm -f "$DEPLOY_DIR/.kube/config" 2>/dev/null && echo "   removed deployments/.kube/config" || true
 rm -rf "$DEPLOY_DIR/.kube" 2>/dev/null || true
 
-# git-service stores cloned workspaces at the host bind mount declared on
-# the git-service compose service (see docker-compose.yml `volumes:`).
-# docker compose down -v wipes named volumes but NOT bind mounts, so
-# without this the next `setup.sh` runs into "destination path already
-# exists" when git-service tries to clone a freshly-created repo into a
-# stale workspace.
-# NOTE: previously hardcoded to ${HOME}/.asdlc/repos. The mount was renamed
-# to ${HOME}/specs/repos (commit 6232ff4) — read it back from the compose
-# file instead so this can't drift again.
+# asdlc-api stores cloned workspaces at the host bind mount declared in
+# docker-compose.yml `volumes:` (REPO_BASE_PATH=/data/repos). compose down
+# -v wipes named volumes but NOT bind mounts, so without this the next
+# project create can hit stale workspace dirs.
+# Read the host path from compose (currently ./data/repos) so this can't drift.
 REPOS_HOST_PATH=$(awk '
-  /^  git-service:/      { in_svc=1; next }
+  /^  asdlc-api:/        { in_svc=1; next }
   in_svc && /^  [a-z]/   { in_svc=0 }
   in_svc && /:\/data\/repos$/ {
     sub(/^[[:space:]]*-[[:space:]]*/, "")
@@ -92,9 +88,14 @@ REPOS_HOST_PATH=$(awk '
 # Expand ${HOME} (and similar) without sourcing the file.
 REPOS_HOST_PATH="${REPOS_HOST_PATH//\$\{HOME\}/$HOME}"
 REPOS_HOST_PATH="${REPOS_HOST_PATH//\$HOME/$HOME}"
+if [[ "$REPOS_HOST_PATH" == ./* ]]; then
+    REPOS_HOST_PATH="$DEPLOY_DIR/${REPOS_HOST_PATH#./}"
+elif [[ -n "$REPOS_HOST_PATH" && "$REPOS_HOST_PATH" != /* ]]; then
+    REPOS_HOST_PATH="$DEPLOY_DIR/$REPOS_HOST_PATH"
+fi
 if [ -n "$REPOS_HOST_PATH" ] && [ -d "$REPOS_HOST_PATH" ]; then
     rm -rf "$REPOS_HOST_PATH" 2>/dev/null \
-        && echo "   removed git-service workspaces at $REPOS_HOST_PATH" \
+        && echo "   removed repo workspaces at $REPOS_HOST_PATH" \
         || echo "   ⚠️  failed to remove $REPOS_HOST_PATH — clean it manually before next setup"
 fi
 

--- a/deployments/scripts/utils.sh
+++ b/deployments/scripts/utils.sh
@@ -328,8 +328,10 @@ load_public_urls() {
     PUBLIC_THUNDER_URL=""
     PUBLIC_CONSOLE_URL=""
     if [ -f "$env_file" ]; then
-        PUBLIC_THUNDER_URL="$(grep -E '^PUBLIC_THUNDER_URL=' "$env_file" | head -1 | cut -d= -f2-)"
-        PUBLIC_CONSOLE_URL="$(grep -E '^PUBLIC_CONSOLE_URL=' "$env_file" | head -1 | cut -d= -f2-)"
+        # grep exits 1 when no match — tolerate with || true so callers using
+        # set -o pipefail don't abort before the defaults below apply.
+        PUBLIC_THUNDER_URL="$(grep -E '^PUBLIC_THUNDER_URL=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+        PUBLIC_CONSOLE_URL="$(grep -E '^PUBLIC_CONSOLE_URL=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)"
     fi
     # First-install fallback: .env doesn't exist yet, so use local defaults.
     : "${PUBLIC_THUNDER_URL:=http://thunder.openchoreo.localhost:8080}"

--- a/deployments/scripts/utils.sh
+++ b/deployments/scripts/utils.sh
@@ -542,6 +542,25 @@ PY
     echo "✅ Public URLs synced"
 }
 
+# ensure_repo_storage prepares the host bind mount for asdlc-api's
+# REPO_BASE_PATH (/data/repos). asdlc-api runs as uid 1000 (appuser); on
+# Linux the host uid often differs, and Docker creates missing bind-mount
+# parents as root — both cause "permission denied" on clone. Mode 1777
+# (sticky, world-writable) is local-dev-only and avoids sudo chown.
+ensure_repo_storage() {
+    local repos_dir="$1"
+    if [ -z "$repos_dir" ]; then
+        echo "❌ ensure_repo_storage: path required"
+        return 1
+    fi
+    mkdir -p "$repos_dir"
+    if ! chmod 1777 "$repos_dir" 2>/dev/null; then
+        echo "❌ Cannot set permissions on $repos_dir"
+        echo "   Fix ownership/permissions so the container user (uid 1000) can write there."
+        return 1
+    fi
+}
+
 generate_machine_ids() {
     local cluster_name="$1"
     echo "🆔 Generating machine IDs..."


### PR DESCRIPTION
## Purpose 

Fixes #40 
On Linux local setups, project creation often failed silently: the BFF could not clone GitHub repos because the bind-mounted repo directory (`~/specs/repos`) was created root-owned by Docker while `asdlc-api` runs as uid 1000. The DB recorded `git_repositories.status=error`, but the console showed a misleading **“No Git repository associated”** empty state.

Resolves local repo clone permission failures and incorrect project overview UI for failed provisioning.

## Goals
- Ensure repo storage is writable by the API container before `docker compose up`
- Stop mapping repo provisioning failures to the “no repo” phase
- Show a clear, user-facing error in the console when repository setup fails

## Approach
**Deployments**
- Move the host bind mount from `${HOME}/specs/repos` to `deployments/data/repos`
- Add `ensure_repo_storage()` in `deployments/scripts/utils.sh` (`mkdir -p` + `chmod 1777`) and call it from `start.sh` before compose starts
- Update `teardown.sh` to resolve the repo path from the `asdlc-api` service in `docker-compose.yml`

**BFF**
- Add `repo-error` SDLC phase and `repoErrorMessage` on `ProjectStatus`
- Extract `applyRepoToProjectStatus()` so `error` repo status is distinct from a missing repo

**Console**
- Handle `repo-error` with a SaaS-friendly empty state (no deployment commands or raw backend errors)
- Map known failure patterns to user-facing copy; link to GitHub settings when credentials/access are likely the cause

**Git**
- Ignore `deployments/data/repos/*` (runtime clones); track only `.gitkeep`

## User stories
- As a developer on Linux, I can create a project and have its GitHub repo cloned without fixing filesystem permissions manually.
- As a user, when repository setup fails, I see that setup failed and what to do next — not “create a new project”.

## Release note
Fixed repository clone failures on Linux local deployments caused by bind-mount permissions, and improved the project overview when Git repository provisioning fails.

## Documentation
N/A

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
- **Unit tests**
  - `asdlc-service/services/project_status_test.go` — `TestApplyRepoToProjectStatus` covers `no-repo`, `repo-cloning`, `repo-error`, and `ready` continuation
- **Integration tests**
  - N/A — deployment script behavior verified manually; no new API integration tests added

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** (no Java changes)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
**Local developers only:**
1. Pull this change
2. Run `cd deployments && bash scripts/start.sh`
3. Clones now live under `deployments/data/repos/` (not `~/specs/repos`)
4. Projects stuck in `error` before the fix must be deleted and recreated

Optional: migrate existing clones with `cp -a ~/specs/repos/. deployments/data/repos/`

Tested on Linux (Docker Compose + k3d local setup).

## Test environment
- OS: Linux
- Browser: Chrome/Firefox (console UI)
- Backend: Go 1.26 (`asdlc-api`), Docker Compose local stack

## Learning
Root cause was a classic Docker bind-mount ownership mismatch: missing host dirs created as root, container writes as uid 1000. Mac/Colima setups were more forgiving. Fix follows existing patterns in `start.sh` (kubeconfig + signing key permission prep) and uses a repo-local path like `deployments/keys/`.