### PR TITLE
fix(progress): parse runner NDJSON envelopes in new-path agent log feed

### DIFF
--- a/asdlc-service/clients/clustergatewayproxy/client.go
+++ b/asdlc-service/clients/clustergatewayproxy/client.go
@@ -54,6 +54,14 @@ import (
 // ErrNotFound is returned by Get* methods when the proxy returns 404.
 var ErrNotFound = errors.New("clustergatewayproxy: not found")
 
+// ErrPodNotReady is returned by StreamPodLog/TailPodLog when the pod
+// exists but its container hasn't started yet (k8s answers the log
+// endpoint with 400 "is waiting to start: ContainerCreating" /
+// "PodInitializing"). Callers tailing a freshly-scheduled Job should
+// treat this like ErrNotFound — empty progress, keep polling — rather
+// than surfacing it as a hard error.
+var ErrPodNotReady = errors.New("clustergatewayproxy: pod not ready")
+
 // AuthProvider supplies the Bearer token attached to proxy requests. It
 // matches the Token() method of *oauth.TokenProvider so that type satisfies
 // the interface as-is.
@@ -394,10 +402,28 @@ func (c *Client) StreamPodLog(ctx context.Context, namespace, podName string, op
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		_ = resp.Body.Close()
+		// A freshly-scheduled pod answers its log endpoint with 400
+		// "container … is waiting to start: ContainerCreating" (or
+		// "PodInitializing") until the container is up. That's a
+		// not-ready-yet signal, not a real failure — surface it as a
+		// typed sentinel so live-tail callers can keep polling silently.
+		if resp.StatusCode == http.StatusBadRequest && isContainerNotStarted(string(body)) {
+			return nil, ErrPodNotReady
+		}
 		return nil, fmt.Errorf("clustergatewayproxy: GET %s status %d: %s",
 			path, resp.StatusCode, string(body))
 	}
 	return resp.Body, nil
+}
+
+// isContainerNotStarted reports whether a k8s log-endpoint error body
+// indicates the container simply hasn't started yet (vs a genuine
+// failure). Matches the substrings k8s uses across ContainerCreating /
+// PodInitializing waiting states.
+func isContainerNotStarted(body string) bool {
+	return strings.Contains(body, "ContainerCreating") ||
+		strings.Contains(body, "PodInitializing") ||
+		strings.Contains(body, "waiting to start")
 }
 
 // TailPodLog reads the pod log in one shot — used by JobWatcher to

--- a/asdlc-service/services/progress_service.go
+++ b/asdlc-service/services/progress_service.go
@@ -543,7 +543,13 @@ func (s *progressService) getAgentProgressNewPath(ctx context.Context, task *mod
 		LimitBytes: newPathLogPageBytes,
 	})
 	if err != nil {
-		if errors.Is(err, clustergatewayproxy.ErrNotFound) {
+		// ErrNotFound: pod GC'd / not scheduled. ErrPodNotReady: pod
+		// scheduled but container still starting (ContainerCreating /
+		// PodInitializing). Both mean "no logs yet" — return empty +
+		// non-final so the console keeps polling instead of flashing
+		// "Live progress unavailable" at task start.
+		if errors.Is(err, clustergatewayproxy.ErrNotFound) ||
+			errors.Is(err, clustergatewayproxy.ErrPodNotReady) {
 			return resp, nil
 		}
 		return nil, fmt.Errorf("tail pod log: %w", err)
@@ -656,20 +662,25 @@ func textToProgressEvents(text string, limit int, truncated *bool) []observer.Pr
 	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 	for scanner.Scan() {
 		ts, msg := splitTimestampPrefix(scanner.Text())
-		out = append(out, observer.ProgressEvent{
-			SchemaVersion: observer.ProgressSchemaVersion,
-			Ts:            ts,
-			// `kind: log` + `summary` matches the typed envelope the
-			// console's `summaryFor`/`iconFor` switch on (see
-			// console/src/components/tasks/TaskActivityFeed.tsx:38, 52
-			// and console/src/services/api/types.ts:260). The legacy
-			// Observer path uses the same shape (see
-			// clients/observer/schema.go:64). Using `summary` (not
-			// `message`) lets the console render without any client
-			// change.
-			Kind:    "log",
-			Summary: msg,
-		})
+		// The runner emits typed NDJSON envelopes (kind:phase/tool_use/
+		// gh_action/git_commit/…; schema at
+		// remote-worker/src/lib/progress/schema.ts). Decode each line
+		// with the SAME parser the legacy Observer path uses
+		// (parseAndSort → ParseProgressLine) so the console renders
+		// formatted rows instead of raw JSON. Genuinely non-JSON lines
+		// (e.g. "[oneshot] …" bootstrap output) fall back to kind:log
+		// with the line as `summary` inside ParseProgressLine.
+		ev := observer.ParseProgressLine(msg)
+		// Prefer the envelope's own `ts`; fall back to the K8s
+		// `timestamps=true` prefix so cursor math + ordering still work
+		// for lines that carry no embedded ts (the log fallback).
+		if ev.Ts == "" {
+			ev.Ts = ts
+		}
+		if ev.SchemaVersion == 0 {
+			ev.SchemaVersion = observer.ProgressSchemaVersion
+		}
+		out = append(out, ev)
 	}
 	if len(out) > limit {
 		// Keep the newest `limit` events so the live tail surfaces


### PR DESCRIPTION
## Problem

In the live-progress activity feed, coding-agent runs dispatched via the new `ca-…` run-name path render **raw NDJSON** instead of formatted rows:

```
{"schemaVersion":1,"ts":"…","seq":1,"kind":"phase","phase":"workspace_provisioning"}
{"schemaVersion":1,"ts":"…","seq":4,"kind":"tool_use","tool":"Skill","summary":"…"}
```

## Root cause

The new-path pod-log reader (`getAgentProgressNewPath`, introduced in `bf3c192`) funnels pod stdout through `textToProgressEvents`, which wrapped **every** line as a raw `kind:log` event with the whole JSON string in `summary`. The console's `summaryFor` renders `kind:log` verbatim → raw JSON on screen.

The legacy Observer path (`parseAndSort`) decodes each line with `observer.ParseProgressLine`, which parses the typed envelope (`phase` / `tool_use` / `gh_action` / …) and only falls back to `kind:log` for genuinely non-JSON lines. The new path simply never called it.

## Fix

- **`textToProgressEvents`** now decodes each line with `observer.ParseProgressLine` — identical to the Observer path. Typed envelopes render as proper rows; non-JSON bootstrap lines (`[oneshot] …`) still show as log entries. Prefers the envelope's `ts`, falls back to the K8s `timestamps=true` prefix so cursor math + ordering are unchanged. Fixes both the live tail and the terminal snapshot (shared helper).
- **`clustergatewayproxy.ErrPodNotReady`** — new typed sentinel. `StreamPodLog` returns it on the `400 "… is waiting to start: ContainerCreating / PodInitializing"` the k8s log endpoint emits during pod startup. The live-tail path treats it like `ErrNotFound` (empty + non-final), so the console no longer flashes **"Live progress unavailable — falling back to status polling"** at task start.

## Scope

BFF-only (`asdlc-service`); no platform/OC surface touched.

- `asdlc-service/services/progress_service.go`
- `asdlc-service/clients/clustergatewayproxy/client.go`

## Testing

- `go build ./...`, `go vet ./services/ ./clients/clustergatewayproxy/`, `go test ./services/` — all pass.
- Rebuilt `asdlc-api` locally and confirmed clean startup (`progress: cluster-gateway-proxy log source enabled`). Snapshots are re-parsed on read, so existing captured runs render correctly too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)