### PR TITLE
fix(tasks): closed aep:provision gate derives deployed (unblocks dependent dispatch) + skills/env follow-ups

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -45,6 +45,16 @@ services:
     build:
       context: ../services/aep-api
     container_name: aep-api
+    # Fast SYN-retransmit recovery for the local Colima env. Its docker-bridge
+    # NAT intermittently drops a SYN under concurrent outbound bursts (the BFF's
+    # parallel git fetches + GitHub API calls on a project page load); the kernel
+    # default (tcp_syn_retries=6) then leaves the connect hanging ~50-76s before
+    # a retransmit lands — surfacing as hanging tasks/versions endpoints. 2
+    # retries recovers (or fails fast) within ~7s so reads degrade gracefully and
+    # the console re-polls. Namespaced sysctl (per-netns); harmless elsewhere.
+    # Proper durable fix tracked in docs/design/gitfs-fetch-on-read-followup.md.
+    sysctls:
+      net.ipv4.tcp_syn_retries: "2"
     ports:
       - "9090:9090"
     depends_on:
@@ -235,6 +245,10 @@ services:
       context: ..
       dockerfile: services/agents/Dockerfile
     container_name: aep-agents
+    # See aep-api: bound the Colima docker-bridge SYN-drop stall to ~7s so the
+    # agents service's Anthropic API calls (plan/design turns) don't hang.
+    sysctls:
+      net.ipv4.tcp_syn_retries: "2"
     ports:
       - "4000:4000"
     depends_on:

