### PR TITLE
aep-api: GET /projects/{p}/tags — spec version tags + specDirty (#117)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -38,6 +38,16 @@ BFF, which is its only backend.
    **autonomously** — there is no human code-review gate. Humans intervene
    on failure, not by default.
 
+## Spec versioning
+
+The whole spec — requirements, design, and validation files under the repo's
+`specs/` tree — is versioned as **one incrementing `v<N>` git tag sequence**,
+cut when the user approves/publishes. There are no per-artifact version
+trails (the earlier `v<N>-<M>` design-revision tags are legacy). The console
+reads this via `GET /projects/{p}/tags` (`latest` + `specDirty`): the
+"vN published" chip is the latest tag, and "draft changes" means `specs/`
+moved on GitHub after that tag.
+
 ## Personas
 
 - **Developer/User** — gives requirements *and* owns the design gate: reviews and

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -2977,7 +2977,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List project build tags
+      summary: List spec version tags
       tags:
         - Projects
   /projects/{projectName}/tasks:

--- a/services/aep-api/internal/api/huma_register.go
+++ b/services/aep-api/internal/api/huma_register.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	"github.com/wso2/aep/aep-api/internal/platform/auth"
 
+	"github.com/wso2/aep/aep-api/internal/feature/artifacts"
 	"github.com/wso2/aep/aep-api/internal/feature/component"
 	"github.com/wso2/aep/aep-api/internal/feature/design"
 	"github.com/wso2/aep/aep-api/internal/feature/execution"
@@ -71,6 +72,7 @@ type HumaDeps struct {
 	SkillMutationSvc  *skills.SkillMutationService
 	SkillImportSvc    *skills.SkillImportService
 	FilesSvc          files.FilesService
+	ArtifactSvc       artifacts.ArtifactService
 	GenAISvc          genai.GenAIService
 	GitHubAppSlug     string
 	BFFPublicURL      string
@@ -94,6 +96,7 @@ func RegisterAllHuma(api huma.API, d HumaDeps) {
 	orgconfig.RegisterConfig(api, d.OrgConfigSvc)
 	skills.RegisterSkill(api, d.SkillSvc, d.SkillMutationSvc, d.SkillImportSvc)
 	files.RegisterFiles(api, d.FilesSvc)
+	artifacts.RegisterTags(api, d.ArtifactSvc)
 	genai.RegisterGenAI(api, d.GenAISvc)
 }
 

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -749,6 +749,7 @@ func Build(cfg config.Config, db *gorm.DB) (*App, error) {
 		SkillMutationSvc:  skillMutationSvc,
 		SkillImportSvc:    skillImportSvc,
 		FilesSvc:          filesSvc,
+		ArtifactSvc:       artifactSvcGit,
 		GenAISvc:          genaiSvc,
 		GitHubAppSlug:     cfg.GitHubAppSlug,
 		BFFPublicURL:      cfg.BFFPublicURL,

--- a/services/aep-api/internal/feature/artifacts/artifact_service.go
+++ b/services/aep-api/internal/feature/artifacts/artifact_service.go
@@ -161,6 +161,9 @@ type ArtifactService interface {
 	// the task stale-design attention flag. Never returns an error: an
 	// unavailable repo/mirror degrades to "".
 	LatestDesignTag(ctx context.Context, orgID, projectID string) string
+	// ListSpecVersionTags lists the `v<N>` spec version tags (newest first)
+	// with the latest tag and whether specs/ moved since it (#117).
+	ListSpecVersionTags(ctx context.Context, orgID, projectID string) (*TagList, error)
 	GetRequirementsAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	// GetDesignAtCommit reads the design bundle at an exact commit — the publish

--- a/services/aep-api/internal/feature/artifacts/artifactstest/fakes.go
+++ b/services/aep-api/internal/feature/artifacts/artifactstest/fakes.go
@@ -43,6 +43,7 @@ type FakeArtifactService struct {
 	DiscardDesignFunc            func(ctx context.Context, orgID, projectID string) (map[string]string, error)
 	ListRequirementsVersionsFunc func(ctx context.Context, orgID, projectID string) ([]artifacts.RequirementsVersionInfo, error)
 	ListDesignVersionsFunc       func(ctx context.Context, orgID, projectID string) ([]artifacts.DesignVersionInfo, error)
+	ListSpecVersionTagsFunc      func(ctx context.Context, orgID, projectID string) (*artifacts.TagList, error)
 	LatestDesignTagFunc          func(ctx context.Context, orgID, projectID string) string
 	GetRequirementsAtTagFunc     func(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
 	GetDesignAtTagFunc           func(ctx context.Context, orgID, projectID, tag string) (map[string]string, error)
@@ -105,6 +106,13 @@ func (f *FakeArtifactService) ListDesignVersions(ctx context.Context, orgID, pro
 		panic("artifactstest: ListDesignVersions called but ListDesignVersionsFunc is not set")
 	}
 	return f.ListDesignVersionsFunc(ctx, orgID, projectID)
+}
+
+func (f *FakeArtifactService) ListSpecVersionTags(ctx context.Context, orgID, projectID string) (*artifacts.TagList, error) {
+	if f.ListSpecVersionTagsFunc == nil {
+		panic("artifactstest: ListSpecVersionTags called but ListSpecVersionTagsFunc is not set")
+	}
+	return f.ListSpecVersionTagsFunc(ctx, orgID, projectID)
 }
 
 func (f *FakeArtifactService) LatestDesignTag(ctx context.Context, orgID, projectID string) string {

--- a/services/aep-api/internal/feature/artifacts/spec_tags.go
+++ b/services/aep-api/internal/feature/artifacts/spec_tags.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package artifacts
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/wso2/aep/aep-api/internal/feature/gitrepo"
+)
+
+// GET /projects/{p}/tags (#117). The spec is versioned as ONE incrementing
+// `v<N>` sequence covering the whole specs/ tree (requirements + design +
+// validation together); legacy `v<N>-<M>` design-revision tags are not part
+// of the sequence and are excluded here.
+
+// specTreePrefix scopes the dirtiness check: only blobs under specs/ count.
+const specTreePrefix = "specs/"
+
+// TagList is the wire shape of list-project-tags. Field semantics match the
+// contract (packages/contracts/api/v1/openapi.yaml TagList).
+type TagList struct {
+	Tags []string `json:"tags" doc:"Spec version tags (v<N>), newest first."`
+	// Latest is the newest user-tagged spec version; absent when nothing is
+	// tagged yet.
+	Latest string `json:"latest,omitempty" doc:"Newest spec version tag (e.g. v3); absent when nothing is tagged."`
+	// SpecDirty is true when the specs/ tree at HEAD differs from the specs/
+	// tree at Latest — the spec changed after it was last versioned.
+	SpecDirty bool `json:"specDirty,omitempty" doc:"True when specs/ changed after latest was tagged."`
+}
+
+// ListSpecVersionTags lists the project's `v<N>` spec version tags, newest
+// first, with the latest tag and whether specs/ moved since it. One origin
+// fetch (the HEAD tree read; its refspec also freshens all tags), then
+// local-mirror reads: the tag list and the sha-addressed tag tree.
+func (s *artifactService) ListSpecVersionTags(ctx context.Context, orgID, projectID string) (*TagList, error) {
+	_, ref, err := s.readyRef(ctx, orgID, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	headEntries, _, err := s.git.Workspace().List(ctx, ref, "")
+	if err != nil {
+		return nil, fmt.Errorf("list head tree: %w", err)
+	}
+	tags, err := s.listVersionTagsLocal(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+
+	type versionTag struct {
+		n    int
+		info gitrepo.TagInfo
+	}
+	var versions []versionTag
+	for _, t := range tags {
+		if n, ok := parseRequirementsTag(t.Name); ok {
+			versions = append(versions, versionTag{n: n, info: t})
+		}
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i].n > versions[j].n })
+
+	out := &TagList{Tags: make([]string, 0, len(versions))}
+	for _, v := range versions {
+		out.Tags = append(out.Tags, v.info.Name)
+	}
+	if len(versions) == 0 {
+		return out, nil
+	}
+
+	latest := versions[0]
+	out.Latest = latest.info.Name
+	// Sha-addressed (the peeled tag commit) — a local read, no second fetch.
+	tagEntries, _, err := s.git.Workspace().List(ctx, ref, latest.info.CommitHash)
+	if err != nil {
+		return nil, fmt.Errorf("list tree at %s: %w", latest.info.Name, err)
+	}
+	out.SpecDirty = !specTreesEqual(headEntries, tagEntries)
+	return out, nil
+}
+
+// specTreesEqual compares the specs/ subtrees of two blob listings by
+// path→blob-sha — content-identical trees compare equal without any reads.
+func specTreesEqual(a, b []gitrepo.Entry) bool {
+	as, bs := specTreeShas(a), specTreeShas(b)
+	if len(as) != len(bs) {
+		return false
+	}
+	for path, sha := range as {
+		if bs[path] != sha {
+			return false
+		}
+	}
+	return true
+}
+
+func specTreeShas(entries []gitrepo.Entry) map[string]string {
+	out := map[string]string{}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Path, specTreePrefix) {
+			out[e.Path] = e.SHA
+		}
+	}
+	return out
+}

--- a/services/aep-api/internal/feature/artifacts/spec_tags_test.go
+++ b/services/aep-api/internal/feature/artifacts/spec_tags_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package artifacts
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// ListSpecVersionTags (#117): the spec is versioned as ONE incrementing
+// `v<N>` sequence over the whole specs/ tree; legacy `v<N>-<M>` design tags
+// are not part of it. specDirty = the specs/ tree at HEAD differs from the
+// specs/ tree at the latest tag.
+
+func seedSpec() map[string]string {
+	return map[string]string{
+		"specs/requirements/requirements.md": "# Reqs\n",
+		"specs/design/design.md":             "# Design\n",
+		"src/main.go":                        "package main\n",
+	}
+}
+
+func TestListSpecVersionTags_NoTags(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, seedSpec())
+
+	got, err := r.svc.ListSpecVersionTags(context.Background(), r.org, r.proj)
+	if err != nil {
+		t.Fatalf("ListSpecVersionTags: %v", err)
+	}
+	if len(got.Tags) != 0 || got.Latest != "" || got.SpecDirty {
+		t.Fatalf("want empty clean TagList, got %+v", got)
+	}
+}
+
+func TestListSpecVersionTags_LatestCleanAtTag(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, seedSpec())
+	r.remote.Tag(t, "v1", "spec v1")
+
+	got, err := r.svc.ListSpecVersionTags(context.Background(), r.org, r.proj)
+	if err != nil {
+		t.Fatalf("ListSpecVersionTags: %v", err)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"v1"}) || got.Latest != "v1" {
+		t.Fatalf("want tags [v1] latest v1, got %+v", got)
+	}
+	if got.SpecDirty {
+		t.Fatalf("HEAD == v1: want clean, got dirty")
+	}
+}
+
+func TestListSpecVersionTags_DirtyWhenSpecsMovedAfterTag(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, seedSpec())
+	r.remote.Tag(t, "v1", "spec v1")
+	r.remote.Seed(t, map[string]string{
+		"specs/requirements/requirements.md": "# Reqs — edited after v1\n",
+	}, "post-tag spec edit")
+
+	got, err := r.svc.ListSpecVersionTags(context.Background(), r.org, r.proj)
+	if err != nil {
+		t.Fatalf("ListSpecVersionTags: %v", err)
+	}
+	if !got.SpecDirty {
+		t.Fatalf("specs/ changed after v1: want dirty, got %+v", got)
+	}
+}
+
+func TestListSpecVersionTags_NonSpecCommitStaysClean(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, seedSpec())
+	r.remote.Tag(t, "v1", "spec v1")
+	r.remote.Seed(t, map[string]string{
+		"src/main.go": "package main // agents wrote code\n",
+	}, "post-tag code commit")
+
+	got, err := r.svc.ListSpecVersionTags(context.Background(), r.org, r.proj)
+	if err != nil {
+		t.Fatalf("ListSpecVersionTags: %v", err)
+	}
+	if got.SpecDirty {
+		t.Fatalf("only src/ changed after v1: want clean, got %+v", got)
+	}
+}
+
+func TestListSpecVersionTags_SequenceAndLegacyExclusion(t *testing.T) {
+	t.Parallel()
+	r := newRig(t, seedSpec())
+	r.remote.Tag(t, "v1", "spec v1")
+	r.remote.Tag(t, "v1-1", "legacy design revision")
+	r.remote.Seed(t, map[string]string{
+		"specs/design/design.md": "# Design r2\n",
+	}, "spec change")
+	r.remote.Tag(t, "v2", "spec v2")
+
+	got, err := r.svc.ListSpecVersionTags(context.Background(), r.org, r.proj)
+	if err != nil {
+		t.Fatalf("ListSpecVersionTags: %v", err)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"v2", "v1"}) {
+		t.Fatalf("want tags [v2 v1] (newest first, v1-1 excluded), got %+v", got.Tags)
+	}
+	if got.Latest != "v2" {
+		t.Fatalf("want latest v2, got %q", got.Latest)
+	}
+	if got.SpecDirty {
+		t.Fatalf("HEAD == v2: want clean, got dirty")
+	}
+}

