### PR TITLE
Console: projects listing page with requirement-first create flow

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -68,7 +68,11 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
-- _none_
+- Projects listing page — card-grid landing page with server-side search and
+  requirement-first create (`/projects/new`) —
+  [#71](https://github.com/wso2/labs-agentic-engineer/issues/71) (BE
+  handshake: [#72](https://github.com/wso2/labs-agentic-engineer/issues/72),
+  ADR-0005)
 
 ## Feature inventory
 

--- a/apps/console/design/decisions/ADR-0005-requirement-first-project-creation.md
+++ b/apps/console/design/decisions/ADR-0005-requirement-first-project-creation.md
@@ -1,0 +1,33 @@
+# ADR-0005: Project creation is requirement-first
+
+- **Status:** Accepted
+- **Date:** 2026-07-03 (grilling of the projects-listing feature,
+  [#71](https://github.com/wso2/labs-agentic-engineer/issues/71))
+- **Context:** the projects listing feature needed a "Create project"
+  action. A plain metadata dialog (name/description → `POST /projects`) was
+  proposed and rejected.
+
+## Decision
+
+Creating a project starts from a **requirement prompt**, not metadata. The
+console's create flow (a dedicated `/projects/new` page) asks *what do you
+want to build*, then confirms a suggested project name and the repo URL
+(derived by convention from the connected GitHub org + project name), and
+sends the prompt with `POST /projects`. The backend persists the prompt as
+the project's initial requirement and kicks off spec derivation; the user
+lands on the new project's overview.
+
+Any future surface that creates projects follows the same rule: a project
+is born from a requirement (PRD: "give a requirement → project is born"),
+never as an empty metadata shell.
+
+## Consequences
+
+- `CreateProjectRequest` carries a `prompt` field (contract change agreed
+  via the BE handshake for #71).
+- The PRD's Home/empty-state description becomes shipped behavior rather
+  than aspiration once #71 ships.
+- Metadata-only creation is not exposed in the console UI; if an
+  API-level escape hatch stays possible, the console never offers it.
+- Name suggestion is client-side in v1; a smarter backend suggestion can
+  replace it without changing this decision.

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -16,20 +16,93 @@
  * under the License.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import type { components } from "../../../generated/aep-api";
 import { client } from "../../../api/client";
-import { projectKeys } from "./keys";
+import { githubKeys, projectKeys } from "./keys";
 
-export function useProjectsList() {
-  return useQuery({
-    queryKey: projectKeys.lists(),
-    queryFn: async () => {
-      const { data, error } = await client.GET("/projects");
+type CreateProjectRequest = components["schemas"]["CreateProjectRequest"];
+
+export function useProjectsList(search = "") {
+  return useInfiniteQuery({
+    queryKey: projectKeys.list(search),
+    queryFn: async ({ pageParam }) => {
+      const { data, error } = await client.GET("/projects", {
+        params: {
+          query: {
+            ...(search && { search }),
+            ...(pageParam && { cursor: pageParam }),
+          },
+        },
+      });
       if (error) {
         throw new Error(error.detail ?? error.title ?? "Failed to load projects");
       }
       return data;
     },
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
+    // Keep the previous result visible while a new search resolves — no
+    // flicker between keystrokes.
+    placeholderData: keepPreviousData,
     staleTime: 30_000,
+  });
+}
+
+export function useProject(projectName: string) {
+  return useQuery({
+    queryKey: projectKeys.detail(projectName),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/projects/{projectName}", {
+        params: { path: { projectName } },
+      });
+      if (error) {
+        throw new Error(error.detail ?? error.title ?? "Failed to load project");
+      }
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreateProjectRequest) => {
+      const { data, error } = await client.POST("/projects", { body });
+      if (error) {
+        throw new Error(
+          error.detail ?? error.title ?? "Failed to create project",
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
+    },
+  });
+}
+
+// The connected GitHub org, for the repo-URL preview in the create flow.
+// get-github-status is untyped in the contract (issue #72 asks the BFF to
+// firm this up), so the org is read defensively from the likely fields.
+export function useGithubOrg() {
+  return useQuery({
+    queryKey: githubKeys.status,
+    queryFn: async () => {
+      const { data, error } = await client.GET("/org/credentials/github");
+      if (error || !data) return null;
+      const status = data as Record<string, unknown>;
+      const org = status.org ?? status.owner ?? status.login;
+      return typeof org === "string" && org ? org : null;
+    },
+    staleTime: 5 * 60_000,
+    retry: false,
   });
 }

--- a/apps/console/src/features/projects/components/ProjectCreate.tsx
+++ b/apps/console/src/features/projects/components/ProjectCreate.tsx
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Grid,
+  PageContent,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  ArrowLeft,
+  GitHub,
+  ShoppingCart,
+  Dumbbell,
+  ReceiptText,
+} from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import { useCreateProject, useGithubOrg } from "../api/queries";
+import {
+  isValidProjectName,
+  repoUrlFor,
+  suggestProjectName,
+} from "../lib/projectName";
+
+// Issue #71 decision: clicking an example acts as prompt + Start in one
+// click — it jumps straight to the name/repo confirmation step.
+const EXAMPLE_PROMPTS = [
+  {
+    icon: <ShoppingCart size={24} />,
+    title: "Online store",
+    prompt:
+      "An online store for handmade ceramics with a product catalog, cart, and checkout",
+  },
+  {
+    icon: <Dumbbell size={24} />,
+    title: "Workout tracker",
+    prompt:
+      "A gym workout tracker where I can log exercises, sets, and weights and see progress over time",
+  },
+  {
+    icon: <ReceiptText size={24} />,
+    title: "Invoicing tool",
+    prompt:
+      "An invoicing tool for freelancers that creates invoices, tracks payments, and exports PDFs",
+  },
+] as const;
+
+function ExampleCard({
+  icon,
+  title,
+  prompt,
+  onPick,
+}: (typeof EXAMPLE_PROMPTS)[number] & { onPick: (prompt: string) => void }) {
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardActionArea sx={{ height: "100%" }} onClick={() => onPick(prompt)}>
+        <CardContent>
+          <Stack direction="row" spacing={1.5} sx={{ alignItems: "center", mb: 1 }}>
+            {icon}
+            <Typography variant="subtitle1">{title}</Typography>
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {prompt}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+export function ProjectCreate() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<"prompt" | "confirm">("prompt");
+  const [prompt, setPrompt] = useState("");
+  const [name, setName] = useState("");
+  const { data: githubOrg } = useGithubOrg();
+  const createProject = useCreateProject();
+
+  const start = (chosenPrompt: string) => {
+    setPrompt(chosenPrompt);
+    setName(suggestProjectName(chosenPrompt));
+    createProject.reset();
+    setStep("confirm");
+  };
+
+  const nameError = name && !isValidProjectName(name)
+    ? "Lowercase letters, digits, and dashes; must start with a letter."
+    : null;
+
+  const accept = () => {
+    createProject.mutate(
+      { name, prompt },
+      {
+        onSuccess: (project) =>
+          void navigate({
+            to: "/projects/$projectName",
+            params: { projectName: project.name },
+          }),
+      },
+    );
+  };
+
+  return (
+    <PageContent>
+      <Box sx={{ maxWidth: 720, mx: "auto", pt: { xs: 4, md: 8 } }}>
+        {step === "prompt" ? (
+          <Stack spacing={4}>
+            <Box sx={{ textAlign: "center" }}>
+              <Typography variant="h4" gutterBottom>
+                What do you want to build?
+              </Typography>
+              <Typography variant="body1" color="text.secondary">
+                Describe it in your own words — AEP turns your requirement
+                into a project and starts deriving its design.
+              </Typography>
+            </Box>
+            <Stack spacing={2}>
+              <TextField
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder="e.g. A booking system for a small hair salon with staff calendars and SMS reminders"
+                multiline
+                minRows={3}
+                autoFocus
+                fullWidth
+              />
+              <Box sx={{ textAlign: "right" }}>
+                <Button
+                  variant="contained"
+                  disabled={!prompt.trim()}
+                  onClick={() => start(prompt.trim())}
+                >
+                  Start
+                </Button>
+              </Box>
+            </Stack>
+            <Grid container spacing={2}>
+              {EXAMPLE_PROMPTS.map((example) => (
+                <Grid key={example.title} size={{ xs: 12, sm: 4 }}>
+                  <ExampleCard {...example} onPick={start} />
+                </Grid>
+              ))}
+            </Grid>
+          </Stack>
+        ) : (
+          <Stack spacing={3}>
+            <Box>
+              <Typography variant="h4" gutterBottom>
+                Name your project
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                “{prompt}”
+              </Typography>
+            </Box>
+            <TextField
+              label="Project name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              error={Boolean(nameError)}
+              helperText={
+                nameError ?? "Suggested from your prompt — change it if you like."
+              }
+              fullWidth
+            />
+            <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+              <GitHub size={18} />
+              <Typography variant="body2" color="text.secondary">
+                Specs and source will live in{" "}
+                <Box component="span" sx={{ fontFamily: "monospace" }}>
+                  {repoUrlFor(githubOrg ?? null, name)}
+                </Box>
+              </Typography>
+            </Stack>
+            {createProject.isError && (
+              <Alert severity="error">
+                {createProject.error instanceof Error
+                  ? createProject.error.message
+                  : "Failed to create project"}
+              </Alert>
+            )}
+            <Stack direction="row" spacing={2} sx={{ justifyContent: "flex-end" }}>
+              <Button
+                startIcon={<ArrowLeft size={18} />}
+                onClick={() => setStep("prompt")}
+                disabled={createProject.isPending}
+              >
+                Back
+              </Button>
+              <Button
+                variant="contained"
+                onClick={accept}
+                disabled={!name || Boolean(nameError) || createProject.isPending}
+                loading={createProject.isPending}
+              >
+                Create project
+              </Button>
+            </Stack>
+          </Stack>
+        )}
+      </Box>
+    </PageContent>
+  );
+}

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  PageContent,
+  PageTitle,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Link } from "@tanstack/react-router";
+import { useProject } from "../api/queries";
+
+// Stub navigation target for the projects listing (issue #71). The real
+// overview — component map, deployment state, activity — is its own feature.
+export function ProjectOverview({ projectName }: { projectName: string }) {
+  const { data, isPending, isError, error, refetch } = useProject(projectName);
+
+  if (isPending) {
+    return (
+      <PageContent>
+        <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
+          <CircularProgress aria-label="Loading project" />
+        </Box>
+      </PageContent>
+    );
+  }
+
+  if (isError) {
+    return (
+      <PageContent>
+        <Alert
+          severity="error"
+          action={<Button onClick={() => void refetch()}>Retry</Button>}
+        >
+          Failed to load project
+          {error instanceof Error && error.message ? `: ${error.message}` : ""}
+        </Alert>
+      </PageContent>
+    );
+  }
+
+  return (
+    <PageContent>
+      <PageTitle>
+        <PageTitle.Header>{data.displayName ?? data.name}</PageTitle.Header>
+        {data.description && (
+          <PageTitle.SubHeader>{data.description}</PageTitle.SubHeader>
+        )}
+      </PageTitle>
+      <Typography variant="body2" color="text.secondary">
+        The project overview — component map, deployment state, and activity —
+        is on its way. Meanwhile, head{" "}
+        <Link to="/">back to your projects</Link>.
+      </Typography>
+    </PageContent>
+  );
+}

--- a/apps/console/src/features/projects/components/ProjectsList.tsx
+++ b/apps/console/src/features/projects/components/ProjectsList.tsx
@@ -16,79 +16,126 @@
  * under the License.
  */
 
+import { useState } from "react";
 import {
   Alert,
   Box,
   Button,
+  Card,
+  CardActionArea,
+  CardContent,
   CircularProgress,
-  List,
-  ListItem,
-  ListItemText,
+  Grid,
   PageContent,
   PageTitle,
+  SearchBar,
   Typography,
 } from "@wso2/oxygen-ui";
 import { Folder, Plus } from "@wso2/oxygen-ui-icons-react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import type { components } from "../../../generated/aep-api";
 import { useProjectsList } from "../api/queries";
+import { useDebouncedValue } from "../hooks/useDebouncedValue";
 
-function ProjectsBody() {
-  const { data, isPending, isError, error, refetch } = useProjectsList();
+type Project = components["schemas"]["Project"];
 
-  if (isPending) {
-    return (
-      <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
-        <CircularProgress aria-label="Loading projects" />
-      </Box>
-    );
-  }
+function formatCreatedAt(createdAt?: string): string | null {
+  if (!createdAt) return null;
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return `Created ${date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })}`;
+}
 
-  if (isError) {
-    return (
-      <Alert
-        severity="error"
-        action={<Button onClick={() => void refetch()}>Retry</Button>}
-      >
-        Failed to load projects
-        {error instanceof Error && error.message ? `: ${error.message}` : ""}
-      </Alert>
-    );
-  }
-
-  const items = data.items ?? [];
-
-  if (items.length === 0) {
-    // PRD: home = projects list; empty state prompts "start building".
-    return (
-      <Box sx={{ textAlign: "center", py: 8 }}>
-        <Folder size={48} style={{ opacity: 0.3, marginBottom: 16 }} />
-        <Typography variant="h6" gutterBottom>
-          No projects yet
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Start building — give a requirement and AEP turns it into a project.
-        </Typography>
-        <Button variant="contained" startIcon={<Plus size={20} />} disabled>
-          Start building
-        </Button>
-      </Box>
-    );
-  }
+function ProjectCard({ project }: { project: Project }) {
+  const navigate = useNavigate();
+  const created = formatCreatedAt(project.createdAt);
 
   return (
-    <List>
-      {items.map((project) => (
-        <ListItem key={project.name}>
-          <ListItemText
-            primary={project.displayName ?? project.name}
-            secondary={project.description}
-          />
-        </ListItem>
-      ))}
-    </List>
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardActionArea
+        sx={{ height: "100%", alignItems: "stretch" }}
+        onClick={() =>
+          void navigate({
+            to: "/projects/$projectName",
+            params: { projectName: project.name },
+          })
+        }
+      >
+        <CardContent
+          sx={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
+          <Typography variant="h6" gutterBottom>
+            {project.displayName ?? project.name}
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              flexGrow: 1,
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {project.description}
+          </Typography>
+          {created && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1.5 }}>
+              {created}
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+function EmptyState() {
+  return (
+    <Box sx={{ textAlign: "center", py: 8 }}>
+      <Folder size={48} style={{ opacity: 0.3, marginBottom: 16 }} />
+      <Typography variant="h6" gutterBottom>
+        No projects yet
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Tell AEP what you want to build and it becomes your first project.
+      </Typography>
+      <Button
+        variant="contained"
+        startIcon={<Plus size={20} />}
+        component={Link}
+        to="/projects/new"
+      >
+        Create project
+      </Button>
+    </Box>
   );
 }
 
 export function ProjectsList() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search.trim());
+  const {
+    data,
+    isPending,
+    isError,
+    error,
+    refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useProjectsList(debouncedSearch);
+
+  const items = data?.pages.flatMap((page) => page.items ?? []) ?? [];
+  // True-empty (no projects at all, not a fruitless search) hides the page
+  // action and centers the create button instead — issue #71 decision.
+  const isTrueEmpty = !isPending && !isError && items.length === 0 && !debouncedSearch;
+
   return (
     <PageContent>
       <PageTitle>
@@ -96,13 +143,71 @@ export function ProjectsList() {
         <PageTitle.SubHeader>
           Everything AEP is building for you, one project per app.
         </PageTitle.SubHeader>
-        <PageTitle.Actions>
-          <Button variant="contained" startIcon={<Plus size={20} />} disabled>
-            Start building
-          </Button>
-        </PageTitle.Actions>
+        {!isTrueEmpty && (
+          <PageTitle.Actions>
+            <Button
+              variant="contained"
+              startIcon={<Plus size={20} />}
+              component={Link}
+              to="/projects/new"
+            >
+              Create project
+            </Button>
+          </PageTitle.Actions>
+        )}
       </PageTitle>
-      <ProjectsBody />
+
+      {isPending ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
+          <CircularProgress aria-label="Loading projects" />
+        </Box>
+      ) : isError ? (
+        <Alert
+          severity="error"
+          action={<Button onClick={() => void refetch()}>Retry</Button>}
+        >
+          Failed to load projects
+          {error instanceof Error && error.message ? `: ${error.message}` : ""}
+        </Alert>
+      ) : isTrueEmpty ? (
+        <EmptyState />
+      ) : (
+        <>
+          <Box sx={{ maxWidth: 420, mb: 3 }}>
+            <SearchBar
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search projects..."
+            />
+          </Box>
+          {items.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
+              No projects match “{debouncedSearch}”.
+            </Typography>
+          ) : (
+            <>
+              <Grid container spacing={3}>
+                {items.map((project) => (
+                  <Grid key={project.name} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                    <ProjectCard project={project} />
+                  </Grid>
+                ))}
+              </Grid>
+              {hasNextPage && (
+                <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+                  <Button
+                    variant="outlined"
+                    onClick={() => void fetchNextPage()}
+                    loading={isFetchingNextPage}
+                  >
+                    View more
+                  </Button>
+                </Box>
+              )}
+            </>
+          )}
+        </>
+      )}
     </PageContent>
   );
 }

--- a/apps/console/src/features/projects/hooks/useDebouncedValue.ts
+++ b/apps/console/src/features/projects/hooks/useDebouncedValue.ts
@@ -16,14 +16,15 @@
  * under the License.
  */
 
-export const projectKeys = {
-  all: ["projects"] as const,
-  lists: () => [...projectKeys.all, "list"] as const,
-  list: (search: string) => [...projectKeys.lists(), { search }] as const,
-  details: () => [...projectKeys.all, "detail"] as const,
-  detail: (name: string) => [...projectKeys.details(), name] as const,
-};
+import { useEffect, useState } from "react";
 
-export const githubKeys = {
-  status: ["github", "status"] as const,
-};
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/apps/console/src/features/projects/lib/projectName.ts
+++ b/apps/console/src/features/projects/lib/projectName.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Client-side name suggestion (issue #71 decision: heuristic, no backend
+// call). Filler words carry no meaning for a project name.
+const FILLER = new Set([
+  "a", "an", "the", "and", "or", "of", "for", "to", "with", "in", "on",
+  "that", "which", "my", "our", "me", "i", "want", "need", "like", "build",
+  "make", "create", "app", "application", "website", "web", "site", "tool",
+  "system", "platform", "service", "software", "simple", "new", "online",
+  "some", "it", "is", "should", "be", "can", "will", "where", "users",
+  "user", "lets", "let",
+]);
+
+const NAME_MAX = 40;
+const NAME_PATTERN = /^[a-z]([a-z0-9-]*[a-z0-9])?$/;
+
+export function isValidProjectName(name: string): boolean {
+  return name.length <= NAME_MAX && NAME_PATTERN.test(name);
+}
+
+export function suggestProjectName(prompt: string): string {
+  const words = prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .split(/[\s-]+/)
+    .filter((w) => w && !FILLER.has(w));
+  const slug = words
+    .slice(0, 3)
+    .join("-")
+    .replace(/^[^a-z]+/, "")
+    .replace(/-+/g, "-")
+    .replace(/-$/, "")
+    .slice(0, NAME_MAX)
+    .replace(/-$/, "");
+  return isValidProjectName(slug) ? slug : "my-project";
+}
+
+export function repoUrlFor(org: string | null, name: string): string {
+  return `github.com/${org ?? "<your-org>"}/${name || "<project-name>"}`;
+}

--- a/apps/console/src/layouts/AppLayout.tsx
+++ b/apps/console/src/layouts/AppLayout.tsx
@@ -26,7 +26,7 @@ import {
   UserMenu,
   version as OXYGEN_UI_VERSION,
 } from "@wso2/oxygen-ui";
-import { Home, Settings, User as UserIcon, WSO2 } from "@wso2/oxygen-ui-icons-react";
+import { FolderOpen, Settings, User as UserIcon, WSO2 } from "@wso2/oxygen-ui-icons-react";
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 
 // TODO(auth): replace with the signed-in user when auth lands.
@@ -38,8 +38,8 @@ const devUser = {
 
 // Sidebar highlight follows the route; grows one mapping per top-level route.
 function activeItemFor(pathname: string): string {
-  if (pathname === "/") return "home";
-  return "home";
+  if (pathname === "/" || pathname.startsWith("/projects")) return "projects";
+  return "projects";
 }
 
 // App shell per the oxygen-ui skill's canonical AppLayout: Header + Sidebar +
@@ -55,10 +55,21 @@ export function AppLayout() {
         <Header>
           <Header.Toggle />
           <Header.Brand>
-            <Header.BrandLogo>
-              <WSO2 size={24} />
-            </Header.BrandLogo>
-            <Header.BrandTitle>Agentic Engineer</Header.BrandTitle>
+            {/* Logo/title lead home — the projects list (issue #71). */}
+            <Link
+              to="/"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                textDecoration: "none",
+                color: "inherit",
+              }}
+            >
+              <Header.BrandLogo>
+                <WSO2 size={24} />
+              </Header.BrandLogo>
+              <Header.BrandTitle>Agentic Engineer</Header.BrandTitle>
+            </Link>
           </Header.Brand>
           <Header.Spacer />
           <Header.Actions>
@@ -82,11 +93,11 @@ export function AppLayout() {
         <Sidebar activeItem={activeItem}>
           <Sidebar.Nav>
             <Sidebar.Category>
-              <Sidebar.Item id="home" link={<Link to="/" />}>
+              <Sidebar.Item id="projects" link={<Link to="/" />}>
                 <Sidebar.ItemIcon>
-                  <Home />
+                  <FolderOpen />
                 </Sidebar.ItemIcon>
-                <Sidebar.ItemLabel>Home</Sidebar.ItemLabel>
+                <Sidebar.ItemLabel>Projects</Sidebar.ItemLabel>
               </Sidebar.Item>
             </Sidebar.Category>
           </Sidebar.Nav>

--- a/apps/console/src/mocks/fixtures/projects.ts
+++ b/apps/console/src/mocks/fixtures/projects.ts
@@ -1,5 +1,6 @@
 import type { components } from "../../generated/aep-api";
 
+type Project = components["schemas"]["Project"];
 type ProjectList = components["schemas"]["ProjectList"];
 type ErrorModel = components["schemas"]["ErrorModel"];
 
@@ -10,20 +11,92 @@ export type ProjectsScenario = "empty" | "some" | "error";
 
 export const emptyProjects: ProjectList = { items: [] };
 
-export const someProjects: ProjectList = {
-  items: [
-    {
-      name: "demo-shop",
-      displayName: "Demo Shop",
-      description: "Sample project seeded by the mock layer",
-      status: "active",
-    },
-  ],
-};
+export const seedProjects: Project[] = [
+  {
+    name: "demo-shop",
+    displayName: "Demo Shop",
+    description: "Sample storefront seeded by the mock layer",
+    status: "active",
+    createdAt: "2026-06-12T09:30:00Z",
+  },
+  {
+    name: "gym-tracker",
+    displayName: "Gym Tracker",
+    description: "Track workouts, sets, and progress over time",
+    status: "active",
+    createdAt: "2026-06-20T14:05:00Z",
+  },
+  {
+    name: "invoice-hub",
+    displayName: "Invoice Hub",
+    description: "Small-business invoicing with PDF export",
+    status: "active",
+    createdAt: "2026-07-01T08:15:00Z",
+  },
+  {
+    name: "salon-booking",
+    displayName: "Salon Booking",
+    description: "Appointments with staff calendars and SMS reminders",
+    status: "active",
+    createdAt: "2026-06-25T10:00:00Z",
+  },
+  {
+    name: "pet-adoption",
+    displayName: "Pet Adoption",
+    description: "Browse shelters and apply to adopt",
+    status: "active",
+    createdAt: "2026-06-18T16:45:00Z",
+  },
+  {
+    name: "recipe-box",
+    displayName: "Recipe Box",
+    description: "Save, tag, and share family recipes",
+    status: "active",
+    createdAt: "2026-06-15T11:20:00Z",
+  },
+  {
+    name: "event-radar",
+    displayName: "Event Radar",
+    description: "Local events with reminders and friends' plans",
+    status: "active",
+    createdAt: "2026-06-22T09:10:00Z",
+  },
+  {
+    name: "fleet-watch",
+    displayName: "Fleet Watch",
+    description: "Delivery fleet tracking and route history",
+    status: "active",
+    createdAt: "2026-06-28T13:40:00Z",
+  },
+  {
+    name: "study-buddy",
+    displayName: "Study Buddy",
+    description: "Flashcards and spaced-repetition study plans",
+    status: "active",
+    createdAt: "2026-06-30T18:05:00Z",
+  },
+];
+
+// Mock server-side page size for the projects list (View more pagination).
+export const PROJECTS_PAGE_SIZE = 6;
 
 export const projectsError: ErrorModel = {
   type: "about:blank",
   status: 500,
   title: "Internal Server Error",
   detail: "Mock error scenario for the projects list",
+};
+
+export const duplicateProjectError: ErrorModel = {
+  type: "about:blank",
+  status: 409,
+  title: "Conflict",
+  detail: "A project with this name already exists",
+};
+
+// The connected GitHub org surfaced by get-github-status; the create flow
+// derives the repo-URL preview from it (issue #72 confirms the field name).
+export const githubStatus = {
+  connected: true,
+  org: "acme-dev",
 };

--- a/apps/console/src/mocks/handlers/projects.ts
+++ b/apps/console/src/mocks/handlers/projects.ts
@@ -1,10 +1,17 @@
 import { http, HttpResponse } from "msw";
+import type { components } from "../../generated/aep-api";
 import {
+  duplicateProjectError,
   emptyProjects,
+  githubStatus,
   projectsError,
-  someProjects,
+  PROJECTS_PAGE_SIZE,
+  seedProjects,
   type ProjectsScenario,
 } from "../fixtures/projects";
+
+type Project = components["schemas"]["Project"];
+type CreateProjectRequest = components["schemas"]["CreateProjectRequest"];
 
 function scenario(): ProjectsScenario {
   return (
@@ -13,20 +20,88 @@ function scenario(): ProjectsScenario {
   );
 }
 
+// Projects created through the UI in this session; layered on top of the
+// scenario's seed so the create flow behaves statefully in mock mode.
+const createdProjects: Project[] = [];
+
+function currentProjects(): Project[] {
+  const seed = scenario() === "some" ? seedProjects : [];
+  return [...seed, ...createdProjects];
+}
+
 export const projectsHandlers = [
   // Wildcard prefix: matches whatever runtime API base URL sits in front of
   // /api/v1.
-  http.get("*/api/v1/projects", () => {
-    switch (scenario()) {
-      case "error":
-        return HttpResponse.json(projectsError, {
-          status: 500,
-          headers: { "Content-Type": "application/problem+json" },
-        });
-      case "some":
-        return HttpResponse.json(someProjects);
-      default:
-        return HttpResponse.json(emptyProjects);
+  http.get("*/api/v1/projects", ({ request }) => {
+    if (scenario() === "error") {
+      return HttpResponse.json(projectsError, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
     }
+    const params = new URL(request.url).searchParams;
+    const search = params.get("search")?.trim();
+    const matches = currentProjects().filter((p) => {
+      if (!search) return true;
+      const q = search.toLowerCase();
+      return (
+        p.name?.toLowerCase().includes(q) ||
+        p.displayName?.toLowerCase().includes(q)
+      );
+    });
+    if (matches.length === 0 && !search) {
+      return HttpResponse.json(emptyProjects);
+    }
+    // The cursor is opaque to the client; the mock's is a plain offset.
+    const offset = Number(params.get("cursor") ?? 0) || 0;
+    const items = matches.slice(offset, offset + PROJECTS_PAGE_SIZE);
+    const next = offset + PROJECTS_PAGE_SIZE;
+    return HttpResponse.json({
+      items,
+      ...(next < matches.length && { nextCursor: String(next) }),
+    });
   }),
+
+  http.post("*/api/v1/projects", async ({ request }) => {
+    const body = (await request.json()) as CreateProjectRequest;
+    if (currentProjects().some((p) => p.name === body.name)) {
+      return HttpResponse.json(duplicateProjectError, {
+        status: 409,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    const project: Project = {
+      name: body.name,
+      displayName: body.displayName ?? body.name,
+      ...(body.description !== undefined && { description: body.description }),
+      status: "active",
+      createdAt: new Date().toISOString(),
+    };
+    createdProjects.push(project);
+    return HttpResponse.json(project, { status: 201 });
+  }),
+
+  http.get("*/api/v1/projects/:projectName", ({ params }) => {
+    const project = currentProjects().find(
+      (p) => p.name === params.projectName,
+    );
+    if (!project) {
+      return HttpResponse.json(
+        {
+          type: "about:blank",
+          status: 404,
+          title: "Not Found",
+          detail: `Project ${String(params.projectName)} not found`,
+        },
+        { status: 404, headers: { "Content-Type": "application/problem+json" } },
+      );
+    }
+    return HttpResponse.json(project);
+  }),
+
+  // get-github-status: the create flow reads the connected org for the
+  // repo-URL preview.
+  http.get("*/api/v1/org/credentials/github", () =>
+    HttpResponse.json(githubStatus),
+  ),
 ];

--- a/apps/console/src/routes/projects.$projectName.tsx
+++ b/apps/console/src/routes/projects.$projectName.tsx
@@ -16,14 +16,14 @@
  * under the License.
  */
 
-export const projectKeys = {
-  all: ["projects"] as const,
-  lists: () => [...projectKeys.all, "list"] as const,
-  list: (search: string) => [...projectKeys.lists(), { search }] as const,
-  details: () => [...projectKeys.all, "detail"] as const,
-  detail: (name: string) => [...projectKeys.details(), name] as const,
-};
+import { createFileRoute } from "@tanstack/react-router";
+import { ProjectOverview } from "../features/projects/components/ProjectOverview";
 
-export const githubKeys = {
-  status: ["github", "status"] as const,
-};
+export const Route = createFileRoute("/projects/$projectName")({
+  component: ProjectOverviewRoute,
+});
+
+function ProjectOverviewRoute() {
+  const { projectName } = Route.useParams();
+  return <ProjectOverview projectName={projectName} />;
+}

--- a/apps/console/src/routes/projects.new.tsx
+++ b/apps/console/src/routes/projects.new.tsx
@@ -16,14 +16,9 @@
  * under the License.
  */
 
-export const projectKeys = {
-  all: ["projects"] as const,
-  lists: () => [...projectKeys.all, "list"] as const,
-  list: (search: string) => [...projectKeys.lists(), { search }] as const,
-  details: () => [...projectKeys.all, "detail"] as const,
-  detail: (name: string) => [...projectKeys.details(), name] as const,
-};
+import { createFileRoute } from "@tanstack/react-router";
+import { ProjectCreate } from "../features/projects/components/ProjectCreate";
 
-export const githubKeys = {
-  status: ["github", "status"] as const,
-};
+export const Route = createFileRoute("/projects/new")({
+  component: ProjectCreate,
+});

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -490,6 +490,12 @@ components:
           type: string
         name:
           type: string
+        prompt:
+          description: >-
+            The user's initial requirement — what they want built. Persisted
+            as the project's requirement and triggers spec derivation for the
+            new project.
+          type: string
       required:
         - name
       type: object
@@ -1167,6 +1173,9 @@ components:
           type:
             - array
             - "null"
+        nextCursor:
+          description: Cursor for the next page; absent on the last page.
+          type: string
       required:
         - items
       type: object
@@ -2143,6 +2152,13 @@ paths:
           name: cursor
           schema:
             description: Opaque pagination cursor
+            type: string
+        - description: Case-insensitive substring match on name and displayName
+          explode: false
+          in: query
+          name: search
+          schema:
+            description: Case-insensitive substring match on name and displayName
             type: string
       responses:
         "200":


### PR DESCRIPTION
Implements #71 (console feature). FE side of the #72 BE handshake.

## What

- **Projects grid** (`/`, the landing page): metadata cards (display name, description, created date), debounced **server-side search**, **View more** cursor pagination, centered empty state, load-error with retry.
- **`/projects/new`** requirement-first create: centered "What do you want to build?" prompt with three one-click example cards → suggested project name (client-side heuristic) + repo-URL preview (connected GitHub org + name) → `POST /projects` carrying the prompt → lands on the new project's overview.
- **Stub `/projects/$projectName`** overview as the navigation target (real overview is its own feature).
- **Nav**: sidebar Projects item (route-synced), header logo/title link home.
- **Contract proposal** in `packages/contracts/api/v1/openapi.yaml` (FE-first per the console flow): `CreateProjectRequest.prompt`, `list-projects?search=`, `ProjectList.nextCursor`.
- **Typed MSW mocks**: stateful create, search, paging, duplicate-name 409, project detail, github-status org.
- ADR-0005 (requirement-first project creation) + PRD in-flight line.

## Screenshots

| Grid | Create — prompt | Create — confirm |
|---|---|---|
| ![grid](https://raw.githubusercontent.com/hevayo/labs-agentic-engineer/assets/console-issue-71/projects-grid.png) | ![prompt](https://raw.githubusercontent.com/hevayo/labs-agentic-engineer/assets/console-issue-71/project-create-prompt.png) | ![confirm](https://raw.githubusercontent.com/hevayo/labs-agentic-engineer/assets/console-issue-71/project-create-confirm.png) |

## Verification

Mock mode (`VITE_API_MODE=mock`) driven end-to-end with Playwright: grid populated/empty/error, search, View more (6+3 pages), card → overview, create with prompt in the POST body, example-card one-click start, duplicate 409 inline, nav links. `typecheck`/`lint`/production build clean.

## Notes for review

- The contract edit is the agreed **proposal**; the spec is exported from aep-api by `make gen`, so `openapi-check` will flag drift until #72 lands BE-side. FE and BE ship separately per the flow; smoke against the real BFF + closing #71 happens after #72.
- Decisions and their why: grilling-outcome comment on #71.

Refs #71, #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
