### PR TITLE
fix(agents): bound Anthropic key resolve with timeout + single-flight

### DIFF
--- a/agents/src/shared/anthropic-key-resolver.test.ts
+++ b/agents/src/shared/anthropic-key-resolver.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createServer,
+  type Server,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  resolveAnthropicKey,
+  resetAnthropicCache,
+  invalidateAnthropicCache,
+  AnthropicKeyError,
+} from "./anthropic-key-resolver.js";
+
+interface TestServer {
+  server: Server;
+  baseUrl: string;
+  requests: number;
+}
+
+/**
+ * Stand up a one-off effective-key stub and point the resolver at it via
+ * ASDLC_API_URL (read at call time, so per-test reassignment is enough). The
+ * handler receives the running request count so tests can assert coalescing.
+ */
+function startServer(
+  handler: (req: IncomingMessage, res: ServerResponse, count: number) => void,
+): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const ctx: TestServer = {
+      server: undefined as unknown as Server,
+      baseUrl: "",
+      requests: 0,
+    };
+    const server = createServer((req, res) => {
+      ctx.requests += 1;
+      handler(req, res, ctx.requests);
+    });
+    ctx.server = server;
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      ctx.baseUrl = `http://127.0.0.1:${port}`;
+      process.env.ASDLC_API_URL = ctx.baseUrl;
+      resolve(ctx);
+    });
+  });
+}
+
+function stopServer(ts: TestServer): Promise<void> {
+  return new Promise((resolve) => {
+    // Drop any still-open (e.g. deliberately hung) sockets so close resolves.
+    ts.server.closeAllConnections?.();
+    ts.server.close(() => resolve());
+  });
+}
+
+function jsonOk(res: ServerResponse, body: unknown): void {
+  res.setHeader("Content-Type", "application/json");
+  res.statusCode = 200;
+  res.end(JSON.stringify(body));
+}
+
+test("resolveAnthropicKey: empty orgId is a 400 resolver_error", async () => {
+  resetAnthropicCache();
+  await assert.rejects(
+    () => resolveAnthropicKey(""),
+    (err: unknown) =>
+      err instanceof AnthropicKeyError &&
+      err.code === "resolver_error" &&
+      err.status === 400,
+  );
+});
+
+test("resolveAnthropicKey: coalesces concurrent misses into one upstream call", async () => {
+  resetAnthropicCache();
+  const ts = await startServer((_req, res) => {
+    // Delay so all six callers pile up while the first fetch is in flight.
+    setTimeout(() => jsonOk(res, { source: "org", key: "sk-ant-aaa" }), 40);
+  });
+  try {
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => resolveAnthropicKey("org-sf")),
+    );
+    for (const r of results) {
+      assert.equal(r.source, "org");
+      assert.equal(r.key, "sk-ant-aaa");
+    }
+    assert.equal(ts.requests, 1, "expected a single coalesced upstream call");
+  } finally {
+    await stopServer(ts);
+  }
+});
+
+test("resolveAnthropicKey: serves from cache, refetches after invalidate", async () => {
+  resetAnthropicCache();
+  const ts = await startServer((_req, res) =>
+    jsonOk(res, { source: "platform", key: "sk-ant-bbb" }),
+  );
+  try {
+    const a = await resolveAnthropicKey("org-cache");
+    assert.equal(a.key, "sk-ant-bbb");
+    assert.equal(ts.requests, 1);
+
+    const b = await resolveAnthropicKey("org-cache");
+    assert.equal(b.key, "sk-ant-bbb");
+    assert.equal(ts.requests, 1, "second call should hit the in-process cache");
+
+    invalidateAnthropicCache("org-cache");
+    const c = await resolveAnthropicKey("org-cache");
+    assert.equal(c.key, "sk-ant-bbb");
+    assert.equal(ts.requests, 2, "invalidate should force a refetch");
+  } finally {
+    await stopServer(ts);
+  }
+});
+
+test("resolveAnthropicKey: times out a hung upstream instead of hanging", async () => {
+  resetAnthropicCache();
+  const prev = process.env.ANTHROPIC_KEY_RESOLVE_TIMEOUT_MS;
+  process.env.ANTHROPIC_KEY_RESOLVE_TIMEOUT_MS = "120";
+  const ts = await startServer((_req, res) => {
+    // Never respond. The fallback timer is unref'd so it can't keep the test
+    // process alive; the resolver's own timeout should fire first.
+    const t = setTimeout(() => res.end(), 5_000);
+    t.unref?.();
+  });
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      () => resolveAnthropicKey("org-timeout"),
+      (err: unknown) => {
+        assert.ok(err instanceof AnthropicKeyError);
+        assert.equal((err as AnthropicKeyError).code, "resolver_unreachable");
+        assert.equal((err as AnthropicKeyError).status, 502);
+        assert.match((err as AnthropicKeyError).message, /did not respond within/);
+        return true;
+      },
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed < 2_000, `expected a fast timeout, took ${elapsed}ms`);
+  } finally {
+    process.env.ANTHROPIC_KEY_RESOLVE_TIMEOUT_MS = prev;
+    await stopServer(ts);
+  }
+});
+
+test("resolveAnthropicKey: 'none' rejects and is not cached", async () => {
+  resetAnthropicCache();
+  const ts = await startServer((_req, res) =>
+    jsonOk(res, { source: "none", key: "" }),
+  );
+  try {
+    await assert.rejects(
+      () => resolveAnthropicKey("org-none"),
+      (err: unknown) =>
+        err instanceof AnthropicKeyError &&
+        err.code === "no_anthropic_key_configured" &&
+        err.status === 503,
+    );
+    await assert.rejects(() => resolveAnthropicKey("org-none"), AnthropicKeyError);
+    assert.equal(ts.requests, 2, "absence must not be cached");
+  } finally {
+    await stopServer(ts);
+  }
+});
+
+test("resolveAnthropicKey: non-2xx surfaces resolver_error", async () => {
+  resetAnthropicCache();
+  const ts = await startServer((_req, res) => {
+    res.statusCode = 500;
+    res.end("boom");
+  });
+  try {
+    await assert.rejects(
+      () => resolveAnthropicKey("org-5xx"),
+      (err: unknown) =>
+        err instanceof AnthropicKeyError && err.code === "resolver_error",
+    );
+  } finally {
+    await stopServer(ts);
+  }
+});

