### PR TITLE
refactor(genai): rename conversation routes to /agents/{conversationId}/messages

### DIFF
--- a/console-legacy/console/src/services/api/openapi.gen.ts
+++ b/console-legacy/console/src/services/api/openapi.gen.ts
@@ -383,7 +383,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/projects/{projectName}/conversations/{conversationId}": {
+    "/projects/{projectName}/agents/{conversationId}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -392,22 +392,6 @@ export interface paths {
         };
         /** Rehydrate a chat conversation (messages only) */
         get: operations["get-conversation"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/projects/{projectName}/conversations/{conversationId}/turns": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
         put?: never;
         /** Start a generation/chat turn (202 — runs detached; attach via the turn stream) */
         post: operations["create-turn"];

--- a/console-legacy/console/src/services/api/turns.ts
+++ b/console-legacy/console/src/services/api/turns.ts
@@ -20,7 +20,7 @@
  * The committed-truth turn client — the console's entry points to the BFF's
  * resumable generation endpoints (shared-volume-clone D13/D16/D18):
  *
- *   - `startTurn`   POST …/conversations/{id}/turns {useCase, instruction,
+ *   - `startTurn`   POST …/agents/{id}/messages {useCase, instruction,
  *                   target?} → 202 {turnId}. No file content ever leaves the
  *                   browser — the backend snapshots HEAD itself.
  *   - `attachTurnStream`  GET …/turns/{id}/stream?from=N — replay + live tail
@@ -143,7 +143,7 @@ export async function getConversation(
   conversationId: string,
 ): Promise<ConversationMessage[]> {
   const res = await fetch(
-    `${API_V1}/projects/${encodeURIComponent(projectName)}/conversations/${encodeURIComponent(conversationId)}`,
+    `${API_V1}/projects/${encodeURIComponent(projectName)}/agents/${encodeURIComponent(conversationId)}/messages`,
     { cache: 'no-store', headers: await authHeaders() },
   );
   if (!res.ok) return [];
@@ -163,7 +163,7 @@ export async function startTurn(
   body: StartTurnBody,
 ): Promise<StartTurnResult> {
   const res = await fetch(
-    `${API_V1}/projects/${encodeURIComponent(projectName)}/conversations/${encodeURIComponent(conversationId)}/turns`,
+    `${API_V1}/projects/${encodeURIComponent(projectName)}/agents/${encodeURIComponent(conversationId)}/messages`,
     {
       method: 'POST',
       headers: await authHeaders(),

--- a/services/aep-api/internal/feature/genai/genai_component_test.go
+++ b/services/aep-api/internal/feature/genai/genai_component_test.go
@@ -58,13 +58,13 @@ const (
 )
 
 func turnsPath(uuid string) string {
-	return "/api/v1/projects/" + testProj + "/conversations/" + uuid + "/turns"
+	return "/api/v1/projects/" + testProj + "/agents/" + uuid + "/messages"
 }
 func turnPath(turnID string) string {
 	return "/api/v1/projects/" + testProj + "/turns/" + turnID
 }
 func convPath(uuid string) string {
-	return "/api/v1/projects/" + testProj + "/conversations/" + uuid
+	return "/api/v1/projects/" + testProj + "/agents/" + uuid + "/messages"
 }
 
 // ---- SSE script helpers ------------------------------------------------------

--- a/services/aep-api/internal/feature/genai/genai_huma.go
+++ b/services/aep-api/internal/feature/genai/genai_huma.go
@@ -18,11 +18,11 @@ package genai
 
 // genai_huma.go — the committed-truth turn HTTP edge (design §6 API delta):
 //
-//	POST …/conversations/{id}/turns {useCase,instruction,target?} → 202 {turnId}
+//	POST …/agents/{id}/messages {useCase,instruction,target?}    → 202 {turnId}
 //	GET  …/turns/{turnId}                                         → status
 //	GET  …/turns/active                                           → status | 204
 //	GET  …/turns/{turnId}/stream?from=N (SSE, Last-Event-ID)      → replay + tail
-//	GET  …/conversations/{id}                                     → rehydrate
+//	GET  …/agents/{id}/messages                                   → rehydrate
 //
 // The stream events are the raw agents StreamParts plus ONE aep-api terminal
 // event (turn-committed / turn-failed), each stamped with `id: <index>`; the
@@ -121,7 +121,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 	huma.Register(api, huma.Operation{
 		OperationID:   "create-turn",
 		Method:        http.MethodPost,
-		Path:          "/projects/{projectName}/conversations/{conversationId}/turns",
+		Path:          "/projects/{projectName}/agents/{conversationId}/messages",
 		Summary:       "Start a generation/chat turn (202 — runs detached; attach via the turn stream)",
 		Tags:          []string{"GenAI"},
 		Security:      humakit.SecurityUserJWT,
@@ -214,7 +214,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 	huma.Register(api, huma.Operation{
 		OperationID: "get-conversation",
 		Method:      http.MethodGet,
-		Path:        "/projects/{projectName}/conversations/{conversationId}",
+		Path:        "/projects/{projectName}/agents/{conversationId}/messages",
 		Summary:     "Rehydrate a chat conversation (messages only)",
 		Tags:        []string{"GenAI"},
 		Security:    humakit.SecurityUserJWT,


### PR DESCRIPTION
## What

Aligns the `aep-api` BFF and the `console-legacy` client with the contract
(`packages/contracts/api/v1/openapi.yaml`), which unifies the chat **rehydrate**
and **turn-create** endpoints under a single resource (`#rename from convo`):

| operation | before | after |
|---|---|---|
| `get-conversation` (rehydrate) | `GET /projects/{p}/conversations/{c}` | `GET /projects/{p}/agents/{c}/messages` |
| `create-turn` | `POST /projects/{p}/conversations/{c}/turns` | `POST /projects/{p}/agents/{c}/messages` |

`get-conversation` and `create-turn` now share one path, differentiated by HTTP method.

## Scope / not changed

- The turn **status/active/stream** routes (`/projects/{p}/turns/...`) are **unchanged** — they are not part of the contract (SSE deferred/legacy) and are still required by the FE.
- The internal **S2S agents-service client** (`/conversations/{id}/turns` from `aep-api` → agents) is a separate internal API and is untouched.
- `apps/console` (new console) was already generated against the renamed path — no change needed.

## Changes

- **aep-api** — `internal/feature/genai/genai_huma.go`: the two `huma.Register` path strings + the header doc comment. No struct/handler/service changes (path params already present). Component-test helpers (`turnsPath`, `convPath`) updated.
- **console-legacy** — `services/api/turns.ts`: `getConversation` + `startTurn` fetch URLs. `openapi.gen.ts` hand-updated to merge the two path entries (no codegen — regenerating would drop the `/turns/*` client types the contract doesn't define).

## Verification

- `go test ./internal/feature/genai/...` → PASS
- console-legacy `tsc --noEmit` → clean; no stale `/conversations/` refs remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)