### PR TITLE
aep-api: join repoUrl into GET /projects (#108)

### DIFF
--- a/services/aep-api/internal/feature/artifacts/harness_test.go
+++ b/services/aep-api/internal/feature/artifacts/harness_test.go
@@ -73,6 +73,9 @@ func (s *stubRepoRepo) GetByOrgAndSlug(context.Context, string, string) (*models
 func (s *stubRepoRepo) ListAllReady(context.Context) ([]models.GitRepository, error) {
 	return nil, nil
 }
+func (s *stubRepoRepo) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	panic("stubRepoRepo: ListByOrg not expected in artifacts tests")
+}
 func (s *stubRepoRepo) ListAll(context.Context) ([]models.GitRepository, error) {
 	return nil, nil
 }

--- a/services/aep-api/internal/feature/component/component_ensure_test.go
+++ b/services/aep-api/internal/feature/component/component_ensure_test.go
@@ -30,6 +30,9 @@ import (
 // EnsureComponent; the rest panic if reached.
 type ensureRepoSvc struct{ repo *models.GitRepository }
 
+func (r ensureRepoSvc) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	panic("ensureRepoSvc: ListByOrg not expected")
+}
 func (r ensureRepoSvc) GetRepo(context.Context, string, string) (*models.GitRepository, error) {
 	return r.repo, nil
 }

--- a/services/aep-api/internal/feature/component/fakes_test.go
+++ b/services/aep-api/internal/feature/component/fakes_test.go
@@ -59,6 +59,9 @@ func (s *stubRepoSvc) GetRepo(ctx context.Context, orgID, projectID string) (*mo
 	}
 	return s.GetRepoFunc(ctx, orgID, projectID)
 }
+func (s *stubRepoSvc) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	panic("stubRepoSvc: ListByOrg not expected in component tests")
+}
 func (s *stubRepoSvc) CreateRepo(context.Context, string, string, string, string) (*models.GitRepository, error) {
 	panic("stubRepoSvc: CreateRepo not expected")
 }

--- a/services/aep-api/internal/feature/gitrepo/fakes_test.go
+++ b/services/aep-api/internal/feature/gitrepo/fakes_test.go
@@ -156,6 +156,18 @@ func (f *fakeRepoRepo) ListAllReady(context.Context) ([]models.GitRepository, er
 	return out, nil
 }
 
