### PR TITLE
fix(migration): exclude _skills sentinel from F2 cross-org verify

### DIFF
--- a/asdlc-service/database/migrations/git_repo_composite_unique.go
+++ b/asdlc-service/database/migrations/git_repo_composite_unique.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/wso2/asdlc/asdlc-service/models"
 	"gorm.io/gorm"
 )
 
@@ -47,13 +48,18 @@ func RunGitRepoCompositeUnique(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("F2 expand (composite unique): %w", err)
 	}
 
-	// 2. verify — audit SQL from §9.1; expected 0 (the global unique forbade dupes).
+	// 2. verify — audit SQL from §9.1; expected 0 for real project repos. The
+	// per-org skills sentinel (models.SkillsRepoSentinelProjectID) is by design
+	// one row per org and so legitimately spans every org — exclude it, or this
+	// guard would abort on any deployment where ≥2 orgs have a skills repo. Only
+	// real project repos had to satisfy the old global unique we are dropping.
 	var spanning int64
 	if err := db.WithContext(ctx).Raw(
 		`SELECT count(*) FROM (
 		   SELECT project_id FROM git_repositories
+		   WHERE project_id <> ?
 		   GROUP BY project_id HAVING count(DISTINCT org_id) > 1
-		 ) t`).Scan(&spanning).Error; err != nil {
+		 ) t`, models.SkillsRepoSentinelProjectID).Scan(&spanning).Error; err != nil {
 		return fmt.Errorf("F2 verify: %w", err)
 	}
 	if spanning > 0 {


### PR DESCRIPTION
## Problem

`app-factory-api` (BFF) is in **CrashLoopBackOff** on the `cloud-cp` dev cluster. It dies during the startup DB migration, not at runtime:

```
ERROR git_repositories composite-unique (F2) migration failed
  error: F2 aborted: 1 project_id value(s) span multiple orgs;
         resolve the collisions before dropping the global unique
```

`main.go` treats the migration error as fatal (`os.Exit(1)`) → crash loop.

## Root cause

The F2 migration (`git_repo_composite_unique.go`) replaces the global `UNIQUE(project_id)` with composite `UNIQUE(org_id, project_id)` via expand → **verify** → contract. The verify step aborts if any `project_id` spans multiple orgs, on the assumption "the old global unique guaranteed it cannot."

That assumption is false because of the **skills sentinel**: the skills feature stores one `git_repositories` row per org with `project_id = "_skills"` (`models.SkillsRepoSentinelProjectID`), created lazily by `ensureSkillsRepo`. So `_skills` legitimately spans every org. Once ≥2 orgs have a skills repo, the verify guard miscounts the sentinel as a cross-org collision and aborts **forever** — no data fix helps, since per-org `_skills` is by design and gets re-created on use.

Confirmed on the dev DB: the only spanning value is `_skills` (orgs `anjana112`, `anjanas`), and the table is already in the target end-state — composite unique `ux_git_repositories_org_project` present, old global unique `idx_git_repositories_project_id` already absent. The expand/contract steps are no-ops; only the verify guard blocks startup.

## Fix

Exclude the sentinel from the verify query (`WHERE project_id <> models.SkillsRepoSentinelProjectID`). Real project-repo collisions are still caught and still abort. No data change.

## Testing

- `go build ./database/migrations/` passes.
- Ran the patched verify query against the live dev DB → returns 0, so the migration would proceed and the pod would boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)