### PR TITLE
collab: seed rooms from the Files API; oracle returns projectName (#114)

### DIFF
--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -249,9 +249,13 @@ components:
           type: string
         name:
           type: string
+        projectName:
+          description: The room's project, resolved by the oracle from `spec-<org>-<project>`; the collab service uses it for the seed read (#114).
+          type: string
       required:
         - name
         - email
+        - projectName
       type: object
     CollectSpecInputBody:
       additionalProperties: false

--- a/services/aep-api/internal/feature/requirements/collab_huma.go
+++ b/services/aep-api/internal/feature/requirements/collab_huma.go
@@ -58,6 +58,10 @@ type collabValidateOutput struct {
 	Body struct {
 		Name  string `json:"name"`
 		Email string `json:"email"`
+		// ProjectName is the room's project, resolved by this oracle from
+		// `spec-<org>-<project>` — the collab service can't split the room ID
+		// itself (it doesn't know the org) and needs this for the seed read (#114).
+		ProjectName string `json:"projectName"`
 	}
 }
 
@@ -133,6 +137,7 @@ func RegisterCollab(api huma.API, repos repoOracle) {
 		out := &collabValidateOutput{}
 		out.Body.Name = name
 		out.Body.Email = email
+		out.Body.ProjectName = project
 		return out, nil
 	})
 }

