### PR TITLE
perf(aep-api): read latest design tag from local mirror without a fetch

### DIFF
--- a/services/aep-api/internal/feature/artifacts/artifact_service.go
+++ b/services/aep-api/internal/feature/artifacts/artifact_service.go
@@ -155,6 +155,12 @@ type ArtifactService interface {
 	// Versions.
 	ListRequirementsVersions(ctx context.Context, orgID, projectID string) ([]RequirementsVersionInfo, error)
 	ListDesignVersions(ctx context.Context, orgID, projectID string) ([]DesignVersionInfo, error)
+	// LatestDesignTag returns just the newest approved design tag name
+	// (`v<N>-<M>`), or "" when none exist. Unlike ListDesignVersions it reads
+	// the local mirror WITHOUT a fetch — a best-effort, network-free read for
+	// the task stale-design attention flag. Never returns an error: an
+	// unavailable repo/mirror degrades to "".
+	LatestDesignTag(ctx context.Context, orgID, projectID string) string
 	GetRequirementsAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	// GetDesignAtCommit reads the design bundle at an exact commit — the publish
@@ -282,6 +288,24 @@ func (s *artifactService) ListDesignVersions(ctx context.Context, orgID, project
 		return nil, fmt.Errorf("list tags: %w", err)
 	}
 	return tagsToDesignVersions(tags), nil
+}
+
+// LatestDesignTag returns the newest `v<N>-<M>` design tag name read from the
+// local mirror WITHOUT a fetch — the network-free, best-effort read behind the
+// task stale-design attention flag. Any failure (repo not ready, mirror read
+// error, no design tag yet) degrades to "".
+func (s *artifactService) LatestDesignTag(ctx context.Context, orgID, projectID string) string {
+	_, ref, err := s.readyRef(ctx, orgID, projectID)
+	if err != nil {
+		return ""
+	}
+	tags, err := s.listVersionTagsLocal(ctx, ref)
+	if err != nil {
+		slog.WarnContext(ctx, "latest design tag: local tag read failed",
+			"project", projectID, "error", err)
+		return ""
+	}
+	return latestDesignTag(tags)
 }
 
 // ----- Save (hard gate → tag at HEAD) -----

