### PR TITLE
Console: delete a project from its listing card (#107)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -83,6 +83,10 @@ that's a stalled feature — investigate, don't ignore.
   [#71](https://github.com/wso2/labs-agentic-engineer/issues/71) (BE
   handshake: [#72](https://github.com/wso2/labs-agentic-engineer/issues/72),
   ADR-0005)
+- Project delete from listing — card overflow menu + repo-naming confirm
+  dialog, `repoUrl` joined into the project list —
+  [#107](https://github.com/wso2/labs-agentic-engineer/issues/107) (BE
+  handshake: [#108](https://github.com/wso2/labs-agentic-engineer/issues/108))
 - Legacy console replacement — apps/console gets production serving at :8091
   (Docker/nginx packaging, compose service, OC workload.yaml) while legacy
   keeps :8090; ports flip when the retirement checklist completes —

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -146,6 +146,28 @@ export function useCreateProject() {
   });
 }
 
+// Delete a project (#107). The BFF cascade destroys the OC project, its
+// deployments, and the GitHub repo; the confirm dialog owns the warning.
+// Invalidates every list page so the card leaves the grid on success.
+export function useDeleteProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (projectName: string) => {
+      const { error } = await client.DELETE("/projects/{projectName}", {
+        params: { path: { projectName } },
+      });
+      if (error) {
+        throw new Error(
+          error.detail ?? error.title ?? "Failed to delete project",
+        );
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
+    },
+  });
+}
+
 // The connected GitHub org, for the repo-URL preview in the create flow.
 // Read from the consolidated org-config projection (GET /config replaced
 // /org/credentials/github when the contract consolidated org config).

