### PR TITLE
Fix unsafe secrets

### DIFF
--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/cluster-secret-store.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/cluster-secret-store.yaml
@@ -1,0 +1,37 @@
+# ClusterSecretStore — created by the chart if one does not already exist.
+#
+# If a ClusterSecretStore with this name already exists in the cluster (e.g. created
+# by OC's own setup), this template is skipped — Helm will not attempt to adopt or
+# overwrite it. The existing store is used as-is.
+#
+# OpenBao (Vault-compatible) is the only supported secret backend. Other backends
+# (AWS SM, GCP SM, etc.) will be added in a future release.
+#
+# Connects to OpenBao via Kubernetes ServiceAccount auth. The role
+# (openchoreo-secret-writer-role by default) is created by OC's OpenBao Helm chart.
+# Override openbao.authRole / serviceAccountName / serviceAccountNamespace in values
+# if your OpenBao uses a different role or service account.
+{{- $storeName := .Values.externalSecret.secretStoreRef.name | default "default" }}
+{{- $existing := lookup "external-secrets.io/v1" "ClusterSecretStore" "" $storeName }}
+{{- if not $existing }}
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: {{ $storeName }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+spec:
+  provider:
+    vault:
+      server: {{ .Values.openbao.addr | quote }}
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: {{ .Values.openbao.authRole | default "openchoreo-secret-writer-role" | quote }}
+          serviceAccountRef:
+            name: {{ .Values.openbao.serviceAccountName | default "external-secrets-openbao" | quote }}
+            namespace: {{ .Values.openbao.serviceAccountNamespace | default "openbao" | quote }}
+{{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/deployment.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/deployment.yaml
@@ -42,13 +42,11 @@ spec:
               value: "false"
 
             # ── Database ──────────────────────────────────────────────────────
-            {{- if .Values.postgres.url }}
             - name: DATABASE_URL
-              value: {{ .Values.postgres.url | quote }}
-            {{- else }}
-            - name: DATABASE_URL
-              value: "postgres://{{ .Values.postgres.auth.username }}:{{ .Values.postgres.auth.password }}@asdlc-db:5432/{{ .Values.postgres.auth.database }}?sslmode=disable"
-            {{- end }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: databaseURL
 
             # ── OpenChoreo ────────────────────────────────────────────────────
             - name: PLATFORM_API_SERVICE_BASE_URL
@@ -76,7 +74,10 @@ spec:
             - name: THUNDER_SYSTEM_CLIENT_ID
               value: {{ .Values.thunderSystemClient.clientId | quote }}
             - name: THUNDER_SYSTEM_CLIENT_SECRET
-              value: {{ .Values.thunderSystemClient.clientSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: thunderSystemClientSecret
             - name: PLATFORM_IDP_ISSUER
               value: {{ .Values.idp.issuer | quote }}
             - name: PLATFORM_IDP_JWKS_URL
@@ -94,7 +95,10 @@ spec:
             - name: SERVICE_AUTH_CLIENT_ID
               value: {{ .Values.asdlcApi.serviceAuth.clientId | quote }}
             - name: SERVICE_AUTH_CLIENT_SECRET
-              value: {{ .Values.asdlcApi.serviceAuth.clientSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: serviceAuthClientSecret
             - name: SERVICE_AUTH_HOST_HEADER
               value: ""
             - name: SERVICE_AUTH_GIT_TOKEN_URL
@@ -102,7 +106,10 @@ spec:
             - name: SERVICE_AUTH_GIT_CLIENT_ID
               value: "asdlc-bff-to-git-service"
             - name: SERVICE_AUTH_GIT_CLIENT_SECRET
-              value: "asdlc-bff-to-git-service-secret"
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: serviceAuthGitClientSecret
             - name: SERVICE_AUTH_GIT_HOST_HEADER
               value: ""
             - name: SERVICE_AUTH_AGENTS_TOKEN_URL
@@ -110,7 +117,10 @@ spec:
             - name: SERVICE_AUTH_AGENTS_CLIENT_ID
               value: {{ .Values.asdlcApi.agentsJwt.clientId | quote }}
             - name: SERVICE_AUTH_AGENTS_CLIENT_SECRET
-              value: {{ .Values.asdlcApi.agentsJwt.clientSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: serviceAuthAgentsClientSecret
             - name: SERVICE_AUTH_AGENTS_HOST_HEADER
               value: ""
 
@@ -144,21 +154,24 @@ spec:
             - name: GITHUB_WEBHOOK_DELIVERY_URL
               value: {{ .Values.smee.url | default .Values.bff.publicURL | quote }}
             - name: GITHUB_WEBHOOK_SECRET
-              value: {{ .Values.github.webhookSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: githubWebhookSecret
             - name: OAUTH_STATE_SIGNING_KEY
-              value: {{ .Values.github.oauthStateKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: oauthStateKey
             - name: GITHUB_APP_ID
               value: {{ .Values.github.appId | quote }}
             - name: GITHUB_CLIENT_ID
               value: {{ .Values.github.clientId | quote }}
             - name: GITHUB_CLIENT_SECRET
-              value: {{ .Values.github.clientSecret | quote }}
-
-            # ── OpenBao ───────────────────────────────────────────────────────
-            - name: OPENBAO_ADDR
-              value: {{ .Values.openbao.addr | quote }}
-            - name: OPENBAO_TOKEN
-              value: {{ .Values.openbao.token | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: githubClientSecret
 
             # ── Cloud service stubs ───────────────────────────────────────────
             - name: SECRET_MANAGER_API_URL
@@ -174,7 +187,10 @@ spec:
             - name: OBSERVER_OAUTH_CLIENT_ID
               value: {{ .Values.observer.oauth.clientId | quote }}
             - name: OBSERVER_OAUTH_CLIENT_SECRET
-              value: {{ .Values.observer.oauth.clientSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-api-secrets
+                  key: observerOauthClientSecret
             - name: OBSERVER_OAUTH_HOST_HEADER
               value: ""
 
@@ -195,41 +211,43 @@ spec:
 
       volumes:
         - name: task-signing-key
-          configMap:
-            name: asdlc-api-task-signing-key
+          secret:
+            secretName: asdlc-api-task-signing-key
         {{- if .Values.github.appPrivateKeyPem }}
         - name: github-app-key
-          configMap:
-            name: asdlc-api-github-app-key
+          secret:
+            secretName: asdlc-api-github-app-key
         {{- end }}
         - name: repos
           emptyDir: {}
 {{- if .Values.taskSigning.privateKeyPem }}
 ---
-# ConfigMap holding the task-signing RSA private key (only if custom key provided).
-# If not provided, the auto-generation hook job creates this ConfigMap instead.
+# Secret holding the task-signing RSA private key (only if custom key provided).
+# If not provided, the auto-generation hook job creates this Secret instead.
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: asdlc-api-task-signing-key
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: wso2-agentic-engineer
-data:
+type: Opaque
+stringData:
   task-signing.pem: {{ .Values.taskSigning.privateKeyPem | quote }}
 {{- end }}
 {{- if .Values.github.appPrivateKeyPem }}
 ---
-# ConfigMap holding the GitHub App private key
+# Secret holding the GitHub App private key
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: asdlc-api-github-app-key
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: wso2-agentic-engineer
-data:
+type: Opaque
+stringData:
   private-key.pem: {{ .Values.github.appPrivateKeyPem | quote }}
 {{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/deployment.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/deployment.yaml
@@ -160,10 +160,6 @@ spec:
             - name: OPENBAO_TOKEN
               value: {{ .Values.openbao.token | quote }}
 
-            # ── Anthropic ─────────────────────────────────────────────────────
-            - name: ANTHROPIC_PLATFORM_KEY
-              value: {{ .Values.anthropic.apiKey | quote }}
-
             # ── Cloud service stubs ───────────────────────────────────────────
             - name: SECRET_MANAGER_API_URL
               value: {{ .Values.asdlcApi.smApiURL | default "" | quote }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/external-secret.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/external-secret.yaml
@@ -1,0 +1,31 @@
+# Syncs asdlc-api runtime secrets from OpenBao into the asdlc-api-secrets K8s Secret via ESO.
+#
+# OpenBao KV v2 stores each secret as {"value":"..."} — property is hardcoded to "value".
+# Key paths are configurable via values.externalSecret.keys.
+#
+# For dev: secret paths are seeded into OpenBao by push-secret.yaml on helm install.
+# For prod: populate the paths in OpenBao manually before helm install.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: asdlc-api-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: asdlc-api
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "15s" | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreRef.name | default "default" }}
+    kind: {{ .Values.externalSecret.secretStoreRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: asdlc-api-secrets
+    creationPolicy: Owner
+  data:
+    {{- range $secretKey, $remoteKey := .Values.externalSecret.keys }}
+    - secretKey: {{ $secretKey }}
+      remoteRef:
+        key: {{ $remoteKey }}
+        property: "value"
+    {{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/push-secret.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/push-secret.yaml
@@ -1,0 +1,99 @@
+# PushSecret — pushes values from asdlc-api-seed into OpenBao.
+#
+# Two separate PushSecret resources are rendered based on forceDefaultOverride:
+#
+#   forceDefaultOverride: "true"  → asdlc-api-push-force (updatePolicy: Replace)
+#                                    Always overwrites the OpenBao value with values.yaml.
+#                                    Use this to force a specific value on every helm upgrade.
+#
+#   forceDefaultOverride: ""      → asdlc-api-push-seed (updatePolicy: IfNotExists)
+#   (or not set)                    Only writes if the key does not already exist in OpenBao.
+#                                    Dev default: seeds on fresh install, skips on upgrade.
+#
+#   forceDefaultOverride: "false" → Not included in any PushSecret.
+#                                    Helm never touches this secret. The user must pre-seed
+#                                    this path in OpenBao before running helm install.
+#
+# databaseURL is always pushed via asdlc-api-push-seed (IfNotExists).
+# deletionPolicy: None on both — removing secrets.* from values never deletes OpenBao values.
+
+{{/* ── Collect force-override entries ───────────────────────────────────────── */}}
+{{- $forceEntries := list }}
+{{- range $k, $v := .Values.secrets }}
+  {{- if eq ($v.forceDefaultOverride | default "" | toString) "true" }}
+    {{- $forceEntries = append $forceEntries $k }}
+  {{- end }}
+{{- end }}
+
+{{/* ── Collect seed (IfNotExists) entries ────────────────────────────────────── */}}
+{{- $seedEntries := list }}
+{{- range $k, $v := .Values.secrets }}
+  {{- $policy := $v.forceDefaultOverride | default "" | toString }}
+  {{- if eq $policy "" }}
+    {{- $seedEntries = append $seedEntries $k }}
+  {{- end }}
+{{- end }}
+
+{{/* ── PushSecret: Replace (force override) ──────────────────────────────────── */}}
+{{- if $forceEntries }}
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: asdlc-api-push-force
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+spec:
+  updatePolicy: Replace
+  deletionPolicy: None
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: {{ .Values.externalSecret.secretStoreRef.name | default "default" }}
+      kind: {{ .Values.externalSecret.secretStoreRef.kind | default "ClusterSecretStore" }}
+  selector:
+    secret:
+      name: asdlc-api-seed
+  data:
+    {{- range $k := $forceEntries }}
+    - match:
+        secretKey: {{ $k }}
+        remoteRef:
+          remoteKey: {{ index $.Values.externalSecret.keys $k }}
+          property: "value"
+    {{- end }}
+{{- end }}
+
+{{/* ── PushSecret: IfNotExists (seed defaults) ────────────────────────────────── */}}
+{{- $hasSeedEntries := or $seedEntries true }}{{/* always render — databaseURL always seeded */}}
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: asdlc-api-push-seed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+spec:
+  updatePolicy: IfNotExists
+  deletionPolicy: None
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: {{ .Values.externalSecret.secretStoreRef.name | default "default" }}
+      kind: {{ .Values.externalSecret.secretStoreRef.kind | default "ClusterSecretStore" }}
+  selector:
+    secret:
+      name: asdlc-api-seed
+  data:
+    - match:
+        secretKey: databaseURL
+        remoteRef:
+          remoteKey: {{ .Values.externalSecret.keys.databaseURL }}
+          property: "value"
+    {{- range $k := $seedEntries }}
+    - match:
+        secretKey: {{ $k }}
+        remoteRef:
+          remoteKey: {{ index $.Values.externalSecret.keys $k }}
+          property: "value"
+    {{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/seed-secret.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/asdlc-api/seed-secret.yaml
@@ -1,0 +1,40 @@
+# Seed Secret — only rendered when at least one secret has a non-empty value
+# AND forceDefaultOverride != "false".
+#
+# This K8s Secret is the source that PushSecrets (push-secret.yaml) read from to
+# write values into OpenBao.
+#
+# forceDefaultOverride: "false" secrets are excluded — they are pre-configured in
+# OpenBao by the user and Helm must not touch them.
+#
+# databaseURL is always included and derived from postgres.* — never set separately.
+{{- $hasSecrets := false }}
+{{- range $k, $v := .Values.secrets }}
+  {{- $policy := $v.forceDefaultOverride | default "" | toString }}
+  {{- if ne $policy "false" }}
+    {{- $hasSecrets = true }}
+  {{- end }}
+{{- end }}
+{{- if $hasSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: asdlc-api-seed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+type: Opaque
+stringData:
+  {{- if .Values.postgres.url }}
+  databaseURL: {{ .Values.postgres.url | quote }}
+  {{- else }}
+  databaseURL: "postgres://{{ .Values.postgres.auth.username }}:{{ .Values.postgres.auth.password }}@asdlc-db:5432/{{ .Values.postgres.auth.database }}?sslmode=disable"
+  {{- end }}
+  {{- range $k, $v := .Values.secrets }}
+  {{- $policy := $v.forceDefaultOverride | default "" | toString }}
+  {{- if ne $policy "false" }}
+  {{ $k }}: {{ $v.value | default "" | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/postgres/secret.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/postgres/secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.postgres.url }}
+# K8s Secret for the bundled dev PostgreSQL StatefulSet.
+# Only rendered when postgres.url is empty (i.e. the bundled StatefulSet is in use).
+# Production deployments use an external database via postgres.url — this secret is skipped.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: asdlc-db-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-agentic-engineer
+type: Opaque
+stringData:
+  password: {{ .Values.postgres.auth.password | quote }}
+{{- end }}

--- a/deployments/helm-charts/wso2-ae-platform/templates/postgres/statefulset.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/templates/postgres/statefulset.yaml
@@ -36,7 +36,10 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.auth.username | quote }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgres.auth.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: asdlc-db-credentials
+                  key: password
           readinessProbe:
             exec:
               command:

--- a/deployments/helm-charts/wso2-ae-platform/values.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/values.yaml
@@ -32,10 +32,15 @@ bff:
   publicURL: "http://asdlc-api.openchoreo.localhost:8080"
 
 # ── OpenBao ───────────────────────────────────────────────────────────────────
+# OpenBao is the only supported secret backend. Other backends will be added later.
 openbao:
   addr: "http://openbao.openbao.svc.cluster.local:8200"
-  # Dev default — override for production
-  token: "root"
+  # Kubernetes auth config for the ClusterSecretStore ESO uses to access OpenBao.
+  # Defaults match OC's built-in OpenBao setup (role created by OC's values-openbao.yaml).
+  # Override only if your OpenBao uses a different role or service account.
+  authRole: "openchoreo-secret-writer-role"
+  serviceAccountName: "external-secrets-openbao"
+  serviceAccountNamespace: "openbao"
 
 # ── Observer ──────────────────────────────────────────────────────────────────
 observer:
@@ -43,7 +48,6 @@ observer:
   oauth:
     tokenURL: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/token"
     clientId: "openchoreo-observer-resource-reader-client"
-    clientSecret: "openchoreo-observer-resource-reader-client-secret"
 
 # ── PostgreSQL (direct StatefulSet — not an OC Resource) ─────────────────────
 # Set postgres.url to use an external database and skip the bundled StatefulSet.
@@ -87,14 +91,13 @@ github:
   repoVisibility: "private"
   committerName: "ASDLC Bot"
   committerEmail: "bot@asdlc.dev"
-  webhookSecret: "dev-webhook-secret"
-  oauthStateKey: "dev-oauth-state-key-32-chars-long!!"
   appId: ""
   clientId: ""
-  clientSecret: ""
   # GitHub App private key PEM (optional — leave empty for PAT-based auth)
   # Pass via: --set-file github.appPrivateKeyPem=key.pem
   appPrivateKeyPem: ""
+  # Secrets (webhookSecret, oauthStateKey, clientSecret) are stored in the
+  # secret store and synced by ESO — not set here.
 
 # ── asdlc-api (BFF) ──────────────────────────────────────────────────────────
 asdlcApi:
@@ -111,12 +114,12 @@ asdlcApi:
   # Service identity for OC API calls (registered in OC Thunder by bootstrap job)
   serviceAuth:
     clientId: "asdlc-api-client"
-    clientSecret: "asdlc-api-client-secret"
     tokenURL: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/token"
+    # clientSecret stored in secret store at externalSecret.keys.serviceAuthClientSecret
   # JWT for BFF → agents-service calls
   agentsJwt:
     clientId: "asdlc-bff-to-agents-service"
-    clientSecret: "asdlc-bff-to-agents-service-secret"
+    # clientSecret stored in secret store at externalSecret.keys.serviceAuthAgentsClientSecret
   smApiURL: ""
   clusterGatewayProxyURL: ""
   resources:
@@ -174,4 +177,43 @@ console:
 # Must match the client registered in OC Thunder by the bootstrap job.
 thunderSystemClient:
   clientId: "asdlc-system-client"
-  clientSecret: "asdlc-system-client-secret"
+  # clientSecret stored in secret store at externalSecret.keys.thunderSystemClientSecret
+
+# ── External Secrets (ESO) ────────────────────────────────────────────────────
+# The chart creates ClusterSecretStore "default" pointing at OpenBao (configured via
+# openbao.* above). OpenBao KV v2 stores secrets as {"value":"..."} — property is
+# hardcoded to "value" in all templates.
+externalSecret:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  # Paths in OpenBao where each secret is stored.
+  # Change these if you use different key paths in your OpenBao instance.
+  keys:
+    databaseURL: "asdlc/platform/db/url"
+    thunderSystemClientSecret: "asdlc/platform/thunder/system-client-secret"
+    serviceAuthClientSecret: "asdlc/platform/service-auth/client-secret"
+    serviceAuthGitClientSecret: "asdlc/platform/service-auth/git-secret"
+    serviceAuthAgentsClientSecret: "asdlc/platform/service-auth/agents-secret"
+    githubWebhookSecret: "asdlc/platform/github/webhook-secret"
+    oauthStateKey: "asdlc/platform/github/oauth-state-key"
+    githubClientSecret: "asdlc/platform/github/client-secret"
+    observerOauthClientSecret: "asdlc/platform/observer/client-secret"
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+# Each entry controls one secret pushed into OpenBao by the chart.
+#
+#   value:               the secret value to push
+#   forceDefaultOverride: controls the push behaviour:
+#     "" (or not set)  → push only if the key is absent in OpenBao (IfNotExists)
+#                         Safe default: seeds on fresh install, never overwrites on upgrade.
+#     "true"           → always overwrite OpenBao with this value on every helm install/upgrade
+#                         Use when you need to force a specific value regardless of what's in OpenBao.
+#     "false"          → do not push at all — Helm never touches this path in OpenBao.
+#                         Use for secrets you pre-configured in OpenBao manually (prod pattern).
+#
+# Dev users:  set values here or via --set. Values are seeded once on first install.
+# Prod users: set forceDefaultOverride: "false" for all secrets and pre-seed OpenBao manually.
+# WARNING: non-empty values here appear in Helm release history.
+secrets: {}

--- a/deployments/helm-charts/wso2-ae-platform/values.yaml
+++ b/deployments/helm-charts/wso2-ae-platform/values.yaml
@@ -96,10 +96,6 @@ github:
   # Pass via: --set-file github.appPrivateKeyPem=key.pem
   appPrivateKeyPem: ""
 
-# ── Anthropic ─────────────────────────────────────────────────────────────────
-anthropic:
-  apiKey: ""
-
 # ── asdlc-api (BFF) ──────────────────────────────────────────────────────────
 asdlcApi:
   # Hostname for the OC control-plane gateway HTTPRoute

--- a/deployments/helm-charts/wso2-agentic-engineer-bundle/templates/task-signing-key-job.yaml
+++ b/deployments/helm-charts/wso2-agentic-engineer-bundle/templates/task-signing-key-job.yaml
@@ -27,7 +27,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
   - apiGroups: [""]
-    resources: ["configmaps"]
+    resources: ["secrets"]
     verbs: ["get", "create", "patch"]
 ---
 # ClusterRoleBinding for the key generator
@@ -52,8 +52,8 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Post-install/upgrade Job: generate BFF task signing key if it doesn't exist
-# Runs before main Deployments so ConfigMap is ready for them to mount.
-# Idempotent — subsequent runs reuse the existing ConfigMap, avoiding JWT invalidation.
+# Runs before main Deployments so Secret is ready for them to mount.
+# Idempotent — subsequent runs reuse the existing Secret, avoiding JWT invalidation.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -94,32 +94,32 @@ spec:
                 apk add --no-cache kubectl
               fi
 
-              CONFIGMAP_NAME="asdlc-api-task-signing-key"
+              SECRET_NAME="asdlc-api-task-signing-key"
               KEY_FILE="/tmp/task-signing.pem"
 
-              echo "Checking if task signing key ConfigMap already exists..."
-              if kubectl get configmap "$CONFIGMAP_NAME" -n {{ .Release.Namespace }} >/dev/null 2>&1; then
-                echo "✅ Task signing key ConfigMap already exists (reusing existing key)"
-                echo "   This preserves JWT verification across helm upgrades and pod restarts"
+              echo "Checking if task signing key Secret already exists..."
+              if kubectl get secret "$SECRET_NAME" -n {{ .Release.Namespace }} >/dev/null 2>&1; then
+                echo "Task signing key Secret already exists (reusing existing key)"
+                echo "This preserves JWT verification across helm upgrades and pod restarts"
                 exit 0
               fi
 
-              echo "🔐 Generating new RSA 2048 task signing key..."
+              echo "Generating new RSA 2048 task signing key..."
               if ! command -v openssl &>/dev/null; then
                 apk add --no-cache openssl
               fi
               openssl genpkey -algorithm RSA -out "$KEY_FILE" -pkeyopt rsa_keygen_bits:2048
 
               if [ ! -f "$KEY_FILE" ]; then
-                echo "❌ Failed to generate signing key"
+                echo "Failed to generate signing key"
                 exit 1
               fi
 
-              echo "📦 Storing in ConfigMap..."
-              kubectl create configmap "$CONFIGMAP_NAME" \
+              echo "Storing in Secret..."
+              kubectl create secret generic "$SECRET_NAME" \
                 --from-file=task-signing.pem="$KEY_FILE" \
                 -n {{ .Release.Namespace }} \
                 --dry-run=client -o yaml | kubectl apply -f -
 
-              echo "✅ Task signing key generated and stored in ConfigMap"
-              echo "   Key will be reused on future helm upgrades (idempotent)"
+              echo "Task signing key generated and stored in Secret"
+              echo "Key will be reused on future helm upgrades (idempotent)"

--- a/deployments/helm-charts/wso2-agentic-engineer-bundle/values.yaml
+++ b/deployments/helm-charts/wso2-agentic-engineer-bundle/values.yaml
@@ -69,11 +69,6 @@ github:
   webhookSecret: "dev-webhook-secret"
   oauthStateKey: "dev-oauth-state-key-32-chars-long!!"
 
-# ── Anthropic ─────────────────────────────────────────────────────────────────
-anthropic:
-  # Platform fallback API key (used when no per-org key is configured)
-  apiKey: ""
-
 # ── PostgreSQL ────────────────────────────────────────────────────────────────
 # By default a PostgreSQL StatefulSet is deployed in the wso2-ae namespace.
 # Set postgres.url to use an external database instead (skips StatefulSet).

--- a/deployments/helm-charts/wso2-agentic-engineer-bundle/values.yaml
+++ b/deployments/helm-charts/wso2-agentic-engineer-bundle/values.yaml
@@ -61,13 +61,11 @@ github:
   # PEM-encoded GitHub App private key. Pass via: --set-file github.appPrivateKey=key.pem
   appPrivateKeyPem: ""
   clientId: ""
-  clientSecret: ""
   appSlug: "asdlc-platform"
   repoVisibility: "private"
   committerName: "ASDLC Bot"
   committerEmail: "bot@asdlc.dev"
-  webhookSecret: "dev-webhook-secret"
-  oauthStateKey: "dev-oauth-state-key-32-chars-long!!"
+  # Secrets (clientSecret, webhookSecret, oauthStateKey) stored in the secret store.
 
 # ── PostgreSQL ────────────────────────────────────────────────────────────────
 # By default a PostgreSQL StatefulSet is deployed in the wso2-ae namespace.
@@ -124,7 +122,6 @@ wso2-ae-platform:
       scopes: "openid profile email"
   thunderSystemClient:
     clientId: "asdlc-system-client"
-    clientSecret: "asdlc-system-client-secret"
   asdlcApi:
     serviceAuth:
       tokenURL: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/token"
@@ -133,10 +130,34 @@ wso2-ae-platform:
     oauth:
       tokenURL: "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/token"
       clientId: "openchoreo-observer-resource-reader-client"
-      clientSecret: "openchoreo-observer-resource-reader-client-secret"
   openbao:
     addr: "http://openbao.openbao.svc.cluster.local:8200"
     token: "root"
-  postgres:
-    auth:
-      password: "asdlc-dev-password"
+  # Dev defaults — seeded into OpenBao on first helm install (IfNotExists).
+  # Values already in OpenBao are never overwritten (forceDefaultOverride: "").
+  # For production: set forceDefaultOverride: "false" for each secret and pre-seed OpenBao manually.
+  secrets:
+    thunderSystemClientSecret:
+      value: "asdlc-system-client-secret"
+      forceDefaultOverride: ""
+    serviceAuthClientSecret:
+      value: "asdlc-api-client-secret"
+      forceDefaultOverride: ""
+    serviceAuthGitClientSecret:
+      value: "asdlc-bff-to-git-service-secret"
+      forceDefaultOverride: ""
+    serviceAuthAgentsClientSecret:
+      value: "asdlc-bff-to-agents-service-secret"
+      forceDefaultOverride: ""
+    githubWebhookSecret:
+      value: "dev-webhook-secret"
+      forceDefaultOverride: ""
+    oauthStateKey:
+      value: "dev-oauth-state-key-32-chars-long!!"
+      forceDefaultOverride: ""
+    githubClientSecret:
+      value: ""
+      forceDefaultOverride: ""
+    observerOauthClientSecret:
+      value: "openchoreo-observer-resource-reader-client-secret"
+      forceDefaultOverride: ""


### PR DESCRIPTION
 ## Purpose                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Helm chart secrets were being passed as plaintext `value:` fields in pod specs and embedded in Helm release history, violating basic secret hygiene.                                                              
                                                                                                                                                                                                                     
  Resolves #56                                                                                                                                                                                                       
                                                                                                                                                                                                                    
  ## Goals                                                                                                                                                                                                          
                                                                                                                                                                                                                    
  - Ensure no secret value appears as a plaintext `value:` in any pod spec or Helm release manifest                                                                                                                 
  - Provide a clear dev vs. production workflow for secret management                                                                                                                                               
  - Allow per-secret control over whether Helm seeds, forces, or skips pushing to the secret store                                                                                                                  
                                                                                                                                                                                                                    
  ## Approach                                                                                                                                                                                                       
                                                                                                                                                                                                                    
  Introduces an ESO-based secret management pipeline using OpenBao as the secret backend:                                                                                                                           
                                                                                                                                                                                                                    
  values.yaml (secrets.*.value)                                                                                                                                                                                     
      → K8s Secret "asdlc-api-seed"  (staging area)
      → PushSecret → OpenBao         (ESO pushes values in)                                                                                                                                                         
      → ExternalSecret               (ESO reads back every 15s)                                                                                                                                                     
      → K8s Secret "asdlc-api-secrets"                                                                                                                                                                              
      → pod env vars via secretKeyRef                                                                                                                                                                               
                                                                                                                                                                                                                    
  **Per-secret `forceDefaultOverride` policy** — each secret in `wso2-ae-platform.secrets` now takes an object with `value` and `forceDefaultOverride`:                                                             
                                                                                                                                                                                                                    
  | `forceDefaultOverride` | Behaviour |                                                                                                                                                                            
  |---|---|                                                                                                                                                                                                         
  | `""` (default) | Push to OpenBao only if the key is absent (`IfNotExists`) — seeds on first install, never overwrites on upgrade |                                                                              
  | `"true"` | Always overwrite OpenBao with the values.yaml value on every `helm install/upgrade` |                                                                                                                
  | `"false"` | Do not push at all — rely on a value pre-seeded in OpenBao. Use for production. |                                                                                                                   
                                                                                                                                                                                                                    
  **Dev pattern:** leave `forceDefaultOverride: ""` — values are seeded into OpenBao on first install and never touched on upgrade. Values appear in Helm release history, which is acceptable for non-production   
  use.                                                                                                                                                                                                              
                                                                                                                                                                                                                    
  **Production pattern:** pre-seed each secret path in OpenBao before `helm install`, then set `forceDefaultOverride: "false"` so the chart never writes to the store and values never appear in release history.   
                                                                                                                                                                                                                    
  Additional fixes:                                                                                                                                                                                                 
  - `OPENBAO_TOKEN` removed from `deployment.yaml` — dead code (BFF never reads it)                                                                                                                                 
  - `POSTGRES_PASSWORD` for the bundled dev StatefulSet now uses `secretKeyRef` via a dedicated `asdlc-db-credentials` K8s Secret                                                                                   
  - Task signing key auto-generation via a Helm hook Job (no longer requires manual `--set-file`)                                                                                                                   
  - `ClusterSecretStore` creation skipped if one already exists in the cluster (idempotent installs)                                                                                                                
                                                                                                      