### PR TITLE
Add local one-shot harness for the coding-agent runner

### DIFF
--- a/runners/remote-worker/.dockerignore
+++ b/runners/remote-worker/.dockerignore
@@ -21,3 +21,4 @@ coverage
 .env
 .env.*
 plugin/node_modules
+local

--- a/runners/remote-worker/.gitignore
+++ b/runners/remote-worker/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+local/.env.local
+local/workspace/

--- a/runners/remote-worker/local/README.md
+++ b/runners/remote-worker/local/README.md
@@ -1,0 +1,52 @@
+# Local one-shot harness
+
+Run the coding-agent runner on your machine without the platform (no k3d,
+no BFF, no Argo). The runner executes in its real Docker image; the only
+substitution is `token-stub.mjs`, a loopback HTTP server that plays the
+platform's `POST /internal/v1/tasks/{taskId}/credentials/refresh` endpoint
+and hands back your GitHub PAT.
+
+## What a run does
+
+1. Starts the token stub on `127.0.0.1:8377` (host side).
+2. Builds the runner image from `../Dockerfile` (cached after the first time).
+3. Runs the one-shot container: clones `AEP_REPO_URL`'s default branch,
+   loads the `aep` skill plugin, and lets the agent work `AEP_PROMPT` —
+   branch, commit, push, PR, exactly as a cluster run would.
+
+`AEP_PLATFORM_URL` is left unset, so the per-task skills pull is skipped;
+the base plugin at `../plugin` is bind-mounted read-only into the
+container, so skill edits are live on the next run without a rebuild.
+
+## Usage
+
+```bash
+colima start                        # or however you run the docker daemon
+cp env.local.example .env.local     # fill in the four required values
+./run-local.sh
+```
+
+The runner streams progress NDJSON to stdout. After exit, the cloned
+workspace (including `.logs/claude.log`, the full SDK transcript) is kept
+under `workspace/<org>/<project>/<taskId>/` for inspection.
+
+## Testing a custom task
+
+- **Real flow:** create a GitHub issue in the test repo whose body is the
+  task spec, and set `AEP_PROMPT` to point at its URL — the `aep` skill
+  drives issue-comment/branch/PR conventions from there.
+- **Skill iteration:** edit `../plugin/skills/aep/SKILL.md` or add a new
+  `../plugin/skills/<name>/SKILL.md`; the mount picks it up on the next run.
+  (In-cluster, per-task skills come from the BFF snapshot instead — that
+  path needs the full `deployments/` setup.)
+
+## Safety notes
+
+- The agent runs with `bypassPermissions` — that is why the harness only
+  runs it containerized, never bare on the host.
+- Scope `GITHUB_PAT` to a single throwaway test repo (fine-grained PAT).
+- The stub returns the PAT to any caller; keep `STUB_BIND=127.0.0.1`
+  (default). On a Linux host `host-gateway` cannot reach loopback, so you
+  would need `STUB_BIND=0.0.0.0` — accept that trade-off consciously.
+- `.env.local` and `workspace/` are gitignored; `local/` is dockerignored
+  so secrets never enter the image build context.

--- a/runners/remote-worker/local/README.md
+++ b/runners/remote-worker/local/README.md
@@ -22,6 +22,7 @@ container, so skill edits are live on the next run without a rebuild.
 
 ```bash
 colima start                        # or however you run the docker daemon
+cd runners/remote-worker/local
 cp env.local.example .env.local     # fill in the four required values
 ./run-local.sh
 ```
@@ -45,8 +46,10 @@ under `workspace/<org>/<project>/<taskId>/` for inspection.
 - The agent runs with `bypassPermissions` — that is why the harness only
   runs it containerized, never bare on the host.
 - Scope `GITHUB_PAT` to a single throwaway test repo (fine-grained PAT).
-- The stub returns the PAT to any caller; keep `STUB_BIND=127.0.0.1`
-  (default). On a Linux host `host-gateway` cannot reach loopback, so you
-  would need `STUB_BIND=0.0.0.0` — accept that trade-off consciously.
+- The stub only releases the PAT to callers presenting the per-run
+  `AEP_BEARER` (a fresh random value each run, passed automatically as
+  `STUB_BEARER`). Still keep `STUB_BIND=127.0.0.1` (default); on a Linux
+  host `host-gateway` cannot reach loopback, so you would need
+  `STUB_BIND=0.0.0.0` — the bearer check is what keeps that tolerable.
 - `.env.local` and `workspace/` are gitignored; `local/` is dockerignored
   so secrets never enter the image build context.

