### PR TITLE
Update openapi specs for proposed contracts

### DIFF
--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -99,25 +99,6 @@ components:
         - commitSha
         - files
       type: object
-    ArtifactVersion:
-      additionalProperties: false
-      properties:
-        commitHash:
-          type: string
-        sourceDesign:
-          type: string
-        sourceSpec:
-          type: string
-        tagName:
-          type: string
-        version:
-          format: int64
-          type: integer
-      required:
-        - version
-        - tagName
-        - commitHash
-      type: object
     BuildLogEntry:
       additionalProperties: false
       properties:
@@ -214,12 +195,6 @@ components:
       required:
         - title
         - status
-      type: object
-    CallerIdentity:
-      additionalProperties: false
-      properties:
-        mode:
-          type: string
       type: object
     ClientSecretOutputBody:
       additionalProperties: false
@@ -425,19 +400,6 @@ components:
         - componentType
         - spec
       type: object
-    ConfigKey:
-      additionalProperties: false
-      properties:
-        credentialClass:
-          type: string
-        key:
-          type: string
-        secret:
-          type: boolean
-      required:
-        - key
-        - secret
-      type: object
     ConfigKeyDTO:
       additionalProperties: false
       properties:
@@ -579,9 +541,6 @@ components:
             Repository name for the project's GitHub repo; defaults to the
             project name, the organization is fixed server-side (issue #71).
           type: string
-        repoName:
-          description: Optional Git repository name override (DNS-label slug); defaults to the project name.
-          type: string
       required:
         - name
       type: object
@@ -617,59 +576,6 @@ components:
           type: string
       required:
         - path
-      type: object
-    Dependency:
-      additionalProperties: false
-      properties:
-        candidates:
-          items:
-            $ref: "#/components/schemas/DependencyCandidate"
-          type:
-            - array
-            - "null"
-        config:
-          items:
-            $ref: "#/components/schemas/ConfigKey"
-          type:
-            - array
-            - "null"
-        description:
-          type: string
-        kind:
-          type: string
-        name:
-          type: string
-        needsSpec:
-          type: boolean
-        parameters:
-          additionalProperties:
-            type: string
-          type: object
-        reason:
-          type: string
-        resourceType:
-          type: string
-        specPath:
-          type: string
-        specUrl:
-          type: string
-        status:
-          type: string
-      required:
-        - kind
-        - name
-      type: object
-    DependencyCandidate:
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        label:
-          type: string
-        url:
-          type: string
-      required:
-        - label
       type: object
     DependencyStatus:
       additionalProperties: false
@@ -732,129 +638,6 @@ components:
             - "null"
       required:
         - items
-      type: object
-    Design:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/Design.json
-          format: uri
-          readOnly: true
-          type: string
-        components:
-          items:
-            $ref: "#/components/schemas/DesignComponent"
-          type:
-            - array
-            - "null"
-        hasUnsavedChanges:
-          type: boolean
-        overview:
-          type: string
-        projectId:
-          type: string
-        sourceSpec:
-          type: string
-        status:
-          type: string
-        version:
-          format: int64
-          type: integer
-        versions:
-          items:
-            $ref: "#/components/schemas/ArtifactVersion"
-          type:
-            - array
-            - "null"
-      required:
-        - projectId
-        - overview
-        - components
-        - status
-        - version
-        - hasUnsavedChanges
-      type: object
-    DesignBundle:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/DesignBundle.json
-          format: uri
-          readOnly: true
-          type: string
-        design:
-          $ref: "#/components/schemas/Design"
-        files:
-          additionalProperties:
-            type: string
-          type: object
-      required:
-        - files
-        - design
-      type: object
-    DesignComponent:
-      additionalProperties: false
-      properties:
-        appPath:
-          type: string
-        buildpack:
-          type: string
-        callerIdentity:
-          $ref: "#/components/schemas/CallerIdentity"
-        componentAgentInstructions:
-          type: string
-        componentType:
-          type: string
-        dependencies:
-          items:
-            $ref: "#/components/schemas/Dependency"
-          type:
-            - array
-            - "null"
-        description:
-          type: string
-        entrypoint:
-          type: string
-        exposesAPI:
-          $ref: "#/components/schemas/ExposesAPI"
-        exposure:
-          type: string
-        language:
-          type: string
-        name:
-          type: string
-        openAPISpec:
-          type: string
-        version:
-          type: string
-      required:
-        - name
-        - componentType
-        - language
-        - dependencies
-        - entrypoint
-        - buildpack
-        - appPath
-        - openAPISpec
-        - componentAgentInstructions
-      type: object
-    DesignSaveBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/DesignSaveBody.json
-          format: uri
-          readOnly: true
-          type: string
-        commitSha:
-          description: "Commit to read, gate and tag (the publish's just-applied commit). Empty: resolve HEAD."
-          type: string
       type: object
     DisconnectOutputBody:
       additionalProperties: false
@@ -987,18 +770,6 @@ components:
         - status
         - createdAt
       type: object
-    ExposesAPI:
-      additionalProperties: false
-      properties:
-        auth:
-          type: string
-        managed:
-          type: boolean
-        orgPublished:
-          type: boolean
-        userContext:
-          type: string
-      type: object
     ExternalResourceDTO:
       additionalProperties: false
       properties:
@@ -1058,24 +829,6 @@ components:
         - path
         - sha
       type: object
-    FormFile:
-      additionalProperties: false
-      properties:
-        ContentType:
-          type: string
-        Filename:
-          type: string
-        IsSet:
-          type: boolean
-        Size:
-          format: int64
-          type: integer
-      required:
-        - ContentType
-        - IsSet
-        - Size
-        - Filename
-      type: object
     GitProviderProjection:
       additionalProperties: false
       properties:
@@ -1124,28 +877,6 @@ components:
         - status
         - connectedAt
       type: object
-    GitProviderWrite:
-      additionalProperties: false
-      properties:
-        githubLogin:
-          type: string
-        kind:
-          enum:
-            - github
-          type: string
-        mode:
-          enum:
-            - pat
-          type: string
-        pat:
-          type: string
-      required:
-        - kind
-        - mode
-        - pat
-      type:
-        - object
-        - "null"
     IDPProjection:
       additionalProperties: false
       properties:
@@ -1170,24 +901,6 @@ components:
         - publisherClientId
         - hasClientSecret
       type: object
-    IDPWrite:
-      additionalProperties: false
-      properties:
-        issuer:
-          type: string
-        jwksUrl:
-          type: string
-        kind:
-          enum:
-            - platform
-            - asgardeo
-            - custom
-          type: string
-      required:
-        - kind
-      type:
-        - object
-        - "null"
     ImportResult:
       additionalProperties: false
       properties:
@@ -1245,21 +958,6 @@ components:
         - status
         - connectedAt
       type: object
-    LLMWrite:
-      additionalProperties: false
-      properties:
-        apiKey:
-          type: string
-        kind:
-          enum:
-            - anthropic
-          type: string
-      required:
-        - kind
-        - apiKey
-      type:
-        - object
-        - "null"
     Lineage:
       additionalProperties: false
       properties:
@@ -1444,64 +1142,6 @@ components:
       required:
         - items
       type: object
-    ProjectStatus:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ProjectStatus.json
-          format: uri
-          readOnly: true
-          type: string
-        deployStatus:
-          description: >-
-            Result of the latest dev deployment (e.g. in_progress /
-            succeeded / failed); absent when nothing was deployed.
-          type: string
-        deployedVersion:
-          description: >-
-            Version tag currently deployed to the dev environment; absent
-            when nothing deployed.
-          type: string
-        designStatus:
-          type: string
-        hasDesign:
-          type: boolean
-        hasSpec:
-          type: boolean
-        hasTasks:
-          type: boolean
-        phase:
-          type: string
-        repoErrorMessage:
-          type: string
-        repoStatus:
-          type: string
-        repoUrl:
-          type: string
-        specDirty:
-          description: >-
-            True when the spec/design changed after specVersion was
-            published.
-          type: boolean
-        specStatus:
-          type: string
-        specVersion:
-          description: >-
-            Latest published spec version tag (e.g. v1); absent when
-            nothing published.
-          type: string
-      required:
-        - phase
-        - repoStatus
-        - repoUrl
-        - hasSpec
-        - hasDesign
-        - hasTasks
-        - specStatus
-        - designStatus
-      type: object
     ProvisionBody:
       additionalProperties: false
       properties:
@@ -1524,54 +1164,6 @@ components:
             type: string
           description: Provisioning parameters (override the design defaults)
           type: object
-      type: object
-    RequirementsBundle:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/RequirementsBundle.json
-          format: uri
-          readOnly: true
-          type: string
-        files:
-          additionalProperties:
-            type: string
-          type: object
-        hasUnsavedChanges:
-          type: boolean
-        projectId:
-          type: string
-        status:
-          type: string
-        version:
-          format: int64
-          type: integer
-        versions:
-          items:
-            $ref: "#/components/schemas/ArtifactVersion"
-          type:
-            - array
-            - "null"
-      required:
-        - projectId
-        - files
-        - status
-      type: object
-    SaveBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/SaveBody.json
-          format: uri
-          readOnly: true
-          type: string
-        commitSha:
-          description: "Commit to gate and tag (the publish's just-applied commit). Empty: resolve HEAD."
-          type: string
       type: object
     SaveValuesBody:
       additionalProperties: false
@@ -1642,44 +1234,6 @@ components:
         - version
         - contentSha
         - updatedAt
-      type: object
-    SpecBundle:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/SpecBundle.json
-          format: uri
-          readOnly: true
-          type: string
-        files:
-          items:
-            $ref: "#/components/schemas/SpecFile"
-          type: array
-      required:
-        - files
-      type: object
-    SpecFile:
-      additionalProperties: false
-      properties:
-        content:
-          description: Raw file content, inline.
-          type: string
-        group:
-          description: Which spec-view section the file belongs to.
-          enum:
-            - requirements
-            - designs
-            - validation
-          type: string
-        path:
-          description: File path within the project's spec tree (e.g. requirements/prd.md).
-          type: string
-      required:
-        - path
-        - group
-        - content
       type: object
     StartConnectInputBody:
       additionalProperties: false
@@ -1911,52 +1465,6 @@ components:
           type: string
       required:
         - turnId
-      type: object
-    TurnStatus:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/TurnStatus.json
-          format: uri
-          readOnly: true
-          type: string
-        commitSha:
-          type: string
-        conversationId:
-          type: string
-        createdAt:
-          format: date-time
-          type: string
-        message:
-          type: string
-        noChanges:
-          type: boolean
-        paths:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        reason:
-          type: string
-        status:
-          type: string
-        turnId:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-        useCase:
-          type: string
-      required:
-        - turnId
-        - conversationId
-        - useCase
-        - status
-        - createdAt
-        - updatedAt
       type: object
     UpdateConfigBody:
       additionalProperties: false

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -118,75 +118,6 @@ components:
         - tagName
         - commitHash
       type: object
-    BoardTask:
-      additionalProperties: false
-      properties:
-        assignee:
-          type: string
-        componentName:
-          type: string
-        componentTaskId:
-          type: string
-        dependsOnComponents:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnExternalResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnOrgServices:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        description:
-          type: string
-        dispatchedAt:
-          format: date-time
-          type: string
-        errorMessage:
-          type: string
-        execType:
-          type: string
-        externalResourceName:
-          type: string
-        id:
-          type: string
-        labels:
-          items:
-            $ref: "#/components/schemas/LabelInfo"
-          type:
-            - array
-            - "null"
-        lifecycleStatus:
-          type: string
-        resourceName:
-          type: string
-        status:
-          type: string
-        title:
-          type: string
-        type:
-          type: string
-        url:
-          type: string
-      required:
-        - id
-        - title
-        - url
-      type: object
     BuildLogEntry:
       additionalProperties: false
       properties:
@@ -221,72 +152,74 @@ components:
       required:
         - logs
       type: object
+    BuildRequest:
+      additionalProperties: false
+      type: object
+    BuildResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/BuildResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        tag:
+          type: string
+      required:
+        - tag
+      type: object
+    BuildStatus:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/BuildStatus.json
+          format: uri
+          readOnly: true
+          type: string
+        status:
+          enum:
+            - started
+            - in_progress
+            - completed
+            - failed
+          type: string
+        tasks:
+          items:
+            $ref: "#/components/schemas/BuildStatusTask"
+          type:
+            - array
+            - "null"
+        workflow_status:
+          type: string
+      required:
+        - status
+        - workflow_status
+      type: object
+    BuildStatusTask:
+      additionalProperties: false
+      properties:
+        status:
+          enum:
+            - started
+            - in_progress
+            - completed
+            - failed
+          type: string
+        title:
+          type: string
+      required:
+        - title
+        - status
+      type: object
     CallerIdentity:
       additionalProperties: false
       properties:
         mode:
           type: string
-      type: object
-    ChatHistoryMessage:
-      additionalProperties: false
-      properties:
-        content:
-          type: string
-        role:
-          type: string
-      required:
-        - role
-        - content
-      type: object
-    ChatTurnRequest:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ChatTurnRequest.json
-          format: uri
-          readOnly: true
-          type: string
-        files:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        history:
-          items:
-            $ref: "#/components/schemas/ChatHistoryMessage"
-          type:
-            - array
-            - "null"
-        message:
-          type: string
-        mode:
-          type: string
-        requestSessionBaseline:
-          type: boolean
-      required:
-        - message
-        - history
-        - mode
-      type: object
-    ChatUndoOutputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ChatUndoOutputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        files:
-          additionalProperties:
-            type: string
-          type: object
-      required:
-        - files
       type: object
     ClientSecretOutputBody:
       additionalProperties: false
@@ -356,7 +289,7 @@ components:
           readOnly: true
           type: string
         rawSpec:
-          description: Raw OpenAPI YAML/JSON (paste path)
+          description: Raw OpenAPI 3.x YAML/JSON (paste path)
           type: string
         specUrl:
           description: HTTPS URL to fetch the OpenAPI spec from
@@ -492,140 +425,20 @@ components:
         - componentType
         - spec
       type: object
-    ComponentTask:
+    ConfigKey:
       additionalProperties: false
       properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ComponentTask.json
-          format: uri
-          readOnly: true
+        credentialClass:
           type: string
-        batchId:
+        key:
           type: string
-        body:
-          type: string
-        bodySyncPending:
+        secret:
           type: boolean
-        branchName:
-          type: string
-        buildAuthRetryCount:
-          format: int64
-          type: integer
-        cause:
-          type: string
-        componentName:
-          type: string
-        createdAt:
-          format: date-time
-          type: string
-        dependsOnComponents:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnExternalResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnOrgServices:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dispatchDeferredAt:
-          format: date-time
-          type: string
-        dispatchedAt:
-          format: date-time
-          type: string
-        errorMessage:
-          type: string
-        execType:
-          type: string
-        externalResourceName:
-          type: string
-        id:
-          type: string
-        issueNumber:
-          format: int64
-          type: integer
-        issueUrl:
-          type: string
-        labels:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        lastBuildRunName:
-          type: string
-        lastBuildSha:
-          type: string
-        lastCodingAgentRunName:
-          type: string
-        lastEventAt:
-          format: date-time
-          type: string
-        lifecycleStatus:
-          type: string
-        mergeCommitSha:
-          type: string
-        order:
-          format: int64
-          type: integer
-        projectId:
-          type: string
-        pullRequestNumber:
-          format: int64
-          type: integer
-        pullRequestUrl:
-          type: string
-        rationale:
-          type: string
-        resourceName:
-          type: string
-        sourceDesignVersion:
-          type: string
-        sourceSpecVersion:
-          type: string
-        status:
-          type: string
-        title:
-          type: string
-        type:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-        workspacePath:
-          type: string
       required:
-        - id
-        - projectId
-        - componentName
-        - title
-        - type
-        - order
-        - status
-        - workspacePath
-        - execType
-        - lifecycleStatus
-        - createdAt
-        - updatedAt
+        - key
+        - secret
       type: object
-    ConfigKey:
+    ConfigKeyDTO:
       additionalProperties: false
       properties:
         credentialClass:
@@ -725,6 +538,17 @@ components:
         - gitProvider
         - idp
       type: object
+    ConsumerDTO:
+      additionalProperties: false
+      properties:
+        componentName:
+          type: string
+        projectId:
+          type: string
+      required:
+        - projectId
+        - componentName
+      type: object
     CreateProjectRequest:
       additionalProperties: false
       properties:
@@ -744,7 +568,16 @@ components:
         name:
           type: string
         prompt:
-          description: Optional requirement prompt that kicks off spec derivation (issue #72).
+          description: >-
+            The user's initial requirement — what they want built. Persisted
+            as the project's requirement and kicks off spec derivation for
+            the new project (issue #72). Projects created without a prompt
+            keep today's behavior.
+          type: string
+        repoName:
+          description: >-
+            Repository name for the project's GitHub repo; defaults to the
+            project name, the organization is fixed server-side (issue #71).
           type: string
         repoName:
           description: Optional Git repository name override (DNS-label slug); defaults to the project name.
@@ -838,27 +671,19 @@ components:
       required:
         - label
       type: object
-    DependencyOutputName:
-      additionalProperties: false
-      properties:
-        name:
-          type: string
-      required:
-        - name
-      type: object
-    DependencyStatusOutputBody:
+    DependencyStatus:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/DependencyStatusOutputBody.json
+            - /api/v1/DependencyStatus.json
           format: uri
           readOnly: true
           type: string
         outputs:
           items:
-            $ref: "#/components/schemas/DependencyOutputName"
+            type: string
           type:
             - array
             - "null"
@@ -869,6 +694,7 @@ components:
       required:
         - status
         - ready
+        - outputs
       type: object
     Deployment:
       additionalProperties: false
@@ -1016,21 +842,19 @@ components:
         - openAPISpec
         - componentAgentInstructions
       type: object
-    DesignFileInputBody:
+    DesignSaveBody:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/DesignFileInputBody.json
+            - /api/v1/DesignSaveBody.json
           format: uri
           readOnly: true
           type: string
-        content:
-          description: New file contents
+        commitSha:
+          description: "Commit to read, gate and tag (the publish's just-applied commit). Empty: resolve HEAD."
           type: string
-      required:
-        - content
       type: object
     DisconnectOutputBody:
       additionalProperties: false
@@ -1064,31 +888,6 @@ components:
       required:
         - issuer
         - jwksUrl
-      type: object
-    DispatchResult:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/DispatchResult.json
-          format: uri
-          readOnly: true
-          type: string
-        componentName:
-          type: string
-        error:
-          type: string
-        runName:
-          type: string
-        status:
-          type: string
-        taskId:
-          type: string
-      required:
-        - taskId
-        - componentName
-        - status
       type: object
     EnvVar:
       additionalProperties: false
@@ -1160,6 +959,34 @@ components:
           format: uri
           type: string
       type: object
+    ExecutionView:
+      additionalProperties: false
+      properties:
+        createdAt:
+          format: date-time
+          type: string
+        endedAt:
+          format: date-time
+          type: string
+        id:
+          type: string
+        kind:
+          type: string
+        reason:
+          type: string
+        runName:
+          type: string
+        startedAt:
+          format: date-time
+          type: string
+        status:
+          type: string
+      required:
+        - id
+        - kind
+        - status
+        - createdAt
+      type: object
     ExposesAPI:
       additionalProperties: false
       properties:
@@ -1172,40 +999,18 @@ components:
         userContext:
           type: string
       type: object
-    ExternalResourceConfigKeyDTO:
-      additionalProperties: false
-      properties:
-        key:
-          type: string
-        secret:
-          type: boolean
-      required:
-        - key
-        - secret
-      type: object
-    ExternalResourceConsumer:
-      additionalProperties: false
-      properties:
-        componentName:
-          type: string
-        projectId:
-          type: string
-      required:
-        - projectId
-        - componentName
-      type: object
     ExternalResourceDTO:
       additionalProperties: false
       properties:
-        configKeys:
+        config:
           items:
-            $ref: "#/components/schemas/ExternalResourceConfigKeyDTO"
+            $ref: "#/components/schemas/ConfigKeyDTO"
           type:
             - array
             - "null"
         consumers:
           items:
-            $ref: "#/components/schemas/ExternalResourceConsumer"
+            $ref: "#/components/schemas/ConsumerDTO"
           type:
             - array
             - "null"
@@ -1215,7 +1020,7 @@ components:
           type: string
       required:
         - name
-        - configKeys
+        - config
         - consumers
       type: object
     FileContent:
@@ -1271,32 +1076,6 @@ components:
         - Size
         - Filename
       type: object
-    GenerateRequirementFileInputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/GenerateRequirementFileInputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        prompt:
-          description: Optional user prompt (for bootstrap skills)
-          type: string
-        skillId:
-          description: Document-generation skill ID (required)
-          type: string
-        sources:
-          description: Optional source filenames to feed the skill
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-      required:
-        - skillId
-      type: object
     GitProviderProjection:
       additionalProperties: false
       properties:
@@ -1345,6 +1124,28 @@ components:
         - status
         - connectedAt
       type: object
+    GitProviderWrite:
+      additionalProperties: false
+      properties:
+        githubLogin:
+          type: string
+        kind:
+          enum:
+            - github
+          type: string
+        mode:
+          enum:
+            - pat
+          type: string
+        pat:
+          type: string
+      required:
+        - kind
+        - mode
+        - pat
+      type:
+        - object
+        - "null"
     IDPProjection:
       additionalProperties: false
       properties:
@@ -1369,6 +1170,24 @@ components:
         - publisherClientId
         - hasClientSecret
       type: object
+    IDPWrite:
+      additionalProperties: false
+      properties:
+        issuer:
+          type: string
+        jwksUrl:
+          type: string
+        kind:
+          enum:
+            - platform
+            - asgardeo
+            - custom
+          type: string
+      required:
+        - kind
+      type:
+        - object
+        - "null"
     ImportResult:
       additionalProperties: false
       properties:
@@ -1426,35 +1245,28 @@ components:
         - status
         - connectedAt
       type: object
-    LabelInfo:
+    LLMWrite:
       additionalProperties: false
       properties:
-        color:
+        apiKey:
           type: string
-        name:
+        kind:
+          enum:
+            - anthropic
           type: string
       required:
-        - name
-        - color
-      type: object
-    ListExternalResourcesOutputBody:
+        - kind
+        - apiKey
+      type:
+        - object
+        - "null"
+    Lineage:
       additionalProperties: false
       properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ListExternalResourcesOutputBody.json
-          format: uri
-          readOnly: true
+        designTag:
           type: string
-        externalResources:
-          items:
-            $ref: "#/components/schemas/ExternalResourceDTO"
-          type:
-            - array
-            - "null"
-      required:
-        - externalResources
+        specTag:
+          type: string
       type: object
     OrganizationList:
       additionalProperties: false
@@ -1610,56 +1422,6 @@ components:
       required:
         - name
       type: object
-    ProjectBoard:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ProjectBoard.json
-          format: uri
-          readOnly: true
-          type: string
-        done:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        failed:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        inProgress:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        onHold:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        todo:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        url:
-          type: string
-      required:
-        - url
-        - todo
-        - inProgress
-        - done
-        - onHold
-        - failed
-      type: object
     ProjectList:
       additionalProperties: false
       properties:
@@ -1677,7 +1439,7 @@ components:
             - array
             - "null"
         nextCursor:
-          description: Opaque cursor for the next page; absent on the last page.
+          description: Cursor for the next page; absent on the last page.
           type: string
       required:
         - items
@@ -1740,18 +1502,18 @@ components:
         - specStatus
         - designStatus
       type: object
-    ProvisionDependencyInputBody:
+    ProvisionBody:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/ProvisionDependencyInputBody.json
+            - /api/v1/ProvisionBody.json
           format: uri
           readOnly: true
           type: string
         environments:
-          description: Environment names to bind the resource to (e.g. ["development"])
+          description: "Environments to provision (default: [development])"
           items:
             type: string
           type:
@@ -1760,41 +1522,8 @@ components:
         params:
           additionalProperties:
             type: string
-          description: Provisioning parameters (applied to all envs)
+          description: Provisioning parameters (override the design defaults)
           type: object
-      required:
-        - environments
-      type: object
-    ProvisionDependencyOutputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ProvisionDependencyOutputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        status:
-          type: string
-      required:
-        - status
-      type: object
-    ReqFileInputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ReqFileInputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        content:
-          description: New file content
-          type: string
-      required:
-        - content
       type: object
     RequirementsBundle:
       additionalProperties: false
@@ -1830,36 +1559,27 @@ components:
         - files
         - status
       type: object
-    RequirementsSnapshotFile:
+    SaveBody:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/RequirementsSnapshotFile.json
+            - /api/v1/SaveBody.json
           format: uri
           readOnly: true
           type: string
-        content:
+        commitSha:
+          description: "Commit to gate and tag (the publish's just-applied commit). Empty: resolve HEAD."
           type: string
-        existed:
-          type: boolean
-        filename:
-          type: string
-        snapshotId:
-          type: string
-      required:
-        - snapshotId
-        - filename
-        - existed
       type: object
-    SaveExternalResourceValuesInputBody:
+    SaveValuesBody:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/SaveExternalResourceValuesInputBody.json
+            - /api/v1/SaveValuesBody.json
           format: uri
           readOnly: true
           type: string
@@ -1868,25 +1588,10 @@ components:
             additionalProperties:
               type: string
             type: object
-          description: Per-environment key→value map (development required)
+          description: "Per-environment { configKey: value } maps. Secret keys are routed to the secret manager by the registered schema."
           type: object
       required:
         - environments
-      type: object
-    SaveExternalResourceValuesOutputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/SaveExternalResourceValuesOutputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        status:
-          type: string
-      required:
-        - status
       type: object
     SkillDetailBody:
       additionalProperties: false
@@ -2006,66 +1711,163 @@ components:
       required:
         - authorizeUrl
       type: object
-    TaskStatusResponse:
+    StatusMsg:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/TaskStatusResponse.json
+            - /api/v1/StatusMsg.json
           format: uri
           readOnly: true
-          type: string
-        buildSteps:
-          items:
-            $ref: "#/components/schemas/WorkflowRunTask"
-          type:
-            - array
-            - "null"
-        task:
-          $ref: "#/components/schemas/ComponentTask"
-      required:
-        - task
-      type: object
-    Tasks:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/Tasks.json
-          format: uri
-          readOnly: true
-          type: string
-        hasUnsavedChanges:
-          type: boolean
-        projectId:
-          type: string
-        sourceDesign:
           type: string
         status:
           type: string
-        tasks:
+      required:
+        - status
+      type: object
+    TagList:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/TagList.json
+          format: uri
+          readOnly: true
+          type: string
+        tags:
           items:
-            $ref: "#/components/schemas/ComponentTask"
-          type:
-            - array
-            - "null"
-        version:
-          format: int64
-          type: integer
-        versions:
-          items:
-            $ref: "#/components/schemas/ArtifactVersion"
+            type: string
           type:
             - array
             - "null"
       required:
-        - projectId
-        - tasks
-        - status
-        - version
-        - hasUnsavedChanges
+        - tags
+      type: object
+    TaskDetail:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/TaskDetail.json
+          format: uri
+          readOnly: true
+          type: string
+        attention:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        component:
+          type: string
+        dependsOn:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        derivedStatus:
+          type: string
+        executionHistory:
+          items:
+            $ref: "#/components/schemas/ExecutionView"
+          type:
+            - array
+            - "null"
+        executions:
+          additionalProperties:
+            $ref: "#/components/schemas/ExecutionView"
+          type: object
+        executorClass:
+          type: string
+        hold:
+          type: boolean
+        issueNumber:
+          format: int64
+          type: integer
+        issueUrl:
+          type: string
+        lineage:
+          $ref: "#/components/schemas/Lineage"
+        operation:
+          type: string
+        origin:
+          type: string
+        rationale:
+          type: string
+        title:
+          type: string
+      required:
+        - executionHistory
+        - issueNumber
+        - title
+        - issueUrl
+        - dependsOn
+        - lineage
+        - derivedStatus
+        - hold
+        - attention
+        - executions
+      type: object
+    TaskView:
+      additionalProperties: false
+      properties:
+        attention:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        component:
+          type: string
+        dependsOn:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        derivedStatus:
+          type: string
+        executions:
+          additionalProperties:
+            $ref: "#/components/schemas/ExecutionView"
+          type: object
+        executorClass:
+          type: string
+        hold:
+          type: boolean
+        issueNumber:
+          format: int64
+          type: integer
+        issueUrl:
+          type: string
+        lineage:
+          $ref: "#/components/schemas/Lineage"
+        operation:
+          type: string
+        origin:
+          type: string
+        rationale:
+          type: string
+        title:
+          type: string
+      required:
+        - issueNumber
+        - title
+        - issueUrl
+        - dependsOn
+        - lineage
+        - derivedStatus
+        - hold
+        - attention
+        - executions
       type: object
     TurnInputBody:
       additionalProperties: false
@@ -2109,6 +1911,52 @@ components:
           type: string
       required:
         - turnId
+      type: object
+    TurnStatus:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/TurnStatus.json
+          format: uri
+          readOnly: true
+          type: string
+        commitSha:
+          type: string
+        conversationId:
+          type: string
+        createdAt:
+          format: date-time
+          type: string
+        message:
+          type: string
+        noChanges:
+          type: boolean
+        paths:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        reason:
+          type: string
+        status:
+          type: string
+        turnId:
+          type: string
+        updatedAt:
+          format: date-time
+          type: string
+        useCase:
+          type: string
+      required:
+        - turnId
+        - conversationId
+        - useCase
+        - status
+        - createdAt
+        - updatedAt
       type: object
     UpdateConfigBody:
       additionalProperties: false
@@ -2240,6 +2088,7 @@ components:
         - path
         - content
       type: object
+  securitySchemes:
     userJWT:
       bearerFormat: JWT
       description: Thunder end-user JWT (RS256, JWKS-verified)
@@ -2446,7 +2295,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListExternalResourcesOutputBody"
+                items:
+                  $ref: "#/components/schemas/ExternalResourceDTO"
+                type:
+                  - array
+                  - "null"
           description: OK
         default:
           content:
@@ -2456,19 +2309,19 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List the org's registered external resources with their consuming components
+      summary: List the org's external-resource catalog
       tags:
         - Dependencies
   /dependencies/external-resources/{name}:
     delete:
       operationId: delete-external-resource
       parameters:
-        - description: External resource name to delete
+        - description: External resource name
           in: path
           name: name
           required: true
           schema:
-            description: External resource name to delete
+            description: External resource name
             type: string
       responses:
         "204":
@@ -2481,7 +2334,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Delete a registered external resource (only when no component uses it)
+      summary: Delete an external-resource catalog entry (409 if in use)
       tags:
         - Dependencies
   /organizations:
@@ -2516,6 +2369,20 @@ paths:
           schema:
             description: Opaque pagination cursor
             type: string
+        - description: Case-insensitive substring match on name and displayName
+          explode: false
+          in: query
+          name: search
+          schema:
+            description: Case-insensitive substring match on name and displayName
+            type: string
+        - description: Maximum number of items to return (server default when absent)
+          explode: false
+          in: query
+          name: limit
+          schema:
+            description: Maximum number of items to return (server default when absent)
+            type: integer
       responses:
         "200":
           content:
@@ -2613,9 +2480,9 @@ paths:
       summary: Get a project
       tags:
         - Projects
-  /projects/{projectName}/board:
-    get:
-      operationId: get-board
+  /projects/{projectName}/build:
+    post:
+      operationId: build-project
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -2624,12 +2491,18 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BuildRequest"
+        required: true
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProjectBoard"
+                $ref: "#/components/schemas/BuildResponse"
           description: OK
         default:
           content:
@@ -2639,9 +2512,45 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Get a project's kanban board
+      summary: Trigger a project build
       tags:
-        - Board
+        - Projects
+  /projects/{projectName}/build/{tag}:
+    get:
+      operationId: get-project-build
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+        - description: Build tag
+          in: path
+          name: tag
+          required: true
+          schema:
+            description: Build tag
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BuildStatus"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Get project build status
+      tags:
+        - Projects
   /projects/{projectName}/components:
     get:
       operationId: list-components
@@ -2900,7 +2809,7 @@ paths:
         - Config
   /projects/{projectName}/components/{componentName}/dependencies/{depName}/access-request:
     post:
-      operationId: create-access-request
+      operationId: request-org-service-access
       parameters:
         - description: Consumer project name (DNS-label slug)
           in: path
@@ -2909,19 +2818,19 @@ paths:
           schema:
             description: Consumer project name (DNS-label slug)
             type: string
-        - description: Consumer component requesting access
+        - description: Consumer component name
           in: path
           name: componentName
           required: true
           schema:
-            description: Consumer component requesting access
+            description: Consumer component name
             type: string
-        - description: Org-service dependency name (== provider component to publish org-wide)
+        - description: org-service dependency name (the provider component)
           in: path
           name: depName
           required: true
           schema:
-            description: Org-service dependency name (== provider component to publish org-wide)
+            description: org-service dependency name (the provider component)
             type: string
       responses:
         "201":
@@ -2938,12 +2847,12 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Request cross-project access to a project-only org-service dependency
+      summary: Request access to a cross-project org-service dependency
       tags:
         - Dependencies
   /projects/{projectName}/components/{componentName}/dependencies/{depName}/provision:
     post:
-      operationId: provision-dependency
+      operationId: provision-platform-resource
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -2952,12 +2861,12 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: Component name
+        - description: Component the drawer opened on (context only)
           in: path
           name: componentName
           required: true
           schema:
-            description: Component name
+            description: Component the drawer opened on (context only)
             type: string
         - description: Platform-resource dependency name
           in: path
@@ -2970,14 +2879,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProvisionDependencyInputBody"
-        required: true
+              $ref: "#/components/schemas/ProvisionBody"
       responses:
         "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvisionDependencyOutputBody"
+                $ref: "#/components/schemas/StatusMsg"
           description: Accepted
         default:
           content:
@@ -2987,7 +2895,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Author the OC Resource model for a platform-resource dep and mark it in-flight (async)
+      summary: Provision a platform-resource dependency (async)
       tags:
         - Dependencies
   /projects/{projectName}/components/{componentName}/dependencies/{depName}/spec:
@@ -3001,19 +2909,19 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: Component name
+        - description: Consumer component name
           in: path
           name: componentName
           required: true
           schema:
-            description: Component name
+            description: Consumer component name
             type: string
-        - description: Dependency name
+        - description: External dependency name
           in: path
           name: depName
           required: true
           schema:
-            description: Dependency name
+            description: External dependency name
             type: string
       requestBody:
         content:
@@ -3050,33 +2958,33 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: Component name
+        - description: Component the drawer opened on (context only)
           in: path
           name: componentName
           required: true
           schema:
-            description: Component name
+            description: Component the drawer opened on (context only)
             type: string
-        - description: Platform-resource dependency name
+        - description: Dependency name
           in: path
           name: depName
           required: true
           schema:
-            description: Platform-resource dependency name
+            description: Dependency name
             type: string
-        - description: "Environment name (default: development)"
+        - description: "Environment (default: development)"
           explode: false
           in: query
           name: environment
           schema:
-            description: "Environment name (default: development)"
+            description: "Environment (default: development)"
             type: string
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DependencyStatusOutputBody"
+                $ref: "#/components/schemas/DependencyStatus"
           description: OK
         default:
           content:
@@ -3086,7 +2994,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Get the provisioning status and masked outputs for a platform-resource dependency
+      summary: Get a dependency's provisioning status (outputs masked to names)
       tags:
         - Dependencies
   /projects/{projectName}/components/{componentName}/deployments:
@@ -3161,7 +3069,7 @@ paths:
       summary: Get a component's OpenAPI spec
       tags:
         - Components
-  /projects/{projectName}/conversations/{conversationId}:
+  /projects/{projectName}/agents/{conversationId}/messages: #rename from convo
     get:
       operationId: get-conversation
       parameters:
@@ -3196,7 +3104,6 @@ paths:
       summary: Rehydrate a chat conversation (messages only)
       tags:
         - GenAI
-  /projects/{projectName}/conversations/{conversationId}/turns:
     post:
       operationId: create-turn
       parameters:
@@ -3268,12 +3175,12 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List a project's cross-project access requests
+      summary: List a consumer project's access requests
       tags:
         - Dependencies
   /projects/{projectName}/dependencies/external-resources/{name}/values:
     post:
-      operationId: save-external-resource-values
+      operationId: collect-external-resource-values
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -3282,25 +3189,24 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: External resource name (e.g. openweather)
+        - description: External resource (dependency) name
           in: path
           name: name
           required: true
           schema:
-            description: External resource name (e.g. openweather)
+            description: External resource (dependency) name
             type: string
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SaveExternalResourceValuesInputBody"
-        required: true
+              $ref: "#/components/schemas/SaveValuesBody"
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SaveExternalResourceValuesOutputBody"
+                $ref: "#/components/schemas/StatusMsg"
           description: OK
         default:
           content:
@@ -3310,332 +3216,9 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Save an external resource's per-environment values and provision it
+      summary: Collect an external dependency's values and provision it
       tags:
         - Dependencies
-  /projects/{projectName}/design:
-    get:
-      operationId: get-design
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Design"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the assembled design
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/bundle:
-    get:
-      operationId: get-design-bundle
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DesignBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the design bundle (file map + assembled design)
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/components/{componentName}:
-    delete:
-      operationId: delete-design-component
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Component directory name under components/
-          in: path
-          name: componentName
-          required: true
-          schema:
-            description: Component directory name under components/
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DesignBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Delete a component directory under components/
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/discard:
-    post:
-      operationId: discard-design-changes
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Design"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Discard unsaved design changes
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/files/{path...}:
-    delete:
-      operationId: delete-design-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: File path under specs/design/
-          in: path
-          name: path
-          required: true
-          schema:
-            description: File path under specs/design/
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DesignBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Delete a single file under specs/design/
-      tags:
-        - Design(Deprecated)
-    put:
-      operationId: update-design-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: File path under specs/design/
-          in: path
-          name: path
-          required: true
-          schema:
-            description: File path under specs/design/
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DesignFileInputBody"
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DesignBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Write a single file under specs/design/
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/generate:
-    post:
-      operationId: generate-design
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Generate the design (architect agent, SSE stream)
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/save:
-    post:
-      operationId: save-design
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Design"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Save the design and proceed
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/versions:
-    get:
-      operationId: list-design-versions
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/ArtifactVersion"
-                type:
-                  - array
-                  - "null"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: List design versions
-      tags:
-        - Design(Deprecated)
-  /projects/{projectName}/design/versions/{tag}/bundle:
-    get:
-      operationId: get-design-bundle-at-tag
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Design version tag (e.g. v1-2)
-          in: path
-          name: tag
-          required: true
-          schema:
-            description: Design version tag (e.g. v1-2)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DesignBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the design bundle at a tag
-      tags:
-        - Design(Deprecated)
   /projects/{projectName}/files:
     get:
       operationId: list-files
@@ -3748,220 +3331,9 @@ paths:
       summary: Read a spec file at HEAD
       tags:
         - Files
-  /projects/{projectName}/requirements:
+  /projects/{projectName}/spec/collab-session:
     get:
-      operationId: get-requirements
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the requirements bundle
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/chat:
-    post:
-      operationId: stream-requirements-chat
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ChatTurnRequest"
-              description: Chat turn request (message is required)
-        required: true
-      responses:
-        "200":
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Stream a requirements-chat turn (SSE)
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/chat/baseline/{baselineId}:
-    delete:
-      operationId: drop-requirements-chat-baseline
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Session baseline snapshot identifier
-          in: path
-          name: baselineId
-          required: true
-          schema:
-            description: Session baseline snapshot identifier
-            type: string
-      responses:
-        "204":
-          description: No Content
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Drop the chat-session baseline snapshot
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/chat/baseline/{baselineId}/files/{name}:
-    get:
-      operationId: get-requirements-chat-baseline-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Session baseline snapshot identifier
-          in: path
-          name: baselineId
-          required: true
-          schema:
-            description: Session baseline snapshot identifier
-            type: string
-        - description: Requirement filename
-          in: path
-          name: name
-          required: true
-          schema:
-            description: Requirement filename
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsSnapshotFile"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get a requirement file as captured in the chat-session baseline
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/chat/baseline/{baselineId}/files/{name}/revert:
-    post:
-      operationId: revert-requirements-chat-baseline-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Session baseline snapshot identifier
-          in: path
-          name: baselineId
-          required: true
-          schema:
-            description: Session baseline snapshot identifier
-            type: string
-        - description: Requirement filename
-          in: path
-          name: name
-          required: true
-          schema:
-            description: Requirement filename
-            type: string
-      responses:
-        "204":
-          description: No Content
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Revert a requirement file to the chat-session baseline
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/chat/turns/{turnId}/undo:
-    post:
-      operationId: undo-requirements-chat-turn
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Chat turn identifier to undo
-          in: path
-          name: turnId
-          required: true
-          schema:
-            description: Chat turn identifier to undo
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ChatUndoOutputBody"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Undo a requirements-chat turn
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/collab-session:
-    get:
-      operationId: get-collab-session
+      operationId: get-spec-collab-session
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -3991,185 +3363,12 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Get the collaboration session descriptor
+      summary: Get the collaboration session descriptor for the spec workspace
       tags:
         - Collaboration
-  /projects/{projectName}/requirements/discard:
-    post:
-      operationId: discard-requirements
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Discard unsaved requirements changes
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/files/{name}:
-    delete:
-      operationId: delete-requirement-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Requirement filename
-          in: path
-          name: name
-          required: true
-          schema:
-            description: Requirement filename
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Delete a requirement file
-      tags:
-        - Requirements(Deprecated)
-    put:
-      operationId: update-requirement-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Requirement filename
-          in: path
-          name: name
-          required: true
-          schema:
-            description: Requirement filename
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ReqFileInputBody"
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Create or update a requirement file
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/files/{name}/generate:
-    post:
-      operationId: generate-requirement-file
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Requirement filename
-          in: path
-          name: name
-          required: true
-          schema:
-            description: Requirement filename
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/GenerateRequirementFileInputBody"
-        required: true
-      responses:
-        "200":
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Generate a requirement file via a skill (SSE stream)
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/save:
-    post:
-      operationId: save-requirements
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Save the requirements bundle (cut a new version)
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/versions:
+  /projects/{projectName}/tags:
     get:
-      operationId: list-requirements-versions
+      operationId: list-project-tags
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -4183,11 +3382,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: "#/components/schemas/ArtifactVersion"
-                type:
-                  - array
-                  - "null"
+                $ref: "#/components/schemas/TagList"
           description: OK
         default:
           content:
@@ -4197,101 +3392,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List requirements versions
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/requirements/versions/{tag}:
-    get:
-      operationId: get-requirements-at-version
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: Version tag (e.g. v1)
-          in: path
-          name: tag
-          required: true
-          schema:
-            description: Version tag (e.g. v1)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RequirementsBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the requirements bundle at a version tag
-      tags:
-        - Requirements(Deprecated)
-  /projects/{projectName}/spec:
-    get:
-      operationId: get-project-spec
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SpecBundle"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get the project's spec bundle (requirement, design, and validation files)
-      tags:
-        - Spec
-  /projects/{projectName}/status:
-    get:
-      operationId: get-project-status
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectStatus"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get a project's SDLC status
+      summary: List project build tags
       tags:
         - Projects
   /projects/{projectName}/tasks:
@@ -4305,13 +3406,24 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
+        - description: Which Tasks to return (default open)
+          explode: false
+          in: query
+          name: state
+          schema:
+            description: Which Tasks to return (default open)
+            enum:
+              - open
+              - closed
+              - all
+            type: string
       responses:
         "200":
           content:
             application/json:
               schema:
                 items:
-                  $ref: "#/components/schemas/ComponentTask"
+                  $ref: "#/components/schemas/TaskView"
                 type:
                   - array
                   - "null"
@@ -4324,97 +3436,10 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List a project's tasks
+      summary: List a project's Tasks (live GitHub ⋈ executions → derived status)
       tags:
         - Tasks
-  /projects/{projectName}/tasks/dispatch:
-    post:
-      operationId: dispatch-tasks
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/DispatchResult"
-                type:
-                  - array
-                  - "null"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Dispatch a project's tasks to the coding agent
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/generate:
-    post:
-      operationId: generate-tasks
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Generate a project's tasks (tech-lead agent, SSE stream)
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/generated:
-    get:
-      operationId: get-generated-tasks
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Tasks"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get a project's generated tasks
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/{taskId}:
+  /projects/{projectName}/tasks/{issueNumber}:
     get:
       operationId: get-task
       parameters:
@@ -4425,19 +3450,20 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: ComponentTask UUID
+        - description: GitHub issue number of the Task
           in: path
-          name: taskId
+          name: issueNumber
           required: true
           schema:
-            description: ComponentTask UUID
-            type: string
+            description: GitHub issue number of the Task
+            format: int64
+            type: integer
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ComponentTask"
+                $ref: "#/components/schemas/TaskDetail"
           description: OK
         default:
           content:
@@ -4447,12 +3473,12 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Get a task
+      summary: Get one Task with its full Execution history
       tags:
         - Tasks
-  /projects/{projectName}/tasks/{taskId}/progress/agent:
+  /projects/{projectName}/tasks/{issueNumber}/log: #old /projects/{projectName}/executions/{executionId}/progress
     get:
-      operationId: get-task-agent-progress
+      operationId: get-execution-progress
       parameters:
         - description: Project name (DNS-label slug)
           in: path
@@ -4461,26 +3487,19 @@ paths:
           schema:
             description: Project name (DNS-label slug)
             type: string
-        - description: ComponentTask UUID
+        - description: Execution id
           in: path
-          name: taskId
+          name: executionId
           required: true
           schema:
-            description: ComponentTask UUID
+            description: Execution id
             type: string
-        - description: "Cursor: only return lines after this epoch-millis (0 ⇒ initial load)"
+        - description: "Cursor: only lines after this epoch-millis (0 ⇒ initial load)"
           explode: false
           in: query
           name: sinceMillis
           schema:
-            description: "Cursor: only return lines after this epoch-millis (0 ⇒ initial load)"
-            type: string
-        - description: Max lines to return (0 ⇒ server default)
-          explode: false
-          in: query
-          name: limit
-          schema:
-            description: Max lines to return (0 ⇒ server default)
+            description: "Cursor: only lines after this epoch-millis (0 ⇒ initial load)"
             type: string
       responses:
         "200":
@@ -4497,161 +3516,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Poll a task's coding-agent progress
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/{taskId}/progress/build:
-    get:
-      operationId: get-task-build-progress
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: ComponentTask UUID
-          in: path
-          name: taskId
-          required: true
-          schema:
-            description: ComponentTask UUID
-            type: string
-        - description: "Cursor: only return lines after this epoch-millis (0 ⇒ initial load)"
-          explode: false
-          in: query
-          name: sinceMillis
-          schema:
-            description: "Cursor: only return lines after this epoch-millis (0 ⇒ initial load)"
-            type: string
-        - description: Max lines to return (0 ⇒ server default)
-          explode: false
-          in: query
-          name: limit
-          schema:
-            description: Max lines to return (0 ⇒ server default)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProgressResponse"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Poll a task's build progress
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/{taskId}/regenerate-body:
-    post:
-      operationId: regenerate-task-body
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: ComponentTask UUID
-          in: path
-          name: taskId
-          required: true
-          schema:
-            description: ComponentTask UUID
-            type: string
-      responses:
-        "200":
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Regenerate a single task's body (Phase 2 detail, SSE stream)
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/{taskId}/retry:
-    post:
-      operationId: retry-task
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: ComponentTask UUID
-          in: path
-          name: taskId
-          required: true
-          schema:
-            description: ComponentTask UUID
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DispatchResult"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Retry a failed task
-      tags:
-        - Tasks
-  /projects/{projectName}/tasks/{taskId}/status:
-    get:
-      operationId: get-task-status
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-        - description: ComponentTask UUID
-          in: path
-          name: taskId
-          required: true
-          schema:
-            description: ComponentTask UUID
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TaskStatusResponse"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get a task's status with build-run steps
+      summary: Poll an Execution's progress (build steps / coding status)
       tags:
         - Tasks
   /skills:

--- a/packages/contracts/workflows/v1/openapi.yaml
+++ b/packages/contracts/workflows/v1/openapi.yaml
@@ -1,0 +1,220 @@
+components:
+  schemas:
+    ErrorDetail:
+      additionalProperties: false
+      properties:
+        location:
+          description: Where the error occurred, e.g. 'body.items[3].tags' or 'path.thing-id'
+          type: string
+        message:
+          description: Error message text
+          type: string
+        value:
+          description: The value at the given location
+      type: object
+    ErrorModel:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/ErrorModel.json
+          format: uri
+          readOnly: true
+          type: string
+        detail:
+          description: A human-readable explanation specific to this occurrence of the problem.
+          examples:
+            - Property foo is required but is missing.
+          type: string
+        errors:
+          description: Optional list of individual error details
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+          type:
+            - array
+            - "null"
+        instance:
+          description: A URI reference that identifies the specific occurrence of the problem.
+          examples:
+            - https://example.com/error-log/abc123
+          format: uri
+          type: string
+        status:
+          description: HTTP status code
+          examples:
+            - 400
+          format: int64
+          type: integer
+        title:
+          description: A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
+          examples:
+            - Bad Request
+          type: string
+        type:
+          default: about:blank
+          description: A URI reference to human-readable documentation for the error.
+          examples:
+            - https://example.com/errors/example
+          format: uri
+          type: string
+      type: object
+  securitySchemes:
+    userJWT:
+      bearerFormat: JWT
+      description: Thunder end-user JWT (RS256, JWKS-verified)
+      scheme: bearer
+      type: http
+info:
+  title: AEP Workflows API
+  version: 1.0.0
+openapi: 3.1.0
+paths:
+  /projects/{projectName}/design/generate:
+    post:
+      operationId: generate-design
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+      responses:
+        "200":
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Generate the design (architect agent, SSE stream)
+      tags:
+        - Workflows
+  /projects/{projectName}/tasks/plan:
+    post:
+      operationId: plan-tasks
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+      responses:
+        "200":
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Plan implementation Tasks (SSE — raw StreamPart frames + [DONE])
+      tags:
+        - Workflows
+  /projects/{projectName}/tasks/{issueNumber}/execute: # maybe execute all
+    post:
+      operationId: execute-task
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+        - description: GitHub issue number of the Task
+          in: path
+          name: issueNumber
+          required: true
+          schema:
+            description: GitHub issue number of the Task
+            format: int64
+            type: integer
+      responses:
+        "202":
+          description: Accepted
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Stamp aep:execute and dispatch through the funnel (async)
+      tags:
+        - Workflows
+  /projects/{projectName}/tasks/{issueNumber}/hold: # no need if execute-all lands
+    delete:
+      operationId: unhold-task
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+        - description: GitHub issue number of the Task
+          in: path
+          name: issueNumber
+          required: true
+          schema:
+            description: GitHub issue number of the Task
+            format: int64
+            type: integer
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Remove the aep:hold label and re-evaluate (idempotent)
+      tags:
+        - Workflows
+    post:
+      operationId: hold-task
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+        - description: GitHub issue number of the Task
+          in: path
+          name: issueNumber
+          required: true
+          schema:
+            description: GitHub issue number of the Task
+            format: int64
+            type: integer
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Set the aep:hold label (level-triggered; idempotent)
+      tags:
+        - Workflows


### PR DESCRIPTION
## What

Updates the hand-authored OpenAPI contracts under `packages/contracts` to reflect the proposed API surface:

- **`api/v1/openapi.yaml`** — reworked the v1 API spec for the proposed contracts (net trim of ~915 lines).
- **`workflows/v1/openapi.yaml`** — new workflows v1 spec (+220 lines).

## Notes

- Contracts-only change; the OpenAPI spec is the source of truth and is not generated (per `packages/contracts/AGENTS.md`).
- Rebased onto the latest `aep-rewrite` so the diff is limited to the two spec files (the earlier conversations + files port already landed via #105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)