--- a/services/aep-api/internal/feature/requirements/requirements_component_test.go
+++ b/services/aep-api/internal/feature/requirements/requirements_component_test.go
@@ -40,6 +40,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -409,5 +411,44 @@ func TestReqComponent_CollabValidate_MissingRoom(t *testing.T) {
 	resp := h.AsOrg("acme").Get("/api/v1/collab/validate")
 	if resp.Code != 400 {
 		t.Fatalf("collab-validate no room: want 400, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+// TestReqComponent_CollabValidate_ReturnsProjectName pins the success path:
+// the oracle resolves `spec-<org>-<project>` and the response carries the
+// projectName the collab service needs for its seed read (#114). Uses a raw
+// request via ClaimsHeader because the Req builder can't set X-Room-Id.
+func TestReqComponent_CollabValidate_ReturnsProjectName(t *testing.T) {
+	t.Parallel()
+	repos := &fakeCollabRepos{
+		GetRepoFunc: func(_ context.Context, orgID, projectID string) (*models.GitRepository, error) {
+			if orgID != "acme" || projectID != "demo-shop" {
+				return nil, nil
+			}
+			return &models.GitRepository{Status: "ready"}, nil
+		},
+	}
+	h := newReqHarness(t, &artifactstest.FakeArtifactService{}, repos)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/collab/validate", nil)
+	key, value := componenttest.ClaimsHeader(t, "acme")
+	req.Header.Set(key, value)
+	req.Header.Set("X-Room-Id", "spec-acme-demo-shop")
+	rec := httptest.NewRecorder()
+	h.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("collab-validate: want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Name        string `json:"name"`
+		Email       string `json:"email"`
+		ProjectName string `json:"projectName"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("collab-validate: unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if body.ProjectName != "demo-shop" {
+		t.Fatalf("collab-validate: want projectName demo-shop, got %q body=%s", body.ProjectName, rec.Body.String())
 	}
 }

--- a/services/collab/src/bff.ts
+++ b/services/collab/src/bff.ts
@@ -16,33 +16,45 @@
  * under the License.
  */
 
-// Thin client for the two BFF calls this service makes. The BFF is the only
-// authority: room access (validate-collab-access) and spec content
-// (get-project-spec). Git, credentials, and tenancy all stay its monopoly.
+// Thin client for the BFF calls this service makes. The BFF is the only
+// authority: room access (validate-collab-access) and spec content (the
+// Files API, #114). Git, credentials, and tenancy all stay its monopoly.
 
 export interface CollabIdentity {
   name: string;
   email: string;
   /**
    * Project resolved from the room ID by the oracle — only the BFF can split
-   * `spec-<org>-<project>` (it knows the caller's org). Phase 2 of #86 adds
-   * this field to the validate-collab-access response; the mock BFF already
-   * serves it.
+   * `spec-<org>-<project>` (it knows the caller's org).
    */
   projectName: string;
 }
 
+/**
+ * One spec file ready for seeding. `path` is the ROOM KEY — the repo path
+ * with the `specs/` prefix stripped (e.g. requirements/prd.md), matching what
+ * the console looks up (#113 decision 2). The strip happens here, at the
+ * Files API boundary, and nowhere else.
+ */
 export interface SpecFile {
   path: string;
-  group: string;
   content: string;
+}
+
+/** The Files API serves repo-relative paths; rooms key by the remainder. */
+export const SPECS_PREFIX = "specs/";
+
+export function toRoomPath(repoPath: string): string | null {
+  return repoPath.startsWith(SPECS_PREFIX)
+    ? repoPath.slice(SPECS_PREFIX.length)
+    : null;
 }
 
 export interface BffClient {
   /** Resolves to the caller's display identity, or throws on deny. */
   validateAccess(token: string, roomId: string): Promise<CollabIdentity>;
-  /** Spec bundle for seeding, read as the connecting user. */
-  fetchSpecBundle(token: string, projectName: string): Promise<SpecFile[]>;
+  /** Spec files for seeding, read via the Files API as the connecting user. */
+  fetchSpecFiles(token: string, projectName: string): Promise<SpecFile[]>;
 }
 
 export class BffAccessDeniedError extends Error {
@@ -73,18 +85,45 @@ export function createBffClient(
       };
     },
 
-    async fetchSpecBundle(token, projectName) {
-      const res = await fetchImpl(
-        `${base}/projects/${encodeURIComponent(projectName)}/spec`,
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
-      if (!res.ok) {
+    async fetchSpecFiles(token, projectName) {
+      const project = encodeURIComponent(projectName);
+      const headers = { Authorization: `Bearer ${token}` };
+
+      const listRes = await fetchImpl(`${base}/projects/${project}/files`, {
+        headers,
+      });
+      if (!listRes.ok) {
         throw new Error(
-          `Failed to fetch spec bundle for ${projectName} (${res.status})`,
+          `Failed to list spec files for ${projectName} (${listRes.status})`,
         );
       }
-      const body = (await res.json()) as { files: SpecFile[] };
-      return body.files;
+      const metas = ((await listRes.json()) ?? []) as { path: string }[];
+
+      return Promise.all(
+        metas.flatMap((meta) => {
+          const roomPath = toRoomPath(meta.path);
+          if (roomPath === null) return [];
+          const encoded = meta.path
+            .split("/")
+            .map(encodeURIComponent)
+            .join("/");
+          return [
+            (async (): Promise<SpecFile> => {
+              const res = await fetchImpl(
+                `${base}/projects/${project}/files/${encoded}`,
+                { headers },
+              );
+              if (!res.ok) {
+                throw new Error(
+                  `Failed to read ${meta.path} for ${projectName} (${res.status})`,
+                );
+              }
+              const body = (await res.json()) as { content: string };
+              return { path: roomPath, content: body.content };
+            })(),
+          ];
+        }),
+      );
     },
   };
 }

--- a/services/collab/src/fixtures.ts
+++ b/services/collab/src/fixtures.ts
@@ -16,15 +16,21 @@
  * under the License.
  */
 
-import type { SpecFile } from "./bff.js";
+import { toRoomPath, type SpecFile } from "./bff.js";
 
 // Dev-mode seed content. Mirrors the console mock layer's demo-shop project
 // (apps/console/src/mocks/fixtures/project.ts) so `make dev` shows the same
 // spec in both the mocked REST reads and the live collab doc.
-export const devSpecBundle: SpecFile[] = [
+
+/** A spec file as the Files API serves it: repo-relative path under specs/. */
+export interface RepoSpecFile {
+  path: string;
+  content: string;
+}
+
+export const devSpecFiles: RepoSpecFile[] = [
   {
-    path: "requirements/prd.md",
-    group: "requirements",
+    path: "specs/requirements/prd.md",
     content: `# Demo Shop — PRD
 
 ## Goal
@@ -41,8 +47,7 @@ to a cart, and check out.
 `,
   },
   {
-    path: "requirements/user-stories.md",
-    group: "requirements",
+    path: "specs/requirements/user-stories.md",
     content: `# Demo Shop — User stories
 
 - As a shopper, I can search the catalog so that I find products quickly.
@@ -52,8 +57,7 @@ to a cart, and check out.
 `,
   },
   {
-    path: "design/architecture.md",
-    group: "designs",
+    path: "specs/design/architecture.md",
     content: `# Demo Shop — Component architecture
 
 Three components behind the project cell:
@@ -68,8 +72,7 @@ The storefront talks to both services; services share nothing.
 `,
   },
   {
-    path: "validation/validation-plan.md",
-    group: "validation",
+    path: "specs/validation/validation-plan.md",
     content: `# Demo Shop — Validation plan
 
 - Catalog search returns seeded products by name and category.
@@ -79,3 +82,9 @@ The storefront talks to both services; services share nothing.
 `,
   },
 ];
+
+/** The same files keyed for seeding (specs/ stripped — the room key scheme). */
+export const devSeedFiles: SpecFile[] = devSpecFiles.flatMap((f) => {
+  const path = toRoomPath(f.path);
+  return path === null ? [] : [{ path, content: f.content }];
+});

--- a/services/collab/src/mockbff.test.ts
+++ b/services/collab/src/mockbff.test.ts
@@ -22,7 +22,7 @@ import type { AddressInfo } from "node:net";
 import type http from "node:http";
 import { startMockBff } from "./mockbff.js";
 import { createBffClient, BffAccessDeniedError } from "./bff.js";
-import { devSpecBundle } from "./fixtures.js";
+import { devSpecFiles } from "./fixtures.js";
 
 let server: http.Server;
 let base: string;
@@ -82,15 +82,17 @@ test("validate: rooms outside the caller's org are denied", async () => {
   );
 });
 
-test("spec bundle: served for known projects through the real client", async () => {
+test("spec files: list + per-file reads through the real client, keys stripped of specs/", async () => {
   const bff = createBffClient(base);
-  const files = await bff.fetchSpecBundle("opaque-token", "demo-shop");
-  assert.equal(files.length, devSpecBundle.length);
-  assert.equal(files[0]?.path, "requirements/prd.md");
+  const files = await bff.fetchSpecFiles("opaque-token", "demo-shop");
+  assert.equal(files.length, devSpecFiles.length);
+  const prd = files.find((f) => f.path === "requirements/prd.md");
+  assert.ok(prd, "room key is the repo path without specs/");
+  assert.match(prd.content, /Demo Shop — PRD/);
 });
 
-test("spec bundle: unlisted projects get the dev bundle (org-permissive, like the console mocks)", async () => {
+test("spec files: unlisted projects get the dev files (org-permissive, like the console mocks)", async () => {
   const bff = createBffClient(base);
-  const files = await bff.fetchSpecBundle("opaque-token", "any-other-project");
-  assert.equal(files.length, devSpecBundle.length);
+  const files = await bff.fetchSpecFiles("opaque-token", "any-other-project");
+  assert.equal(files.length, devSpecFiles.length);
 });

--- a/services/collab/src/mockbff.ts
+++ b/services/collab/src/mockbff.ts
@@ -29,18 +29,19 @@
 //     like a JWT, else a fixed mock identity — plus `projectName` resolved
 //     from the room ID. The real BFF splits `spec-<org>-<project>` using the
 //     caller's org; the mock uses its configured org ("acme" by default).
-// - GET /api/v1/projects/{project}/spec
-//     200 with the fixture bundle. Like the console's MSW layer, every
-//     project gets the same demo bundle unless `projects` overrides it —
-//     the mock oracle is org-permissive, so the bundle must be too.
+// - GET /api/v1/projects/{project}/files            → FileMeta list
+// - GET /api/v1/projects/{project}/files/{path...}  → FileContent (404 unknown)
+//     Mirror the real Files API (#114): repo-relative specs/ paths. Like the
+//     console's MSW layer, every project gets the same demo files unless
+//     `projects` overrides it — the mock oracle is org-permissive, so the
+//     files must be too.
 
 import http from "node:http";
-import type { SpecFile } from "./bff.js";
-import { devSpecBundle } from "./fixtures.js";
+import { devSpecFiles, type RepoSpecFile } from "./fixtures.js";
 
 export interface MockBffOptions {
-  /** Per-project bundle overrides; unlisted projects get the dev bundle. */
-  projects?: Record<string, SpecFile[]>;
+  /** Per-project file overrides; unlisted projects get the dev files. */
+  projects?: Record<string, RepoSpecFile[]>;
   /** The org used to split room IDs, like the real oracle does. */
   org?: string;
 }
@@ -72,10 +73,21 @@ function json(res: http.ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
-const SPEC_PATH = /^\/api\/v1\/projects\/([^/]+)\/spec$/;
+const FILES_LIST_PATH = /^\/api\/v1\/projects\/([^/]+)\/files$/;
+const FILE_READ_PATH = /^\/api\/v1\/projects\/([^/]+)\/files\/(.+)$/;
+
+// Deterministic stand-in for the git blob sha (unused by the seeder, present
+// for shape fidelity with the real FileMeta/FileContent).
+function mockSha(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash ^ input.charCodeAt(i)) * 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
 
 export function createMockBff(options: MockBffOptions = {}): http.Server {
-  const projects = options.projects ?? { "demo-shop": devSpecBundle };
+  const projects = options.projects ?? { "demo-shop": devSpecFiles };
   const org = options.org ?? "acme";
 
   return http.createServer((req, res) => {
@@ -97,12 +109,37 @@ export function createMockBff(options: MockBffOptions = {}): http.Server {
       });
     }
 
-    const specMatch = req.method === "GET" && url.pathname.match(SPEC_PATH);
-    if (specMatch) {
+    const listMatch =
+      req.method === "GET" && url.pathname.match(FILES_LIST_PATH);
+    if (listMatch) {
       if (!token) return json(res, 401, { title: "Unauthorized" });
-      const project = decodeURIComponent(specMatch[1] ?? "");
-      const files = projects[project] ?? devSpecBundle;
-      return json(res, 200, { files });
+      const project = decodeURIComponent(listMatch[1] ?? "");
+      const files = projects[project] ?? devSpecFiles;
+      return json(
+        res,
+        200,
+        files.map((f) => ({
+          path: f.path,
+          sha: mockSha(f.path + f.content),
+          size: f.content.length,
+        })),
+      );
+    }
+
+    const readMatch =
+      req.method === "GET" && url.pathname.match(FILE_READ_PATH);
+    if (readMatch) {
+      if (!token) return json(res, 401, { title: "Unauthorized" });
+      const project = decodeURIComponent(readMatch[1] ?? "");
+      const path = decodeURIComponent(readMatch[2] ?? "");
+      const files = projects[project] ?? devSpecFiles;
+      const file = files.find((f) => f.path === path);
+      if (!file) return json(res, 404, { title: "not found" });
+      return json(res, 200, {
+        path: file.path,
+        content: file.content,
+        sha: mockSha(file.path + file.content),
+      });
     }
 
     return json(res, 404, { title: "not found" });

--- a/services/collab/src/seed.test.ts
+++ b/services/collab/src/seed.test.ts
@@ -23,12 +23,8 @@ import { seedDocument, filesMap } from "./seed.js";
 import { fragmentToMarkdown } from "./markdown.js";
 
 const bundle = [
-  { path: "requirements/prd.md", group: "requirements", content: "# PRD\n" },
-  {
-    path: "design/arch.excalidraw",
-    group: "designs",
-    content: '{"type":"excalidraw-dsl"}',
-  },
+  { path: "requirements/prd.md", content: "# PRD\n" },
+  { path: "design/arch.excalidraw", content: '{"type":"excalidraw-dsl"}' },
 ];
 
 test("seeds md files as Y.XmlFragments, others as Y.Text entries", () => {

--- a/services/collab/src/seed.ts
+++ b/services/collab/src/seed.ts
@@ -23,6 +23,11 @@ import { isMarkdownPath, markdownToFragment } from "./markdown.js";
 // Doc model (#86 decision 2 + phase 6): one Y.Doc per project. Markdown
 // files are Y.XmlFragments keyed by path (Tiptap's collaboration binding
 // needs rich structure); everything else is a Y.Text in Y.Map('files').
+//
+// KEY SCHEME INVARIANT (#113 decision 2 / #114): doc keys are the repo path
+// with the `specs/` prefix stripped (requirements/prd.md). The console's spec
+// feature strips identically at its API boundary; any future peer that writes
+// to rooms (agents, #86) must too. The strip lives in bff.ts (toRoomPath).
 export const FILES_MAP = "files";
 
 export function filesMap(doc: Y.Doc): Y.Map<Y.Text> {

--- a/services/collab/src/server.test.ts
+++ b/services/collab/src/server.test.ts
@@ -24,7 +24,7 @@ import type { BffClient } from "./bff.js";
 import { BffAccessDeniedError } from "./bff.js";
 import { buildAuthenticateHook, buildLoadDocumentHook } from "./server.js";
 import { filesMap } from "./seed.js";
-import { devSpecBundle } from "./fixtures.js";
+import { devSeedFiles } from "./fixtures.js";
 import type { Document } from "@hocuspocus/server";
 
 const prodConfig: CollabConfig = {
@@ -49,8 +49,8 @@ function fakeBff(overrides: Partial<BffClient> = {}): BffClient {
       email: "jo@example.com",
       projectName: "shop",
     }),
-    fetchSpecBundle: async () => [
-      { path: "requirements/prd.md", group: "requirements", content: "# P\n" },
+    fetchSpecFiles: async () => [
+      { path: "requirements/prd.md", content: "# P\n" },
     ],
     ...overrides,
   };
@@ -135,7 +135,7 @@ test("load seeds from fixtures in dev mode (md files become fragments)", async (
     documentName: "spec-acme-shop",
     context: { user: { name: "d", email: "d", kind: "dev" }, token: null, projectName: null },
   });
-  for (const file of devSpecBundle) {
+  for (const file of devSeedFiles) {
     if (file.path.endsWith(".md")) {
       assert.ok(
         doc.getXmlFragment(file.path).length > 0,
@@ -147,15 +147,13 @@ test("load seeds from fixtures in dev mode (md files become fragments)", async (
   }
 });
 
-test("load seeds from the BFF bundle with the joiner's token", async () => {
+test("load seeds from the BFF's Files API with the joiner's token", async () => {
   const calls: string[] = [];
   const load = buildLoadDocumentHook(prodConfig, {
     bff: fakeBff({
-      fetchSpecBundle: async (token, project) => {
+      fetchSpecFiles: async (token, project) => {
         calls.push(token, project);
-        return [
-          { path: "requirements/prd.md", group: "requirements", content: "hi" },
-        ];
+        return [{ path: "requirements/prd.md", content: "hi" }];
       },
     }),
   });
@@ -173,11 +171,11 @@ test("load seeds from the BFF bundle with the joiner's token", async () => {
   assert.match(doc.getXmlFragment("requirements/prd.md").toString(), /hi/);
 });
 
-test("load opens an unseeded doc when the bundle fetch fails (room must survive)", async () => {
+test("load opens an unseeded doc when the files fetch fails (room must survive)", async () => {
   const load = buildLoadDocumentHook(prodConfig, {
     bff: fakeBff({
-      fetchSpecBundle: async () => {
-        throw new Error("bundle fetch exploded (404)");
+      fetchSpecFiles: async () => {
+        throw new Error("files fetch exploded (404)");
       },
     }),
   });

--- a/services/collab/src/server.ts
+++ b/services/collab/src/server.ts
@@ -25,7 +25,7 @@ import type { CollabConfig } from "./env.js";
 import type { BffClient } from "./bff.js";
 import { isSpecRoom } from "./room.js";
 import { seedDocument } from "./seed.js";
-import { devSpecBundle } from "./fixtures.js";
+import { devSeedFiles } from "./fixtures.js";
 
 // Connection context established by onAuthenticate and consumed by later
 // hooks. The token is retained for the seed read (performed as the first
@@ -84,12 +84,12 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
     const { document, documentName, context } = data;
 
     if (config.devMode) {
-      seedDocument(document, devSpecBundle);
+      seedDocument(document, devSeedFiles);
       deps.log?.(`seeded ${documentName} from dev fixtures`);
       return document;
     }
 
-    // Real path: read the spec bundle as the first joiner (the oracle
+    // Real path: read the spec files as the first joiner (the oracle
     // resolved the room into context.projectName).
     if (!deps.bff || !context.token || !context.projectName) {
       deps.log?.(
@@ -101,7 +101,7 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
     // by the oracle, and an unseeded-but-live doc beats a dead connection
     // (transient BFF errors would otherwise hard-fail every join).
     try {
-      const files = await deps.bff.fetchSpecBundle(
+      const files = await deps.bff.fetchSpecFiles(
         context.token,
         context.projectName,
       );


### PR DESCRIPTION
Closes #114.

Real-mode collab rooms opened **empty** for two stacked reasons, both proven in a live two-user test: `/collab/validate` never returned `projectName` (the #86 phase 2 field reached the mock BFF only), and the seed source `GET /projects/{p}/spec` was never implemented (and left the contract in #111). This PR fixes both.

## aep-api + contract

- `validate-collab-access` returns **`projectName`** — the handler already resolves it from `spec-<org>-<project>`; it just wasn't in the response. Contracted as a required field on `CollabValidateOutputBody`.
- Component test pins the success path (200 + projectName) via a raw `ClaimsHeader` request, since the harness's request builder can't set `X-Room-Id`.

## services/collab

- `fetchSpecBundle` (dead `/spec`) → **`fetchSpecFiles`**: `GET /projects/{p}/files` + per-file `GET /files/{path...}`, as the connecting user.
- **Room keys stay unprefixed** (`requirements/prd.md`) — the scheme the just-shipped console looks up (#113 decision 2). The `specs/` strip lives in one place (`bff.ts` `toRoomPath`); the invariant is recorded in `seed.ts` for future room writers (agents, #86). The seeder's `SpecFile` drops the never-used `group` field.
- Mock BFF mirrors the real Files API routes (FileMeta list + FileContent reads, 404 on unknown paths); fixtures move to repo-shaped `specs/` paths with a derived stripped set for dev-mode seeding.
- Failure behavior unchanged: a failed seed logs and opens the room empty — authorized users never get a dead connection.

## Verified

- aep-api requirements feature tests + collab suite (25/25) green; repo typecheck clean.
- **Live end-to-end** on the local stack (aep-api container rebuilt with this change): two Thunder users (mark, john) joined `spec-default-store-handmade-ceramics`; the collab server logged `seeded … (1 files) from BFF`; both editors opened with the real `requirements.md` content and a live edit synced both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