--- a/runners/remote-worker/local/env.local.example
+++ b/runners/remote-worker/local/env.local.example
@@ -22,7 +22,8 @@ AEP_PROMPT=
 
 # --- optional (defaults applied by run-local.sh) -------------------------------
 
-#AEP_TASK_ID=                 # UUID; default: fresh uuidgen per run
+#AEP_TASK_ID=                 # UUID; default: fresh random UUID per run
+#AEP_BEARER=                  # default: fresh random value per run; the stub requires it on refresh calls
 #AEP_ORG_ID=local-org
 #AEP_PROJECT_ID=local-project
 #AEP_COMPONENT_NAME=demo-component

--- a/runners/remote-worker/local/env.local.example
+++ b/runners/remote-worker/local/env.local.example
@@ -1,0 +1,33 @@
+# Copy to .env.local (gitignored) and fill in. run-local.sh sources this file.
+
+# --- required ----------------------------------------------------------------
+
+# Anthropic API key used by the Claude Agent SDK inside the container.
+ANTHROPIC_API_KEY=
+
+# GitHub token for clone/push/PR against the test repo. Use a fine-grained
+# PAT scoped to ONLY that repo: contents read/write, pull requests
+# read/write, issues read/write.
+GITHUB_PAT=
+
+# The repo the agent works on. Use a throwaway test repo you own.
+AEP_REPO_URL=https://github.com/<you>/<test-repo>
+
+# The task instruction. The preloaded `aep` skill expects a GitHub issue URL
+# (create one in the test repo first), e.g.:
+#   AEP_PROMPT="Work the component task in GitHub issue https://github.com/<you>/<test-repo>/issues/1"
+# For a quick smoke test without an issue, override the workflow explicitly:
+#   AEP_PROMPT="There is no GitHub issue for this task; skip issue lookup and issue comments. Create a feature branch, add a short haiku to HAIKU.md, verify nothing else changed, push, and open a PR titled 'test: local runner smoke' (no Closes line needed)."
+AEP_PROMPT=
+
+# --- optional (defaults applied by run-local.sh) -------------------------------
+
+#AEP_TASK_ID=                 # UUID; default: fresh uuidgen per run
+#AEP_ORG_ID=local-org
+#AEP_PROJECT_ID=local-project
+#AEP_COMPONENT_NAME=demo-component
+#AEP_IDENTITY_NAME=AEP Local Agent
+#AEP_IDENTITY_EMAIL=aep-local@users.noreply.github.com
+#STUB_PORT=8377
+#STUB_BIND=127.0.0.1          # on a Linux host use 0.0.0.0 (host-gateway cannot reach loopback)
+#IMAGE_TAG=aep-remote-worker:local