--- a/apps/console/src/features/projects/components/DeleteProjectDialog.tsx
+++ b/apps/console/src/features/projects/components/DeleteProjectDialog.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@wso2/oxygen-ui";
+import type { components } from "../../../generated/aep-api";
+import { useDeleteProject } from "../api/queries";
+
+type Project = components["schemas"]["Project"];
+
+// "https://github.com/acme/shop.git" → "acme/shop", for the warning copy.
+// Anything unparseable falls back to the raw URL — still better than silence.
+function repoDisplayName(repoUrl: string): string {
+  const match = /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/.exec(repoUrl);
+  return match?.[1] ?? repoUrl;
+}
+
+interface DeleteProjectDialogProps {
+  // The project being confirmed for deletion; null keeps the dialog closed.
+  project: Project | null;
+  onClose: () => void;
+}
+
+// Confirmation dialog for deleting a project from the listing (#107).
+// Names the GitHub repository that the cascade destroys when the list
+// payload carries one; projects without a repo get generic copy.
+export function DeleteProjectDialog({
+  project,
+  onClose,
+}: DeleteProjectDialogProps) {
+  const deleteProject = useDeleteProject();
+  const busy = deleteProject.isPending;
+
+  const close = () => {
+    if (busy) return;
+    deleteProject.reset();
+    onClose();
+  };
+
+  const confirm = () => {
+    if (!project) return;
+    deleteProject.mutate(project.name, { onSuccess: onClose });
+  };
+
+  const displayName = project?.displayName ?? project?.name;
+
+  return (
+    <Dialog open={project !== null} onClose={close} maxWidth="xs" fullWidth>
+      <DialogTitle>Delete {displayName}?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This permanently deletes the project, its deployments, and{" "}
+          {project?.repoUrl ? (
+            <>
+              the GitHub repository <strong>{repoDisplayName(project.repoUrl)}</strong>
+            </>
+          ) : (
+            "its GitHub repository"
+          )}{" "}
+          — including all specs and code.
+        </DialogContentText>
+        {deleteProject.isError && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {deleteProject.error instanceof Error && deleteProject.error.message
+              ? deleteProject.error.message
+              : "Failed to delete project"}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={close} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          onClick={confirm}
+          variant="contained"
+          color="error"
+          loading={busy}
+        >
+          Delete project
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/console/src/features/projects/components/ProjectsList.tsx
+++ b/apps/console/src/features/projects/components/ProjectsList.tsx
@@ -26,6 +26,11 @@ import {
   CardContent,
   CircularProgress,
   Grid,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
   PageContent,
   PageTitle,
   SearchBar,
@@ -33,11 +38,17 @@ import {
   useMediaQuery,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { Folder, Plus } from "@wso2/oxygen-ui-icons-react";
+import {
+  EllipsisVertical,
+  Folder,
+  Plus,
+  Trash2,
+} from "@wso2/oxygen-ui-icons-react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
 import { useProjectsList } from "../api/queries";
 import { useDebouncedValue } from "../hooks/useDebouncedValue";
+import { DeleteProjectDialog } from "./DeleteProjectDialog";
 
 type Project = components["schemas"]["Project"];
 
@@ -52,12 +63,21 @@ function formatCreatedAt(createdAt?: string): string | null {
   })}`;
 }
 
-function ProjectCard({ project }: { project: Project }) {
+function ProjectCard({
+  project,
+  onDelete,
+}: {
+  project: Project;
+  onDelete: (project: Project) => void;
+}) {
   const navigate = useNavigate();
   const created = formatCreatedAt(project.createdAt);
+  // Overflow (⋮) menu anchor — a sibling of CardActionArea (never nested
+  // inside it: button-in-button), absolutely positioned over the corner.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
   return (
-    <Card variant="outlined" sx={{ height: "100%" }}>
+    <Card variant="outlined" sx={{ height: "100%", position: "relative" }}>
       <CardActionArea
         sx={{ height: "100%", alignItems: "stretch" }}
         onClick={() =>
@@ -70,7 +90,7 @@ function ProjectCard({ project }: { project: Project }) {
         <CardContent
           sx={{ display: "flex", flexDirection: "column", height: "100%" }}
         >
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" gutterBottom sx={{ pr: 4 }}>
             {project.displayName ?? project.name}
           </Typography>
           <Typography
@@ -93,6 +113,31 @@ function ProjectCard({ project }: { project: Project }) {
           )}
         </CardContent>
       </CardActionArea>
+      <IconButton
+        aria-label={`Actions for ${project.displayName ?? project.name}`}
+        size="small"
+        onClick={(e) => setMenuAnchor(e.currentTarget)}
+        sx={{ position: "absolute", top: 8, right: 8 }}
+      >
+        <EllipsisVertical size={18} />
+      </IconButton>
+      <Menu
+        anchorEl={menuAnchor}
+        open={menuAnchor !== null}
+        onClose={() => setMenuAnchor(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            setMenuAnchor(null);
+            onDelete(project);
+          }}
+        >
+          <ListItemIcon>
+            <Trash2 size={18} />
+          </ListItemIcon>
+          <ListItemText>Delete project</ListItemText>
+        </MenuItem>
+      </Menu>
     </Card>
   );
 }
@@ -137,6 +182,8 @@ const GRID_ROWS_PER_PAGE = 3;
 
 export function ProjectsList() {
   const [search, setSearch] = useState("");
+  // The project awaiting delete confirmation; one dialog serves the grid.
+  const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
   const debouncedSearch = useDebouncedValue(search.trim());
   const columns = useGridColumns();
   const {
@@ -208,7 +255,7 @@ export function ProjectsList() {
               <Grid container spacing={3}>
                 {items.map((project) => (
                   <Grid key={project.name} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-                    <ProjectCard project={project} />
+                    <ProjectCard project={project} onDelete={setDeleteTarget} />
                   </Grid>
                 ))}
               </Grid>
@@ -227,6 +274,10 @@ export function ProjectsList() {
           )}
         </>
       )}
+      <DeleteProjectDialog
+        project={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+      />
     </PageContent>
   );
 }

--- a/apps/console/src/mocks/fixtures/projects.ts
+++ b/apps/console/src/mocks/fixtures/projects.ts
@@ -19,6 +19,7 @@ export const seedProjects: Project[] = [
     description: "Sample storefront seeded by the mock layer",
     status: "active",
     createdAt: "2026-06-12T09:30:00Z",
+    repoUrl: "https://github.com/acme-dev/demo-shop.git",
   },
   {
     name: "gym-tracker",
@@ -26,7 +27,10 @@ export const seedProjects: Project[] = [
     description: "Track workouts, sets, and progress over time",
     status: "active",
     createdAt: "2026-06-20T14:05:00Z",
+    repoUrl: "https://github.com/acme-dev/gym-tracker.git",
   },
+  // invoice-hub deliberately has NO repoUrl — exercises the delete dialog's
+  // generic-copy variant (failed/absent repo provisioning, #107).
   {
     name: "invoice-hub",
     displayName: "Invoice Hub",
@@ -135,6 +139,15 @@ export const duplicateProjectError: ErrorModel = {
   status: 409,
   title: "Conflict",
   detail: "A project with this name already exists",
+};
+
+// Delete-failure scenario (#107): toggle in the browser devtools:
+//   localStorage.setItem('aep:mock:projects:delete', 'error')
+export const deleteProjectError: ErrorModel = {
+  type: "about:blank",
+  status: 500,
+  title: "Internal Server Error",
+  detail: "Mock error scenario for project deletion",
 };
 
 // The org-config projection (GET /config); the create flow derives the

--- a/apps/console/src/mocks/handlers/projects.ts
+++ b/apps/console/src/mocks/handlers/projects.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import type { components } from "../../generated/aep-api";
 import {
+  deleteProjectError,
   duplicateProjectError,
   emptyProjects,
   orgConfig,
@@ -24,9 +25,15 @@ function scenario(): ProjectsScenario {
 // scenario's seed so the create flow behaves statefully in mock mode.
 const createdProjects: Project[] = [];
 
+// Names deleted through the UI in this session — masks seed AND created
+// entries so the delete flow behaves statefully in mock mode (#107).
+const deletedProjects = new Set<string>();
+
 function currentProjects(): Project[] {
   const seed = scenario() === "some" ? seedProjects : [];
-  return [...seed, ...createdProjects];
+  return [...seed, ...createdProjects].filter(
+    (p) => !deletedProjects.has(p.name),
+  );
 }
 
 export const projectsHandlers = [
@@ -98,6 +105,31 @@ export const projectsHandlers = [
       );
     }
     return HttpResponse.json(project);
+  }),
+
+  // delete-project (#107). Error state via
+  // localStorage.setItem('aep:mock:projects:delete', 'error').
+  http.delete("*/api/v1/projects/:projectName", ({ params }) => {
+    if (localStorage.getItem("aep:mock:projects:delete") === "error") {
+      return HttpResponse.json(deleteProjectError, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    const name = String(params.projectName);
+    if (!currentProjects().some((p) => p.name === name)) {
+      return HttpResponse.json(
+        {
+          type: "about:blank",
+          status: 404,
+          title: "Not Found",
+          detail: `Project ${name} not found`,
+        },
+        { status: 404, headers: { "Content-Type": "application/problem+json" } },
+      );
+    }
+    deletedProjects.add(name);
+    return new HttpResponse(null, { status: 204 });
   }),
 
   // get-config: the create flow reads the connected GitHub org for the

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1597,6 +1597,9 @@ components:
           type: string
         namespaceName:
           type: string
+        repoUrl:
+          description: Clone URL of the project's Git repository; absent when no repo is provisioned (issue #108).
+          type: string
         status:
           type: string
         uid:


### PR DESCRIPTION
Implements #107 (grilled design — decisions comment on the issue).

## What's here

- **Overflow (⋮) menu** on each project card with a **Delete project** item — a sibling of `CardActionArea` (never nested; button-in-button), absolutely positioned; accidental clicks open a menu, not a destructive prompt (grilling Q1).
- **Confirmation dialog** (oxygen-ui confirm pattern, simple Cancel/Delete — grilling Q2): names the GitHub repository the delete cascade destroys, sourced from the list payload's `repoUrl` (grilling Q3/Q4); projects without a repo get the generic warning. Busy state on confirm, inline error `Alert` with retry, and on success the card leaves the grid via `projectKeys.lists()` invalidation (last project → existing empty state).
- **Contract**: optional `repoUrl` on the `Project` schema — BE handshake **#108** (needed before ship; mock mode covers build).
- **MSW**: stateful `DELETE /projects/:projectName` (deleted-names mask over seed + created projects), `repoUrl` on two seed projects with `invoice-hub` deliberately bare for the generic-copy variant, delete-error scenario via `localStorage.setItem('aep:mock:projects:delete', 'error')`.
- **PRD**: #107 in-flight line.

## Verified (mock mode, `VITE_API_MODE=mock`)

Every state from the decisions comment, driven in the browser: overflow menu, repo-named dialog (**acme-dev/gym-tracker** in bold), generic no-repo dialog, busy confirm, inline error with retry (dialog stays open), successful delete (dialog closes, card gone, grid refills from the next page). Typecheck / lint / tests green.

Screenshots to be attached by a human (never pushed to git): listing, menu, repo-named dialog, no-repo dialog, error state.

Refs #107 · BE handshake #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)