--- a/services/aep-api/internal/contracts/taskmeta/derive.go
+++ b/services/aep-api/internal/contracts/taskmeta/derive.go
@@ -61,6 +61,7 @@ type GitHubFacts struct {
 //
 //	on_hold
 //	→ merged-group: deployed / building / failed / merged (PR merged)
+//	→ deployed (a succeeded ops/provision gate — closed-on-success, §3.6)
 //	→ abandoned
 //	→ ready_for_review (PR open)
 //	→ in_progress (active coding/ops Execution)
@@ -112,6 +113,19 @@ func Derive(f GitHubFacts, execs []ExecutionFact) DerivedStatus {
 		return StatusMerged
 	}
 
+	// A succeeded ops/provision Execution is a COMPLETED gate, not abandoned work:
+	// the resolving aep:provision gate issue is CLOSED on success by the readiness
+	// watcher / drawer action (§3.6 close-with-reference), so a closed issue backed
+	// by a succeeded provision must derive deployed — this is exactly how dependent
+	// coding tasks unblock. It therefore sits ABOVE the closed-without-merge =
+	// abandoned rule (that rule targets coding Tasks, whose latest Execution is
+	// coding, never ops/provision). Build Executions are excluded — a build's
+	// terminal state is decided under the merged-PR arm above.
+	if l := latestExcludingBuild(execs); l != nil && l.Status == ExecSucceeded &&
+		(l.Kind == KindOps || l.Kind == KindProvision) {
+		return StatusDeployed
+	}
+
 	// The issue was closed without a merge → the work was abandoned.
 	if !f.IssueOpen {
 		return StatusAbandoned
@@ -134,14 +148,11 @@ func Derive(f GitHubFacts, execs []ExecutionFact) DerivedStatus {
 		return StatusRejected
 	}
 
-	// Otherwise fall back to the latest coding/ops/provision Execution outcome.
-	if latest != nil {
-		switch {
-		case latest.Status == ExecFailed:
-			return StatusFailed
-		case latest.Status == ExecSucceeded && (latest.Kind == KindOps || latest.Kind == KindProvision):
-			return StatusDeployed
-		}
+	// Otherwise fall back to the latest Execution outcome. A succeeded
+	// ops/provision already returned deployed above; a succeeded coding
+	// execution with no linked PR yet is transient → pending.
+	if latest != nil && latest.Status == ExecFailed {
+		return StatusFailed
 	}
 
 	return StatusPending

--- a/services/aep-api/internal/contracts/taskmeta/derive_test.go
+++ b/services/aep-api/internal/contracts/taskmeta/derive_test.go
@@ -33,6 +33,9 @@ func TestDerive(t *testing.T) {
 	ops := func(s ExecutionStatus, mins int) ExecutionFact {
 		return ExecutionFact{Kind: KindOps, Status: s, CreatedAt: at(mins)}
 	}
+	provision := func(s ExecutionStatus, mins int) ExecutionFact {
+		return ExecutionFact{Kind: KindProvision, Status: s, CreatedAt: at(mins)}
+	}
 
 	tests := []struct {
 		name  string
@@ -91,6 +94,19 @@ func TestDerive(t *testing.T) {
 		{"ops running", GitHubFacts{IssueOpen: true}, []ExecutionFact{ops(ExecRunning, 0)}, StatusInProgress},
 		{"ops failed", GitHubFacts{IssueOpen: true}, []ExecutionFact{ops(ExecFailed, 0)}, StatusFailed},
 		{"ops succeeded is deployed", GitHubFacts{IssueOpen: true}, []ExecutionFact{ops(ExecSucceeded, 0)}, StatusDeployed},
+
+		// provision gate issues — the aep:provision issue is CLOSED on success by
+		// the readiness watcher (§3.6), so a closed issue backed by a succeeded
+		// provision must derive DEPLOYED, not abandoned. This is what unblocks a
+		// dependent coding Task's dispatch gate; the earlier bug returned abandoned
+		// (closed-check fired first) and hung the consumer forever.
+		{"open provision succeeded is deployed", GitHubFacts{IssueOpen: true}, []ExecutionFact{provision(ExecSucceeded, 0)}, StatusDeployed},
+		{"CLOSED provision succeeded is deployed (gate closed-on-success, §3.6)", GitHubFacts{IssueOpen: false}, []ExecutionFact{provision(ExecSucceeded, 0)}, StatusDeployed},
+		{"CLOSED ops succeeded is deployed", GitHubFacts{IssueOpen: false}, []ExecutionFact{ops(ExecSucceeded, 0)}, StatusDeployed},
+		// a declined provision (issue closed WITHOUT a succeeded run) is still abandoned.
+		{"closed provision with no succeeded run is abandoned", GitHubFacts{IssueOpen: false}, []ExecutionFact{provision(ExecFailed, 0)}, StatusAbandoned},
+		// hold still wins over a succeeded provision.
+		{"hold beats deployed provision", GitHubFacts{IssueOpen: false, HoldPresent: true}, []ExecutionFact{provision(ExecSucceeded, 0)}, StatusOnHold},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/services/aep-api/internal/feature/execution/funnel_provision_test.go
+++ b/services/aep-api/internal/feature/execution/funnel_provision_test.go
@@ -87,6 +87,32 @@ func TestFunnel_ProvisionDepDeployed_Dispatches(t *testing.T) {
 	}
 }
 
+// The readiness watcher CLOSES the aep:provision gate issue on success (§3.6
+// close-with-reference), so the dispatch gate must still see a CLOSED issue
+// backed by a succeeded provision as deployed. The earlier bug derived a closed
+// issue as abandoned (never deployed), hanging the consumer's dispatch forever —
+// caught live on a fresh cluster, not by the "open"-issue test above.
+func TestFunnel_ProvisionDepDeployed_ClosedIssue_Dispatches(t *testing.T) {
+	store := newFakeStore()
+	markProvisionDeployed(store, 1, "orders-db") // platform resource provisioned + issue closed
+
+	issues := newFakeIssues([]gitrepo.IssueInfo{
+		provisionIssue(1, "orders-db", taskmeta.GateResourceProvisioning, "closed"),
+		taskIssue(2, "order-service", nil, []string{taskmeta.LabelExecute}, "open"),
+	})
+	exec := &fakeExecutor{store: store, startOK: true}
+	f := newTestFunnelP(store, issues,
+		map[string]bool{"order-service": true},
+		map[string][]string{"order-service": {"orders-db"}}, exec)
+
+	if err := f.OnExecuteIntent(context.Background(), "o/r", 2); err != nil {
+		t.Fatalf("OnExecuteIntent: %v", err)
+	}
+	if len(exec.got) != 1 {
+		t.Fatalf("a CLOSED provision issue backed by a succeeded run must still dispatch the consumer, got %d", len(exec.got))
+	}
+}
+
 func TestFunnel_ProvisionDepPending_Queues(t *testing.T) {
 	store := newFakeStore()
 	// The provision issue exists but is NOT deployed (no succeeded provision row).

--- a/services/aep-api/internal/feature/skills/reconcile_more_test.go
+++ b/services/aep-api/internal/feature/skills/reconcile_more_test.go
@@ -170,11 +170,13 @@ func TestLoadEmbeddedBuiltins(t *testing.T) {
 		t.Fatalf("loadEmbeddedBuiltins: %v", err)
 	}
 	by := nameSet(got)
-	// The four shipped built-ins, all kind=builtin, with `go` bumped to v2.
+	// The four shipped built-ins, all kind=builtin. `go`, `api-management`, and
+	// `react-webapp` are v2 (the latter two carry the dependencies[] vocabulary
+	// after the connections[]→dependencies[] migration).
 	wantVersions := map[string]int{
-		"api-management":         1,
+		"api-management":         2,
 		"go":                     2,
-		"react-webapp":           1,
+		"react-webapp":           2,
 		"thunder-authentication": 1,
 	}
 	for name, wantV := range wantVersions {


### PR DESCRIPTION
Three commits on top of `aep-rewrite` (since the #94 merge): one real bug fix in the dependency-management provision gate, plus two test/infra follow-ups.

## `fix(tasks)`: a closed `aep:provision` gate issue must derive `deployed`, not `abandoned`

The readiness watcher / drawer action **closes** an `aep:provision` gate issue on success (§3.6 close-with-reference). But `taskmeta.Derive` checked `!IssueOpen → abandoned` **before** the succeeded-ops/provision arm, so a closed provision issue backed by a succeeded provision `Execution` derived `abandoned` instead of `deployed`. The funnel's `depsGate` then saw the platform-resource / external dep as never-deployed and **held the consumer coding Task's dispatch forever** — the dispatch-in-dependency-order path was broken for every resolved provision dep once its gate issue closed.

- Reorders `Derive` so a succeeded ops/provision `Execution` derives `deployed` even on a closed issue. A *declined* provision (closed with no succeeded run) still derives `abandoned`.
- Adds `derive_test` cases for closed+succeeded provision/ops (and hold-beats-deployed).
- Adds `TestFunnel_ProvisionDepDeployed_ClosedIssue_Dispatches` with a **closed** gate issue — the existing test used an open one, which is why the bug shipped.
- Verified live on a fresh cluster: consumer `catalog-service` dispatched once its `postgres-cnpg` provision closed; `orders-service` correctly stayed held on its unbuilt component dep.

## `test(skills)`: builtin `api-management` + `react-webapp` are v2 after the `dependencies[]` migration

`TestLoadEmbeddedBuiltins` still asserted `aep.version 1` for these two skills, but both `SKILL.md` files were bumped to v2 when their `dependsOn`/`dependentApis` frontmatter was migrated to the unified `dependencies[]` vocabulary. Updates the expected versions to match the shipped skills.

## `Fix git connection issues` (local Colima env)

Adds a namespaced `net.ipv4.tcp_syn_retries: "2"` sysctl to the `aep-api` and `aep-agents` compose services. Colima's docker-bridge NAT intermittently drops a SYN under concurrent outbound bursts (the BFF's parallel git fetches + GitHub API calls on a project-page load); the kernel default (`tcp_syn_retries=6`) then leaves the connect hanging ~50–76s, surfacing as hanging tasks/versions endpoints. Two retries recover (or fail fast) within ~7s so reads degrade gracefully and the console re-polls. Per-netns, harmless elsewhere; a durable fix is tracked separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