--- a/runners/remote-worker/local/run-local.sh
+++ b/runners/remote-worker/local/run-local.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Run the coding-agent runner as a local one-shot container, standing in
+# for the platform dispatch flow (BFF -> Argo -> pod). A loopback token
+# stub (token-stub.mjs) plays the git-service credentials/refresh
+# endpoint; everything else is the same code path as a cluster run.
+#
+# Usage:
+#   cp env.local.example .env.local    # then fill in
+#   ./run-local.sh [path/to/env-file]
+#
+# The plugin/ dir is bind-mounted read-only over /app/plugin, so skill
+# edits are live without an image rebuild (mirrors the k3d dev flow).
+# Exit code mirrors the runner: 0 success, 1 agent failure, 2 provisioning.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKER_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="${1:-$SCRIPT_DIR/.env.local}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "env file not found: $ENV_FILE (cp env.local.example .env.local and fill it in)" >&2
+  exit 2
+fi
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+for v in ANTHROPIC_API_KEY GITHUB_PAT AEP_REPO_URL AEP_PROMPT; do
+  if [ -z "${!v:-}" ]; then
+    echo "missing required var in $ENV_FILE: $v" >&2
+    exit 2
+  fi
+done
+
+export AEP_TASK_ID="${AEP_TASK_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+export AEP_ORG_ID="${AEP_ORG_ID:-local-org}"
+export AEP_PROJECT_ID="${AEP_PROJECT_ID:-local-project}"
+export AEP_COMPONENT_NAME="${AEP_COMPONENT_NAME:-demo-component}"
+export AEP_IDENTITY_NAME="${AEP_IDENTITY_NAME:-AEP Local Agent}"
+export AEP_IDENTITY_EMAIL="${AEP_IDENTITY_EMAIL:-aep-local@users.noreply.github.com}"
+export AEP_BEARER="${AEP_BEARER:-local-dev-bearer}"
+STUB_PORT="${STUB_PORT:-8377}"
+STUB_BIND="${STUB_BIND:-127.0.0.1}"
+IMAGE_TAG="${IMAGE_TAG:-aep-remote-worker:local}"
+# The container reaches the host-side stub via host.docker.internal.
+# AEP_PLATFORM_URL stays unset: oneshot.ts then skips the per-task skills
+# pull and credhelper/gh fall back to AEP_GIT_SERVICE_URL for refreshes.
+export AEP_GIT_SERVICE_URL="http://host.docker.internal:${STUB_PORT}"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "docker daemon not reachable — start it first (e.g. 'colima start')" >&2
+  exit 2
+fi
+
+echo ">> starting token stub on ${STUB_BIND}:${STUB_PORT}"
+GITHUB_PAT="$GITHUB_PAT" STUB_PORT="$STUB_PORT" STUB_BIND="$STUB_BIND" \
+  node "$SCRIPT_DIR/token-stub.mjs" &
+STUB_PID=$!
+trap 'kill "$STUB_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 20); do
+  curl -sf "http://127.0.0.1:${STUB_PORT}/healthz" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+if ! curl -sf "http://127.0.0.1:${STUB_PORT}/healthz" >/dev/null 2>&1; then
+  echo "token stub failed to start on port ${STUB_PORT}" >&2
+  exit 2
+fi
+
+echo ">> building runner image ${IMAGE_TAG}"
+docker build -t "$IMAGE_TAG" "$WORKER_DIR"
+
+mkdir -p "$SCRIPT_DIR/workspace"
+
+echo ">> dispatching task ${AEP_TASK_ID} on ${AEP_REPO_URL}"
+EXIT_CODE=0
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$SCRIPT_DIR/workspace:/home/aep/aep-workspace" \
+  -v "$WORKER_DIR/plugin:/app/plugin:ro" \
+  -e ANTHROPIC_API_KEY \
+  -e AEP_TASK_ID -e AEP_ORG_ID -e AEP_PROJECT_ID -e AEP_COMPONENT_NAME \
+  -e AEP_REPO_URL -e AEP_PROMPT -e AEP_BEARER -e AEP_GIT_SERVICE_URL \
+  -e AEP_IDENTITY_NAME -e AEP_IDENTITY_EMAIL \
+  "$IMAGE_TAG" || EXIT_CODE=$?
+
+WS="$SCRIPT_DIR/workspace/$AEP_ORG_ID/$AEP_PROJECT_ID/$AEP_TASK_ID"
+case "$EXIT_CODE" in
+  0) STATUS="success" ;;
+  1) STATUS="agent reported failure" ;;
+  2) STATUS="provisioning error (agent never ran)" ;;
+  *) STATUS="unexpected exit" ;;
+esac
+echo ""
+echo ">> runner finished: ${STATUS} (exit code ${EXIT_CODE})"
+echo ">> workspace kept at: $WS"
+echo ">> full SDK transcript: $WS/.logs/claude.log"
+exit "$EXIT_CODE"

--- a/runners/remote-worker/local/run-local.sh
+++ b/runners/remote-worker/local/run-local.sh
@@ -50,13 +50,17 @@ for v in ANTHROPIC_API_KEY GITHUB_PAT AEP_REPO_URL AEP_PROMPT; do
   fi
 done
 