+func (f *fakeRepoRepo) ListByOrg(_ context.Context, ocOrgID string) ([]models.GitRepository, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []models.GitRepository
+	for _, r := range f.rows {
+		if r.OrgID == ocOrgID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeRepoRepo) ListAll(context.Context) ([]models.GitRepository, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/services/aep-api/internal/feature/gitrepo/repo_service.go
+++ b/services/aep-api/internal/feature/gitrepo/repo_service.go
@@ -44,6 +44,9 @@ type RepoService interface {
 	// See docs/design/skills-repo-storage.md §10.
 	EnsureBareRepo(ctx context.Context, orgID, projectID, repoName string) (*models.GitRepository, error)
 	GetRepo(ctx context.Context, orgID, projectID string) (*models.GitRepository, error)
+	// ListByOrg returns the org's repo rows (all statuses) — the source for
+	// the project-list repoUrl annotation (#108).
+	ListByOrg(ctx context.Context, orgID string) ([]models.GitRepository, error)
 	// SetWebhookID is called by the webhook registration service after a hook
 	// is provisioned for the repo on GitHub. Stored alongside the repo record
 	// so cleanup can deregister.
@@ -234,6 +237,14 @@ func (s *repoService) GetRepo(ctx context.Context, orgID, projectID string) (*mo
 		return nil, ErrRepoNotFound
 	}
 	return repo, nil
+}
+
+func (s *repoService) ListByOrg(ctx context.Context, orgID string) ([]models.GitRepository, error) {
+	rows, err := s.repo.ListByOrg(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("list repos by org: %w", err)
+	}
+	return rows, nil
 }
 
 func (s *repoService) SetWebhookID(ctx context.Context, orgID, projectID string, hookID int64) error {

--- a/services/aep-api/internal/feature/orgcreds/build_credentials_service_test.go
+++ b/services/aep-api/internal/feature/orgcreds/build_credentials_service_test.go
@@ -65,6 +65,9 @@ func (f *fakeRepoRepo) GetByOrgAndProjectID(ctx context.Context, ocOrgID, projec
 func (f *fakeRepoRepo) ListAllReady(context.Context) ([]models.GitRepository, error) {
 	return nil, nil
 }
+func (f *fakeRepoRepo) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	panic("fakeRepoRepo: ListByOrg not expected in orgcreds tests")
+}
 func (f *fakeRepoRepo) ListAll(context.Context) ([]models.GitRepository, error) {
 	return nil, nil
 }

--- a/services/aep-api/internal/feature/project/project_component_test.go
+++ b/services/aep-api/internal/feature/project/project_component_test.go
@@ -51,6 +51,9 @@ type conflictRepoSvc struct{}
 func (conflictRepoSvc) CreateRepo(context.Context, string, string, string, string) (*models.GitRepository, error) {
 	return nil, fmt.Errorf("create github repo: %w", gitrepo.ErrRepoNameConflict)
 }
+func (conflictRepoSvc) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	return nil, nil
+}
 func (conflictRepoSvc) EnsureBareRepo(context.Context, string, string, string) (*models.GitRepository, error) {
 	panic("EnsureBareRepo not expected")
 }

--- a/services/aep-api/internal/feature/project/project_service.go
+++ b/services/aep-api/internal/feature/project/project_service.go
@@ -101,6 +101,22 @@ func (s *projectService) ListProjects(ctx context.Context, orgName string, limit
 	if err != nil {
 		return nil, translateHTTPError(err)
 	}
+	// Annotate each project with its repo URL from the BFF's own rows (#108
+	// — the delete dialog names the repo the cascade destroys). Best-effort:
+	// a failing join degrades to a repoUrl-less list, never a 500.
+	if s.repoSvc != nil && len(list.Items) > 0 {
+		if repos, repoErr := s.repoSvc.ListByOrg(ctx, orgName); repoErr != nil {
+			slog.WarnContext(ctx, "repoUrl annotation skipped", "org", orgName, "error", repoErr)
+		} else {
+			byProject := make(map[string]string, len(repos))
+			for _, r := range repos {
+				byProject[r.ProjectID] = r.RepoURL
+			}
+			for i := range list.Items {
+				list.Items[i].RepoURL = byProject[list.Items[i].Name]
+			}
+		}
+	}
 	// The search filter is applied Go-side over the FETCHED PAGE only — the
 	// OpenChoreo list API takes just (limit, cursor), so a match on a later
 	// page is not pulled forward; the caller pages via nextCursor and filters

--- a/services/aep-api/internal/feature/project/project_service_test.go
+++ b/services/aep-api/internal/feature/project/project_service_test.go
@@ -47,6 +47,7 @@ type fakeRepoSvc struct {
 	CreateRepoFunc func(ctx context.Context, orgID, projectID, projectName, repoName string) (*models.GitRepository, error)
 	GetRepoFunc    func(ctx context.Context, orgID, projectID string) (*models.GitRepository, error)
 	DeleteRepoFunc func(ctx context.Context, orgID, projectID string) error
+	ListByOrgFunc  func(ctx context.Context, orgID string) ([]models.GitRepository, error)
 }
 
 func (f *fakeRepoSvc) CreateRepo(ctx context.Context, orgID, projectID, projectName, repoName string) (*models.GitRepository, error) {
@@ -54,6 +55,12 @@ func (f *fakeRepoSvc) CreateRepo(ctx context.Context, orgID, projectID, projectN
 		panic("fakeRepoSvc: CreateRepo not set")
 	}
 	return f.CreateRepoFunc(ctx, orgID, projectID, projectName, repoName)
+}
+func (f *fakeRepoSvc) ListByOrg(ctx context.Context, orgID string) ([]models.GitRepository, error) {
+	if f.ListByOrgFunc == nil {
+		panic("fakeRepoSvc: ListByOrg not set")
+	}
+	return f.ListByOrgFunc(ctx, orgID)
 }
 func (f *fakeRepoSvc) EnsureBareRepo(context.Context, string, string, string) (*models.GitRepository, error) {
 	panic("fakeRepoSvc: EnsureBareRepo not expected in project tests")
@@ -238,6 +245,56 @@ func TestListProjects_SurfacesNextCursorAndPassesParams(t *testing.T) {
 	}
 	if list.NextCursor != "next-tok" || len(list.Items) != 1 {
 		t.Fatalf("list = %+v; want 1 item + NextCursor next-tok", list)
+	}
+}
+
+// ListProjects joins each project's git repo URL from the BFF's own rows
+// (#108): repo-less projects stay bare, and a failing join degrades to a
+// repoUrl-less list rather than a 500 — the listing must never break because
+// the annotation source is down.
+func TestListProjects_JoinsRepoURLBestEffort(t *testing.T) {
+	t.Parallel()
+	oc := &ocmocks.ProjectClientMock{
+		ListProjectsFunc: func(context.Context, string, int, string) (*models.ProjectList, error) {
+			return &models.ProjectList{Items: []models.Project{
+				{Name: "web"},
+				{Name: "no-repo"},
+			}}, nil
+		},
+	}
+	repoSvc := &fakeRepoSvc{
+		ListByOrgFunc: func(_ context.Context, orgID string) ([]models.GitRepository, error) {
+			if orgID != "acme" {
+				t.Errorf("ListByOrg org = %q, want acme", orgID)
+			}
+			return []models.GitRepository{
+				{OrgID: "acme", ProjectID: "web", RepoURL: "https://github.com/acme/web.git"},
+			}, nil
+		},
+	}
+	svc := NewProjectService(oc, repoSvc, nil, nil, nil, nil)
+
+	list, err := svc.ListProjects(context.Background(), "acme", 100, "", "")
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if list.Items[0].RepoURL != "https://github.com/acme/web.git" {
+		t.Fatalf("web repoUrl = %q, want the joined clone URL", list.Items[0].RepoURL)
+	}
+	if list.Items[1].RepoURL != "" {
+		t.Fatalf("no-repo project got repoUrl %q, want empty", list.Items[1].RepoURL)
+	}
+
+	// Join failure → list still returns, just unannotated.
+	repoSvc.ListByOrgFunc = func(context.Context, string) ([]models.GitRepository, error) {
+		return nil, errors.New("db down")
+	}
+	list, err = svc.ListProjects(context.Background(), "acme", 100, "", "")
+	if err != nil {
+		t.Fatalf("ListProjects with failing join: %v", err)
+	}
+	if list.Items[0].RepoURL != "" {
+		t.Fatalf("failing join must not annotate: got %q", list.Items[0].RepoURL)
 	}
 }
 

--- a/services/aep-api/internal/feature/requirements/requirements_component_test.go
+++ b/services/aep-api/internal/feature/requirements/requirements_component_test.go
@@ -68,6 +68,9 @@ type fakeCollabRepos struct {
 
 var _ gitrepo.RepoService = (*fakeCollabRepos)(nil)
 
+func (f *fakeCollabRepos) ListByOrg(context.Context, string) ([]models.GitRepository, error) {
+	panic("fakeCollabRepos: ListByOrg not expected")
+}
 func (f *fakeCollabRepos) GetRepo(ctx context.Context, orgID, projectID string) (*models.GitRepository, error) {
 	if f.GetRepoFunc == nil {
 		panic("fakeCollabRepos: GetRepo not set")

--- a/services/aep-api/models/project.go
+++ b/services/aep-api/models/project.go
@@ -25,6 +25,10 @@ type Project struct {
 	DeploymentPipeline string `json:"deploymentPipeline,omitempty"`
 	CreatedAt          string `json:"createdAt,omitempty"`
 	Status             string `json:"status,omitempty"`
+	// RepoURL is the clone URL of the project's git repo, joined from the
+	// BFF's own git_repositories rows on list reads (#108); absent when no
+	// repo is provisioned.
+	RepoURL string `json:"repoUrl,omitempty" doc:"Clone URL of the project's Git repository; absent when no repo is provisioned."`
 }
 
 type ProjectList struct {

--- a/services/aep-api/repositories/repo_repository.go
+++ b/services/aep-api/repositories/repo_repository.go
@@ -42,6 +42,9 @@ type RepoRepository interface {
 	// are not misread as orphans. Bounded by the table size, like
 	// ListAllReady.
 	ListAll(ctx context.Context) ([]models.GitRepository, error)
+	// ListByOrg returns the org's repo rows (all statuses). Feeds the
+	// project-list repoUrl annotation (#108); one indexed query per page.
+	ListByOrg(ctx context.Context, ocOrgID string) ([]models.GitRepository, error)
 	Create(ctx context.Context, repo *models.GitRepository) error
 	Update(ctx context.Context, repo *models.GitRepository) error
 	// DeleteByOrgAndProjectID deletes the repo row scoped to (ocOrgID,
@@ -105,6 +108,16 @@ func (r *repoRepository) ListAllReady(ctx context.Context) ([]models.GitReposito
 func (r *repoRepository) ListAll(ctx context.Context) ([]models.GitRepository, error) {
 	var rows []models.GitRepository
 	if err := r.db.WithContext(ctx).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *repoRepository) ListByOrg(ctx context.Context, ocOrgID string) ([]models.GitRepository, error) {
+	var rows []models.GitRepository
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ?", ocOrgID).
+		Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/services/aep-api/repositories/repo_repository_dbtest_test.go
+++ b/services/aep-api/repositories/repo_repository_dbtest_test.go
@@ -278,3 +278,44 @@ func TestLookupOrgProjectByRepoURL(t *testing.T) {
 		t.Fatalf("Lookup(todo) = (%q,%q,%v); want empty (no unanchored suffix match)", o, p, err)
 	}
 }
+
+// TestRepoRepository_ListByOrg proves the list-projects repoUrl join source
+// (#108): only the caller org's rows come back, all statuses included.
+func TestRepoRepository_ListByOrg(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t)
+
+	repo := repositories.NewRepoRepository(db)
+	ctx := context.Background()
+
+	for _, r := range []models.GitRepository{
+		{OrgID: "orga", ProjectID: "web", RepoURL: "https://github.com/a/web.git", Status: "ready"},
+		{OrgID: "orga", ProjectID: "api", RepoURL: "https://github.com/a/api.git", Status: "pending"},
+		{OrgID: "orgb", ProjectID: "web", RepoURL: "https://github.com/b/web.git", Status: "ready"},
+	} {
+		if err := repo.Create(ctx, &r); err != nil {
+			t.Fatalf("create %s/%s: %v", r.OrgID, r.ProjectID, err)
+		}
+	}
+
+	rows, err := repo.ListByOrg(ctx, "orga")
+	if err != nil {
+		t.Fatalf("ListByOrg: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("ListByOrg(orga) returned %d rows, want 2 (all statuses, no cross-org leak)", len(rows))
+	}
+	for _, r := range rows {
+		if r.OrgID != "orga" {
+			t.Fatalf("cross-org leak: %+v", r)
+		}
+	}
+
+	empty, err := repo.ListByOrg(ctx, "orgc")
+	if err != nil {
+		t.Fatalf("ListByOrg(orgc): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("ListByOrg(orgc) = %d rows, want 0", len(empty))
+	}
+}


### PR DESCRIPTION
Implements the BE handshake #108 for console feature #107 (delete a project from its listing card).

- `repositories.RepoRepository.ListByOrg` — the org's repo rows, one indexed query per list page; dbtest proves org isolation (no cross-org leak, all statuses included).
- `gitrepo.RepoService.ListByOrg` passthrough.
- `models.Project.RepoURL` (`repoUrl,omitempty`) — matches the contract field shipped with the FE PR #109.
- `projectService.ListProjects` annotates each page item from a projectID→repoURL map. **Best-effort:** a failing join warn-logs and returns the list without `repoUrl` — the listing never 500s because the annotation source is down. Same BFF-composite pattern as `GetProjectStatus` (ADR-0006 precedent).

Tests: new service-tier join test (annotated / repo-less / failing-join cases), `ListByOrg` dbtest; full suite green except the pre-existing environmental `gitfs` failure.

Refs #108 · FE: #109 · Feature: #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)