--- a/services/aep-api/internal/feature/artifacts/tags_huma.go
+++ b/services/aep-api/internal/feature/artifacts/tags_huma.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/wso2/aep/aep-api/internal/feature/gitrepo"
+	"github.com/wso2/aep/aep-api/internal/platform/humakit"
+)
+
+type listTagsInput struct {
+	humakit.OrgScopedInput
+	ProjectName string `path:"projectName" doc:"Project name (DNS-label slug)"`
+}
+
+type listTagsOutput struct{ Body *TagList }
+
+// RegisterTags registers the spec-version tag read (#117). The console's
+// overview and spec view poll it for the "vN published" / "draft changes"
+// chips.
+func RegisterTags(api huma.API, svc ArtifactService) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-project-tags",
+		Method:      http.MethodGet,
+		Path:        "/projects/{projectName}/tags",
+		Summary:     "List spec version tags",
+		Tags:        []string{"Projects"},
+		Security:    humakit.SecurityUserJWT,
+	}, func(ctx context.Context, in *listTagsInput) (*listTagsOutput, error) {
+		tags, err := svc.ListSpecVersionTags(ctx, in.OrgHandle, in.ProjectName)
+		if err != nil {
+			switch {
+			case errors.Is(err, gitrepo.ErrRepoNotFound), errors.Is(err, gitrepo.ErrRepoNotReady):
+				return nil, huma.Error404NotFound("project repository not found")
+			default:
+				return nil, huma.Error500InternalServerError("internal error")
+			}
+		}
+		return &listTagsOutput{Body: tags}, nil
+	})
+}


