### PR TITLE
Console SSO — Thunder login (oidc-client-ts) + header org/project switchers (#91)

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",
-    "test": "echo \"@aep/console: no tests yet\"",
+    "test": "vitest run",
     "lint": "eslint .",
     "typecheck": "tsc -p tsconfig.json",
     "gen": "openapi-typescript ../../packages/contracts/api/v1/openapi.yaml -o src/generated/aep-api.d.ts && tsr generate"
@@ -29,9 +29,11 @@
     "@tiptap/starter-kit": "^3.27.2",
     "@wso2/oxygen-ui": "0.11.0",
     "@wso2/oxygen-ui-icons-react": "0.11.0",
+    "oidc-client-ts": "^3.5.0",
     "openapi-fetch": "0.14.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-oidc-context": "^3.3.1",
     "y-prosemirror": "^1.3.7",
     "yjs": "13.6.31"
   },
@@ -45,6 +47,7 @@
     "msw": "^2.12.0",
     "openapi-typescript": "^7.4.2",
     "typescript": "5.9.3",
-    "vite": "^7.3.6"
+    "vite": "^7.3.6",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/console/src/api/authFetch.test.ts
+++ b/apps/console/src/api/authFetch.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createAuthFetch } from "./authFetch";
+
+function deps(overrides: Partial<Parameters<typeof createAuthFetch>[0]> = {}) {
+  return {
+    getToken: vi.fn().mockResolvedValue("tok-1"),
+    renewToken: vi.fn().mockResolvedValue("tok-2"),
+    redirectToSignIn: vi.fn(),
+    ...overrides,
+  };
+}
+
+const ok = () => new Response("ok", { status: 200 });
+const unauthorized = () => new Response("nope", { status: 401 });
+
+describe("createAuthFetch", () => {
+  it("attaches the Bearer token to every request", async () => {
+    const fetch = vi.fn().mockResolvedValue(ok());
+    const d = deps({ fetch });
+    await createAuthFetch(d)("https://bff/api/v1/projects");
+
+    const sent = fetch.mock.calls[0]![0] as Request;
+    expect(sent.headers.get("Authorization")).toBe("Bearer tok-1");
+    expect(d.renewToken).not.toHaveBeenCalled();
+  });
+
+  it("sends without a header when there is no session token", async () => {
+    const fetch = vi.fn().mockResolvedValue(ok());
+    const d = deps({ fetch, getToken: vi.fn().mockResolvedValue(null) });
+    await createAuthFetch(d)("https://bff/api/v1/projects");
+
+    const sent = fetch.mock.calls[0]![0] as Request;
+    expect(sent.headers.get("Authorization")).toBeNull();
+  });
+
+  it("on 401: renews, retries once with the new token, returns the retry", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(ok());
+    const d = deps({ fetch });
+    const response = await createAuthFetch(d)("https://bff/api/v1/projects");
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const retried = fetch.mock.calls[1]![0] as Request;
+    expect(retried.headers.get("Authorization")).toBe("Bearer tok-2");
+    expect(d.redirectToSignIn).not.toHaveBeenCalled();
+  });
+
+  it("preserves the request body on the retry", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(ok());
+    const d = deps({ fetch });
+    await createAuthFetch(d)("https://bff/api/v1/projects", {
+      method: "POST",
+      body: JSON.stringify({ name: "demo" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const retried = fetch.mock.calls[1]![0] as Request;
+    expect(await retried.text()).toBe(JSON.stringify({ name: "demo" }));
+    expect(retried.method).toBe("POST");
+  });
+
+  it("redirects to sign-in when renewal fails, returning the original 401", async () => {
+    const fetch = vi.fn().mockResolvedValue(unauthorized());
+    const d = deps({ fetch, renewToken: vi.fn().mockResolvedValue(null) });
+    const response = await createAuthFetch(d)("https://bff/api/v1/projects");
+
+    expect(response.status).toBe(401);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(d.redirectToSignIn).toHaveBeenCalledOnce();
+  });
+
+  it("redirects to sign-in when the retry still comes back 401", async () => {
+    const fetch = vi.fn().mockResolvedValue(unauthorized());
+    const d = deps({ fetch });
+    const response = await createAuthFetch(d)("https://bff/api/v1/projects");
+
+    expect(response.status).toBe(401);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(d.redirectToSignIn).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/console/src/api/authFetch.ts
+++ b/apps/console/src/api/authFetch.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The single global 401 handler (api-guidelines non-negotiable #3), as a
+// fetch wrapper under the openapi-fetch client. Every request carries the
+// session's Bearer token; a 401 means the token went stale mid-session, so:
+// silent renew → retry once → if still unauthorized, full sign-in redirect
+// preserving the current URL (issue #91 decision). Features never see 401s.
+
+export interface AuthFetchDeps {
+  getToken: () => Promise<string | null>;
+  renewToken: () => Promise<string | null>;
+  redirectToSignIn: () => void;
+  fetch?: typeof globalThis.fetch;
+}
+
+function withBearer(request: Request, token: string | null): Request {
+  if (!token) return request;
+  const headers = new Headers(request.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+  return new Request(request, { headers });
+}
+
+export function createAuthFetch(deps: AuthFetchDeps): typeof globalThis.fetch {
+  const doFetch = deps.fetch ?? globalThis.fetch.bind(globalThis);
+
+  return async function authFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const request = withBearer(new Request(input, init), await deps.getToken());
+    // Clone before the first send — a consumed body can't be resent.
+    const retryable = request.clone();
+
+    const response = await doFetch(request);
+    if (response.status !== 401) return response;
+
+    const renewed = await deps.renewToken();
+    if (!renewed) {
+      deps.redirectToSignIn();
+      return response;
+    }
+
+    const retried = await doFetch(withBearer(retryable, renewed));
+    if (retried.status === 401) deps.redirectToSignIn();
+    return retried;
+  };
+}

--- a/apps/console/src/api/client.ts
+++ b/apps/console/src/api/client.ts
@@ -16,23 +16,22 @@
  * under the License.
  */
 
-import createClient, { type Middleware } from "openapi-fetch";
+import createClient from "openapi-fetch";
 import type { paths } from "../generated/aep-api";
 import { env } from "../config/env";
+import { getAccessToken, redirectToSignIn, renewAccessToken } from "../auth/token";
+import { createAuthFetch } from "./authFetch";
 
-// The single global 401 handler (api-guidelines non-negotiable #3).
-// TODO(auth): wire the re-auth flow here when auth lands; features never
-// handle 401s themselves.
-const auth401: Middleware = {
-  onResponse({ response }) {
-    if (response.status === 401) {
-      console.warn("[api] 401 from BFF — re-auth flow not implemented yet");
-    }
-    return response;
-  },
-};
-
+// Token attach + the single global 401 handler live in the fetch wrapper
+// (see authFetch.ts); features never handle auth themselves.
+//
 // The contract's paths are unprefixed; its `servers` entry is /api/v1, which
 // openapi-fetch does not apply automatically — so it lives in the baseUrl.
-export const client = createClient<paths>({ baseUrl: `${env.apiBaseUrl}/api/v1` });
-client.use(auth401);
+export const client = createClient<paths>({
+  baseUrl: `${env.apiBaseUrl}/api/v1`,
+  fetch: createAuthFetch({
+    getToken: getAccessToken,
+    renewToken: renewAccessToken,
+    redirectToSignIn,
+  }),
+});

--- a/apps/console/src/auth/AuthGuard.tsx
+++ b/apps/console/src/auth/AuthGuard.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useMemo, type PropsWithChildren } from "react";
+import { hasAuthParams, useAuth } from "react-oidc-context";
+import { env } from "../config/env";
+import { getUserManager } from "./userManager";
+import { decodeJwtClaims, identityFromClaims, type TokenClaims } from "./claims";
+import { MOCK_ORG, MOCK_USER } from "./mockSession";
+import { AuthScreen } from "./AuthScreen";
+import { SessionContext, type Session } from "./SessionContext";
+
+const MOCK_SESSION: Session = {
+  user: MOCK_USER,
+  orgHandle: MOCK_ORG,
+  signOut: () => {
+    console.info("[auth] mock mode — sign-out is a no-op");
+  },
+};
+
+// Gates the whole app (rendered at __root): children only ever see a
+// signed-in state, with the session in context.
+export function AuthGuard({ children }: PropsWithChildren) {
+  if (env.authMode === "mock") {
+    return (
+      <SessionContext.Provider value={MOCK_SESSION}>
+        {children}
+      </SessionContext.Provider>
+    );
+  }
+  return <OidcGuard>{children}</OidcGuard>;
+}
+
+// RP-initiated logout when the IdP advertises end_session_endpoint; some
+// Thunder versions don't (dev-thunder-setup's v0.47.0), so fall back to
+// best-effort token revocation + dropping the local session, then a fresh
+// page load — the guard restarts the login flow, which prompts again.
+// Uses the raw UserManager: the react-oidc-context wrapper converts the
+// signoutRedirect rejection into auth.error instead of rethrowing, which
+// would strand the user on the error screen.
+async function signOut(): Promise<void> {
+  const userManager = getUserManager();
+  try {
+    await userManager.signoutRedirect();
+  } catch {
+    try {
+      await userManager.revokeTokens();
+    } catch {
+      // Best effort — revocation failing must not block sign-out.
+    }
+    await userManager.removeUser();
+    window.location.assign("/");
+  }
+}
+
+function OidcGuard({ children }: PropsWithChildren) {
+  const auth = useAuth();
+
+  // Kick off the redirect only when settled-unauthenticated: not while the
+  // provider is loading, not mid-navigation, and not while ?code&state from
+  // Thunder is still being exchanged.
+  const shouldSignIn =
+    !auth.isLoading &&
+    !auth.isAuthenticated &&
+    !auth.activeNavigator &&
+    !auth.error &&
+    !hasAuthParams();
+
+  useEffect(() => {
+    if (shouldSignIn) {
+      const returnTo = window.location.pathname + window.location.search;
+      void auth.signinRedirect({ state: { returnTo } });
+    }
+  }, [shouldSignIn, auth]);
+
+  const session = useMemo<Session>(() => {
+    const idClaims = (auth.user?.profile ?? {}) as TokenClaims;
+    const accessClaims = auth.user
+      ? (decodeJwtClaims(auth.user.access_token) ?? {})
+      : {};
+    const identity = identityFromClaims(idClaims, accessClaims);
+    return {
+      user: { name: identity.name, email: identity.email },
+      orgHandle: identity.orgHandle,
+      signOut: () => void signOut(),
+    };
+  }, [auth]);
+
+  if (auth.error) {
+    return (
+      <AuthScreen
+        label=""
+        error={auth.error.message}
+        onRetry={() => void auth.signinRedirect()}
+      />
+    );
+  }
+  if (!auth.isAuthenticated) {
+    return (
+      <AuthScreen
+        label={
+          hasAuthParams() || auth.isLoading
+            ? "Completing sign-in…"
+            : "Redirecting to sign-in…"
+        }
+      />
+    );
+  }
+  return (
+    <SessionContext.Provider value={session}>
+      {children}
+    </SessionContext.Provider>
+  );
+}

--- a/apps/console/src/auth/AuthProvider.tsx
+++ b/apps/console/src/auth/AuthProvider.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { PropsWithChildren } from "react";
+import { AuthProvider as OidcProvider } from "react-oidc-context";
+import type { User } from "oidc-client-ts";
+import { env } from "../config/env";
+import { router } from "../router";
+import { getUserManager } from "./userManager";
+
+// After the code exchange, land where the user originally asked to go
+// (stashed in OAuth state by AuthGuard/redirectToSignIn) instead of
+// staying on /callback.
+function onSigninCallback(user: User | undefined): void {
+  const returnTo =
+    (user?.state as { returnTo?: string } | undefined)?.returnTo ?? "/";
+  router.history.replace(returnTo);
+}
+
+// Outermost provider (issue #91): thunder mode wraps the app in
+// react-oidc-context around the shared UserManager; mock mode needs no
+// provider at all — AuthGuard supplies the fixed dev session.
+export function AppAuthProvider({ children }: PropsWithChildren) {
+  if (env.authMode === "mock") {
+    return children;
+  }
+  return (
+    <OidcProvider
+      userManager={getUserManager()}
+      onSigninCallback={onSigninCallback}
+    >
+      {children}
+    </OidcProvider>
+  );
+}

--- a/apps/console/src/auth/AuthScreen.tsx
+++ b/apps/console/src/auth/AuthScreen.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Box, Button, CircularProgress, Typography } from "@wso2/oxygen-ui";
+
+// Full-viewport auth transition screen: spinner while redirecting to or
+// returning from Thunder, message + retry when the handshake fails.
+export function AuthScreen({
+  label,
+  error,
+  onRetry,
+}: {
+  label: string;
+  error?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 2,
+        bgcolor: "background.default",
+      }}
+    >
+      {error ? (
+        <>
+          <Typography variant="h6">Sign-in failed</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {error}
+          </Typography>
+          {onRetry && (
+            <Button variant="contained" onClick={onRetry}>
+              Try again
+            </Button>
+          )}
+        </>
+      ) : (
+        <>
+          <CircularProgress size={32} />
+          <Typography variant="body2" color="text.secondary">
+            {label}
+          </Typography>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/apps/console/src/auth/SessionContext.tsx
+++ b/apps/console/src/auth/SessionContext.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createContext, useContext } from "react";
+
+// What the app knows about the signed-in user, mode-agnostic: real claims
+// in thunder mode, the fixed dev identity in mock mode. Everything under
+// AuthGuard can rely on it existing.
+export interface Session {
+  user: { name: string; email: string; role?: string };
+  /** Active org, resolved with the BFF's precedence (ouHandle > ouName > ouId). */
+  orgHandle: string | null;
+  signOut: () => void;
+}
+
+export const SessionContext = createContext<Session | null>(null);
+
+export function useSession(): Session {
+  const session = useContext(SessionContext);
+  if (!session) {
+    throw new Error("useSession must be used inside AuthGuard");
+  }
+  return session;
+}

--- a/apps/console/src/auth/claims.test.ts
+++ b/apps/console/src/auth/claims.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  decodeJwtClaims,
+  identityFromClaims,
+  resolveOrgHandle,
+} from "./claims";
+
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (v: unknown) => {
+    const bytes = new TextEncoder().encode(JSON.stringify(v));
+    const bin = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+    return btoa(bin)
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replace(/=+$/, "");
+  };
+  return `${b64({ alg: "RS256" })}.${b64(payload)}.signature`;
+}
+
+describe("decodeJwtClaims", () => {
+  it("decodes a base64url payload", () => {
+    expect(decodeJwtClaims(jwt({ sub: "u1", ouHandle: "acme" }))).toEqual({
+      sub: "u1",
+      ouHandle: "acme",
+    });
+  });
+
+  it("handles base64url characters (- and _)", () => {
+    const claims = { name: "ÿþ?>~", note: "a?b>c" };
+    expect(decodeJwtClaims(jwt(claims))).toEqual(claims);
+  });
+
+  it("returns null for garbage", () => {
+    expect(decodeJwtClaims("not-a-jwt")).toBeNull();
+    expect(decodeJwtClaims("a.b.c")).toBeNull();
+    expect(decodeJwtClaims("")).toBeNull();
+  });
+});
+
+describe("resolveOrgHandle", () => {
+  it("mirrors the BFF precedence: ouHandle > ouName > ouId", () => {
+    expect(
+      resolveOrgHandle({ ouHandle: "h", ouName: "n", ouId: "i" }),
+    ).toBe("h");
+    expect(resolveOrgHandle({ ouName: "n", ouId: "i" })).toBe("n");
+    expect(resolveOrgHandle({ ouId: "i" })).toBe("i");
+  });
+
+  it("skips empty and non-string values", () => {
+    expect(resolveOrgHandle({ ouHandle: "", ouName: "n" })).toBe("n");
+    expect(resolveOrgHandle({ ouHandle: 42, ouName: "n" })).toBe("n");
+    expect(resolveOrgHandle({})).toBeNull();
+  });
+});
+
+describe("identityFromClaims", () => {
+  it("prefers name, then given/family, then username, email, sub", () => {
+    expect(identityFromClaims({ name: "N", given_name: "G" }).name).toBe("N");
+    expect(
+      identityFromClaims({ given_name: "G", family_name: "F", username: "u" })
+        .name,
+    ).toBe("G F");
+    expect(identityFromClaims({ username: "u", email: "e@x" }).name).toBe("u");
+    expect(identityFromClaims({ email: "e@x" }).name).toBe("e@x");
+    expect(identityFromClaims({ sub: "s" }).name).toBe("s");
+    expect(identityFromClaims({}).name).toBe("User");
+  });
+
+  it("takes the first source that has a value (ID token before access token)", () => {
+    const identity = identityFromClaims(
+      { name: "From ID" },
+      { name: "From access", ouHandle: "acme" },
+    );
+    expect(identity.name).toBe("From ID");
+    // ou* lives only on the access token — still found.
+    expect(identity.orgHandle).toBe("acme");
+  });
+
+  it("resolves the org per-source, not per-claim across sources", () => {
+    // ID token has ouName only; access token has ouHandle. The first source
+    // with any org claim wins (ouName), matching a BFF that reads one token.
+    expect(
+      identityFromClaims({ ouName: "n" }, { ouHandle: "h" }).orgHandle,
+    ).toBe("n");
+  });
+
+  it("returns empty email when no source has one", () => {
+    expect(identityFromClaims({ name: "N" }).email).toBe("");
+  });
+});

--- a/apps/console/src/auth/claims.ts
+++ b/apps/console/src/auth/claims.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type TokenClaims = Record<string, unknown>;
+
+// Decodes a JWT payload without verifying it — display/routing only. The
+// BFF re-verifies every token; nothing security-relevant hangs off this.
+export function decodeJwtClaims(token: string): TokenClaims | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const b64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+    // atob yields latin-1 code points; decode the underlying UTF-8 bytes so
+    // non-ASCII names survive.
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as TokenClaims)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+// Mirrors the BFF's auth.ResolveOuHandle precedence exactly (jwt.go):
+// ouHandle > ouName > ouId. The console must agree with the server on
+// which org a token addresses.
+export function resolveOrgHandle(claims: TokenClaims): string | null {
+  return (
+    str(claims["ouHandle"]) ?? str(claims["ouName"]) ?? str(claims["ouId"]) ?? null
+  );
+}
+
+export interface SessionIdentity {
+  name: string;
+  email: string;
+  orgHandle: string | null;
+}
+
+// Builds the display identity from token claim sets in precedence order
+// (ID token first, access token as fallback — Thunder puts the ou* claims
+// on the access token).
+export function identityFromClaims(...sources: TokenClaims[]): SessionIdentity {
+  const first = (pick: (c: TokenClaims) => string | undefined) => {
+    for (const claims of sources) {
+      const value = pick(claims);
+      if (value) return value;
+    }
+    return undefined;
+  };
+
+  const givenFamily = (c: TokenClaims) => {
+    const parts = [str(c["given_name"]), str(c["family_name"])].filter(Boolean);
+    return parts.length > 0 ? parts.join(" ") : undefined;
+  };
+
+  const email = first((c) => str(c["email"])) ?? "";
+  const name =
+    first((c) => str(c["name"])) ??
+    first(givenFamily) ??
+    first((c) => str(c["username"])) ??
+    (email || undefined) ??
+    first((c) => str(c["sub"])) ??
+    "User";
+
+  let orgHandle: string | null = null;
+  for (const claims of sources) {
+    orgHandle = resolveOrgHandle(claims);
+    if (orgHandle) break;
+  }
+
+  return { name, email, orgHandle };
+}

--- a/apps/console/src/auth/mockSession.ts
+++ b/apps/console/src/auth/mockSession.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The mock-auth identity for default dev (VITE_API_MODE=mock): a fixed
+// user and org, no Thunder required. The org matches the collab mock
+// BFF's default so spec rooms resolve the same way in both places.
+
+export const MOCK_USER = {
+  name: "Developer",
+  email: "developer@example.com",
+  role: "Developer",
+} as const;
+
+export const MOCK_ORG = "acme";
+
+// JWT-shaped but unsigned — enough for the collab mock BFF, which decodes
+// name/email claims without verifying. Never sent to a real BFF: real API
+// runs use thunder auth mode.
+export function mockAccessToken(): string {
+  const b64 = (v: unknown) =>
+    btoa(JSON.stringify(v))
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replace(/=+$/, "");
+  return `${b64({ alg: "none" })}.${b64({
+    name: MOCK_USER.name,
+    email: MOCK_USER.email,
+    ouHandle: MOCK_ORG,
+  })}.dev`;
+}

--- a/apps/console/src/auth/token.ts
+++ b/apps/console/src/auth/token.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { env } from "../config/env";
+import { mockAccessToken } from "./mockSession";
+import { getUserManager } from "./userManager";
+
+// Token access for non-React code: the API client attaches it, the collab
+// provider hands it to the WebSocket. Mode-aware so callers never are.
+
+export async function getAccessToken(): Promise<string | null> {
+  if (env.authMode === "mock") return mockAccessToken();
+  const user = await getUserManager().getUser();
+  return user?.access_token ?? null;
+}
+
+// Refresh-token renewal, deduplicated: parallel 401s share one renew.
+let renewInFlight: Promise<string | null> | null = null;
+
+export function renewAccessToken(): Promise<string | null> {
+  if (env.authMode === "mock") return Promise.resolve(mockAccessToken());
+  renewInFlight ??= getUserManager()
+    .signinSilent()
+    .then((user) => user?.access_token ?? null)
+    .catch(() => null)
+    .finally(() => {
+      renewInFlight = null;
+    });
+  return renewInFlight;
+}
+
+// Full re-auth, preserving where the user was (restored by the provider's
+// onSigninCallback after the round-trip).
+export function redirectToSignIn(): void {
+  if (env.authMode === "mock") return;
+  const returnTo = window.location.pathname + window.location.search;
+  void getUserManager().signinRedirect({ state: { returnTo } });
+}

--- a/apps/console/src/auth/userManager.ts
+++ b/apps/console/src/auth/userManager.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { UserManager, WebStorageStateStore } from "oidc-client-ts";
+import { env } from "../config/env";
+
+// One UserManager for the app (thunder mode only): react-oidc-context
+// renders around it, and non-React code (API client, collab provider)
+// reads tokens from it via token.ts.
+let instance: UserManager | null = null;
+
+export function getUserManager(): UserManager {
+  instance ??= new UserManager({
+    // Thunder speaks standard OIDC discovery at
+    // <thunderUrl>/.well-known/openid-configuration.
+    authority: env.thunderUrl,
+    client_id: env.thunderClientId,
+    redirect_uri: `${window.location.origin}/callback`,
+    post_logout_redirect_uri: window.location.origin,
+    response_type: "code",
+    scope: env.thunderScopes,
+    // sessionStorage per issue #91 decision (per-tab; Thunder's own session
+    // cookie makes new-tab logins silent). Also required so PKCE state
+    // survives the redirect.
+    userStore: new WebStorageStateStore({ store: window.sessionStorage }),
+    automaticSilentRenew: true,
+    loadUserInfo: false,
+  });
+  return instance;
+}

--- a/apps/console/src/config/authMode.test.ts
+++ b/apps/console/src/config/authMode.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveAuthMode } from "./authMode";
+
+describe("resolveAuthMode", () => {
+  it("always uses thunder in production, whatever the flags say", () => {
+    expect(resolveAuthMode(false, "mock", "mock")).toBe("thunder");
+    expect(resolveAuthMode(false, undefined, undefined)).toBe("thunder");
+  });
+
+  it("defaults dev to the API mode: mock APIs → mock auth", () => {
+    expect(resolveAuthMode(true, "mock", undefined)).toBe("mock");
+  });
+
+  it("defaults dev to thunder when the API is real (proxy mode)", () => {
+    expect(resolveAuthMode(true, undefined, undefined)).toBe("thunder");
+    expect(resolveAuthMode(true, "proxy", undefined)).toBe("thunder");
+  });
+
+  it("VITE_AUTH_MODE=thunder opts dev into real login with mock APIs", () => {
+    expect(resolveAuthMode(true, "mock", "thunder")).toBe("thunder");
+  });
+
+  it("VITE_AUTH_MODE=mock forces mock auth in dev", () => {
+    expect(resolveAuthMode(true, undefined, "mock")).toBe("mock");
+  });
+
+  it("ignores unknown override values", () => {
+    expect(resolveAuthMode(true, "mock", "bogus")).toBe("mock");
+    expect(resolveAuthMode(true, undefined, "bogus")).toBe("thunder");
+  });
+});

--- a/apps/console/src/config/authMode.ts
+++ b/apps/console/src/config/authMode.ts
@@ -16,16 +16,18 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+export type AuthMode = "mock" | "thunder";
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
-});
+// Issue #91 dev-mode matrix: production always signs in against Thunder;
+// in dev the default follows the API mode (mock APIs → mock auth, nothing
+// to run), and VITE_AUTH_MODE=thunder opts into real OIDC against the
+// dev-thunder-setup container while MSW keeps serving the APIs.
+export function resolveAuthMode(
+  isDev: boolean,
+  apiMode: string | undefined,
+  override: string | undefined,
+): AuthMode {
+  if (!isDev) return "thunder";
+  if (override === "thunder" || override === "mock") return override;
+  return apiMode === "mock" ? "mock" : "thunder";
+}