-export AEP_TASK_ID="${AEP_TASK_ID:-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+# node (required by the stub anyway) generates UUIDs — uuidgen is not
+# universally present. The bearer defaults to a fresh random value per
+# run; the stub requires it on every refresh call, so the PAT is never
+# handed out unauthenticated even if STUB_BIND is widened.
+export AEP_TASK_ID="${AEP_TASK_ID:-$(node -e 'console.log(crypto.randomUUID())')}"
 export AEP_ORG_ID="${AEP_ORG_ID:-local-org}"
 export AEP_PROJECT_ID="${AEP_PROJECT_ID:-local-project}"
 export AEP_COMPONENT_NAME="${AEP_COMPONENT_NAME:-demo-component}"
 export AEP_IDENTITY_NAME="${AEP_IDENTITY_NAME:-AEP Local Agent}"
 export AEP_IDENTITY_EMAIL="${AEP_IDENTITY_EMAIL:-aep-local@users.noreply.github.com}"
-export AEP_BEARER="${AEP_BEARER:-local-dev-bearer}"
+export AEP_BEARER="${AEP_BEARER:-$(node -e 'console.log(crypto.randomUUID())')}"
 STUB_PORT="${STUB_PORT:-8377}"
 STUB_BIND="${STUB_BIND:-127.0.0.1}"
 IMAGE_TAG="${IMAGE_TAG:-aep-remote-worker:local}"
@@ -72,6 +76,7 @@ fi
 
 echo ">> starting token stub on ${STUB_BIND}:${STUB_PORT}"
 GITHUB_PAT="$GITHUB_PAT" STUB_PORT="$STUB_PORT" STUB_BIND="$STUB_BIND" \
+  STUB_BEARER="$AEP_BEARER" \
   node "$SCRIPT_DIR/token-stub.mjs" &
 STUB_PID=$!
 trap 'kill "$STUB_PID" 2>/dev/null || true' EXIT

--- a/runners/remote-worker/local/token-stub.mjs
+++ b/runners/remote-worker/local/token-stub.mjs
@@ -29,7 +29,10 @@
 //
 // SECURITY: every response carries a real GitHub PAT. Keep the bind
 // address on loopback (the default) and never expose this beyond your
-// machine.
+// machine. When STUB_BEARER is set (run-local.sh always sets it to the
+// per-run AEP_BEARER), callers must present that exact
+// `Authorization: Bearer` value — the runner already sends it on every
+// refresh call, so this costs nothing and de-fangs a non-loopback bind.
 
 import http from "node:http";
 
@@ -39,9 +42,15 @@ if (pat === "") {
   process.exit(1);
 }
 const port = Number(process.env.STUB_PORT || 8377);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error(`[token-stub] STUB_PORT is not a valid port: ${process.env.STUB_PORT}`);
+  process.exit(1);
+}
 const bind = process.env.STUB_BIND || "127.0.0.1";
+const expectedBearer = process.env.STUB_BEARER ?? "";
 
 const REFRESH_RE = /^\/internal\/v1\/tasks\/([^/]+)\/credentials\/refresh$/;
+const JSON_HEADERS = { "Content-Type": "application/json", "Cache-Control": "no-store" };
 
 const server = http.createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://localhost");
