### PR TITLE
deploy: collab server in docker-compose; console /collab proxy fixed

### DIFF
--- a/apps/console/nginx.conf
+++ b/apps/console/nginx.conf
@@ -76,9 +76,11 @@ http {
             add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
         }
 
-        # Collaborative editing WebSocket proxy — forwards /collab/* to the
-        # collab-server. WebSocket upgrade headers are required.
-        location /collab/ {
+        # Collaborative editing WebSocket proxy — forwards /collab* to the
+        # collab-server. WebSocket upgrade headers are required. Prefix match
+        # WITHOUT the trailing slash: the SPA's same-origin fallback connects
+        # to wss://<host>/collab (no slash — useCollabSpec's collabWsUrl).
+        location /collab {
             set $collab_backend collab-server:3400;
             proxy_pass http://$collab_backend;
             proxy_http_version 1.1;

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -388,11 +388,39 @@ services:
       - "8091:3000"
     depends_on:
       - aep-api
+      - collab-server
     environment:
       AEP_API_PROXY_URL: "http://aep-api:9090"
       VITE_THUNDER_URL: "${PUBLIC_THUNDER_URL}"
       VITE_THUNDER_CLIENT_ID: "${VITE_THUNDER_CLIENT_ID:-aep-console-client}"
       VITE_THUNDER_SCOPES: "${VITE_THUNDER_SCOPES:-openid profile email}"
+    networks:
+      - aep
+
+  # ---------------------------------------------------------------------------
+  # collab-server — Yjs/Hocuspocus collaboration rooms for the spec workspace
+  # (#86 / #114). The browser reaches it same-origin through the new console's
+  # nginx /collab proxy (its default upstream is exactly `collab-server:3400`,
+  # so the console needs no COLLAB_WS_URL/COLLAB_SERVER_URL overrides). Room
+  # auth + seeding go to aep-api with the joining user's token: the oracle
+  # (validate-collab-access) resolves the room's project, then the seeder
+  # reads the spec via the Files API.
+  # ---------------------------------------------------------------------------
+  collab-server:
+    build:
+      # Repo root — @aep/collab is a root-pnpm-workspace member.
+      context: ..
+      dockerfile: services/collab/Dockerfile
+    container_name: aep-collab
+    ports:
+      # Host mapping is for direct debugging only; the browser path is the
+      # console's /collab proxy.
+      - "3400:3400"
+    depends_on:
+      - aep-api
+    environment:
+      COLLAB_PORT: "3400"
+      AEP_API_BASE: "http://aep-api:9090/api/v1"
     networks:
       - aep
 

--- a/services/collab/.env.example
+++ b/services/collab/.env.example
@@ -1,6 +1,7 @@
 # services/collab — Yjs collaboration server (#86)
 
-# WebSocket listen port.
+# WebSocket listen port. docker-compose runs the service at 3400 (the console
+# nginx's default `collab-server:3400` upstream).
 COLLAB_PORT=8091
 
 # BFF base URL incl. API prefix. Unset => dev mode is implied.

--- a/services/collab/Dockerfile
+++ b/services/collab/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Collab service (services/collab) — Yjs/Hocuspocus rooms with BFF-oracle auth
+# and Files-API seeding (#86 / #114). Built from the REPO ROOT context
+# (docker-compose sets `context: ..`) so pnpm resolves the workspace lockfile;
+# @aep/collab has no workspace-package dependencies, so only its own tree is
+# copied. Runs from TypeScript source via tsx, like @aep/agents.
+FROM node:22-bookworm-slim
+
+RUN corepack enable
+WORKDIR /repo
+
+# Workspace manifests first for install-layer caching.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
+COPY services/collab ./services/collab
+
+RUN pnpm install --frozen-lockfile --filter @aep/collab...
+
+WORKDIR /repo/services/collab
+
+USER 1000
+EXPOSE 3400
+# The server listens on COLLAB_PORT (compose sets 3400, matching the console
+# nginx's default `collab-server:3400` upstream).
+CMD ["pnpm", "start"]


### PR DESCRIPTION
Follow-up to #118 — makes seeded spec collaboration work on the deployed compose stack, not just the local dev harness.

## What

- **`services/collab/Dockerfile`** (new): repo-root context like the agents image (pnpm workspace lockfile), runs via `tsx`; `@aep/collab` has no workspace-package deps so only its own tree is copied.
- **compose `collab-server` service**: named to match the console nginx's default upstream (`collab-server:3400`), `AEP_API_BASE=http://aep-api:9090/api/v1` for the oracle + Files-API seed reads, host `:3400` published for direct debugging only. Console `depends_on` it.
- **nginx fix** (`apps/console/nginx.conf`): `location /collab/` → `location /collab`. The SPA's same-origin fallback connects to `wss://<host>/collab` (no trailing slash), which the old location never matched — the handshake fell through to the SPA block and failed. This was latent until now because no deployed collab upstream existed.
- `.env.example` port comment updated. No console env changes needed: empty `collabWsUrl` already means "same-origin /collab".

## Verified on the deployed stack

Rebuilt `collab-server` + `console` images, `docker compose up -d`. Thunder login at :8091 (deployed console, not the dev server), opened a real project's spec workspace:
- collab connected through the nginx proxy (no "solo" chip),
- `aep-collab` logged `seeded spec-default-store-handmade-ceramics (1 files) from BFF`,
- the editor opened with the real `requirements.md` content.

One environment note: the token-endpoint CORS filter on the Thunder HTTPRoute only holds one console origin at a time — re-running `deployments/scripts/patch-thunder-new-console.sh` (default :8091) restored it after earlier dev-origin patching. Worth making additive someday, but that's the existing script's behavior, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