--- a/apps/console/src/config/env.ts
+++ b/apps/console/src/config/env.ts
@@ -16,8 +16,13 @@
  * under the License.
  */
 
+import { resolveAuthMode } from "./authMode";
+
 interface RuntimeEnv {
   VITE_API_BASE_URL?: string;
+  VITE_THUNDER_URL?: string;
+  VITE_THUNDER_CLIENT_ID?: string;
+  VITE_THUNDER_SCOPES?: string;
 }
 
 declare global {
@@ -40,4 +45,16 @@ function getEnv(key: keyof RuntimeEnv): string | undefined {
 
 export const env = {
   apiBaseUrl: getEnv("VITE_API_BASE_URL") || "/aep-api-service",
+  // VITE_AUTH_MODE is a dev-only switch, so it is read from build-time env
+  // only — runtime config cannot demote production to mock auth.
+  authMode: resolveAuthMode(
+    import.meta.env.DEV,
+    import.meta.env.VITE_API_MODE,
+    import.meta.env.VITE_AUTH_MODE,
+  ),
+  // Thunder OIDC (issue #91). Dev default is the dev-thunder-setup
+  // container; deployments override via window._env_.
+  thunderUrl: getEnv("VITE_THUNDER_URL") || "http://localhost:8097",
+  thunderClientId: getEnv("VITE_THUNDER_CLIENT_ID") || "aep-console-client",
+  thunderScopes: getEnv("VITE_THUNDER_SCOPES") || "openid profile email",
 } as const;

--- a/apps/console/src/features/organizations/api/keys.ts
+++ b/apps/console/src/features/organizations/api/keys.ts
@@ -16,16 +16,7 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
-
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
-});
+export const organizationKeys = {
+  all: ["organizations"] as const,
+  list: () => [...organizationKeys.all, "list"] as const,
+};

