### PR TITLE
Add the full-screen spec view with grouped files and build trigger (#80)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -68,6 +68,11 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
+- Spec view — full-screen spec workspace (grouped requirement/design/validation
+  file listing, placeholder textarea content, UI-only build trigger) —
+  [#80](https://github.com/wso2/labs-agentic-engineer/issues/80) (BE
+  handshake: [#81](https://github.com/wso2/labs-agentic-engineer/issues/81),
+  ADR-0007)
 - Project overview page — spec/build/deployment status cards (versioned),
   components list, project-view tab shell —
   [#77](https://github.com/wso2/labs-agentic-engineer/issues/77) (BE

--- a/apps/console/design/decisions/ADR-0007-design-gate-is-build-trigger.md
+++ b/apps/console/design/decisions/ADR-0007-design-gate-is-build-trigger.md
@@ -1,0 +1,29 @@
+# ADR-0007: The design gate is exercised by triggering build, not a separate approval
+
+- **Status:** Accepted
+- **Date:** 2026-07-05 (grilling of the spec-view feature,
+  [#80](https://github.com/wso2/labs-agentic-engineer/issues/80))
+- **Context:** the PRD described the design gate as a blocking
+  "review and approve" step, implying a recorded approval action. The
+  spec view needed to decide what its primary CTA does; a separate
+  approve-then-build two-step was proposed and rejected.
+
+## Decision
+
+The developer passes the design gate by **triggering the build** from the
+spec view. There is no separate "approve" action anywhere in the console
+or the contract: reviewing the derived design and clicking **Build** *is*
+the approval. The trigger maps to the existing non-deprecated **Tasks
+surface** (`generate-tasks` / `dispatch-tasks`), not a new approval
+endpoint.
+
+## Consequences
+
+- The PRD's design-gate wording ("reviews and approves") is amended to
+  "reviews, then triggers build" when #80 ships.
+- No `approved` bookkeeping is requested from the BE; gate state is
+  implied by the project reaching the `tasks` phase.
+- Features must not reintroduce an approve/sign-off action for the design
+  gate — supersede this ADR explicitly if that becomes necessary.
+- #80 ships the Build button UI-only (enablement + navigation); the
+  binding to the Tasks surface lands as its own follow-up.

--- a/apps/console/src/features/spec/api/keys.ts
+++ b/apps/console/src/features/spec/api/keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { projectKeys } from "../../projects/api/keys";
+
+// Extends the project cache tree so project-level invalidation reaches the
+// spec bundle too.
+export const specKeys = {
+  bundle: (projectName: string) =>
+    [...projectKeys.detail(projectName), "spec"] as const,
+};

--- a/apps/console/src/features/spec/api/queries.ts
+++ b/apps/console/src/features/spec/api/queries.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { client } from "../../../api/client";
+import { specKeys } from "./keys";
+
+// The file list fills in while agents derive the spec, so the bundle polls
+// at the same cadence as the overview's reads (#77 decision: 10s).
+const SPEC_POLL_MS = 10_000;
+
+export function useProjectSpec(projectName: string) {
+  return useQuery({
+    queryKey: specKeys.bundle(projectName),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/projects/{projectName}/spec", {
+        params: { path: { projectName } },
+      });
+      if (error || data === undefined) {
+        const e = error as { detail?: string; title?: string } | undefined;
+        throw new Error(e?.detail ?? e?.title ?? "Failed to load the spec");
+      }
+      return data;
+    },
+    refetchInterval: SPEC_POLL_MS,
+  });
+}

--- a/apps/console/src/features/spec/components/AddArtifactDialog.tsx
+++ b/apps/console/src/features/spec/components/AddArtifactDialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@wso2/oxygen-ui";
+
+// Static v1 list (#80 decision); the artifact-creation binding lands as its
+// own feature, so this dialog is a preview: selecting a type does nothing.
+const ARTIFACT_TYPES = [
+  {
+    id: "prd",
+    label: "PRD",
+    description: "Product requirements document — goals, users, requirements.",
+  },
+  {
+    id: "user-stories",
+    label: "User stories doc",
+    description: "As-a / I-can / so-that stories the agents design against.",
+  },
+];
+
+export function AddArtifactDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [artifactType, setArtifactType] = useState(
+    ARTIFACT_TYPES[0]?.id ?? "prd",
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Add requirement artifact</DialogTitle>
+      <DialogContent>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Artifact creation isn't wired up yet — it arrives with its own
+          feature. This dialog is a preview.
+        </Alert>
+        <RadioGroup
+          value={artifactType}
+          onChange={(e) => setArtifactType(e.target.value)}
+        >
+          {ARTIFACT_TYPES.map((type) => (
+            <FormControlLabel
+              key={type.id}
+              value={type.id}
+              control={<Radio />}
+              sx={{ alignItems: "flex-start", mb: 1 }}
+              label={
+                <>
+                  <Typography variant="body1">{type.label}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {type.description}
+                  </Typography>
+                </>
+              }
+            />
+          ))}
+        </RadioGroup>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" disabled>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/console/src/features/spec/components/SpecFileList.tsx
+++ b/apps/console/src/features/spec/components/SpecFileList.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { FileText, Plus } from "@wso2/oxygen-ui-icons-react";
+import type { components } from "../../../generated/aep-api";
+
+type SpecFile = components["schemas"]["SpecFile"];
+type SpecGroup = SpecFile["group"];
+
+const GROUPS: { id: SpecGroup; title: string }[] = [
+  { id: "requirements", title: "Requirements" },
+  { id: "designs", title: "Designs" },
+  { id: "validation", title: "Validation" },
+];
+
+function basename(path: string): string {
+  return path.split("/").at(-1) ?? path;
+}
+
+export function SpecFileList({
+  files,
+  selectedPath,
+  onSelect,
+  onAddArtifact,
+  deriving,
+  failed,
+}: {
+  files: SpecFile[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onAddArtifact: () => void;
+  /** Agents are still shaping the spec — empty groups say so. */
+  deriving: boolean;
+  /** Derivation failed — empty groups say that instead. */
+  failed: boolean;
+}) {
+  return (
+    <Box component="nav" aria-label="Spec files" sx={{ py: 1 }}>
+      {GROUPS.map((group) => {
+        const groupFiles = files.filter((f) => f.group === group.id);
+        return (
+          <Box key={group.id} sx={{ mb: 1 }}>
+            <Box
+              sx={{
+                px: 2,
+                py: 0.5,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <Typography variant="overline" color="text.secondary">
+                {group.title}
+              </Typography>
+              {group.id === "requirements" && (
+                <Tooltip title="Add requirement artifact">
+                  <IconButton
+                    size="small"
+                    aria-label="Add requirement artifact"
+                    onClick={onAddArtifact}
+                  >
+                    <Plus size={16} />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Box>
+            {groupFiles.length > 0 ? (
+              <List dense disablePadding>
+                {groupFiles.map((file) => (
+                  <ListItemButton
+                    key={file.path}
+                    selected={file.path === selectedPath}
+                    onClick={() => onSelect(file.path)}
+                    sx={{ px: 2 }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 32 }}>
+                      <FileText size={16} />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={basename(file.path)}
+                      slotProps={{ primary: { noWrap: true } }}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            ) : (
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ px: 2, py: 0.5, fontStyle: "italic" }}
+              >
+                {failed
+                  ? "Derivation failed"
+                  : deriving
+                    ? "Being derived…"
+                    : "No files yet"}
+              </Typography>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  PageContent,
+  TextField,
+  Tooltip,
+  Typography,
+  useAppShell,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft, Hammer } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import type { components } from "../../../generated/aep-api";
+import { useProject, useProjectStatus } from "../../projects/api/queries";
+import { useProjectSpec } from "../api/queries";
+import { AddArtifactDialog } from "./AddArtifactDialog";
+import { SpecFileList } from "./SpecFileList";
+
+type ProjectStatus = components["schemas"]["ProjectStatus"];
+
+// specStatus → header chip, same language as the overview's spec card.
+function specChip(status: ProjectStatus): {
+  label: string;
+  color: "default" | "info" | "success" | "warning" | "error";
+} | null {
+  switch (status.specStatus) {
+    case "draft":
+    case "in_progress":
+      return { label: "In collaboration", color: "info" };
+    case "ready":
+      return { label: "Awaiting your review", color: "warning" };
+    case "approved":
+      return { label: "Approved", color: "success" };
+    case "failed":
+      return { label: "Derivation failed", color: "error" };
+    default:
+      return null;
+  }
+}
+
+// Full-screen spec workspace (#80), per the oxygen-ui sample's
+// LoginEditorView pattern: fullWidth/noPadding page, own header bar,
+// sidebar collapsed while the view is open.
+export function SpecView({ projectName }: { projectName: string }) {
+  const navigate = useNavigate();
+  const { actions } = useAppShell();
+  const project = useProject(projectName);
+  const status = useProjectStatus(projectName);
+  const spec = useProjectSpec(projectName);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [addArtifactOpen, setAddArtifactOpen] = useState(false);
+
+  // Collapse the sidebar while focused on the spec, expand when leaving.
+  useEffect(() => {
+    actions.collapseSidebar();
+    return () => {
+      actions.expandSidebar();
+    };
+  }, [actions]);
+
+  const files = spec.data?.files ?? [];
+  // Default selection: the first requirements file (the seeded PRD).
+  const selected =
+    files.find((f) => f.path === selectedPath) ??
+    files.find((f) => f.group === "requirements") ??
+    files[0] ??
+    null;
+
+  const specStatus = status.data?.specStatus;
+  const deriving =
+    specStatus === "pending" ||
+    specStatus === "draft" ||
+    specStatus === "in_progress";
+  const failed = specStatus === "failed";
+  const chip = status.data ? specChip(status.data) : null;
+  // The design gate: Build arms once design files are generated (#80).
+  const hasDesignFiles = files.some((f) => f.group === "designs");
+
+  const displayName = project.data?.displayName ?? projectName;
+
+  return (
+    <PageContent fullWidth noPadding>
+      <Box
+        sx={{
+          height: "100%",
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: 1,
+            borderColor: "divider",
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            bgcolor: "background.paper",
+          }}
+        >
+          <IconButton
+            aria-label="Back to project overview"
+            onClick={() =>
+              void navigate({
+                to: "/projects/$projectName",
+                params: { projectName },
+              })
+            }
+          >
+            <ArrowLeft size={20} />
+          </IconButton>
+          <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+            <Typography variant="h4" noWrap>
+              Spec
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {displayName}
+            </Typography>
+          </Box>
+
+          {status.data?.specVersion && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color="success"
+              label={`${status.data.specVersion} published`}
+            />
+          )}
+          {status.data?.specDirty && (
+            <Chip size="small" color="warning" label="draft changes" />
+          )}
+          {chip && <Chip size="small" color={chip.color} label={chip.label} />}
+
+          <Divider orientation="vertical" flexItem />
+
+          <Tooltip
+            title={
+              hasDesignFiles
+                ? "Start building from this spec"
+                : "Available once design files are generated"
+            }
+          >
+            {/* span so the tooltip works while the button is disabled */}
+            <span>
+              <Button
+                variant="contained"
+                startIcon={<Hammer size={18} />}
+                disabled={!hasDesignFiles}
+                onClick={() =>
+                  void navigate({
+                    to: "/projects/$projectName",
+                    params: { projectName },
+                  })
+                }
+              >
+                Build
+              </Button>
+            </span>
+          </Tooltip>
+        </Box>
+
+        {failed && (
+          <Alert severity="error" sx={{ borderRadius: 0 }}>
+            Spec derivation hit a problem. Existing files remain browsable;
+            the agents' error details will surface here in a follow-up.
+          </Alert>
+        )}
+
+        {/* Body: grouped file list + file content */}
+        {spec.isPending ? (
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <CircularProgress aria-label="Loading spec" />
+          </Box>
+        ) : spec.isError ? (
+          <Box sx={{ p: 3 }}>
+            <Alert
+              severity="error"
+              action={<Button onClick={() => void spec.refetch()}>Retry</Button>}
+            >
+              Failed to load the spec
+              {spec.error instanceof Error && spec.error.message
+                ? `: ${spec.error.message}`
+                : ""}
+            </Alert>
+          </Box>
+        ) : (
+          <Box sx={{ flexGrow: 1, minHeight: 0, display: "flex" }}>
+            <Box
+              sx={{
+                width: 280,
+                flexShrink: 0,
+                borderRight: 1,
+                borderColor: "divider",
+                overflow: "auto",
+              }}
+            >
+              <SpecFileList
+                files={files}
+                selectedPath={selected?.path ?? null}
+                onSelect={setSelectedPath}
+                onAddArtifact={() => setAddArtifactOpen(true)}
+                deriving={deriving}
+                failed={failed}
+              />
+            </Box>
+            <Box sx={{ flexGrow: 1, minWidth: 0, overflow: "auto", p: 2 }}>
+              {selected ? (
+                // Placeholder for the per-type renderers (WYSIWYG for
+                // markdown, dedicated components for structured files —
+                // each its own feature). Editable but unsaved (#80).
+                <TextField
+                  key={selected.path}
+                  fullWidth
+                  multiline
+                  minRows={20}
+                  defaultValue={selected.content}
+                  aria-label={`Content of ${selected.path}`}
+                  helperText={`${selected.path} — edits aren't saved yet; editing lands with the file editors.`}
+                  slotProps={{
+                    input: {
+                      sx: { fontFamily: "monospace", fontSize: "0.875rem" },
+                    },
+                  }}
+                />
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  {deriving
+                    ? "The agents are shaping the spec — files appear here as they land."
+                    : "Select a file to view its content."}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      <AddArtifactDialog
+        open={addArtifactOpen}
+        onClose={() => setAddArtifactOpen(false)}
+      />
+    </PageContent>
+  );
+}

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -3,15 +3,18 @@ import type { components } from "../../generated/aep-api";
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 type ComponentList = components["schemas"]["ComponentList"];
 type ProjectBoard = components["schemas"]["ProjectBoard"];
+type SpecBundle = components["schemas"]["SpecBundle"];
 type ErrorModel = components["schemas"]["ErrorModel"];
 
-// Scenario switch for the project overview (issue #77). Toggle in devtools:
+// Scenario switch for the project overview (#77) and spec view (#80).
+// Toggle in devtools:
 //   localStorage.setItem('aep:mock:project',
-//     'fresh' | 'spec' | 'building' | 'deployed' | 'deploy-failed' |
-//     'repo-error' | 'error')
+//     'fresh' | 'spec' | 'spec-failed' | 'building' | 'deployed' |
+//     'deploy-failed' | 'repo-error' | 'error')
 export type ProjectScenario =
   | "fresh"
   | "spec"
+  | "spec-failed"
   | "building"
   | "deployed"
   | "deploy-failed"
@@ -46,6 +49,17 @@ export const projectStatuses: Record<
     hasTasks: false,
     specStatus: "draft",
     designStatus: "in_progress",
+  },
+  // Spec derivation hit a problem; the seeded PRD is still there.
+  "spec-failed": {
+    phase: "spec",
+    repoStatus: "ready",
+    repoUrl: REPO_URL,
+    hasSpec: true,
+    hasDesign: false,
+    hasTasks: false,
+    specStatus: "failed",
+    designStatus: "failed",
   },
   // v1 published, agents building, nothing deployed yet.
   building: {
@@ -145,6 +159,7 @@ export const projectComponents: Record<
 > = {
   fresh: emptyComponents,
   spec: emptyComponents,
+  "spec-failed": emptyComponents,
   building: builtComponents,
   deployed: deployedComponents,
   "deploy-failed": builtComponents,
@@ -223,10 +238,120 @@ export const projectBoards: Record<
 > = {
   fresh: emptyBoard,
   spec: emptyBoard,
+  "spec-failed": emptyBoard,
   building: buildingBoard,
   deployed: doneBoard,
   "deploy-failed": doneBoard,
   "repo-error": emptyBoard,
+};
+
+// Spec bundle backing the spec view (#80). The backend seeds a PRD at repo
+// initialization, so requirements is never empty; designs/validation fill
+// in as the agents derive them.
+const seededPrd = `# Demo Shop — PRD
+
+## Goal
+
+A small storefront where customers browse the product catalog, add items
+to a cart, and check out.
+
+## Requirements
+
+- Browse products by category with search.
+- Cart persists across sessions.
+- Checkout with a mocked payment provider.
+- Order history per customer.
+`;
+
+const userStories = `# Demo Shop — User stories
+
+- As a shopper, I can search the catalog so that I find products quickly.
+- As a shopper, my cart survives a page reload so that I don't lose picks.
+- As a shopper, I can check out and see an order confirmation.
+- As a returning customer, I can see my past orders.
+`;
+
+const architectureMd = `# Demo Shop — Component architecture
+
+Three components behind the project cell:
+
+| Component | Type | Responsibility |
+|---|---|---|
+| storefront | webapp | Customer-facing UI |
+| catalog-api | service | Product catalog CRUD + search |
+| orders-api | service | Cart, checkout, order history |
+
+The storefront talks to both services; services share nothing.
+`;
+
+const architectureDiagram = `{
+  "type": "excalidraw-dsl",
+  "components": [
+    { "id": "storefront", "kind": "webapp" },
+    { "id": "catalog-api", "kind": "service" },
+    { "id": "orders-api", "kind": "service" }
+  ],
+  "edges": [
+    { "from": "storefront", "to": "catalog-api" },
+    { "from": "storefront", "to": "orders-api" }
+  ]
+}`;
+
+const validationPlan = `# Demo Shop — Validation plan
+
+- Catalog search returns seeded products by name and category.
+- Cart contents survive a browser restart.
+- Checkout produces an order visible in order history.
+- Each service exposes /healthz returning 200.
+`;
+
+const prdOnlySpec: SpecBundle = {
+  files: [{ path: "requirements/prd.md", group: "requirements", content: seededPrd }],
+};
+
+const collaborationSpec: SpecBundle = {
+  files: [
+    { path: "requirements/prd.md", group: "requirements", content: seededPrd },
+    {
+      path: "requirements/user-stories.md",
+      group: "requirements",
+      content: userStories,
+    },
+    {
+      path: "design/architecture.md",
+      group: "designs",
+      content: architectureMd,
+    },
+  ],
+};
+
+const fullSpec: SpecBundle = {
+  files: [
+    ...collaborationSpec.files,
+    {
+      path: "design/architecture.excalidraw",
+      group: "designs",
+      content: architectureDiagram,
+    },
+    {
+      path: "validation/validation-plan.md",
+      group: "validation",
+      content: validationPlan,
+    },
+  ],
+};
+
+export const projectSpecs: Record<
+  Exclude<ProjectScenario, "error">,
+  SpecBundle
+> = {
+  fresh: prdOnlySpec,
+  spec: collaborationSpec,
+  "spec-failed": prdOnlySpec,
+  building: fullSpec,
+  deployed: fullSpec,
+  "deploy-failed": fullSpec,
+  "repo-error": prdOnlySpec,
 };
 
 export const projectSectionError: ErrorModel = {

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -3,6 +3,7 @@ import {
   projectBoards,
   projectComponents,
   projectSectionError,
+  projectSpecs,
   projectStatuses,
   type ProjectScenario,
 } from "../fixtures/project";
@@ -38,5 +39,8 @@ export const projectHandlers = [
   ),
   http.get("*/api/v1/projects/:projectName/board", () =>
     respond((s) => projectBoards[s]),
+  ),
+  http.get("*/api/v1/projects/:projectName/spec", () =>
+    respond((s) => projectSpecs[s]),
   ),
 ];

--- a/apps/console/src/routes/projects.$projectName_.spec.tsx
+++ b/apps/console/src/routes/projects.$projectName_.spec.tsx
@@ -17,21 +17,16 @@
  */
 
 import { createFileRoute } from "@tanstack/react-router";
-import { FileText } from "@wso2/oxygen-ui-icons-react";
-import { SectionPlaceholder } from "../features/projects/components/SectionPlaceholder";
+import { SpecView } from "../features/spec/components/SpecView";
 
-export const Route = createFileRoute("/projects/$projectName/spec")({
-  component: SpecPlaceholderRoute,
+// `$projectName_` (trailing underscore) un-nests this route from the
+// /projects/$projectName layout: the spec view is a full-screen workspace
+// without the shared project header (#80).
+export const Route = createFileRoute("/projects/$projectName_/spec")({
+  component: SpecRoute,
 });
 
-function SpecPlaceholderRoute() {
+function SpecRoute() {
   const { projectName } = Route.useParams();
-  return (
-    <SectionPlaceholder
-      icon={<FileText size={48} />}
-      title="Spec is on its way"
-      description="This is where you and the agents work out what to build — the requirement and the design together, as one living spec. Its own feature issue will land it."
-      projectName={projectName}
-    />
-  );
+  return <SpecView projectName={projectName} />;
 }

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1422,6 +1422,44 @@ components:
         - contentSha
         - updatedAt
       type: object
+    SpecBundle:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/SpecBundle.json
+          format: uri
+          readOnly: true
+          type: string
+        files:
+          items:
+            $ref: "#/components/schemas/SpecFile"
+          type: array
+      required:
+        - files
+      type: object
+    SpecFile:
+      additionalProperties: false
+      properties:
+        content:
+          description: Raw file content, inline.
+          type: string
+        group:
+          description: Which spec-view section the file belongs to.
+          enum:
+            - requirements
+            - designs
+            - validation
+          type: string
+        path:
+          description: File path within the project's spec tree (e.g. requirements/prd.md).
+          type: string
+      required:
+        - path
+        - group
+        - content
+      type: object
     TaskStatusResponse:
       additionalProperties: false
       properties:
@@ -3463,6 +3501,35 @@ paths:
       summary: Get the requirements bundle at a version tag
       tags:
         - Requirements(Deprecated)
+  /projects/{projectName}/spec:
+    get:
+      operationId: get-project-spec
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpecBundle"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Get the project's spec bundle (requirement, design, and validation files)
+      tags:
+        - Spec
   /projects/{projectName}/status:
     get:
       operationId: get-project-status


### PR DESCRIPTION
Implements #80 (spec view), built against mocks per the console flow. BE handshake: #81.

## What

- **Full-screen spec workspace** at `/projects/:name/spec`, per the oxygen-ui sample's `LoginEditorView` pattern: un-nested route (`projects.$projectName_.spec.tsx` — escapes the project layout, path unchanged), own header bar, app sidebar auto-collapses on entry / expands on leave.
- **Left panel** groups spec files under **Requirements / Designs / Validation**; all groups always render, underived groups show *Being derived…* (or *Derivation failed*). The seeded PRD is selected by default. Requirements has a **+** button opening the artifact-type dialog — a UI-only preview (creation binds later, per the decisions on #80).
- **Content area**: the selected file's raw content in an editable-but-unsaved monospace textarea — the placeholder for the per-type renderers (WYSIWYG md editor, structured-file components), each landing as its own feature.
- **Build button** — the design gate (ADR-0007): arms once design files exist, click returns to the project overview. UI-only in this PR; the binding to the Tasks surface is a follow-up.
- **Header chips**: `specVersion` published, display-only `draft changes` (specDirty), spec status (same language as the overview card).
- **Contract**: `get-project-spec` → `SpecBundle { files: [{path, group, content}] }` in `packages/contracts/api/v1/openapi.yaml` (the source of truth; #81 is the BE request).
- **Mocks**: spec bundle joins the `aep:mock:project` scenario switch; new `spec-failed` scenario. Toggle: `localStorage.setItem('aep:mock:project', 'fresh' | 'spec' | 'spec-failed' | 'building' | 'deployed' | …)`.
- **ADR-0007** (design gate = build trigger) + PRD in-flight line.

## States covered

deriving (PRD only, groups hinted, Build disabled) · failed (banner, files browsable) · design files generated (Build armed) · published + dirty chips · add-artifact dialog · loading / API error.

## Screenshots

(drag-and-drop from `.screenshots-spec-view-80/` — deriving, failed, ready + structured file, published-dirty, add-artifact dialog)

## Verification

- Drove all scenarios in mock mode (`VITE_API_MODE=mock`) in the browser; Build click lands on the overview; sidebar collapse/expand verified.
- `pnpm --filter @aep/console typecheck`, `lint` clean; `make license-check` passes.

Refs #80, #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