@@ -52,15 +61,30 @@ const server = http.createServer((req, res) => {
   const m = req.method === "POST" ? REFRESH_RE.exec(url.pathname) : null;
   if (!m) {
     console.error(`[token-stub] 404 ${req.method} ${url.pathname}`);
-    res
-      .writeHead(404, { "Content-Type": "application/json" })
-      .end('{"error":"not found"}');
+    res.writeHead(404, JSON_HEADERS).end('{"error":"not found"}');
     return;
   }
-  const taskId = decodeURIComponent(m[1]);
+  if (expectedBearer !== "" && req.headers.authorization !== `Bearer ${expectedBearer}`) {
+    console.error(`[token-stub] 401 bad or missing bearer for ${url.pathname}`);
+    res.writeHead(401, JSON_HEADERS).end('{"error":"unauthorized"}');
+    return;
+  }
+  let taskId;
+  try {
+    taskId = decodeURIComponent(m[1]);
+  } catch {
+    console.error(`[token-stub] 400 malformed task id segment`);
+    res.writeHead(400, JSON_HEADERS).end('{"error":"malformed task id"}');
+    return;
+  }
   console.error(`[token-stub] 200 refresh for task ${taskId}`);
-  res.writeHead(200, { "Content-Type": "application/json" });
+  res.writeHead(200, JSON_HEADERS);
   res.end(JSON.stringify({ token: pat, taskId }));
+});
+
+server.on("error", (err) => {
+  console.error(`[token-stub] server error: ${err.message}`);
+  process.exit(1);
 });
 
 server.listen(port, bind, () => {

--- a/runners/remote-worker/local/token-stub.mjs
+++ b/runners/remote-worker/local/token-stub.mjs
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Local-dev credential stub. Stands in for the platform's
+// credentials/refresh endpoint so the runner can be exercised without
+// the BFF/git-service:
+//
+//   POST /internal/v1/tasks/{taskId}/credentials/refresh
+//     -> { "token": $GITHUB_PAT, "taskId": <echoed from path> }
+//
+// The taskId echo satisfies credhelper.sh's anti-misroute tripwire.
+// Identity fields are deliberately omitted so the runner keeps the
+// AEP_IDENTITY_* values it was launched with (no drift rewrite).
+//
+// SECURITY: every response carries a real GitHub PAT. Keep the bind
+// address on loopback (the default) and never expose this beyond your
+// machine.
+
+import http from "node:http";
+
+const pat = process.env.GITHUB_PAT ?? "";
+if (pat === "") {
+  console.error("[token-stub] GITHUB_PAT is not set");
+  process.exit(1);
+}
+const port = Number(process.env.STUB_PORT || 8377);
+const bind = process.env.STUB_BIND || "127.0.0.1";
+
+const REFRESH_RE = /^\/internal\/v1\/tasks\/([^/]+)\/credentials\/refresh$/;
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (req.method === "GET" && url.pathname === "/healthz") {
+    res.writeHead(200).end("ok");
+    return;
+  }
+  const m = req.method === "POST" ? REFRESH_RE.exec(url.pathname) : null;
+  if (!m) {
+    console.error(`[token-stub] 404 ${req.method} ${url.pathname}`);
+    res
+      .writeHead(404, { "Content-Type": "application/json" })
+      .end('{"error":"not found"}');
+    return;
+  }
+  const taskId = decodeURIComponent(m[1]);
+  console.error(`[token-stub] 200 refresh for task ${taskId}`);
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ token: pat, taskId }));
+});
+
+server.listen(port, bind, () => {
+  console.error(`[token-stub] listening on http://${bind}:${port}`);
+});


### PR DESCRIPTION
## Summary

Adds `runners/remote-worker/local/`, a self-contained harness that runs the coding-agent runner as a local Docker one-shot — no k3d, BFF, or Argo needed. The only substitution is a loopback token stub standing in for git-service's `POST /internal/v1/tasks/{taskId}/credentials/refresh`; everything else (workspace provisioning, credhelper/gh wrapper, the `aep` skill plugin, the Agent SDK run) is the production code path in the real runner image.

## What's included

- **`token-stub.mjs`** — loopback HTTP server returning the GitHub PAT plus the `taskId` echo required by the credhelper anti-misroute tripwire. Identity fields are omitted so `AEP_IDENTITY_*` values stick (no drift rewrite).
- **`run-local.sh`** — sources `.env.local`, starts the stub, builds the image, and runs the container with the same `AEP_*` env contract the Argo pod gets. Bind-mounts `plugin/` read-only (live skill edits, mirrors the k3d dev flow) and keeps the workspace + SDK transcript under `local/workspace/` for inspection.
- **`env.local.example` / `README.md`** — required knobs, usage, and safety notes.
- Ignore rules: `.env.local` + `workspace/` gitignored, `local/` dockerignored, so secrets never enter git or the image build context.

## Safety

- Agent runs containerized only (it uses `bypassPermissions`).
- Stub binds to `127.0.0.1` by default; docs call out the Linux `host-gateway` trade-off.
- README recommends a fine-grained PAT scoped to a single throwaway test repo.

## Verification

Validated end-to-end on macOS + colima against a throwaway repo: clone → feature branch → commit → push → PR opened by the agent, runner exit 0, progress NDJSON streamed with the scrubber redacting sensitive values. Stub endpoints, container→host connectivity (`host.docker.internal`), and the image build were verified individually as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)