--- a/services/aep-api/internal/feature/artifacts/artifactstest/fakes.go
+++ b/services/aep-api/internal/feature/artifacts/artifactstest/fakes.go
@@ -43,6 +43,7 @@ type FakeArtifactService struct {
 	DiscardDesignFunc            func(ctx context.Context, orgID, projectID string) (map[string]string, error)
 	ListRequirementsVersionsFunc func(ctx context.Context, orgID, projectID string) ([]artifacts.RequirementsVersionInfo, error)
 	ListDesignVersionsFunc       func(ctx context.Context, orgID, projectID string) ([]artifacts.DesignVersionInfo, error)
+	LatestDesignTagFunc          func(ctx context.Context, orgID, projectID string) string
 	GetRequirementsAtTagFunc     func(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtTagFunc           func(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtCommitFunc        func(ctx context.Context, orgID, projectID, commitSHA string) (map[string]string, error)
@@ -104,6 +105,13 @@ func (f *FakeArtifactService) ListDesignVersions(ctx context.Context, orgID, pro
 		panic("artifactstest: ListDesignVersions called but ListDesignVersionsFunc is not set")
 	}
 	return f.ListDesignVersionsFunc(ctx, orgID, projectID)
+}
+
+func (f *FakeArtifactService) LatestDesignTag(ctx context.Context, orgID, projectID string) string {
+	if f.LatestDesignTagFunc == nil {
+		panic("artifactstest: LatestDesignTag called but LatestDesignTagFunc is not set")
+	}
+	return f.LatestDesignTagFunc(ctx, orgID, projectID)
 }
 
 func (f *FakeArtifactService) GetRequirementsAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error) {

--- a/services/aep-api/internal/feature/artifacts/git_reader.go
+++ b/services/aep-api/internal/feature/artifacts/git_reader.go
@@ -125,7 +125,15 @@ func (s *artifactService) readBundleAtTag(ctx context.Context, ref gitrepo.RepoR
 
 // listVersionTags returns every `v*` tag with its Name, peeled commit SHA, and
 // annotation subject. The local read restores the Message the Git Data refs API
-// could not expose (it is empty only for lightweight tags).
+// could not expose (it is empty only for lightweight tags). Fetches origin
+// first — the freshness-critical path (version lists, save prechecks).
 func (s *artifactService) listVersionTags(ctx context.Context, ref gitrepo.RepoRef) ([]gitrepo.TagInfo, error) {
 	return s.git.Workspace().ListTags(ctx, ref, "v")
+}
+
+// listVersionTagsLocal is listVersionTags without the origin fetch — for the
+// best-effort LatestDesignTag read (the task stale-design attention flag),
+// which must not force a per-read network round-trip.
+func (s *artifactService) listVersionTagsLocal(ctx context.Context, ref gitrepo.RepoRef) ([]gitrepo.TagInfo, error) {
+	return s.git.Workspace().ListTagsLocal(ctx, ref, "v")
 }

--- a/services/aep-api/internal/feature/artifacts/reads_test.go
+++ b/services/aep-api/internal/feature/artifacts/reads_test.go
@@ -114,6 +114,41 @@ func TestGetDesignAtTag_PinsApprovedVersion(t *testing.T) {
 	}
 }
 
+func TestLatestDesignTag_LocalNoFetch(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, map[string]string{"specs/requirements/requirements.md": "spec\n"})
+	ctx := context.Background()
+
+	// No design tag yet → "".
+	if got := r.svc.LatestDesignTag(ctx, r.org, r.proj); got != "" {
+		t.Fatalf("LatestDesignTag (no tags) = %q, want empty", got)
+	}
+
+	if _, err := r.svc.SaveRequirements(ctx, r.org, r.proj, SaveRequest{}); err != nil {
+		t.Fatalf("save requirements: %v", err)
+	}
+	r.seed(map[string]string{
+		"specs/design/design.md":                  "# v1-1\n",
+		"specs/design/components/svc/design.json": validComponentDesignJSON("svc"),
+	}, "design")
+	if _, err := r.svc.SaveDesign(ctx, r.org, r.proj, SaveRequest{}); err != nil {
+		t.Fatalf("save design v1-1: %v", err)
+	}
+	if got := r.svc.LatestDesignTag(ctx, r.org, r.proj); got != "v1-1" {
+		t.Fatalf("LatestDesignTag = %q, want v1-1", got)
+	}
+
+	// A second design revision — the tag was cut through the engine, so the
+	// mirror carries it and the network-free read reflects the newest.
+	r.seed(map[string]string{"specs/design/design.md": "# v1-2\n"}, "design edit")
+	if _, err := r.svc.SaveDesign(ctx, r.org, r.proj, SaveRequest{}); err != nil {
+		t.Fatalf("save design v1-2: %v", err)
+	}
+	if got := r.svc.LatestDesignTag(ctx, r.org, r.proj); got != "v1-2" {
+		t.Fatalf("LatestDesignTag = %q, want v1-2 (newest)", got)
+	}
+}
+
 func TestGetRequirementsAtTag_MissingTag(t *testing.T) {
 	t.Parallel()
 	r := newRig(t, map[string]string{"specs/requirements/requirements.md": "x\n"})

--- a/services/aep-api/internal/feature/task/plan_test.go
+++ b/services/aep-api/internal/feature/task/plan_test.go
@@ -42,6 +42,9 @@ func (p planVersions) ListRequirementsVersions(context.Context, string, string) 
 func (p planVersions) ListDesignVersions(context.Context, string, string) ([]artifacts.DesignVersionInfo, error) {
 	return []artifacts.DesignVersionInfo{{Tag: p.designTag}}, nil
 }
+func (p planVersions) LatestDesignTag(context.Context, string, string) string {
+	return p.designTag
+}
 func (planVersions) GetRequirementsAtTag(context.Context, string, string, string) (map[string]string, error) {
 	return map[string]string{}, nil
 }

--- a/services/aep-api/internal/feature/task/ports.go
+++ b/services/aep-api/internal/feature/task/ports.go
@@ -55,6 +55,11 @@ type RepoResolver interface {
 type VersionReader interface {
 	ListRequirementsVersions(ctx context.Context, orgID, projectID string) ([]artifacts.RequirementsVersionInfo, error)
 	ListDesignVersions(ctx context.Context, orgID, projectID string) ([]artifacts.DesignVersionInfo, error)
+	// LatestDesignTag is the newest design tag name (`v<N>-<M>`) read WITHOUT a
+	// network fetch — the best-effort input to the stale-design attention flag.
+	// The list read path (ListDesignVersions) still fetches; this one must not,
+	// so a task-list page load pays no per-read GitHub round-trip for it.
+	LatestDesignTag(ctx context.Context, orgID, projectID string) string
 	GetRequirementsAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 }

--- a/services/aep-api/internal/feature/task/reads.go
+++ b/services/aep-api/internal/feature/task/reads.go
@@ -245,18 +245,16 @@ func executionView(e *models.Execution) ExecutionView {
 	}
 }
 
-// latestDesignTag returns the newest approved design tag (index 0 of the
-// descending version list), or "" when unavailable. Best-effort — used only for
-// the stale-design attention flag.
+// latestDesignTag returns the newest approved design tag, or "" when
+// unavailable. Best-effort — used only for the stale-design attention flag, so
+// it reads the local mirror WITHOUT a fetch (VersionReader.LatestDesignTag)
+// rather than forcing a live ListDesignVersions round-trip on every task-list
+// call (docs/design/gitfs-fetch-on-read-followup.md §2).
 func (r *Reads) latestDesignTag(ctx context.Context, orgID, projectID string) string {
 	if r.versions == nil {
 		return ""
 	}
-	vs, err := r.versions.ListDesignVersions(ctx, orgID, projectID)
-	if err != nil || len(vs) == 0 {
-		return ""
-	}
-	return vs[0].Tag
+	return r.versions.LatestDesignTag(ctx, orgID, projectID)
 }
 
 func matchesState(issueState, filter string) bool {

--- a/services/aep-api/internal/feature/task/task_component_test.go
+++ b/services/aep-api/internal/feature/task/task_component_test.go
@@ -158,6 +158,12 @@ func (f fakeVersions) ListRequirementsVersions(context.Context, string, string) 
 func (f fakeVersions) ListDesignVersions(context.Context, string, string) ([]artifacts.DesignVersionInfo, error) {
 	return f.design, nil
 }
+func (f fakeVersions) LatestDesignTag(context.Context, string, string) string {
+	if len(f.design) == 0 {
+		return ""
+	}
+	return f.design[0].Tag
+}
 func (f fakeVersions) GetRequirementsAtTag(context.Context, string, string, string) (map[string]string, error) {
 	return nil, nil
 }

--- a/services/aep-api/internal/platform/gitfs/tags.go
+++ b/services/aep-api/internal/platform/gitfs/tags.go
@@ -78,10 +78,11 @@ func (e *Engine) Tag(ctx context.Context, ref RepoRef, spec TagSpec) error {
 	return nil
 }
 
-// ListTags implements Workspace: fetches tags then lists refs/tags/<prefix>*
-// via for-each-ref plumbing. CommitHash is the PEELED commit (annotated tags
-// dereferenced); Message is the tag message subject, empty for lightweight
-// tags.
+// ListTags implements Workspace: fetches origin tags then lists
+// refs/tags/<prefix>* via for-each-ref plumbing. CommitHash is the PEELED
+// commit (annotated tags dereferenced); Message is the tag message subject,
+// empty for lightweight tags. Use this on the freshness-critical paths (the
+// version-list endpoints, the save collision precheck, the plan lineage).
 func (e *Engine) ListTags(ctx context.Context, ref RepoRef, prefix string) ([]TagInfo, error) {
 	p, err := e.pathsFor(ref)
 	if err != nil {
@@ -102,6 +103,33 @@ func (e *Engine) ListTags(ctx context.Context, ref RepoRef, prefix string) ([]Ta
 			return nil, ferr
 		}
 	}
+	return e.readTags(ctx, ref, p, prefix)
+}
+
+// ListTagsLocal implements Workspace: like ListTags but WITHOUT the origin
+// fetch — it lists whatever tags the shared mirror already holds. The mirror is
+// authoritative for every tag this platform creates (Tag pushes AND updates the
+// mirror before returning, and the mirror lives on the shared RWX volume, so a
+// tag cut by any instance is visible to all), so this is correctness-equivalent
+// to ListTags for the platform-owned `v*` tags — only truly out-of-band pushes
+// are missed until the next fetch-bearing op. Intended for best-effort,
+// hot-path reads (the task stale-design attention flag) that must not pay a
+// per-read network round-trip. ensureMirror still clones on first-ever access
+// (a stat when the mirror is already present).
+func (e *Engine) ListTagsLocal(ctx context.Context, ref RepoRef, prefix string) ([]TagInfo, error) {
+	p, err := e.pathsFor(ref)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := e.ensureMirror(ctx, ref, p); err != nil {
+		return nil, err
+	}
+	return e.readTags(ctx, ref, p, prefix)
+}
+
+// readTags lists refs/tags/<prefix>* from the local mirror under the shared
+// flock (a pure ref read — no fetch). Shared by ListTags/ListTagsLocal.
+func (e *Engine) readTags(ctx context.Context, ref RepoRef, p repoPaths, prefix string) ([]TagInfo, error) {
 	release, err := e.locks.RLock(ctx, p.lockPath)
 	if err != nil {
 		return nil, err

--- a/services/aep-api/internal/platform/gitfs/tags_test.go
+++ b/services/aep-api/internal/platform/gitfs/tags_test.go
@@ -149,6 +149,54 @@ func TestListTagsPrefixPeelAndMessage(t *testing.T) {
 	}
 }
 
+func TestListTagsLocalSkipsFetch(t *testing.T) {
+	fx := workspacetest.New(t, seedFiles())
+	ctx := context.Background()
+
+	// Prime the mirror (clone) BEFORE any v* tag exists on origin.
+	mustHead(t, fx, "")
+
+	// A tag pushed out-of-band to origin AFTER the mirror was cloned — the
+	// mirror has no way to know about it without a fetch.
+	fx.Origin.Tag(t, "v1-1", "design v1-1")
+
+	// ListTagsLocal serves the mirror as-is → does NOT see the un-fetched tag.
+	local, err := fx.Engine.ListTagsLocal(ctx, fx.Ref, "v")
+	if err != nil {
+		t.Fatalf("ListTagsLocal: %v", err)
+	}
+	if len(local) != 0 {
+		t.Fatalf("ListTagsLocal = %+v, want empty (no fetch)", local)
+	}
+
+	// ListTags fetches first → sees the out-of-band tag (the freshness-critical
+	// path is unchanged).
+	fetched, err := fx.Engine.ListTags(ctx, fx.Ref, "v")
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	if len(fetched) != 1 || fetched[0].Name != "v1-1" {
+		t.Fatalf("ListTags = %+v, want v1-1 after fetch", fetched)
+	}
+
+	// A tag created THROUGH the engine updates the mirror, so ListTagsLocal
+	// sees it without a fetch — the platform-owned tag path stays correct.
+	if err := fx.Engine.Tag(ctx, fx.Ref, gitfs.TagSpec{Name: "v1-2", Message: "design v1-2"}); err != nil {
+		t.Fatalf("Tag: %v", err)
+	}
+	local2, err := fx.Engine.ListTagsLocal(ctx, fx.Ref, "v")
+	if err != nil {
+		t.Fatalf("ListTagsLocal(after engine tag): %v", err)
+	}
+	names := map[string]bool{}
+	for _, tg := range local2 {
+		names[tg.Name] = true
+	}
+	if !names["v1-2"] {
+		t.Fatalf("ListTagsLocal = %+v, want to include engine-created v1-2", local2)
+	}
+}
+
 func TestDiffThreeDot(t *testing.T) {
 	fx := workspacetest.New(t, seedFiles())
 	ctx := context.Background()

--- a/services/aep-api/internal/platform/gitfs/types.go
+++ b/services/aep-api/internal/platform/gitfs/types.go
@@ -93,6 +93,11 @@ type Workspace interface {
 	// peeled commit SHA and the tag message subject (empty for lightweight
 	// tags). Fetches origin tags first.
 	ListTags(ctx context.Context, ref RepoRef, prefix string) ([]TagInfo, error)
+	// ListTagsLocal is ListTags without the origin fetch — it serves whatever
+	// the shared mirror already holds. Correctness-equivalent to ListTags for
+	// platform-owned `v*` tags (the mirror is updated on tag creation); for
+	// best-effort hot-path reads that must not pay a per-read network fetch.
+	ListTagsLocal(ctx context.Context, ref RepoRef, prefix string) ([]TagInfo, error)
 	// Diff is the local `git diff base...head` (three-dot: merge-base to
 	// head), replacing the remote CompareRefs.
 	Diff(ctx context.Context, ref RepoRef, base, head string) (*CompareResult, error)


### PR DESCRIPTION
## What

The task **stale-design attention flag** only needs the newest design tag's *name*. It was computing it via `ListDesignVersions`, which does a live `git fetch --prune` under the exclusive per-repo lock on **every** `Reads.List` and `Reads.Get` — so a project page load paid a full GitHub round-trip per task read just to learn one tag name (`docs/design/gitfs-fetch-on-read-followup.md` §2).

This decouples that read from the network.

## How

- **gitfs:** add `Workspace.ListTagsLocal` — like `ListTags` but **without** the origin fetch (`ensureMirror` + shared `RLock` + `for-each-ref` over the mirror). Extracts a shared `readTags` helper. `ListTags` (fetch-first) is unchanged for the freshness-critical callers (version-list endpoints, save collision precheck, plan lineage).
- **artifacts:** add `ArtifactService.LatestDesignTag` — reads local tags and reuses the existing `latestDesignTag()`; best-effort, returns `""` on any failure.
- **task:** the `VersionReader` attention read now calls `LatestDesignTag` instead of `ListDesignVersions`.

## Why it's correctness-equivalent (and not a cache)

For the platform-owned `v*` tags this is equivalent to the old fetch path: the bare mirror is on the shared RWX volume and `Tag` updates it **before returning**, so a tag cut by any instance is immediately visible to every instance's local read — no fetch needed. Only a truly out-of-band push (bypassing the platform) is missed until the next fetch-bearing op, which is acceptable for a best-effort advisory flag.

It's **not a cache**: no TTL, no invalidation — the mirror *is* the store. (The design doc's TTL-coalescing option was deliberately not taken.)

## Tests

- `gitfs`: `TestListTagsLocalSkipsFetch` — an out-of-band origin tag is invisible to `ListTagsLocal` but visible to `ListTags`; an engine-cut tag is visible locally.
- `artifacts`: `TestLatestDesignTag_LocalNoFetch`.
- `go build ./...`, `go vet`, and `gitfs`/`artifacts`/`task` suites all green on the `aep-rewrite` base.

## Net effect

A project page load makes one fewer GitHub round-trip per task read, and the stale-design flag no longer contends on the exclusive per-repo git lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
