### PR TITLE
Console: spec view reads via the Files API (#113)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -73,6 +73,10 @@ that's a stalled feature — investigate, don't ignore.
   [#80](https://github.com/wso2/labs-agentic-engineer/issues/80) (BE
   handshake: [#81](https://github.com/wso2/labs-agentic-engineer/issues/81),
   ADR-0007)
+- Spec view on the Files API — read path re-pointed from the never-implemented
+  `/spec` bundle to `list-files` + lazy per-file `read-file`; supersedes #99 —
+  [#113](https://github.com/wso2/labs-agentic-engineer/issues/113) (collab
+  seeding follow-up: [#114](https://github.com/wso2/labs-agentic-engineer/issues/114))
 - Project overview page — spec/build/deployment status cards (versioned),
   components list, project-view tab shell —
   [#77](https://github.com/wso2/labs-agentic-engineer/issues/77) (BE

--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -73,10 +73,13 @@ that's a stalled feature — investigate, don't ignore.
   [#80](https://github.com/wso2/labs-agentic-engineer/issues/80) (BE
   handshake: [#81](https://github.com/wso2/labs-agentic-engineer/issues/81),
   ADR-0007)
-- Spec view on the Files API — read path re-pointed from the never-implemented
-  `/spec` bundle to `list-files` + lazy per-file `read-file`; supersedes #99 —
-  [#113](https://github.com/wso2/labs-agentic-engineer/issues/113) (collab
-  seeding follow-up: [#114](https://github.com/wso2/labs-agentic-engineer/issues/114))
+- Console on the proposed contract (#111) — spec view reads via `list-files` +
+  lazy `read-file` (supersedes #99); overview Build card from `list-tasks`
+  (`/board` is gone); version chips from `/tags` `latest`/`specDirty` —
+  [#113](https://github.com/wso2/labs-agentic-engineer/issues/113) (BE
+  handshake: [#117](https://github.com/wso2/labs-agentic-engineer/issues/117),
+  collab seeding follow-up:
+  [#114](https://github.com/wso2/labs-agentic-engineer/issues/114))
 - Project overview page — spec/build/deployment status cards (versioned),
   components list, project-view tab shell —
   [#77](https://github.com/wso2/labs-agentic-engineer/issues/77) (BE

--- a/apps/console/src/features/projects/api/keys.ts
+++ b/apps/console/src/features/projects/api/keys.ts
@@ -26,7 +26,8 @@ export const projectKeys = {
   status: (name: string) => [...projectKeys.detail(name), "status"] as const,
   components: (name: string) =>
     [...projectKeys.detail(name), "components"] as const,
-  board: (name: string) => [...projectKeys.detail(name), "board"] as const,
+  tasks: (name: string) => [...projectKeys.detail(name), "tasks"] as const,
+  tags: (name: string) => [...projectKeys.detail(name), "tags"] as const,
 };
 
 export const githubKeys = {

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -117,15 +117,32 @@ export function useProjectComponents(projectName: string) {
   );
 }
 
-export function useProjectBoard(projectName: string) {
+export function useProjectTasks(projectName: string) {
   return useProjectResource(
-    projectKeys.board(projectName),
+    projectKeys.tasks(projectName),
     () =>
-      client.GET("/projects/{projectName}/board", {
+      client.GET("/projects/{projectName}/tasks", {
         params: { path: { projectName } },
       }),
-    "build board",
+    "tasks",
   );
+}
+
+// Spec version tags (#117). The BE hasn't implemented /tags yet, so a failed
+// read degrades to "no tags" instead of an error card — the version chips
+// simply don't render until the endpoint lands.
+export function useProjectTags(projectName: string) {
+  return useQuery({
+    queryKey: projectKeys.tags(projectName),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/projects/{projectName}/tags", {
+        params: { path: { projectName } },
+      });
+      if (error || data === undefined) return null;
+      return data;
+    },
+    refetchInterval: OVERVIEW_POLL_MS,
+  });
 }
 
 export function useCreateProject() {

--- a/apps/console/src/features/projects/api/taskBuckets.test.ts
+++ b/apps/console/src/features/projects/api/taskBuckets.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { components } from "../../../generated/aep-api";
+import { bucketTasks } from "./taskBuckets";
+
+type TaskView = components["schemas"]["TaskView"];
+
+function task(issueNumber: number, derivedStatus: string): TaskView {
+  return {
+    issueNumber,
+    derivedStatus,
+    title: `task ${issueNumber}`,
+    issueUrl: `https://github.com/acme/demo/issues/${issueNumber}`,
+    attention: null,
+    dependsOn: null,
+    executions: {},
+    hold: false,
+    lineage: {},
+  };
+}
+
+describe("bucketTasks", () => {
+  it("buckets derivedStatus into board-style counts", () => {
+    const result = bucketTasks([
+      task(1, "pending"),
+      task(2, "on_hold"),
+      task(3, "in_progress"),
+      task(4, "ready_for_review"),
+      task(5, "building"),
+      task(6, "merged"),
+      task(7, "deployed"),
+      task(8, "failed"),
+      task(9, "rejected"),
+    ]);
+    expect(result.counts).toEqual({
+      todo: 2,
+      inProgress: 3,
+      failed: 2,
+      done: 2,
+    });
+    expect(result.total).toBe(9);
+    expect(result.firstFailed?.issueNumber).toBe(8);
+    expect(result.firstInProgress?.issueNumber).toBe(3);
+  });
+
+  it("excludes abandoned and unknown statuses", () => {
+    const result = bucketTasks([task(1, "abandoned"), task(2, "???")]);
+    expect(result.total).toBe(0);
+    expect(result.firstFailed).toBeUndefined();
+  });
+});

--- a/apps/console/src/features/projects/api/taskBuckets.ts
+++ b/apps/console/src/features/projects/api/taskBuckets.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+
+type TaskView = components["schemas"]["TaskView"];
+
+// Board-style buckets over TaskView.derivedStatus (#113 rework: /board is
+// gone from the contract; the Build card derives its counts from list-tasks).
+// `abandoned` is excluded from every bucket — it's not part of the journey.
+const BUCKET_BY_STATUS: Record<string, keyof TaskBuckets["counts"]> = {
+  pending: "todo",
+  on_hold: "todo",
+  in_progress: "inProgress",
+  ready_for_review: "inProgress",
+  building: "inProgress",
+  merged: "done",
+  deployed: "done",
+  failed: "failed",
+  rejected: "failed",
+};
+
+export interface TaskBuckets {
+  counts: { todo: number; inProgress: number; failed: number; done: number };
+  total: number;
+  firstFailed?: TaskView;
+  firstInProgress?: TaskView;
+}
+
+export function bucketTasks(tasks: TaskView[]): TaskBuckets {
+  const buckets: TaskBuckets = {
+    counts: { todo: 0, inProgress: 0, failed: 0, done: 0 },
+    total: 0,
+  };
+  for (const task of tasks) {
+    const bucket = BUCKET_BY_STATUS[task.derivedStatus];
+    if (!bucket) continue;
+    buckets.counts[bucket] += 1;
+    buckets.total += 1;
+    if (bucket === "failed") buckets.firstFailed ??= task;
+    if (bucket === "inProgress") buckets.firstInProgress ??= task;
+  }
+  return buckets;
+}

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -25,9 +25,10 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import {
-  useProjectBoard,
   useProjectComponents,
   useProjectStatus,
+  useProjectTags,
+  useProjectTasks,
 } from "../api/queries";
 import { ComponentsList } from "./ComponentsList";
 import { StatusCards } from "./StatusCards";
@@ -53,7 +54,8 @@ function SectionError({
 // components list each degrade independently (issue #77).
 export function ProjectOverview({ projectName }: { projectName: string }) {
   const status = useProjectStatus(projectName);
-  const board = useProjectBoard(projectName);
+  const tasks = useProjectTasks(projectName);
+  const tags = useProjectTags(projectName);
   const componentsQuery = useProjectComponents(projectName);
 
   return (
@@ -69,7 +71,8 @@ export function ProjectOverview({ projectName }: { projectName: string }) {
           <StatusCards
             projectName={projectName}
             status={status.data}
-            board={board.data}
+            tasks={tasks.data ?? undefined}
+            tags={tags.data}
           />
         </Grid>
       )}

--- a/apps/console/src/features/projects/components/StatusCards.tsx
+++ b/apps/console/src/features/projects/components/StatusCards.tsx
@@ -31,9 +31,11 @@ import {
 import { FileText, Hammer, Rocket } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
+import { bucketTasks } from "../api/taskBuckets";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
-type ProjectBoard = components["schemas"]["ProjectBoard"];
+type TaskView = components["schemas"]["TaskView"];
+type TagList = components["schemas"]["TagList"];
 
 type Tone = "default" | "info" | "success" | "warning" | "error";
 
@@ -48,17 +50,22 @@ interface CardState {
 // The three pipeline cards always render — a fresh project shows the whole
 // journey with the Spec card as the call-to-action (issue #77 decision).
 
-function specCardState(status: ProjectStatus): CardState {
-  if (status.specVersion) {
-    return status.specDirty
+function specCardState(
+  status: ProjectStatus,
+  tags: TagList | null | undefined,
+): CardState {
+  // Version + dirty state come from the tag resource (#117): latest = newest
+  // user-tagged spec version, specDirty = specs/ changed on GitHub since.
+  if (tags?.latest) {
+    return tags.specDirty
       ? {
-          headline: `${status.specVersion} published`,
+          headline: `${tags.latest} published`,
           detail: "The spec has changed since — a new draft is in progress.",
           tone: "warning",
           chip: "draft changes",
         }
       : {
-          headline: `${status.specVersion} published`,
+          headline: `${tags.latest} published`,
           detail: "Spec and design are agreed and versioned.",
           tone: "success",
         };
@@ -101,31 +108,20 @@ function specCardState(status: ProjectStatus): CardState {
 
 function buildCardState(
   status: ProjectStatus,
-  board: ProjectBoard | undefined,
+  tasks: TaskView[] | undefined,
 ): CardState {
-  if (!status.hasTasks || !board) {
+  if (!status.hasTasks || !tasks) {
     return {
       headline: "Waiting on spec",
       detail: "Agents start building once the spec is published.",
       tone: "default",
     };
   }
-  const failed = board.failed ?? [];
-  const inProgress = board.inProgress ?? [];
-  const counts = {
-    todo: (board.todo ?? []).length,
-    inProgress: inProgress.length,
-    failed: failed.length,
-    done: (board.done ?? []).length,
-  };
-  const total = counts.todo + counts.inProgress + counts.failed + counts.done;
+  const { counts, total, firstFailed, firstInProgress } = bucketTasks(tasks);
   if (counts.failed > 0) {
     return {
       headline: `${counts.failed} task${counts.failed > 1 ? "s" : ""} failed`,
-      detail:
-        failed[0]?.errorMessage ??
-        failed[0]?.title ??
-        "A coding task needs attention.",
+      detail: firstFailed?.title ?? "A coding task needs attention.",
       tone: "error",
       chip: `${counts.done}/${total} done`,
     };
@@ -133,7 +129,7 @@ function buildCardState(
   if (counts.inProgress > 0) {
     return {
       headline: `${counts.inProgress} in progress`,
-      detail: inProgress[0]?.title ?? "Agents are coding.",
+      detail: firstInProgress?.title ?? "Agents are coding.",
       tone: "info",
       chip: `${counts.done}/${total} done`,
     };
@@ -152,39 +148,21 @@ function buildCardState(
   };
 }
 
+// Deployment state has no project-level source in the proposed contract
+// (only per-component /deployments) — the card holds a placeholder until a
+// deployments slice aggregates it (#113 rework decision).
 function deployCardState(status: ProjectStatus): CardState {
-  switch (status.deployStatus) {
-    case "succeeded":
-      return {
-        headline: `${status.deployedVersion ?? "Latest"} deployed`,
-        detail: "The dev environment is running this version.",
-        tone: "success",
+  return status.hasTasks
+    ? {
+        headline: "Nothing deployed yet",
+        detail: "Finished builds deploy to dev automatically.",
+        tone: "default",
+      }
+    : {
+        headline: "Waiting on build",
+        detail: "Published builds deploy to dev automatically.",
+        tone: "default",
       };
-    case "failed":
-      return {
-        headline: "Deploy failed",
-        detail: "The last dev deployment did not complete.",
-        tone: "error",
-      };
-    case "in_progress":
-      return {
-        headline: "Deploying…",
-        detail: "A new version is rolling out to dev.",
-        tone: "info",
-      };
-    default:
-      return status.hasTasks
-        ? {
-            headline: "Nothing deployed yet",
-            detail: "Finished builds deploy to dev automatically.",
-            tone: "default",
-          }
-        : {
-            headline: "Waiting on build",
-            detail: "Published builds deploy to dev automatically.",
-            tone: "default",
-          };
-  }
 }
 
 function StatusCard({
@@ -260,11 +238,13 @@ function LoadingCard({ title }: { title: string }) {
 export function StatusCards({
   projectName,
   status,
-  board,
+  tasks,
+  tags,
 }: {
   projectName: string;
   status: ProjectStatus | undefined;
-  board: ProjectBoard | undefined;
+  tasks: TaskView[] | undefined;
+  tags: TagList | null | undefined;
 }) {
   const cards = status
     ? [
@@ -274,7 +254,7 @@ export function StatusCards({
             <StatusCard
               icon={<FileText size={18} />}
               title="Spec"
-              state={specCardState(status)}
+              state={specCardState(status, tags)}
               to="spec"
               projectName={projectName}
             />
@@ -286,7 +266,7 @@ export function StatusCards({
             <StatusCard
               icon={<Hammer size={18} />}
               title="Build"
-              state={buildCardState(status, board)}
+              state={buildCardState(status, tasks)}
               to="builds"
               projectName={projectName}
             />

--- a/apps/console/src/features/spec/api/keys.ts
+++ b/apps/console/src/features/spec/api/keys.ts
@@ -19,8 +19,13 @@
 import { projectKeys } from "../../projects/api/keys";
 
 // Extends the project cache tree so project-level invalidation reaches the
-// spec bundle too.
+// spec reads too.
 export const specKeys = {
-  bundle: (projectName: string) =>
-    [...projectKeys.detail(projectName), "spec"] as const,
+  files: (projectName: string) =>
+    [...projectKeys.detail(projectName), "spec", "files"] as const,
+  // Content is immutable per (path, sha): a sha change from the list poll
+  // makes a new key, so stale content is never shown and unchanged files
+  // never refetch (#113 decision 4).
+  file: (projectName: string, path: string, sha: string) =>
+    [...projectKeys.detail(projectName), "spec", "file", path, sha] as const,
 };

--- a/apps/console/src/features/spec/api/mapping.test.ts
+++ b/apps/console/src/features/spec/api/mapping.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toRepoPath, toSpecEntries, toSpecEntry } from "./mapping";
+
+describe("toSpecEntry", () => {
+  it("strips the specs/ prefix and derives the group from the folder", () => {
+    expect(
+      toSpecEntry({ path: "specs/requirements/prd.md", sha: "a1" }),
+    ).toEqual({ path: "requirements/prd.md", sha: "a1", group: "requirements" });
+    expect(
+      toSpecEntry({ path: "specs/design/architecture.md", sha: "b2" }),
+    ).toEqual({ path: "design/architecture.md", sha: "b2", group: "designs" });
+    expect(
+      toSpecEntry({ path: "specs/validation/plan.md", sha: "c3" }),
+    ).toEqual({ path: "validation/plan.md", sha: "c3", group: "validation" });
+  });
+
+  it("keeps nested paths intact", () => {
+    expect(
+      toSpecEntry({ path: "specs/design/components/orders/design.json", sha: "d4" }),
+    ).toEqual({
+      path: "design/components/orders/design.json",
+      sha: "d4",
+      group: "designs",
+    });
+  });
+
+  it("hides files outside the known folders (#113 decision 3)", () => {
+    expect(toSpecEntry({ path: "specs/notes.md", sha: "x" })).toBeNull();
+    expect(toSpecEntry({ path: "specs/scratch/todo.md", sha: "x" })).toBeNull();
+    expect(toSpecEntry({ path: "README.md", sha: "x" })).toBeNull();
+    // A file literally named like a group folder has no content path.
+    expect(toSpecEntry({ path: "specs/requirements", sha: "x" })).toBeNull();
+  });
+});
+
+describe("toSpecEntries", () => {
+  it("maps and drops hidden files in one pass", () => {
+    expect(
+      toSpecEntries([
+        { path: "specs/requirements/prd.md", sha: "a1" },
+        { path: "specs/notes.md", sha: "x" },
+        { path: "specs/validation/plan.md", sha: "c3" },
+      ]).map((e) => e.path),
+    ).toEqual(["requirements/prd.md", "validation/plan.md"]);
+  });
+});
+
+describe("toRepoPath", () => {
+  it("round-trips with toSpecEntry", () => {
+    expect(toRepoPath("requirements/prd.md")).toBe("specs/requirements/prd.md");
+  });
+});

--- a/apps/console/src/features/spec/api/mapping.ts
+++ b/apps/console/src/features/spec/api/mapping.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+
+type FileMeta = components["schemas"]["FileMeta"];
+
+// The Files API serves repo-relative `specs/...` paths (#113 decision 2);
+// the console's file model, collab room keys (`Y.Map('files')`), and
+// components all keep the historical unprefixed scheme (`requirements/prd.md`).
+// This module is the single place where the two schemes meet.
+
+export type SpecGroup = "requirements" | "designs" | "validation";
+
+export interface SpecFileEntry {
+  /** Unprefixed path (e.g. requirements/prd.md) — the collab room key. */
+  path: string;
+  /** Git blob sha at HEAD; changes when content changes. */
+  sha: string;
+  group: SpecGroup;
+}
+
+const SPECS_PREFIX = "specs/";
+
+// Spec-view section per top-level folder under specs/. Files outside these
+// folders are hidden from the view (#113 decision 3).
+const GROUP_BY_FOLDER: Record<string, SpecGroup> = {
+  requirements: "requirements",
+  design: "designs",
+  validation: "validation",
+};
+
+export function toSpecEntry(meta: FileMeta): SpecFileEntry | null {
+  if (!meta.path.startsWith(SPECS_PREFIX)) return null;
+  const path = meta.path.slice(SPECS_PREFIX.length);
+  const folder = path.split("/")[0] ?? "";
+  const group = GROUP_BY_FOLDER[folder];
+  if (!group || !path.slice(folder.length + 1)) return null;
+  return { path, sha: meta.sha, group };
+}
+
+export function toSpecEntries(metas: FileMeta[]): SpecFileEntry[] {
+  return metas
+    .map(toSpecEntry)
+    .filter((e): e is SpecFileEntry => e !== null);
+}
+
+/** Unprefixed path → the repo-relative path the Files API expects. */
+export function toRepoPath(path: string): string {
+  return SPECS_PREFIX + path;
+}

--- a/apps/console/src/features/spec/api/queries.ts
+++ b/apps/console/src/features/spec/api/queries.ts
@@ -19,24 +19,62 @@
 import { useQuery } from "@tanstack/react-query";
 import { client } from "../../../api/client";
 import { specKeys } from "./keys";
+import { toRepoPath, toSpecEntries } from "./mapping";
 
-// The file list fills in while agents derive the spec, so the bundle polls
-// at the same cadence as the overview's reads (#77 decision: 10s).
+// The file list fills in while agents derive the spec, so it polls at the
+// same cadence as the overview's reads (#77 decision: 10s).
 const SPEC_POLL_MS = 10_000;
 
-export function useProjectSpec(projectName: string) {
+function toError(error: unknown, fallback: string): Error {
+  const e = error as { detail?: string; title?: string } | undefined;
+  return new Error(e?.detail ?? e?.title ?? fallback);
+}
+
+/** Spec file metadata at HEAD (#113): list-files, mapped to the view model. */
+export function useSpecFiles(projectName: string) {
   return useQuery({
-    queryKey: specKeys.bundle(projectName),
+    queryKey: specKeys.files(projectName),
     queryFn: async () => {
-      const { data, error } = await client.GET("/projects/{projectName}/spec", {
-        params: { path: { projectName } },
-      });
-      if (error || data === undefined) {
-        const e = error as { detail?: string; title?: string } | undefined;
-        throw new Error(e?.detail ?? e?.title ?? "Failed to load the spec");
-      }
-      return data;
+      const { data, error } = await client.GET(
+        "/projects/{projectName}/files",
+        { params: { path: { projectName } } },
+      );
+      if (error) throw toError(error, "Failed to load the spec files");
+      return toSpecEntries(data ?? []);
     },
     refetchInterval: SPEC_POLL_MS,
+  });
+}
+
+/**
+ * Content of one spec file, fetched lazily for the selection (#113
+ * decision 4). Immutable per (path, sha) — see specKeys.file.
+ */
+export function useSpecFileContent(
+  projectName: string,
+  file: { path: string; sha: string } | null,
+) {
+  return useQuery({
+    queryKey: specKeys.file(projectName, file?.path ?? "", file?.sha ?? ""),
+    enabled: file !== null,
+    staleTime: Infinity,
+    queryFn: async () => {
+      if (!file) throw new Error("no file selected");
+      // openapi-fetch can't substitute Huma's `{path...}` wildcard (its
+      // serializer only knows `{name}`/`{name*}`, and both percent-encode
+      // the slashes the wildcard exists to keep). Build the concrete URL,
+      // cast to the contract path so the response stays typed.
+      const repoPath = toRepoPath(file.path)
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      const { data, error } = await client.GET(
+        `/projects/${encodeURIComponent(projectName)}/files/${repoPath}` as "/projects/{projectName}/files/{path...}",
+        { params: { path: { projectName, path: toRepoPath(file.path) } } },
+      );
+      if (error || data === undefined)
+        throw toError(error, `Failed to load ${file.path}`);
+      return data;
+    },
   });
 }

--- a/apps/console/src/features/spec/components/SpecFileList.tsx
+++ b/apps/console/src/features/spec/components/SpecFileList.tsx
@@ -27,10 +27,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { FileText, Plus } from "@wso2/oxygen-ui-icons-react";
-import type { components } from "../../../generated/aep-api";
-
-type SpecFile = components["schemas"]["SpecFile"];
-type SpecGroup = SpecFile["group"];
+import type { SpecFileEntry, SpecGroup } from "../api/mapping";
 
 const GROUPS: { id: SpecGroup; title: string }[] = [
   { id: "requirements", title: "Requirements" },
@@ -50,7 +47,7 @@ export function SpecFileList({
   deriving,
   failed,
 }: {
-  files: SpecFile[];
+  files: SpecFileEntry[];
   selectedPath: string | null;
   onSelect: (path: string) => void;
   onAddArtifact: () => void;

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -37,7 +37,7 @@ import { ArrowLeft, Hammer } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
 import { useProject, useProjectStatus } from "../../projects/api/queries";
-import { useProjectSpec } from "../api/queries";
+import { useSpecFileContent, useSpecFiles } from "../api/queries";
 import { useCollabSpec } from "../collab/useCollabSpec";
 import { CollabTextArea } from "../collab/CollabTextArea";
 import { SpecMdEditor } from "../collab/SpecMdEditor";
@@ -75,7 +75,7 @@ export function SpecView({ projectName }: { projectName: string }) {
   const { actions } = useAppShell();
   const project = useProject(projectName);
   const status = useProjectStatus(projectName);
-  const spec = useProjectSpec(projectName);
+  const spec = useSpecFiles(projectName);
   const { user, orgHandle } = useSession();
   // Rooms are org-scoped (`spec-<org>-<project>`); without an org claim fall
   // back to the collab mock BFF's default org so mock mode keeps working.
@@ -91,13 +91,27 @@ export function SpecView({ projectName }: { projectName: string }) {
     };
   }, [actions]);
 
-  const files = spec.data?.files ?? [];
+  const files = spec.data ?? [];
   // Default selection: the first requirements file (the seeded PRD).
   const selected =
     files.find((f) => f.path === selectedPath) ??
     files.find((f) => f.group === "requirements") ??
     files[0] ??
     null;
+
+  // Collab supplies live content when connected; the REST read (lazy, per
+  // selected file) is only the solo fallback, so it stays disabled while a
+  // collab doc backs the selection.
+  const selectedIsMd = selected?.path.endsWith(".md") ?? false;
+  const fragment =
+    selected && selectedIsMd ? collab.getFileFragment(selected.path) : null;
+  const ytext =
+    selected && !selectedIsMd ? collab.getFileText(selected.path) : null;
+  const usesCollab = Boolean((fragment && collab.provider) || ytext);
+  const content = useSpecFileContent(
+    projectName,
+    selected && !usesCollab ? selected : null,
+  );
 
   const specStatus = status.data?.specStatus;
   const deriving =
@@ -282,51 +296,66 @@ export function SpecView({ projectName }: { projectName: string }) {
                 // each its own feature). Collaborative when the collab
                 // service is reachable (#86 phase 5); solo-and-unsaved
                 // otherwise (#86 decision 10).
-                (() => {
-                  const isMd = selected.path.endsWith(".md");
-                  const fragment = isMd
-                    ? collab.getFileFragment(selected.path)
-                    : null;
-                  if (fragment && collab.provider) {
-                    // Markdown gets the Tiptap editor on the file's
-                    // Y.XmlFragment (#86 phase 6).
-                    return (
-                      <SpecMdEditor
-                        key={`${selected.path}:md`}
-                        fragment={fragment}
-                        path={selected.path}
-                        provider={collab.provider}
-                        self={collab.self}
-                      />
-                    );
-                  }
-                  const ytext = isMd
-                    ? null
-                    : collab.getFileText(selected.path);
-                  return ytext ? (
-                    <CollabTextArea
-                      key={`${selected.path}:collab`}
-                      ytext={ytext}
-                      path={selected.path}
-                      isLocalTransaction={collab.isLocalTransaction}
+                fragment && collab.provider ? (
+                  // Markdown gets the Tiptap editor on the file's
+                  // Y.XmlFragment (#86 phase 6).
+                  <SpecMdEditor
+                    key={`${selected.path}:md`}
+                    fragment={fragment}
+                    path={selected.path}
+                    provider={collab.provider}
+                    self={collab.self}
+                  />
+                ) : ytext ? (
+                  <CollabTextArea
+                    key={`${selected.path}:collab`}
+                    ytext={ytext}
+                    path={selected.path}
+                    isLocalTransaction={collab.isLocalTransaction}
+                  />
+                ) : content.data ? (
+                  <TextField
+                    key={`${selected.path}:${content.data.sha}`}
+                    fullWidth
+                    multiline
+                    minRows={20}
+                    defaultValue={content.data.content}
+                    aria-label={`Content of ${selected.path}`}
+                    helperText={`${selected.path} — edits aren't saved yet; editing lands with the file editors.`}
+                    slotProps={{
+                      input: {
+                        sx: { fontFamily: "monospace", fontSize: "0.875rem" },
+                      },
+                    }}
+                  />
+                ) : content.isError ? (
+                  <Alert
+                    severity="error"
+                    action={
+                      <Button onClick={() => void content.refetch()}>
+                        Retry
+                      </Button>
+                    }
+                  >
+                    Failed to load {selected.path}
+                    {content.error instanceof Error && content.error.message
+                      ? `: ${content.error.message}`
+                      : ""}
+                  </Alert>
+                ) : (
+                  <Box
+                    sx={{
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <CircularProgress
+                      aria-label={`Loading ${selected.path}`}
                     />
-                  ) : (
-                    <TextField
-                      key={selected.path}
-                      fullWidth
-                      multiline
-                      minRows={20}
-                      defaultValue={selected.content}
-                      aria-label={`Content of ${selected.path}`}
-                      helperText={`${selected.path} — edits aren't saved yet; editing lands with the file editors.`}
-                      slotProps={{
-                        input: {
-                          sx: { fontFamily: "monospace", fontSize: "0.875rem" },
-                        },
-                      }}
-                    />
-                  );
-                })()
+                  </Box>
+                )
               ) : (
                 <Typography variant="body2" color="text.secondary">
                   {deriving

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -36,7 +36,11 @@ import {
 import { ArrowLeft, Hammer } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
-import { useProject, useProjectStatus } from "../../projects/api/queries";
+import {
+  useProject,
+  useProjectStatus,
+  useProjectTags,
+} from "../../projects/api/queries";
 import { useSpecFileContent, useSpecFiles } from "../api/queries";
 import { useCollabSpec } from "../collab/useCollabSpec";
 import { CollabTextArea } from "../collab/CollabTextArea";
@@ -75,6 +79,7 @@ export function SpecView({ projectName }: { projectName: string }) {
   const { actions } = useAppShell();
   const project = useProject(projectName);
   const status = useProjectStatus(projectName);
+  const tags = useProjectTags(projectName);
   const spec = useSpecFiles(projectName);
   const { user, orgHandle } = useSession();
   // Rooms are org-scoped (`spec-<org>-<project>`); without an org claim fall
@@ -197,15 +202,17 @@ export function SpecView({ projectName }: { projectName: string }) {
             </Tooltip>
           )}
 
-          {status.data?.specVersion && (
+          {/* Version chips from the tag resource (#117): latest user tag +
+              whether specs/ moved on GitHub since. */}
+          {tags.data?.latest && (
             <Chip
               size="small"
               variant="outlined"
               color="success"
-              label={`${status.data.specVersion} published`}
+              label={`${tags.data.latest} published`}
             />
           )}
-          {status.data?.specDirty && (
+          {tags.data?.specDirty && (
             <Chip size="small" color="warning" label="draft changes" />
           )}
           {chip && <Chip size="small" color={chip.color} label={chip.label} />}

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -3,7 +3,8 @@ import type { components } from "../../generated/aep-api";
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 type ComponentList = components["schemas"]["ComponentList"];
 type ProjectBoard = components["schemas"]["ProjectBoard"];
-type SpecBundle = components["schemas"]["SpecBundle"];
+type FileMeta = components["schemas"]["FileMeta"];
+type FileContent = components["schemas"]["FileContent"];
 type ErrorModel = components["schemas"]["ErrorModel"];
 
 // Scenario switch for the project overview (#77) and spec view (#80).
@@ -305,54 +306,82 @@ const validationPlan = `# Demo Shop — Validation plan
 - Each service exposes /healthz returning 200.
 `;
 
-const prdOnlySpec: SpecBundle = {
-  files: [{ path: "requirements/prd.md", group: "requirements", content: seededPrd }],
-};
+// Spec files as the Files API serves them (#113): repo-relative paths under
+// specs/, metadata (list-files) split from content (read-file).
+interface MockSpecFile {
+  path: string;
+  content: string;
+}
 
-const collaborationSpec: SpecBundle = {
-  files: [
-    { path: "requirements/prd.md", group: "requirements", content: seededPrd },
-    {
-      path: "requirements/user-stories.md",
-      group: "requirements",
-      content: userStories,
-    },
-    {
-      path: "design/architecture.md",
-      group: "designs",
-      content: architectureMd,
-    },
-  ],
-};
+const prdOnlyFiles: MockSpecFile[] = [
+  { path: "specs/requirements/prd.md", content: seededPrd },
+];
 
-const fullSpec: SpecBundle = {
-  files: [
-    ...collaborationSpec.files,
-    {
-      path: "design/architecture.excalidraw",
-      group: "designs",
-      content: architectureDiagram,
-    },
-    {
-      path: "validation/validation-plan.md",
-      group: "validation",
-      content: validationPlan,
-    },
-  ],
-};
+const collaborationFiles: MockSpecFile[] = [
+  ...prdOnlyFiles,
+  { path: "specs/requirements/user-stories.md", content: userStories },
+  { path: "specs/design/architecture.md", content: architectureMd },
+];
 
-export const projectSpecs: Record<
+const fullFiles: MockSpecFile[] = [
+  ...collaborationFiles,
+  { path: "specs/design/architecture.excalidraw", content: architectureDiagram },
+  { path: "specs/validation/validation-plan.md", content: validationPlan },
+];
+
+export const projectSpecFiles: Record<
   Exclude<ProjectScenario, "error">,
-  SpecBundle
+  MockSpecFile[]
 > = {
-  fresh: prdOnlySpec,
-  spec: collaborationSpec,
-  "spec-failed": prdOnlySpec,
-  building: fullSpec,
-  deployed: fullSpec,
-  "deploy-failed": fullSpec,
-  "repo-error": prdOnlySpec,
+  fresh: prdOnlyFiles,
+  spec: collaborationFiles,
+  "spec-failed": prdOnlyFiles,
+  building: fullFiles,
+  deployed: fullFiles,
+  "deploy-failed": fullFiles,
+  "repo-error": prdOnlyFiles,
 };
+
+// Deterministic stand-in for the git blob sha: stable per content revision,
+// so the console's (path, sha) content caching behaves like it does live.
+function mockSha(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0").repeat(5);
+}
+
+export function specFileMetas(files: MockSpecFile[]): FileMeta[] {
+  return files
+    .map((f) => ({
+      path: f.path,
+      sha: mockSha(f.path + f.content),
+      size: f.content.length,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function specFileContent(
+  files: MockSpecFile[],
+  path: string,
+): FileContent | null {
+  const file = files.find((f) => f.path === path);
+  if (!file) return null;
+  return {
+    path: file.path,
+    content: file.content,
+    sha: mockSha(file.path + file.content),
+  };
+}
+
+export const specFileNotFound = (path: string): ErrorModel => ({
+  type: "about:blank",
+  status: 404,
+  title: "Not Found",
+  detail: `no spec file at ${path}`,
+});
 
 export const projectSectionError: ErrorModel = {
   type: "about:blank",

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -2,7 +2,8 @@ import type { components } from "../../generated/aep-api";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 type ComponentList = components["schemas"]["ComponentList"];
-type ProjectBoard = components["schemas"]["ProjectBoard"];
+type TaskView = components["schemas"]["TaskView"];
+type TagList = components["schemas"]["TagList"];
 type FileMeta = components["schemas"]["FileMeta"];
 type FileContent = components["schemas"]["FileContent"];
 type ErrorModel = components["schemas"]["ErrorModel"];
@@ -72,10 +73,8 @@ export const projectStatuses: Record<
     hasTasks: true,
     specStatus: "approved",
     designStatus: "approved",
-    specVersion: "v1",
-    specDirty: false,
   },
-  // v1 deployed to dev successfully; spec has drifted since.
+  // v1 deployed to dev; spec has drifted since (see projectTags).
   deployed: {
     phase: "components",
     repoStatus: "ready",
@@ -85,10 +84,6 @@ export const projectStatuses: Record<
     hasTasks: true,
     specStatus: "approved",
     designStatus: "approved",
-    specVersion: "v1",
-    specDirty: true,
-    deployedVersion: "v1",
-    deployStatus: "succeeded",
   },
   // v1 build done but the dev deployment failed.
   "deploy-failed": {
@@ -100,9 +95,6 @@ export const projectStatuses: Record<
     hasTasks: true,
     specStatus: "approved",
     designStatus: "approved",
-    specVersion: "v1",
-    specDirty: false,
-    deployStatus: "failed",
   },
   // Repo bootstrap went sideways before any spec work.
   "repo-error": {
@@ -167,83 +159,70 @@ export const projectComponents: Record<
   "repo-error": emptyComponents,
 };
 
-const emptyBoard: ProjectBoard = {
-  url: BOARD_URL,
-  todo: [],
-  inProgress: [],
-  onHold: [],
-  done: [],
-  failed: [],
-};
+// Tasks backing the Build card (list-tasks; the card buckets derivedStatus
+// client-side — see features/projects/api/taskBuckets.ts).
+function task(
+  issueNumber: number,
+  title: string,
+  derivedStatus: string,
+  component?: string,
+): TaskView {
+  return {
+    issueNumber,
+    title,
+    derivedStatus,
+    issueUrl: `${BOARD_URL}/${issueNumber}`,
+    ...(component !== undefined && { component }),
+    attention: null,
+    dependsOn: null,
+    executions: {},
+    hold: false,
+    lineage: { specTag: "v1" },
+  };
+}
 
-const buildingBoard: ProjectBoard = {
-  url: BOARD_URL,
-  todo: [
-    {
-      id: "12",
-      title: "Checkout flow with cart persistence",
-      url: `${BOARD_URL}/12`,
-      componentName: "storefront",
-      status: "todo",
-    },
-  ],
-  inProgress: [
-    {
-      id: "10",
-      title: "Product catalog CRUD endpoints",
-      url: `${BOARD_URL}/10`,
-      componentName: "catalog-api",
-      status: "in_progress",
-      assignee: "coding-agent",
-    },
-  ],
-  onHold: [],
-  done: [
-    {
-      id: "9",
-      title: "Scaffold storefront app shell",
-      url: `${BOARD_URL}/9`,
-      componentName: "storefront",
-      status: "done",
-    },
-  ],
-  failed: [
-    {
-      id: "11",
-      title: "Orders service payment integration",
-      url: `${BOARD_URL}/11`,
-      componentName: "orders-api",
-      status: "failed",
-      errorMessage: "Build failed: missing PAYMENT_GATEWAY_URL config",
-    },
-  ],
-};
+const buildingTasks: TaskView[] = [
+  task(12, "Checkout flow with cart persistence", "pending", "storefront"),
+  task(10, "Product catalog CRUD endpoints", "in_progress", "catalog-api"),
+  task(9, "Scaffold storefront app shell", "merged", "storefront"),
+  task(11, "Orders service payment integration", "failed", "orders-api"),
+];
 
-const doneBoard: ProjectBoard = {
-  url: BOARD_URL,
-  todo: [],
-  inProgress: [],
-  onHold: [],
-  done: [
-    ...(buildingBoard.inProgress ?? []),
-    ...(buildingBoard.todo ?? []),
-    ...(buildingBoard.failed ?? []),
-    ...(buildingBoard.done ?? []),
-  ].map((t) => ({ ...t, status: "done" })),
-  failed: [],
-};
+const doneTasks: TaskView[] = buildingTasks.map((t) => ({
+  ...t,
+  derivedStatus: "deployed",
+}));
 
-export const projectBoards: Record<
+export const projectTasks: Record<
   Exclude<ProjectScenario, "error">,
-  ProjectBoard
+  TaskView[]
 > = {
-  fresh: emptyBoard,
-  spec: emptyBoard,
-  "spec-failed": emptyBoard,
-  building: buildingBoard,
-  deployed: doneBoard,
-  "deploy-failed": doneBoard,
-  "repo-error": emptyBoard,
+  fresh: [],
+  spec: [],
+  "spec-failed": [],
+  building: buildingTasks,
+  deployed: doneTasks,
+  "deploy-failed": doneTasks,
+  "repo-error": [],
+};
+
+// Spec version tags (#117): latest = newest user tag; specDirty = specs/
+// moved on GitHub since. The 'deployed' scenario drifts to exercise the
+// "draft changes" chip.
+const noTags: TagList = { tags: [] };
+const v1Tags: TagList = { tags: ["v1"], latest: "v1", specDirty: false };
+
+export const projectTags: Record<
+  Exclude<ProjectScenario, "error">,
+  TagList
+> = {
+  fresh: noTags,
+  spec: noTags,
+  "spec-failed": noTags,
+  building: v1Tags,
+  deployed: { ...v1Tags, specDirty: true },
+  "deploy-failed": v1Tags,
+  "repo-error": noTags,
 };
 
 // Spec bundle backing the spec view (#80). The backend seeds a PRD at repo

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -3,8 +3,11 @@ import {
   projectBoards,
   projectComponents,
   projectSectionError,
-  projectSpecs,
+  projectSpecFiles,
   projectStatuses,
+  specFileContent,
+  specFileMetas,
+  specFileNotFound,
   type ProjectScenario,
 } from "../fixtures/project";
 
@@ -40,7 +43,28 @@ export const projectHandlers = [
   http.get("*/api/v1/projects/:projectName/board", () =>
     respond((s) => projectBoards[s]),
   ),
-  http.get("*/api/v1/projects/:projectName/spec", () =>
-    respond((s) => projectSpecs[s]),
+  // Files API (#113): list-files metadata + per-file content reads, exactly
+  // as aep-api serves them (repo-relative specs/ paths).
+  http.get("*/api/v1/projects/:projectName/files", () =>
+    respond((s) => specFileMetas(projectSpecFiles[s])),
   ),
+  http.get("*/api/v1/projects/:projectName/files/*", ({ request }) => {
+    const s = scenario();
+    if (s === "error") {
+      return HttpResponse.json(projectSectionError, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    const pathname = new URL(request.url).pathname;
+    const path = decodeURIComponent(pathname.replace(/^.*\/files\//, ""));
+    const file = specFileContent(projectSpecFiles[s], path);
+    if (!file) {
+      return HttpResponse.json(specFileNotFound(path), {
+        status: 404,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    return HttpResponse.json(file);
+  }),
 ];

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -1,10 +1,11 @@
 import { http, HttpResponse, type JsonBodyType } from "msw";
 import {
-  projectBoards,
   projectComponents,
   projectSectionError,
   projectSpecFiles,
   projectStatuses,
+  projectTags,
+  projectTasks,
   specFileContent,
   specFileMetas,
   specFileNotFound,
@@ -40,8 +41,11 @@ export const projectHandlers = [
   http.get("*/api/v1/projects/:projectName/components", () =>
     respond((s) => projectComponents[s]),
   ),
-  http.get("*/api/v1/projects/:projectName/board", () =>
-    respond((s) => projectBoards[s]),
+  http.get("*/api/v1/projects/:projectName/tasks", () =>
+    respond((s) => projectTasks[s]),
+  ),
+  http.get("*/api/v1/projects/:projectName/tags", () =>
+    respond((s) => projectTags[s]),
   ),
   // Files API (#113): list-files metadata + per-file content reads, exactly
   // as aep-api serves them (repo-relative specs/ paths).

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -99,75 +99,6 @@ components:
         - commitSha
         - files
       type: object
-    BoardTask:
-      additionalProperties: false
-      properties:
-        assignee:
-          type: string
-        componentName:
-          type: string
-        componentTaskId:
-          type: string
-        dependsOnComponents:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnExternalResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnOrgServices:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        dependsOnResources:
-          items:
-            type: string
-          type:
-            - array
-            - "null"
-        description:
-          type: string
-        dispatchedAt:
-          format: date-time
-          type: string
-        errorMessage:
-          type: string
-        execType:
-          type: string
-        externalResourceName:
-          type: string
-        id:
-          type: string
-        labels:
-          items:
-            $ref: "#/components/schemas/LabelInfo"
-          type:
-            - array
-            - "null"
-        lifecycleStatus:
-          type: string
-        resourceName:
-          type: string
-        status:
-          type: string
-        title:
-          type: string
-        type:
-          type: string
-        url:
-          type: string
-      required:
-        - id
-        - title
-        - url
-      type: object
     BuildLogEntry:
       additionalProperties: false
       properties:
@@ -1027,17 +958,6 @@ components:
         - status
         - connectedAt
       type: object
-    LabelInfo:
-      additionalProperties: false
-      properties:
-        color:
-          type: string
-        name:
-          type: string
-      required:
-        - name
-        - color
-      type: object
     Lineage:
       additionalProperties: false
       properties:
@@ -1200,56 +1120,6 @@ components:
       required:
         - name
       type: object
-    ProjectBoard:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/ProjectBoard.json
-          format: uri
-          readOnly: true
-          type: string
-        done:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        failed:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        inProgress:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        onHold:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        todo:
-          items:
-            $ref: "#/components/schemas/BoardTask"
-          type:
-            - array
-            - "null"
-        url:
-          type: string
-      required:
-        - url
-        - todo
-        - inProgress
-        - done
-        - onHold
-        - failed
-      type: object
     ProjectList:
       additionalProperties: false
       properties:
@@ -1274,6 +1144,7 @@ components:
       type: object
     ProjectStatus:
       additionalProperties: false
+      description: Computed SDLC phase and artifact states.
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
@@ -1282,17 +1153,8 @@ components:
           format: uri
           readOnly: true
           type: string
-        deployStatus:
-          description: >-
-            Result of the latest dev deployment (e.g. in_progress /
-            succeeded / failed); absent when nothing was deployed.
-          type: string
-        deployedVersion:
-          description: >-
-            Version tag currently deployed to the dev environment; absent
-            when nothing deployed.
-          type: string
         designStatus:
+          description: '"", draft, approved'
           type: string
         hasDesign:
           type: boolean
@@ -1301,24 +1163,18 @@ components:
         hasTasks:
           type: boolean
         phase:
+          description: no-repo, repo-cloning, repo-error, prompt, spec, architecture, tasks, components
           type: string
         repoErrorMessage:
+          description: Set when phase is repo-error.
           type: string
         repoStatus:
+          description: '"", pending, cloning, ready, error'
           type: string
         repoUrl:
           type: string
-        specDirty:
-          description: >-
-            True when the spec/design changed after specVersion was
-            published.
-          type: boolean
         specStatus:
-          type: string
-        specVersion:
-          description: >-
-            Latest published spec version tag (e.g. v1); absent when
-            nothing published.
+          description: '"", draft, approved'
           type: string
       required:
         - phase
@@ -1478,6 +1334,12 @@ components:
           format: uri
           readOnly: true
           type: string
+        latest:
+          description: Newest user-tagged spec version (e.g. v3); absent when nothing is tagged. Proposed frontend-first (#117).
+          type: string
+        specDirty:
+          description: True when specs/ changed on GitHub after `latest` was tagged. Proposed frontend-first (#117).
+          type: boolean
         tags:
           items:
             type: string
@@ -2176,35 +2038,6 @@ paths:
       summary: Get a project
       tags:
         - Projects
-  /projects/{projectName}/board:
-    get:
-      operationId: get-board
-      parameters:
-        - description: Project name (DNS-label slug)
-          in: path
-          name: projectName
-          required: true
-          schema:
-            description: Project name (DNS-label slug)
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectBoard"
-          description: OK
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ErrorModel"
-          description: Error
-      security:
-        - userJWT: []
-      summary: Get a project's kanban board
-      tags:
-        - Board
   /projects/{projectName}/build:
     post:
       operationId: build-project

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -99,6 +99,75 @@ components:
         - commitSha
         - files
       type: object
+    BoardTask:
+      additionalProperties: false
+      properties:
+        assignee:
+          type: string
+        componentName:
+          type: string
+        componentTaskId:
+          type: string
+        dependsOnComponents:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        dependsOnExternalResources:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        dependsOnOrgServices:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        dependsOnResources:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        description:
+          type: string
+        dispatchedAt:
+          format: date-time
+          type: string
+        errorMessage:
+          type: string
+        execType:
+          type: string
+        externalResourceName:
+          type: string
+        id:
+          type: string
+        labels:
+          items:
+            $ref: "#/components/schemas/LabelInfo"
+          type:
+            - array
+            - "null"
+        lifecycleStatus:
+          type: string
+        resourceName:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+      required:
+        - id
+        - title
+        - url
+      type: object
     BuildLogEntry:
       additionalProperties: false
       properties:
@@ -958,6 +1027,17 @@ components:
         - status
         - connectedAt
       type: object
+    LabelInfo:
+      additionalProperties: false
+      properties:
+        color:
+          type: string
+        name:
+          type: string
+      required:
+        - name
+        - color
+      type: object
     Lineage:
       additionalProperties: false
       properties:
@@ -1120,6 +1200,56 @@ components:
       required:
         - name
       type: object
+    ProjectBoard:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/ProjectBoard.json
+          format: uri
+          readOnly: true
+          type: string
+        done:
+          items:
+            $ref: "#/components/schemas/BoardTask"
+          type:
+            - array
+            - "null"
+        failed:
+          items:
+            $ref: "#/components/schemas/BoardTask"
+          type:
+            - array
+            - "null"
+        inProgress:
+          items:
+            $ref: "#/components/schemas/BoardTask"
+          type:
+            - array
+            - "null"
+        onHold:
+          items:
+            $ref: "#/components/schemas/BoardTask"
+          type:
+            - array
+            - "null"
+        todo:
+          items:
+            $ref: "#/components/schemas/BoardTask"
+          type:
+            - array
+            - "null"
+        url:
+          type: string
+      required:
+        - url
+        - todo
+        - inProgress
+        - done
+        - onHold
+        - failed
+      type: object
     ProjectList:
       additionalProperties: false
       properties:
@@ -1141,6 +1271,64 @@ components:
           type: string
       required:
         - items
+      type: object
+    ProjectStatus:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/ProjectStatus.json
+          format: uri
+          readOnly: true
+          type: string
+        deployStatus:
+          description: >-
+            Result of the latest dev deployment (e.g. in_progress /
+            succeeded / failed); absent when nothing was deployed.
+          type: string
+        deployedVersion:
+          description: >-
+            Version tag currently deployed to the dev environment; absent
+            when nothing deployed.
+          type: string
+        designStatus:
+          type: string
+        hasDesign:
+          type: boolean
+        hasSpec:
+          type: boolean
+        hasTasks:
+          type: boolean
+        phase:
+          type: string
+        repoErrorMessage:
+          type: string
+        repoStatus:
+          type: string
+        repoUrl:
+          type: string
+        specDirty:
+          description: >-
+            True when the spec/design changed after specVersion was
+            published.
+          type: boolean
+        specStatus:
+          type: string
+        specVersion:
+          description: >-
+            Latest published spec version tag (e.g. v1); absent when
+            nothing published.
+          type: string
+      required:
+        - phase
+        - repoStatus
+        - repoUrl
+        - hasSpec
+        - hasDesign
+        - hasTasks
+        - specStatus
+        - designStatus
       type: object
     ProvisionBody:
       additionalProperties: false
@@ -1988,6 +2176,35 @@ paths:
       summary: Get a project
       tags:
         - Projects
+  /projects/{projectName}/board:
+    get:
+      operationId: get-board
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectBoard"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Get a project's kanban board
+      tags:
+        - Board
   /projects/{projectName}/build:
     post:
       operationId: build-project
@@ -2874,6 +3091,35 @@ paths:
       summary: Get the collaboration session descriptor for the spec workspace
       tags:
         - Collaboration
+  /projects/{projectName}/status:
+    get:
+      operationId: get-project-status
+      parameters:
+        - description: Project name (DNS-label slug)
+          in: path
+          name: projectName
+          required: true
+          schema:
+            description: Project name (DNS-label slug)
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectStatus"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Get a project's SDLC status
+      tags:
+        - Projects
   /projects/{projectName}/tags:
     get:
       operationId: list-project-tags


### PR DESCRIPTION
Closes #113. Supersedes #99 (closed). Follow-ups: #114 (collab seeding), #117 (BE: /tags with latest + specDirty).

Two commits; the second reworks the first's contract approach after deciding the #111 proposed contract is the source of truth.

## Spec view → Files API (commit 1)

- `useSpecFiles` polls `GET /projects/{p}/files` (10s); `useSpecFileContent` lazily fetches the selected file via `GET /files/{path...}`, keyed `(path, sha)` with infinite staleness — sha changes refetch automatically.
- One path adapter (`features/spec/api/mapping.ts`): Files API serves `specs/`-prefixed repo paths; console model + collab room keys keep the unprefixed scheme. Files outside `requirements/`, `design/`, `validation/` are hidden.
- `openapi-fetch` can't serialize Huma's `{path...}` wildcard — the read call builds the concrete URL cast to the contract path (localized in `queries.ts`).
- MSW mocks mirror the real endpoints; the dead `/spec` handler is gone.

## Console adopts the proposed contract (commit 2)

- **Contract = #111 + two frontend-first proposals** (per `design/api-guidelines.md`): the lean `/status` aep-api already serves (no `specVersion`/`specDirty`/`deployStatus`/`deployedVersion`), and `TagList.latest` + `TagList.specDirty` (#117). The #115 `/board`/rich-status restoration is reverted — `/board`, `ProjectBoard`, `BoardTask`, `LabelInfo` stay removed.
- **Build card** buckets `list-tasks` `derivedStatus` (todo: pending/on_hold; in progress: in_progress/ready_for_review/building; done: merged/deployed; failed: failed/rejected; abandoned excluded) — `features/projects/api/taskBuckets.ts` + vitest.
- **Version chips** (overview Spec card + spec view header): "vN published" ← `tags.latest`, "draft changes" ← `tags.specDirty`; `/tags` failing (unimplemented in BE today) degrades to no chips.
- **Deployment card**: static placeholder until a deployments slice aggregates per-component `/deployments`.

## Verified

- Repo-wide typecheck clean; console vitest 28/28; lint clean. (Pre-existing unrelated red: `gitfs` `TestListTagsPrefixPeelAndMessage` fails identically on a clean tree — git identity autodetect in the test env.)
- Mock mode: overview `building` scenario shows "v1 published" / "1 task failed, 1/4 done" from tasks / deploy placeholder; `deployed` scenario shows the "draft changes" chip from `specDirty`; `fresh`/`error` states intact.
- Real mode (dev server → live aep-api, Thunder login): spec page lists and renders real file content via the Files API wildcard read; lean `/status` keeps ProjectLayout/spec chips working; `/tags` 404 degrades silently as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