--- a/agents/src/shared/anthropic-key-resolver.ts
+++ b/agents/src/shared/anthropic-key-resolver.ts
@@ -52,6 +52,7 @@ export class AnthropicKeyError extends Error {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_RESOLVE_TIMEOUT_MS = 5_000;
 
 interface CacheEntry {
   value: EffectiveKey;
@@ -59,6 +60,13 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+
+/**
+ * In-flight resolves keyed by orgId. Single-flight: a cache miss under
+ * concurrency (cold start, or right after an invalidate) coalesces onto one
+ * upstream call instead of firing N parallel resolves for the same org.
+ */
+const inFlight = new Map<string, Promise<EffectiveKey>>();
 
 /**
  * Invalidate the cached entry for ocOrgId. Called by the
@@ -69,10 +77,21 @@ export function invalidateAnthropicCache(ocOrgId: string): void {
 }
 
 /**
- * Reset the entire cache. Useful in tests.
+ * Reset the entire cache (and any in-flight resolves). Useful in tests.
  */
 export function resetAnthropicCache(): void {
   cache.clear();
+  inFlight.clear();
+}
+
+/**
+ * Upper bound for a single effective-key resolve against asdlc-api. Read at
+ * call time so it can be tuned via env without a rebuild. A hung BFF must not
+ * be able to hang every agent request indefinitely.
+ */
+function resolveTimeoutMs(): number {
+  const raw = parseInt(process.env.ANTHROPIC_KEY_RESOLVE_TIMEOUT_MS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_RESOLVE_TIMEOUT_MS;
 }
 
 function asdlcApiUrl(): string {
@@ -86,7 +105,12 @@ function asdlcApiUrl(): string {
 /**
  * Resolve the effective Anthropic key for ocOrgId. Throws AnthropicKeyError
  * when no key is configured (org row absent AND platform env empty) or
- * when the resolver itself is unreachable / returns a non-2xx.
+ * when the resolver itself is unreachable / times out / returns a non-2xx.
+ *
+ * Hot path: called once per agent request. A fresh value is served from the
+ * 5-minute cache; a miss goes to asdlc-api under a single-flight guard (so a
+ * burst of concurrent misses for one org makes a single upstream call) with a
+ * bounded timeout (so a hung BFF can't hang agent requests indefinitely).
  *
  * The returned key is used inline by `createAnthropic({ apiKey: key })`
  * — see shared/create-agent.ts. It is never logged.
@@ -102,11 +126,45 @@ export async function resolveAnthropicKey(
     );
   }
 
-  const now = Date.now();
   const cached = cache.get(ocOrgId);
-  if (cached && cached.expiresAt > now) {
+  if (cached && cached.expiresAt > Date.now()) {
     return cached.value;
   }
+
+  // Single-flight: if a resolve for this org is already running, await it
+  // rather than starting another. The cache read above and the map ops below
+  // run synchronously with no intervening await, so at most one fetch is in
+  // flight per org. Errors (and "none") are intentionally not cached, so a
+  // failed resolve clears the slot and the next call retries.
+  const pending = inFlight.get(ocOrgId);
+  if (pending) return pending;
+
+  const p = fetchEffectiveKey(ocOrgId);
+  inFlight.set(ocOrgId, p);
+  try {
+    return await p;
+  } finally {
+    inFlight.delete(ocOrgId);
+  }
+}
+
+/**
+ * AbortSignal.timeout rejects with a "TimeoutError"; a manual abort surfaces
+ * as "AbortError". Checked by name (not `instanceof Error`) because Node's
+ * DOMException does not extend Error.
+ */
+function isAbortLike(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name;
+  return name === "TimeoutError" || name === "AbortError";
+}
+
+/**
+ * One uncached fetch of the effective key from asdlc-api, bounded by a
+ * timeout that covers both the request and the response body read. Caches the
+ * value on success; throws (without caching) otherwise.
+ */
+async function fetchEffectiveKey(ocOrgId: string): Promise<EffectiveKey> {
+  const timeoutMs = resolveTimeoutMs();
 
   let resp: Response;
   try {
@@ -117,11 +175,21 @@ export async function resolveAnthropicKey(
         headers: {
           accept: "application/json",
         },
+        signal: AbortSignal.timeout(timeoutMs),
       },
     );
   } catch (err) {
+    // A timeout/abort means the upstream is effectively unreachable — surface
+    // it as such rather than hanging the caller.
+    if (isAbortLike(err)) {
+      throw new AnthropicKeyError(
+        `asdlc-api did not respond within ${timeoutMs}ms`,
+        "resolver_unreachable",
+        502,
+      );
+    }
     throw new AnthropicKeyError(
-      `asdlc-api unreachable: ${(err as Error).message}`,
+      `asdlc-api unreachable: ${(err as Error)?.message ?? String(err)}`,
       "resolver_unreachable",
       502,
     );
@@ -136,7 +204,25 @@ export async function resolveAnthropicKey(
     );
   }
 
-  const data = (await resp.json()) as EffectiveKey;
+  let data: EffectiveKey;
+  try {
+    data = (await resp.json()) as EffectiveKey;
+  } catch (err) {
+    // The timeout also covers the body read: a BFF that sends 200 headers and
+    // then stalls the body is still a hung upstream, not a bad payload.
+    if (isAbortLike(err)) {
+      throw new AnthropicKeyError(
+        `asdlc-api did not respond within ${timeoutMs}ms`,
+        "resolver_unreachable",
+        502,
+      );
+    }
+    throw new AnthropicKeyError(
+      `asdlc-api returned an unreadable body: ${(err as Error)?.message ?? String(err)}`,
+      "resolver_error",
+      502,
+    );
+  }
   if (!data || (data.source !== "org" && data.source !== "platform" && data.source !== "none")) {
     throw new AnthropicKeyError(
       "asdlc-api returned an unexpected effective-key shape",
@@ -158,7 +244,7 @@ export async function resolveAnthropicKey(
 
   cache.set(ocOrgId, {
     value: data,
-    expiresAt: now + CACHE_TTL_MS,
+    expiresAt: Date.now() + CACHE_TTL_MS,
   });
 
   console.log(


### PR DESCRIPTION
## Problem

`resolveAnthropicKey` runs on the hot path of **every** agent request (architect, tech-lead, requirements-chat, etc.). On a cache miss it called `asdlc-api` with two latency hazards:

- **No timeout** — a hung/slow BFF would hang the agent request indefinitely (unbounded tail latency).
- **No single-flight** — concurrent misses for one org (cold start, or right after a `/cache/invalidate`) fired N parallel resolves at the BFF.

## Fix

- **Bounded timeout** via `AbortSignal.timeout`, covering both the request *and* the response-body read (a BFF that sends `200` headers then stalls the body is still a hung upstream). Configurable via `ANTHROPIC_KEY_RESOLVE_TIMEOUT_MS` (default `5000`ms), read at call time. Timeouts surface as the existing `resolver_unreachable` (502).
- **Single-flight coalescing** keyed by orgId: concurrent misses await one shared fetch. The cache read + map ops run synchronously with no intervening `await`, so at most one fetch is in flight per org. Errors and `"none"` stay uncached, so a newly configured key is still picked up immediately.

No change to existing error codes/statuses or the 5-minute cache semantics.

## Tests

Adds `agents/src/shared/anthropic-key-resolver.test.ts`:

- coalescing → exactly 1 upstream call for 6 concurrent callers
- cache hit + refetch-after-invalidate
- fast timeout on a hung upstream
- `"none"` rejects and is not cached
- non-2xx → `resolver_error`
- empty-org guard

`npm run typecheck` clean; full agents suite **64/64** passing.