--- a/apps/console/src/features/organizations/api/queries.ts
+++ b/apps/console/src/features/organizations/api/queries.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { client } from "../../../api/client";
+import { organizationKeys } from "./keys";
+
+// Orgs for the header switcher. Near-static reference data → long staleTime.
+// Note: the BFF lists every org it can see, not the caller's memberships —
+// fine for the issue #91 display list; membership filtering is issue #92.
+export function useOrganizations() {
+  return useQuery({
+    queryKey: organizationKeys.list(),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/organizations");
+      if (error) {
+        throw new Error(
+          error.detail ?? error.title ?? "Failed to load organizations",
+        );
+      }
+      return data;
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -19,15 +19,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import * as Y from "yjs";
 import { HocuspocusProvider } from "@hocuspocus/provider";
+import { getAccessToken } from "../../../auth/token";
 
 // Console side of #86 phase 5: connect the spec view to the collab service.
 // One room + one Y.Doc per project (`spec-<org>-<project>`), Y.Map('files')
 // of path → Y.Text. If no collab server is reachable the view degrades to
 // solo (#86 decision 10) — callers keep their non-collaborative fallback.
 //
-// Until auth lands the connection identifies as the AppLayout dev user via a
-// JWT-shaped unsigned token (the collab mock BFF reads name/email claims;
-// the real oracle will verify a real JWT here instead).
+// The connection authenticates with the session's access token (#91): a real
+// Thunder JWT in thunder mode (verified by the BFF oracle), the unsigned
+// mock token in mock mode (decoded by the collab mock BFF). The token is a
+// getter so reconnects pick up silently-renewed tokens.
 
 export interface CollabPeer {
   clientId: number;
@@ -60,16 +62,6 @@ const PEER_COLORS = [
   "#ba68c8", "#4dd0e1", "#f06292", "#aed581",
 ];
 
-// TODO(auth): replace with the session token when platform auth lands.
-function devToken(name: string, email: string): string {
-  const b64 = (v: unknown) =>
-    btoa(JSON.stringify(v))
-      .replaceAll("+", "-")
-      .replaceAll("/", "_")
-      .replace(/=+$/, "");
-  return `${b64({ alg: "none" })}.${b64({ name, email })}.dev`;
-}
-
 function collabWsUrl(): string {
   const env = (window as { _env_?: { collabWsUrl?: string } })._env_;
   if (env?.collabWsUrl) return env.collabWsUrl;
@@ -78,13 +70,10 @@ function collabWsUrl(): string {
   return `${proto}//${window.location.host}/collab`;
 }
 
-// TODO(auth): org comes from the session once auth lands; the collab mock
-// BFF's default org is used until then.
-const DEV_ORG = "acme";
-
 export function useCollabSpec(
   projectName: string,
   user: { name: string; email: string },
+  orgHandle: string,
 ): CollabSpec {
   const [status, setStatus] = useState<CollabStatus>("connecting");
   const [peers, setPeers] = useState<CollabPeer[]>([]);
@@ -97,9 +86,9 @@ export function useCollabSpec(
     docRef.current = doc;
     const provider = new HocuspocusProvider({
       url: collabWsUrl(),
-      name: `spec-${DEV_ORG}-${projectName}`,
+      name: `spec-${orgHandle}-${projectName}`,
       document: doc,
-      token: devToken(user.name, user.email),
+      token: async () => (await getAccessToken()) ?? "",
       onSynced: () => setStatus("connected"),
       onStatus: ({ status: s }) => {
         if (s === "disconnected") setStatus("offline");
@@ -145,7 +134,7 @@ export function useCollabSpec(
       docRef.current = null;
       providerRef.current = null;
     };
-  }, [projectName, user.name, user.email]);
+  }, [projectName, user.name, user.email, orgHandle]);
 
   return useMemo(
     () => ({

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -43,9 +43,7 @@ import { CollabTextArea } from "../collab/CollabTextArea";
 import { SpecMdEditor } from "../collab/SpecMdEditor";
 import { AddArtifactDialog } from "./AddArtifactDialog";
 import { SpecFileList } from "./SpecFileList";
-
-// TODO(auth): the signed-in user once auth lands (AppLayout has the same stub).
-const devUser = { name: "Developer", email: "developer@example.com" };
+import { useSession } from "../../../auth/SessionContext";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 
@@ -78,7 +76,10 @@ export function SpecView({ projectName }: { projectName: string }) {
   const project = useProject(projectName);
   const status = useProjectStatus(projectName);
   const spec = useProjectSpec(projectName);
-  const collab = useCollabSpec(projectName, devUser);
+  const { user, orgHandle } = useSession();
+  // Rooms are org-scoped (`spec-<org>-<project>`); without an org claim fall
+  // back to the collab mock BFF's default org so mock mode keeps working.
+  const collab = useCollabSpec(projectName, user, orgHandle ?? "acme");
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [addArtifactOpen, setAddArtifactOpen] = useState(false);
 

--- a/apps/console/src/layouts/AppLayout.tsx
+++ b/apps/console/src/layouts/AppLayout.tsx
@@ -26,15 +26,10 @@ import {
   UserMenu,
   version as OXYGEN_UI_VERSION,
 } from "@wso2/oxygen-ui";
-import { FolderOpen, Settings, User as UserIcon, WSO2 } from "@wso2/oxygen-ui-icons-react";
+import { FolderOpen, LogOut, Settings, User as UserIcon, WSO2 } from "@wso2/oxygen-ui-icons-react";
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
-
-// TODO(auth): replace with the signed-in user when auth lands.
-const devUser = {
-  name: "Developer",
-  email: "developer@example.com",
-  role: "Developer",
-};
+import { useSession } from "../auth/SessionContext";
+import { OrgSwitcher, ProjectSwitcher } from "./HeaderSwitchers";
 
 // Sidebar highlight follows the route; grows one mapping per top-level route.
 function activeItemFor(pathname: string): string {
@@ -43,11 +38,11 @@ function activeItemFor(pathname: string): string {
 }
 
 // App shell per the oxygen-ui skill's canonical AppLayout: Header + Sidebar +
-// Main(Outlet) + Footer. NotificationPanel and org/project switchers arrive
-// with their features.
+// Main(Outlet) + Footer. NotificationPanel arrives with its feature.
 export function AppLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activeItem = activeItemFor(pathname);
+  const { user, signOut } = useSession();
 
   return (
     <AppShell initialCollapsed={false} collapseOnSelectOnMobile>
@@ -71,19 +66,25 @@ export function AppLayout() {
               <Header.BrandTitle>Agentic Engineer</Header.BrandTitle>
             </Link>
           </Header.Brand>
+          <Header.Switchers showDivider={false}>
+            <OrgSwitcher />
+            <ProjectSwitcher />
+          </Header.Switchers>
           <Header.Spacer />
           <Header.Actions>
             <ColorSchemeToggle />
             <Divider orientation="vertical" flexItem sx={{ mx: 2 }} />
             <UserMenu>
-              <UserMenu.Trigger name={devUser.name} />
+              <UserMenu.Trigger name={user.name} />
               <UserMenu.Header
-                name={devUser.name}
-                email={devUser.email}
-                role={devUser.role}
+                name={user.name}
+                email={user.email}
+                {...(user.role ? { role: user.role } : {})}
               />
               <UserMenu.Item icon={<UserIcon />} label="Profile" />
               <UserMenu.Item icon={<Settings />} label="Settings" />
+              <UserMenu.Divider />
+              <UserMenu.Logout icon={<LogOut />} label="Sign out" onClick={signOut} />
             </UserMenu>
           </Header.Actions>
         </Header>

--- a/apps/console/src/layouts/HeaderSwitchers.tsx
+++ b/apps/console/src/layouts/HeaderSwitchers.tsx
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComplexSelect } from "@wso2/oxygen-ui";
+import { Building, FolderOpen } from "@wso2/oxygen-ui-icons-react";
+import { useParams, useRouter, useRouterState } from "@tanstack/react-router";
+import { useSession } from "../auth/SessionContext";
+import { useOrganizations } from "../features/organizations/api/queries";
+import { useProjectsList } from "../features/projects/api/queries";
+
+// Header switchers (issue #91), matching the oxygen-ui sample's
+// Header.Switchers + ComplexSelect pattern.
+
+// Honest single-org switcher: the current org comes from the token (the BFF
+// scopes every request to it — OrgScopedInput), and tokens are single-org,
+// so other orgs render disabled until real switching lands (issue #92).
+export function OrgSwitcher() {
+  const { orgHandle } = useSession();
+  const { data } = useOrganizations();
+
+  const orgs = data?.items ?? [];
+  const current = orgs.find((o) => o.name === orgHandle);
+  // The token's org may be missing from the listing (mock mode, stale list):
+  // still show it as the selected entry rather than an empty select.
+  const entries = current
+    ? orgs
+    : [
+        ...(orgHandle
+          ? [{ name: orgHandle, displayName: orgHandle, uuid: orgHandle }]
+          : []),
+        ...orgs,
+      ];
+  if (entries.length === 0) return null;
+
+  const label = (name?: string, displayName?: string) => displayName || name;
+  const selected = current ?? entries[0];
+
+  return (
+    <ComplexSelect
+      value={orgHandle ?? entries[0]?.name ?? ""}
+      size="small"
+      sx={{ minWidth: 180 }}
+      renderValue={() => (
+        <>
+          <ComplexSelect.MenuItem.Icon>
+            <Building />
+          </ComplexSelect.MenuItem.Icon>
+          <ComplexSelect.MenuItem.Text
+            primary={label(selected?.name, selected?.displayName)}
+          />
+        </>
+      )}
+      label="Organization"
+      labelAnchor="inside"
+    >
+      <ComplexSelect.ListHeader>Organizations</ComplexSelect.ListHeader>
+      {entries.map((org) => {
+        const isCurrent = org.name === (orgHandle ?? entries[0]?.name);
+        return (
+          <ComplexSelect.MenuItem
+            key={org.uuid ?? org.name}
+            value={org.name}
+            disabled={!isCurrent}
+          >
+            <ComplexSelect.MenuItem.Icon>
+              <Building />
+            </ComplexSelect.MenuItem.Icon>
+            <ComplexSelect.MenuItem.Text
+              primary={label(org.name, org.displayName)}
+              secondary={
+                isCurrent ? undefined : "Switching requires re-login — coming soon"
+              }
+            />
+          </ComplexSelect.MenuItem>
+        );
+      })}
+    </ComplexSelect>
+  );
+}
+
+// Project switcher: only inside /projects/$projectName/*; switching swaps
+// the param and keeps the current sub-page (builds → builds, spec → spec).
+export function ProjectSwitcher() {
+  const params = useParams({ strict: false }) as { projectName?: string };
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const router = useRouter();
+  const { data } = useProjectsList("", 50);
+
+  const currentName = params.projectName;
+  if (!currentName) return null;
+
+  const projects = data?.pages.flatMap((page) => page.items ?? []) ?? [];
+  const known = projects.some((p) => p.name === currentName);
+
+  const switchTo = (nextName: string) => {
+    if (!nextName || nextName === currentName) return;
+    // Same sub-page, different project — the param is a single path segment,
+    // so a prefix swap is exact.
+    const next = pathname.replace(
+      `/projects/${currentName}`,
+      `/projects/${nextName}`,
+    );
+    router.history.push(next);
+  };
+
+  return (
+    <ComplexSelect
+      value={known ? currentName : ""}
+      onChange={(e) => switchTo(String(e.target.value))}
+      size="small"
+      sx={{ minWidth: 180 }}
+      renderValue={() => (
+        <>
+          <ComplexSelect.MenuItem.Icon>
+            <FolderOpen />
+          </ComplexSelect.MenuItem.Icon>
+          <ComplexSelect.MenuItem.Text primary={currentName} />
+        </>
+      )}
+      label="Project"
+      labelAnchor="inside"
+    >
+      <ComplexSelect.ListHeader>Projects</ComplexSelect.ListHeader>
+      {projects.map((project) => (
+        /* onClick per item, like legacy AepLayout: ComplexSelect's wrapped
+           MenuItem doesn't reliably surface Select onChange. */
+        <ComplexSelect.MenuItem
+          key={project.name}
+          value={project.name}
+          onClick={() => switchTo(project.name)}
+        >
+          <ComplexSelect.MenuItem.Icon>
+            <FolderOpen />
+          </ComplexSelect.MenuItem.Icon>
+          <ComplexSelect.MenuItem.Text
+            primary={project.displayName || project.name}
+            secondary={
+              project.displayName && project.displayName !== project.name
+                ? project.name
+                : undefined
+            }
+          />
+        </ComplexSelect.MenuItem>
+      ))}
+    </ComplexSelect>
+  );
+}

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -18,22 +18,15 @@
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { createRouter, RouterProvider } from "@tanstack/react-router";
+import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   AcrylicOrangeTheme,
   CssBaseline,
   OxygenUIThemeProvider,
 } from "@wso2/oxygen-ui";
-import { routeTree } from "./generated/routeTree.gen";
-
-const router = createRouter({ routeTree });
-
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: typeof router;
-  }
-}
+import { AppAuthProvider } from "./auth/AuthProvider";
+import { router } from "./router";
 
 // api-guidelines: retry 3 for queries (TanStack default, made explicit),
 // no automatic retry for mutations; per-query staleTime set at the hook.
@@ -58,12 +51,15 @@ async function enableMocking(): Promise<void> {
 void enableMocking().then(() => {
   createRoot(document.getElementById("app")!).render(
     <StrictMode>
-      <OxygenUIThemeProvider theme={AcrylicOrangeTheme}>
-        <CssBaseline />
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-        </QueryClientProvider>
-      </OxygenUIThemeProvider>
+      {/* Auth outermost (issue #91): the OIDC session exists before any UI. */}
+      <AppAuthProvider>
+        <OxygenUIThemeProvider theme={AcrylicOrangeTheme}>
+          <CssBaseline />
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </OxygenUIThemeProvider>
+      </AppAuthProvider>
     </StrictMode>,
   );
 });

--- a/apps/console/src/mocks/browser.ts
+++ b/apps/console/src/mocks/browser.ts
@@ -1,7 +1,12 @@
 import { setupWorker } from "msw/browser";
 import { projectHandlers } from "./handlers/project";
 import { projectsHandlers } from "./handlers/projects";
+import { organizationsHandlers } from "./handlers/organizations";
 
 // Order matters: project-scoped routes (/projects/:name/...) are more
 // specific than /projects/:name, so they register first.
-export const worker = setupWorker(...projectHandlers, ...projectsHandlers);
+export const worker = setupWorker(
+  ...projectHandlers,
+  ...projectsHandlers,
+  ...organizationsHandlers,
+);

--- a/apps/console/src/mocks/fixtures/organizations.ts
+++ b/apps/console/src/mocks/fixtures/organizations.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../generated/aep-api";
+
+type OrganizationList = components["schemas"]["OrganizationList"];
+
+// "acme" matches the mock session's org so the switcher shows the signed-in
+// org as current; the others exercise the disabled-entries state.
+export const seedOrganizations: OrganizationList = {
+  items: [
+    {
+      name: "acme",
+      displayName: "Acme Inc",
+      description: "Default development organization",
+      uuid: "0f0e0d0c-0b0a-4908-8706-050403020100",
+      createdAt: "2026-01-05T09:00:00Z",
+      status: "active",
+    },
+    {
+      name: "globex",
+      displayName: "Globex Corporation",
+      uuid: "1f1e1d1c-1b1a-4918-9716-151413121110",
+      createdAt: "2026-02-11T14:30:00Z",
+      status: "active",
+    },
+    {
+      name: "initech",
+      displayName: "Initech",
+      uuid: "2f2e2d2c-2b2a-4928-a726-252423222120",
+      createdAt: "2026-03-19T11:15:00Z",
+      status: "active",
+    },
+  ],
+};

--- a/apps/console/src/mocks/handlers/organizations.ts
+++ b/apps/console/src/mocks/handlers/organizations.ts
@@ -16,16 +16,13 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+import { http, HttpResponse } from "msw";
+import { seedOrganizations } from "../fixtures/organizations";
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
+export const organizationsHandlers = [
+  // Wildcard prefix: matches whatever runtime API base URL sits in front of
+  // /api/v1.
+  http.get("*/api/v1/organizations", () =>
+    HttpResponse.json(seedOrganizations),
   ),
-});
+];

--- a/apps/console/src/router.ts
+++ b/apps/console/src/router.ts
@@ -16,16 +16,15 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+import { createRouter } from "@tanstack/react-router";
+import { routeTree } from "./generated/routeTree.gen";
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
-});
+// Module-scoped so non-component code (the OIDC signin callback) can
+// navigate without a hook.
+export const router = createRouter({ routeTree });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/apps/console/src/routes/callback.tsx
+++ b/apps/console/src/routes/callback.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { AuthScreen } from "../auth/AuthScreen";
+
+// The registered OAuth redirect URI (<origin>/callback). The code exchange
+// itself happens in the OIDC provider (which then restores the pre-login
+// URL via onSigninCallback) — while it runs, AuthGuard shows its own
+// spinner. This component therefore only renders when someone lands here
+// already signed in (e.g. a bookmarked /callback): bail home.
+export const Route = createFileRoute("/callback")({
+  component: CallbackPage,
+});
+
+function CallbackPage() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    void navigate({ to: "/", replace: true });
+  }, [navigate]);
+  return <AuthScreen label="Completing sign-in…" />;
+}

--- a/apps/console/vitest.config.ts
+++ b/apps/console/vitest.config.ts
@@ -16,16 +16,13 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+// Standalone config (instead of vite.config.ts) so tests skip the app's
+// router-codegen and react plugins: the suite covers pure logic only.
+import { defineConfig } from "vitest/config";
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
 });

--- a/deployments/dev-thunder-setup/README.md
+++ b/deployments/dev-thunder-setup/README.md
@@ -1,0 +1,42 @@
+# dev-thunder-setup
+
+A standalone [Thunder](https://thunderid.dev/) identity provider for
+developing the console's SSO flow (issue #91) without the k3d cluster.
+
+- Plain HTTP on **http://localhost:8097** (the console dev server owns 8090)
+- Seeds **`aep-console-client`** — public PKCE, `authorization_code` +
+  `refresh_token`, redirect `http://localhost:8090/callback`, `ou*` claims
+  on both tokens — mirroring the cluster seed in
+  `../single-cluster/values-thunder.yaml`
+- Seeds test users **`mark`** and **`emily`** (password `admin`), plus the
+  default **`admin`/`admin`**
+
+## Run
+
+```bash
+cd deployments/dev-thunder-setup
+docker compose up -d
+```
+
+First start runs a one-shot setup job (applies `bootstrap/*.yaml`), then the
+server. State persists in named volumes; `docker compose down -v` resets.
+
+## Use with the console
+
+```bash
+cd apps/console
+VITE_API_MODE=mock VITE_AUTH_MODE=thunder pnpm dev
+```
+
+Real OIDC login against this Thunder, MSW still serving the APIs — the
+login machinery in isolation (issue #91 dev topology). OIDC discovery:
+`http://localhost:8097/.well-known/openid-configuration`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yaml` | db-init → setup (bootstrap) → server, image pinned |
+| `deployment.yaml` | Thunder config: `http_only`, public URL `:8097` |
+| `bootstrap/60-aep-console.yaml` | also seeds the CORS `server_config` for `:8090` |
+| `bootstrap/60-aep-console.yaml` | the console OAuth app + test users |

--- a/deployments/dev-thunder-setup/bootstrap/60-aep-console.yaml
+++ b/deployments/dev-thunder-setup/bootstrap/60-aep-console.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# AEP console client + test users for dev-thunder-setup (issue #91).
+# Mirrors the k3d seed (values-thunder.yaml 59-aep-oauth-apps.sh PUBLIC_APPS
+# row): public PKCE client, authorization_code + refresh_token, ou* claims
+# on both tokens. Applied by setup.sh after the image's built-in
+# 01-default-resources.yaml, so the default OU / flows / admin already exist.
+
+# resource_type: server_config
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:8090"
+---
+# resource_type: application
+id: 01900000-0000-7000-8000-0000000000a0
+name: AEP Console
+description: AEP Platform Console (dev-thunder-setup)
+ouId: 01900000-0000-7000-8000-000000000001
+url: "http://localhost:8090"
+logoUrl: "emoji:🛠️"
+# Default Basic Authentication Flow / Default Basic Registration Flow
+# (built-in ids from 01-default-resources.yaml).
+authFlowId: 01900000-0000-7000-8000-000000000061
+registrationFlowId: 01900000-0000-7000-8000-000000000064
+isRegistrationFlowEnabled: false
+allowedUserTypes:
+  - Person
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: aep-console-client
+      redirectUris:
+        - "http://localhost:8090/callback"
+      grantTypes:
+        - authorization_code
+        - refresh_token
+      responseTypes:
+        - code
+      pkceRequired: true
+      tokenEndpointAuthMethod: none
+      publicClient: true
+      token:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
+            - given_name
+            - family_name
+            - username
+            - groups
+            - email
+            - name
+            - ouId
+            - ouName
+            - ouHandle
+        idToken:
+          validityPeriod: 3600
+          userAttributes:
+            - given_name
+            - family_name
+            - username
+            - groups
+            - email
+            - name
+            - ouId
+            - ouName
+            - ouHandle
+      scopeClaims:
+        profile:
+          - name
+          - given_name
+          - family_name
+          - picture
+        email:
+          - email
+          - email_verified
+        group:
+          - groups
+        ou:
+          - ouId
+          - ouName
+          - ouHandle
+---
+# resource_type: user
+id: 01900000-0000-7000-8000-0000000000a1
+type: Person
+ouHandle: default
+attributes:
+  username: mark
+  sub: mark
+  email: mark@testorg.com
+  name: Mark Tester
+  given_name: Mark
+  family_name: Tester
+credentials:
+  password: admin
+---
+# resource_type: user
+id: 01900000-0000-7000-8000-0000000000a2
+type: Person
+ouHandle: default
+attributes:
+  username: emily
+  sub: emily
+  email: emily@testorg.com
+  name: Emily Tester
+  given_name: Emily
+  family_name: Tester
+credentials:
+  password: admin

--- a/deployments/dev-thunder-setup/console-config.js
+++ b/deployments/dev-thunder-setup/console-config.js
@@ -16,16 +16,23 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+/* eslint-disable no-underscore-dangle */
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
-});
+// Thunder management console runtime config (http://localhost:8097/console).
+window.__THUNDERID_RUNTIME_CONFIG__ = {
+  brand: {
+    product_name: 'ThunderID',
+    favicon: {
+      light: 'assets/images/favicon.ico',
+      dark: 'assets/images/favicon-inverted.ico',
+    },
+  },
+  client: {
+    base: '/console',
+    client_id: 'CONSOLE',
+    scopes: ['openid', 'profile', 'email', 'system'],
+  },
+  server: {
+    public_url: 'http://localhost:8097',
+  },
+};

--- a/deployments/dev-thunder-setup/deployment.yaml
+++ b/deployments/dev-thunder-setup/deployment.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Thunder config for dev-thunder-setup: the image's default deployment.yaml
+# with local-dev overrides — plain HTTP (http_only, like the cluster's
+# Thunder behind the gateway), public URL on host port 8095, and CORS for
+# the console dev server on :8090. Everything else matches the image
+# defaults (SQLite, packaged dev certs for token signing).
+
+server:
+  hostname: "0.0.0.0"
+  public_url: "http://localhost:8097"
+  # Container port matches the host port (quick-start guidance): the gate
+  # and console SPAs build URLs from public_url, so the ports must agree.
+  port: 8097
+  http_only: true
+
+# Thunder serves the gate (hosted sign-in SPA) itself; this is the browser
+# -facing address it redirects to, which must be the mapped host port —
+# mirrors gateClient in single-cluster/values-thunder.yaml.
+gate_client:
+  hostname: "localhost"
+  port: 8097
+  scheme: "http"
+
+log:
+  level: "info"
+
+tls:
+  min_version: "1.3"
+  cert_file: "config/certs/server.cert"
+  key_file: "config/certs/server.key"
+
+database:
+  config:
+    type: "sqlite"
+    sqlite:
+      path: "database/configdb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
+  runtime:
+    type: "sqlite"
+    sqlite:
+      path: "database/runtimedb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
+  user:
+    type: "sqlite"
+    sqlite:
+      path: "database/userdb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
+  operation:
+    type: "sqlite"
+    sqlite:
+      path: "database/operationdb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
+crypto:
+  encryption:
+    key: "file://config/certs/crypto.key"
+  password_hashing:
+    algorithm: "PBKDF2"
+  keys:
+    - id: "default-key"
+      cert_file: "config/certs/signing.cert"
+      key_file: "config/certs/signing.key"
+    - id: "ecdsa-key"
+      cert_file: "config/certs/ecdsa-signing.cert"
+      key_file: "config/certs/ecdsa-signing.key"
+
+jwt:
+  preferred_key_id: "default-key"
+
+# CORS is not a config key in this Thunder version — it's a declarative
+# server_config resource, seeded in bootstrap/60-aep-console.yaml.
+
+passkey:
+  allowed_origins:
+    - "http://localhost:8097"
+
+consent:
+  enabled: true
+  base_url: "http://localhost:9090/api/v1"
+
+# Sample SMTP config carried over from the image defaults (unused in dev).
+email:
+  smtp:
+    host: "127.0.0.1"
+    port: 2525
+    username: "dev"
+    password: "dev"
+    from_address: "noreply@thunderid.dev"
+    enable_start_tls: false
+    enable_authentication: true

--- a/deployments/dev-thunder-setup/docker-compose.yaml
+++ b/deployments/dev-thunder-setup/docker-compose.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# dev-thunder-setup — a standalone Thunder for console SSO development
+# (issue #91). Runs plain HTTP on http://localhost:8095 and seeds the
+# aep-console-client PKCE app plus test users (see bootstrap/), so
+# `VITE_AUTH_MODE=thunder pnpm dev` in apps/console signs in for real with
+# nothing else running. Mirrors the k3d cluster's Thunder shape
+# (single-cluster/values-thunder.yaml) at dev scale.
+#
+#   cd deployments/dev-thunder-setup && docker compose up -d
+#
+# Login: admin / admin (or mark|emily / admin — see bootstrap/60-aep-console.yaml).
+
+name: dev-thunder-setup
+
+services:
+  # Copies the image's packaged SQLite databases into the volume once, so
+  # setup and server share writable state across restarts.
+  thunder-db-init:
+    image: ghcr.io/thunder-id/thunderid:0.47.0
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - cp -rn /opt/thunderid/database/* /data/ && (cp -rn /opt/thunderid/consent/repository/database/* /consent-data/ 2>/dev/null || true)
+    volumes:
+      - thunder-db:/data
+      - consent-db:/consent-data
+
+  # One-shot bootstrap: starts Thunder with security disabled, applies every
+  # bootstrap/*.yaml (built-in defaults + our 60-aep-console.yaml), stops.
+  thunder-setup:
+    image: ghcr.io/thunder-id/thunderid:0.47.0
+    restart: "no"
+    command: ["./setup.sh"]
+    environment:
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin
+    depends_on:
+      thunder-db-init:
+        condition: service_completed_successfully
+    volumes:
+      - thunder-db:/opt/thunderid/database
+      - consent-db:/opt/thunderid/consent/repository/database
+      - ./deployment.yaml:/opt/thunderid/deployment.yaml:ro
+      - ./bootstrap/60-aep-console.yaml:/opt/thunderid/bootstrap/60-aep-console.yaml:ro
+
+  thunder:
+    image: ghcr.io/thunder-id/thunderid:0.47.0
+    depends_on:
+      thunder-setup:
+        condition: service_completed_successfully
+    ports:
+      # 8097 on the host: 8090 belongs to the console dev server. Container
+      # port matches (see deployment.yaml server.port).
+      - "8097:8097"
+    volumes:
+      - thunder-db:/opt/thunderid/database
+      - consent-db:/opt/thunderid/consent/repository/database
+      - ./deployment.yaml:/opt/thunderid/deployment.yaml:ro
+      - ./bootstrap/60-aep-console.yaml:/opt/thunderid/bootstrap/60-aep-console.yaml:ro
+      # The gate/console SPAs read their API base from static config.js
+      # files — must agree with server.public_url (quick-start guidance).
+      - ./gate-config.js:/opt/thunderid/apps/gate/config.js:ro
+      - ./console-config.js:/opt/thunderid/apps/console/config.js:ro
+
+volumes:
+  thunder-db:
+  consent-db:

--- a/deployments/dev-thunder-setup/gate-config.js
+++ b/deployments/dev-thunder-setup/gate-config.js
@@ -16,16 +16,22 @@
  * under the License.
  */
 
-import { createRootRoute } from "@tanstack/react-router";
-import { AppLayout } from "../layouts/AppLayout";
-import { AuthGuard } from "../auth/AuthGuard";
+/* eslint-disable no-underscore-dangle */
 
-// Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
-export const Route = createRootRoute({
-  component: () => (
-    <AuthGuard>
-      <AppLayout />
-    </AuthGuard>
-  ),
-});
+// Gate (hosted sign-in) runtime config: point the SPA's API calls at the
+// dev-thunder-setup public URL instead of the image default.
+window.__THUNDERID_RUNTIME_CONFIG__ = {
+  brand: {
+    product_name: 'ThunderID',
+    favicon: {
+      light: 'assets/images/favicon.ico',
+      dark: 'assets/images/favicon-inverted.ico',
+    },
+  },
+  client: {
+    base: '/gate',
+  },
+  server: {
+    public_url: 'http://localhost:8097',
+  },
+};

--- a/deployments/single-cluster/values-thunder.yaml
+++ b/deployments/single-cluster/values-thunder.yaml
@@ -125,7 +125,9 @@ bootstrap:
       )
 
       PUBLIC_APPS=(
-        "AEP Console|AEP Platform Console|aep-console-client|http://localhost:8090,${PUBLIC_CONSOLE_URL}|given_name,family_name,username,groups,ouId,ouName,ouHandle"
+        # Root redirects serve the legacy console; /callback is the new
+        # console's dedicated OAuth route (issue #91).
+        "AEP Console|AEP Platform Console|aep-console-client|http://localhost:8090,http://localhost:8090/callback,${PUBLIC_CONSOLE_URL},${PUBLIC_CONSOLE_URL}/callback|given_name,family_name,username,groups,ouId,ouName,ouHandle"
       )
 
       # ──────────────────────────────────────────────────────────────────

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -636,6 +636,9 @@ components:
           type: string
         name:
           type: string
+        prompt:
+          description: Optional requirement prompt that kicks off spec derivation (issue #72).
+          type: string
       required:
         - name
       type: object
@@ -1450,6 +1453,9 @@ components:
           type:
             - array
             - "null"
+        nextCursor:
+          description: Opaque cursor for the next page; absent on the last page.
+          type: string
       required:
         - items
       type: object

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@wso2/oxygen-ui-icons-react':
         specifier: 0.11.0
         version: 0.11.0(react@19.2.3)
+      oidc-client-ts:
+        specifier: ^3.5.0
+        version: 3.5.0
       openapi-fetch:
         specifier: 0.14.1
         version: 0.14.1
@@ -74,6 +77,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-oidc-context:
+        specifier: ^3.3.1
+        version: 3.3.1(oidc-client-ts@3.5.0)(react@19.2.3)
       y-prosemirror:
         specifier: ^1.3.7
         version: 1.3.7(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-view@1.42.0)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
@@ -111,6 +117,9 @@ importers:
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/contracts: {}
 
@@ -1531,8 +1540,14 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1664,6 +1679,35 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
@@ -1743,6 +1787,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
@@ -1802,6 +1850,10 @@ packages:
 
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1949,6 +2001,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -2017,6 +2072,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2032,6 +2090,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -2307,6 +2369,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2427,6 +2493,14 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  oidc-client-ts@3.5.0:
+    resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
+    engines: {node: '>=18'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2610,6 +2684,13 @@ packages:
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
+  react-oidc-context@3.3.1:
+    resolution: {integrity: sha512-/Azvm9W4DhhOtSDBE73kFInh1b6zZRRfILKbgmk2syExMF0PCYJOn/dGdOOi2BFX8x0rCeUe45NXHU+/+xDcrQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      oidc-client-ts: ^3.1.0
+      react: '>=16.14.0'
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -2722,6 +2803,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2737,9 +2821,15 @@ packages:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -2775,9 +2865,20 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.6:
     resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
@@ -2952,6 +3053,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -2961,6 +3103,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4294,9 +4441,16 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 25.9.4
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.9.4
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -4463,6 +4617,48 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@25.9.4)(typescript@5.9.3)
+      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@workflow/serde@4.1.0': {}
 
   '@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3)':
@@ -4555,6 +4751,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
@@ -4630,6 +4828,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001800: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4744,6 +4944,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -4855,6 +5057,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -4864,6 +5070,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -5119,6 +5327,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jwt-decode@4.0.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5226,6 +5436,12 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.3: {}
+
+  oidc-client-ts@3.5.0:
+    dependencies:
+      jwt-decode: 4.0.0
 
   on-finished@2.4.1:
     dependencies:
@@ -5435,6 +5651,11 @@ snapshots:
 
   react-is@19.2.7: {}
 
+  react-oidc-context@3.3.1(oidc-client-ts@3.5.0)(react@19.2.3):
+    dependencies:
+      oidc-client-ts: 3.5.0
+      react: 19.2.3
+
   react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -5585,6 +5806,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -5593,7 +5816,11 @@ snapshots:
 
   source-map@0.5.7: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -5621,10 +5848,16 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.4.6: {}
 
@@ -5741,6 +5974,34 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.4
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -5748,6 +6009,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
Implements #91 — the console signs users in against Thunder and gains the header org/project switchers.

## What's here

**Auth core** (`apps/console/src/auth/`)
- `oidc-client-ts` + `react-oidc-context` around one shared `UserManager`: Authorization Code + PKCE, **sessionStorage**, refresh-token `automaticSilentRenew`
- `AuthGuard` at `__root` — routes only ever render with a signed-in session in context; dedicated `/callback` route restores the pre-login URL from OAuth state
- Claims util mirrors the BFF's `ResolveOuHandle` precedence (`ouHandle > ouName > ouId`)
- Sign-out: RP-initiated logout when the IdP advertises `end_session_endpoint`; falls back to token revocation + local session clear (Thunder v0.47.0 ships no logout surface)

**API client** — Bearer attach + the single global 401 handler (api-guidelines #3) as a fetch wrapper under `openapi-fetch`: silent renew → one retry (body-preserving clone) → `signinRedirect` keeping the current URL. Unit-tested.

**Header** (`Header.Switchers` + `ComplexSelect`, oxygen-ui canonical pattern)
- **Org switcher, honest single-org**: current org from token claims; other orgs listed but disabled ("switching requires re-login") because tokens are single-org and `OrgScopedInput` derives the org solely from the JWT — real switching is #92
- **Project switcher**: visible in `/projects/$projectName/*`, keeps the current sub-page on switch
- `UserMenu` shows the real identity + Sign out

**Collab** — `useCollabSpec` sends the session access token via an async getter (reconnects pick up renewed tokens); room org comes from the session.

**Dev story**
- Default dev (`VITE_API_MODE=mock`): mock auth + MSW, nothing to run
- `VITE_AUTH_MODE=thunder`: real OIDC against **`deployments/dev-thunder-setup/`** (pinned Thunder 0.47.0 on `http://localhost:8097`, declarative bootstrap: `aep-console-client` PKCE app, CORS `server_config`, test users `mark`/`emily`) while MSW keeps serving APIs

**Also**
- Cluster seed (`values-thunder.yaml`): `/callback` redirect URIs added for the new console; root URIs kept for the legacy console
- Contract: `ProjectList.nextCursor` + `CreateProjectRequest.prompt` added — the console already referenced both, so the branch didn't typecheck without them (`gen` regenerates from the contract)

## Verification

Manual end-to-end drive against dev-thunder-setup (per the issue's verification plan): unauthenticated visit → gate sign-in (`mark`/`admin`) → `/callback` exchange → original URL restored, real identity in the user menu, org `default` from claims; project switch `demo-shop → gym-tracker` staying on `/builds`; disabled org entries with the re-login hint; sign-out landing back at the credential prompt; default mock mode boots with zero containers. Unit tests (21) for claims, auth-mode resolution, and the 401 renew-retry wrapper; typecheck/lint/build/license-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
