### PR TITLE
fix(ci): add version bump step to build-images job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           ref: ${{ needs.prepare-release.outputs.version }}
 
+      - name: Update versions
+        run: |
+          chmod +x .github/scripts/update-versions.sh
+          .github/scripts/update-versions.sh "${{ github.event.inputs.target_version }}"
+
+
       - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0


### PR DESCRIPTION
## Summary
- Adds an Update versions step to the build-images job in the release workflow
- Ensures helm chart files (image tags) are updated to the release version before Docker builds run
- Fixes ae-installer image baking in 0.0.0-dev image references instead of the actual release version

## Root cause
The prepare-release job ran update-versions.sh but changes were never committed (branch is protected). When build-images checked out the git tag, chart files still had 0.0.0-dev placeholders. The installer image embeds these charts at build time, so it ended up referencing non-existent 0.0.0-dev images.

## Test plan
- Trigger the release workflow with a new version
- Verify service pods start with the correct versioned image tags (not 0.0.0-dev)