### PR TITLE
deploy: seed test users into the Administrators group (#123)

### DIFF
--- a/deployments/scripts/seed-test-users.sh
+++ b/deployments/scripts/seed-test-users.sh
@@ -124,5 +124,50 @@ for row in "${USERS[@]}"; do
     esac
 done
 
+# 4. Ensure every test user is in the Administrators group. OpenChoreo's
+# authz grants console access via the token's `groups` claim
+# (administrators-group-binding in wso2-ae-oc-extensions maps the group to
+# the admin ClusterAuthzRole); a user with no group has NO OC entitlement,
+# so every OC-backed project read 403s and the project view never renders
+# (#123). jq is required here, like patch-thunder-new-console.sh.
+echo ""
+GROUP_ID=$(curl -sS -H "Authorization: Bearer ${TOKEN}" \
+    "${THUNDER_URL%/}/groups" 2>/dev/null \
+    | jq -r '.groups[] | select(.name == "Administrators") | .id' | head -1)
+if [ -z "$GROUP_ID" ]; then
+    echo "❌ Administrators group not found in Thunder — OC access will 403 (#123)."
+    exit 1
+fi
+
+MEMBER_IDS=$(curl -sS -H "Authorization: Bearer ${TOKEN}" \
+    "${THUNDER_URL%/}/groups/${GROUP_ID}/members" 2>/dev/null \
+    | jq -r '.members[].id')
+ALL_USERS=$(curl -sS -H "Authorization: Bearer ${TOKEN}" \
+    "${THUNDER_URL%/}/users" 2>/dev/null)
+
+for row in "${USERS[@]}"; do
+    IFS='|' read -r username _ _ <<<"$row"
+    user_id=$(printf '%s' "$ALL_USERS" \
+        | jq -r --arg u "$username" '.users[] | select(.attributes.username == $u) | .id' | head -1)
+    if [ -z "$user_id" ]; then
+        echo "❌ $username — no user id found; cannot add to Administrators"
+        continue
+    fi
+    if printf '%s\n' "$MEMBER_IDS" | grep -qx "$user_id"; then
+        echo "⏭️  $username — already in Administrators"
+        continue
+    fi
+    code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{\"members\":[{\"type\":\"user\",\"id\":\"${user_id}\"}]}" \
+        "${THUNDER_URL%/}/groups/${GROUP_ID}/members/add" 2>/dev/null || echo 000)
+    if [ "$code" = "200" ]; then
+        echo "✅ $username → Administrators group"
+    else
+        echo "❌ $username — members/add failed (HTTP $code)"
+    fi
+done
+
 echo ""
 echo "=== seed-test-users complete ==="


### PR DESCRIPTION
Closes #123.

## Diagnosis

The BFF forwards user JWTs to OpenChoreo for user-facing project calls, and OC's entire user-authz surface is one binding: `administrators-group-binding` (wso2-ae-oc-extensions) maps the token's `groups=Administrators` claim to the admin ClusterAuthzRole. Seeded test users had no group at all → no OC entitlement → `GET /projects/{p}` 403 ("insufficient permissions"), `GET /projects` 200-but-empty, and the console's project layout blocks on get-project, so nothing under it ever rendered. The repo-backed reads (`/status`, `/files`, `/tags`) never touch OC, which is why they all worked.

## Fix (dev seeding)

`seed-test-users.sh` now ensures every test user is a member of Thunder's `Administrators` group — `POST /groups/{id}/members/add` (the shape is from Thunder's `api/group.yaml`; `PUT /groups/{id}` silently ignores a `members` field). Idempotent: already-members are skipped. Matches the binding's stated intent ("human operators logged into the console have immediate admin rights"). Uses `jq`, like `patch-thunder-new-console.sh`.

## Verified live

Re-ran the seeder (mark skipped as already-member from probing, john/chris/emily added), fresh `john` login: token now carries `groups: ["Administrators"]`, `GET /projects/{p}` → 200, and the full project view renders — Spec/Build/Deployment cards + Components — for a regular seeded user for the first time.

## Not in scope

Real-user onboarding entitlements (what non-admin role a JIT-onboarded org member should get, e.g. a Members group → member role binding) — filed separately as a design follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
