### PR TITLE
Console: #71 feedback — editable repo name, full-row pagination

### DIFF
--- a/apps/console/src/features/projects/api/keys.ts
+++ b/apps/console/src/features/projects/api/keys.ts
@@ -19,7 +19,8 @@
 export const projectKeys = {
   all: ["projects"] as const,
   lists: () => [...projectKeys.all, "list"] as const,
-  list: (search: string) => [...projectKeys.lists(), { search }] as const,
+  list: (search: string, limit?: number) =>
+    [...projectKeys.lists(), { search, limit }] as const,
   details: () => [...projectKeys.all, "detail"] as const,
   detail: (name: string) => [...projectKeys.details(), name] as const,
 };

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -29,15 +29,16 @@ import { githubKeys, projectKeys } from "./keys";
 
 type CreateProjectRequest = components["schemas"]["CreateProjectRequest"];
 
-export function useProjectsList(search = "") {
+export function useProjectsList(search = "", limit?: number) {
   return useInfiniteQuery({
-    queryKey: projectKeys.list(search),
+    queryKey: projectKeys.list(search, limit),
     queryFn: async ({ pageParam }) => {
       const { data, error } = await client.GET("/projects", {
         params: {
           query: {
             ...(search && { search }),
             ...(pageParam && { cursor: pageParam }),
+            ...(limit && { limit }),
           },
         },
       });

--- a/apps/console/src/features/projects/components/ProjectCreate.tsx
+++ b/apps/console/src/features/projects/components/ProjectCreate.tsx
@@ -39,11 +39,7 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCreateProject, useGithubOrg } from "../api/queries";
-import {
-  isValidProjectName,
-  repoUrlFor,
-  suggestProjectName,
-} from "../lib/projectName";
+import { isValidProjectName, suggestProjectName } from "../lib/projectName";
 
 // Issue #71 decision: clicking an example acts as prompt + Start in one
 // click — it jumps straight to the name/repo confirmation step.
@@ -96,23 +92,38 @@ export function ProjectCreate() {
   const [step, setStep] = useState<"prompt" | "confirm">("prompt");
   const [prompt, setPrompt] = useState("");
   const [name, setName] = useState("");
+  // The repo name follows the project name until the user edits it (#71
+  // feedback: repo name is changeable, the org is fixed).
+  const [repoName, setRepoName] = useState("");
+  const [repoTouched, setRepoTouched] = useState(false);
   const { data: githubOrg } = useGithubOrg();
   const createProject = useCreateProject();
 
   const start = (chosenPrompt: string) => {
+    const suggested = suggestProjectName(chosenPrompt);
     setPrompt(chosenPrompt);
-    setName(suggestProjectName(chosenPrompt));
+    setName(suggested);
+    setRepoName(suggested);
+    setRepoTouched(false);
     createProject.reset();
     setStep("confirm");
   };
 
-  const nameError = name && !isValidProjectName(name)
-    ? "Lowercase letters, digits, and dashes; must start with a letter."
-    : null;
+  const changeName = (value: string) => {
+    setName(value);
+    if (!repoTouched) setRepoName(value);
+  };
+
+  const invalidNameMessage =
+    "Lowercase letters, digits, and dashes; must start with a letter.";
+  const nameError =
+    name && !isValidProjectName(name) ? invalidNameMessage : null;
+  const repoError =
+    repoName && !isValidProjectName(repoName) ? invalidNameMessage : null;
 
   const accept = () => {
     createProject.mutate(
-      { name, prompt },
+      { name, prompt, ...(repoName !== name && { repoName }) },
       {
         onSuccess: (project) =>
           void navigate({
@@ -178,22 +189,43 @@ export function ProjectCreate() {
             <TextField
               label="Project name"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => changeName(e.target.value)}
               error={Boolean(nameError)}
               helperText={
                 nameError ?? "Suggested from your prompt — change it if you like."
               }
               fullWidth
             />
-            <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-              <GitHub size={18} />
-              <Typography variant="body2" color="text.secondary">
-                Specs and source will live in{" "}
-                <Box component="span" sx={{ fontFamily: "monospace" }}>
-                  {repoUrlFor(githubOrg ?? null, name)}
-                </Box>
-              </Typography>
-            </Stack>
+            <TextField
+              label="Repository name"
+              value={repoName}
+              onChange={(e) => {
+                setRepoTouched(true);
+                setRepoName(e.target.value);
+              }}
+              error={Boolean(repoError)}
+              helperText={
+                repoError ??
+                "Holds the project's specs and source; the organization is fixed."
+              }
+              fullWidth
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <Stack
+                      direction="row"
+                      spacing={0.75}
+                      sx={{ alignItems: "center", mr: 0.5, flexShrink: 0 }}
+                    >
+                      <GitHub size={16} />
+                      <Typography variant="body2" color="text.secondary">
+                        github.com/{githubOrg ?? "<your-org>"}/
+                      </Typography>
+                    </Stack>
+                  ),
+                },
+              }}
+            />
             {createProject.isError && (
               <Alert severity="error">
                 {createProject.error instanceof Error

--- a/apps/console/src/features/projects/components/ProjectsList.tsx
+++ b/apps/console/src/features/projects/components/ProjectsList.tsx
@@ -30,6 +30,8 @@ import {
   PageTitle,
   SearchBar,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@wso2/oxygen-ui";
 import { Folder, Plus } from "@wso2/oxygen-ui-icons-react";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -117,9 +119,26 @@ function EmptyState() {
   );
 }
 
+// Grid columns per breakpoint — must mirror the card Grid size props below.
+function useGridColumns(): number {
+  const theme = useTheme();
+  const lg = useMediaQuery(theme.breakpoints.up("lg"));
+  const md = useMediaQuery(theme.breakpoints.up("md"));
+  const sm = useMediaQuery(theme.breakpoints.up("sm"));
+  if (lg) return 4;
+  if (md) return 3;
+  if (sm) return 2;
+  return 1;
+}
+
+// Rows requested per page: the page size is columns × rows, so View more
+// only ever appears under a completely filled last row (#71 feedback).
+const GRID_ROWS_PER_PAGE = 3;
+
 export function ProjectsList() {
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search.trim());
+  const columns = useGridColumns();
   const {
     data,
     isPending,
@@ -129,7 +148,7 @@ export function ProjectsList() {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useProjectsList(debouncedSearch);
+  } = useProjectsList(debouncedSearch, columns * GRID_ROWS_PER_PAGE);
 
   const items = data?.pages.flatMap((page) => page.items ?? []) ?? [];
   // True-empty (no projects at all, not a fruitless search) hides the page

--- a/apps/console/src/features/projects/lib/projectName.ts
+++ b/apps/console/src/features/projects/lib/projectName.ts
@@ -50,7 +50,3 @@ export function suggestProjectName(prompt: string): string {
     .replace(/-$/, "");
   return isValidProjectName(slug) ? slug : "my-project";
 }
-
-export function repoUrlFor(org: string | null, name: string): string {
-  return `github.com/${org ?? "<your-org>"}/${name || "<project-name>"}`;
-}

--- a/apps/console/src/mocks/fixtures/projects.ts
+++ b/apps/console/src/mocks/fixtures/projects.ts
@@ -75,6 +75,48 @@ export const seedProjects: Project[] = [
     status: "active",
     createdAt: "2026-06-30T18:05:00Z",
   },
+  {
+    name: "plant-care",
+    displayName: "Plant Care",
+    description: "Watering schedules and plant health notes",
+    status: "active",
+    createdAt: "2026-06-10T08:00:00Z",
+  },
+  {
+    name: "team-lunch",
+    displayName: "Team Lunch",
+    description: "Vote on where the team eats on Fridays",
+    status: "active",
+    createdAt: "2026-06-11T12:30:00Z",
+  },
+  {
+    name: "book-club",
+    displayName: "Book Club",
+    description: "Reading lists, meetings, and discussion notes",
+    status: "active",
+    createdAt: "2026-06-14T19:15:00Z",
+  },
+  {
+    name: "run-coach",
+    displayName: "Run Coach",
+    description: "Training plans and race-day countdowns",
+    status: "active",
+    createdAt: "2026-06-17T06:50:00Z",
+  },
+  {
+    name: "expense-lens",
+    displayName: "Expense Lens",
+    description: "Snap receipts and categorize team spend",
+    status: "active",
+    createdAt: "2026-06-23T15:25:00Z",
+  },
+  {
+    name: "ticket-desk",
+    displayName: "Ticket Desk",
+    description: "Lightweight internal helpdesk with SLAs",
+    status: "active",
+    createdAt: "2026-06-27T09:55:00Z",
+  },
 ];
 
 // Mock server-side page size for the projects list (View more pagination).

--- a/apps/console/src/mocks/handlers/projects.ts
+++ b/apps/console/src/mocks/handlers/projects.ts
@@ -54,8 +54,9 @@ export const projectsHandlers = [
     }
     // The cursor is opaque to the client; the mock's is a plain offset.
     const offset = Number(params.get("cursor") ?? 0) || 0;
-    const items = matches.slice(offset, offset + PROJECTS_PAGE_SIZE);
-    const next = offset + PROJECTS_PAGE_SIZE;
+    const limit = Number(params.get("limit")) || PROJECTS_PAGE_SIZE;
+    const items = matches.slice(offset, offset + limit);
+    const next = offset + limit;
     return HttpResponse.json({
       items,
       ...(next < matches.length && { nextCursor: String(next) }),

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -496,6 +496,11 @@ components:
             as the project's requirement and triggers spec derivation for the
             new project.
           type: string
+        repoName:
+          description: >-
+            Name of the GitHub repository to create for the project's specs
+            and source (in the connected org). Defaults to the project name.
+          type: string
       required:
         - name
       type: object
@@ -2160,6 +2165,14 @@ paths:
           schema:
             description: Case-insensitive substring match on name and displayName
             type: string
+        - description: Maximum items per page (server default when absent)
+          explode: false
+          in: query
+          name: limit
+          schema:
+            description: Maximum items per page (server default when absent)
+            format: int64
+            type: integer
       responses:
         "200":
           content:


### PR DESCRIPTION
Follow-up to #73 (merged before the feedback round landed). Addresses the two review comments on #71:

- **Editable repository name (org fixed)**: the create confirm step gains a Repository name field under the fixed `github.com/<org>/` prefix; defaults to the project name and follows it until edited. Sent as `CreateProjectRequest.repoName` when it differs (contract proposal, added to the #72 handshake).
- **Full rows before View more**: the grid requests `columns × 3 rows` per page via a new `list-projects` `limit` param (12/9/6/3 by breakpoint), so View more only appears under a filled last row. Mock seeds grew to 15 to exercise this at desktop width.

| Grid — full rows | Create — repo name |
|---|---|
| ![grid](https://raw.githubusercontent.com/hevayo/labs-agentic-engineer/assets/console-issue-71/projects-grid-full-rows.png) | ![repo](https://raw.githubusercontent.com/hevayo/labs-agentic-engineer/assets/console-issue-71/project-create-repo-name.png) |

Verified in mock mode: 12-card first page → View more loads the remaining 3 and disappears; repo name follows/decouples; `repoName` present in the POST body; duplicate 409 unchanged. Typecheck/lint clean.

Refs #71, #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