### PR DESCRIPTION
Closes #117. Completes the chain from #113/#115: the console's "vN published" / "draft changes" chips now have a live data source.

## Semantics (grilling decision)

The spec is versioned as **one incrementing `v<N>` tag sequence** covering the whole `specs/` tree (requirements + design + validation together). Legacy `v<N>-<M>` design-revision tags are not part of the sequence and are excluded. Documented in the console PRD (new "Spec versioning" section).

- `tags` — the `v<N>` tags, newest first
- `latest` — highest `v<N>`; absent when nothing is tagged
- `specDirty` — the `specs/` subtree at HEAD differs from the subtree at `latest`, compared by path → blob sha (two tree listings, **no content reads**)

## Implementation

- Lives in the **artifacts** feature (it owns the tag scheme and its parse/latest helpers): `spec_tags.go` (service read + `TagList` wire type), `tags_huma.go` (`list-project-tags`, userJWT, org from claims).
- **One origin round trip per poll**: the fetch-bearing HEAD tree read's refspec (`+refs/tags/*`) also freshens all tags, so the tag list (`ListTagsLocal`) and the sha-addressed tag tree read stay local. Same per-poll cost as the console's existing files-list poll.
- Missing/unready repo → 404 (files-feature precedent; the console degrades to no chips). No tags → `200 {"tags":[]}`.
- Contract: only the stale summary fixed ("List project build tags" → "List spec version tags") — the shape landed in PR #115.

## Verified

- Real-git rig tests (TDD): no tags; clean at tag; dirty after a `specs/` edit; **clean after a non-spec (src/) commit**; `v2`+`v1` ordering with legacy `v1-1` excluded.
- Full aep-api suite + repo typecheck green (only the known pre-existing `gitfs` git-identity env failure).
- Live on the rebuilt container: `GET /projects/{p}/tags` with a real Thunder JWT → `200 {"tags":[]}` on an untagged project; unauthenticated → 401.

**Unrelated finding while verifying** (will file separately): `GET /projects/{projectName}` returns 403 "insufficient permissions" for a regular user on the deployed stack (`/status`, `/files`, `/tags` all 200) — it breaks the project layout so the overview never renders. Pre-existing on aep-rewrite, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
