### PR TITLE
fix(ci): ignore GHA cache write errors in build-images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -48,7 +48,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=asdlc-api
-          cache-to: type=gha,mode=max,scope=asdlc-api
+          cache-to: type=gha,mode=max,scope=asdlc-api,ignore-error=true
 
   agents-service:
     name: agents-service
@@ -83,7 +83,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=agents-service
-          cache-to: type=gha,mode=max,scope=agents-service
+          cache-to: type=gha,mode=max,scope=agents-service,ignore-error=true
 
   asdlc-console:
     name: asdlc-console
@@ -120,4 +120,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=asdlc-console
-          cache-to: type=gha,mode=max,scope=asdlc-console
+          cache-to: type=gha,mode=max,scope=asdlc-console,ignore-error=true


### PR DESCRIPTION
## Summary

- Adds `ignore-error=true` to the `cache-to` line for all three jobs (`asdlc-api`, `agents-service`, `asdlc-console`)

Docker Buildx's GHA cache backend intermittently returns `not_found` when writing layer blobs. This causes the workflow to fail even though the image was built and pushed successfully. With `ignore-error=true`, a cache export failure is treated as a warning and the job succeeds.

## Test plan
- [ ] Trigger the workflow by merging a change — confirm all three image jobs pass even if cache export fails