### PR TITLE
Agents as live collab peers — room-scoped turns (#86 phase 4)

### DIFF
--- a/apps/console/src/mocks/fixtures/settings.ts
+++ b/apps/console/src/mocks/fixtures/settings.ts
@@ -21,6 +21,11 @@ import type { components } from "../../generated/aep-api";
 type GitProviderProjection = components["schemas"]["GitProviderProjection"];
 type LLMProjection = components["schemas"]["LLMProjection"];
 type SkillDetailBody = components["schemas"]["SkillDetailBody"];
+
+// The contract's detail body dropped `version` (the BE detail read no longer
+// serves it) but the list's SkillSummary keeps it — the mock catalogue tracks
+// it per skill so list projections and update-sync bookkeeping still work.
+export type MockSkill = SkillDetailBody & { version: number };
 type SkillUpdate = components["schemas"]["SkillUpdate"];
 type ErrorModel = components["schemas"]["ErrorModel"];
 
@@ -127,7 +132,7 @@ export const skillsLoadError: ErrorModel = {
 
 // Two built-ins, one flow skill, one custom (editable) — enough spread to
 // exercise editable/read-only rendering and the updates-available list.
-export const seedSkills: SkillDetailBody[] = [
+export const seedSkills: MockSkill[] = [
   {
     orgId: "org-1",
     name: "high-level-architecture",

--- a/apps/console/src/mocks/handlers/settings.ts
+++ b/apps/console/src/mocks/handlers/settings.ts
@@ -35,6 +35,7 @@ import {
   seedSkills,
   skillsLoadError,
   skillsRepoUrl,
+  type MockSkill,
   type SettingsScenario,
 } from "../fixtures/settings";
 
@@ -66,7 +67,7 @@ function problem(body: object, status: number) {
 // handlers/projects.ts's createdProjects pattern.
 let gitProvider: GitProviderProjection | null = null;
 let llm: LLMProjection | null = null;
-let skills: SkillDetailBody[] = [];
+let skills: MockSkill[] = [];
 let skillUpdates: SkillUpdate[] = [];
 let initialized = false;
 
@@ -81,7 +82,7 @@ function ensureInitialized() {
   skillUpdates = seedSkillUpdates.map((u) => ({ ...u }));
 }
 
-function toSummary(s: SkillDetailBody): SkillSummary {
+function toSummary(s: MockSkill): SkillSummary {
   return {
     name: s.name,
     kind: s.kind,
@@ -317,14 +318,14 @@ export const settingsHandlers = [
         409,
       );
     }
-    const created: SkillDetailBody = {
+    const created: MockSkill = {
       orgId: "org-1",
       name: body.name,
       kind: "custom",
       editable: true,
       description: extractDescription(body.skillMd),
       skillMd: body.skillMd,
-      references: body.references,
+      references: body.references ?? {},
       version: 1,
       contentSha: `sha-${body.name}-1`,
       updatedAt: new Date().toISOString(),
@@ -366,7 +367,7 @@ export const settingsHandlers = [
     }
     const body = (await request.json()) as UpdateSkillInput;
     skill.skillMd = body.skillMd;
-    skill.references = body.references;
+    skill.references = body.references ?? {};
     skill.description = extractDescription(body.skillMd);
     skill.version += 1;
     skill.updatedAt = new Date().toISOString();

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -272,6 +272,9 @@ services:
       # written by aep-api. The :ro mount enforces the reader-only contract
       # structurally (design D3).
       WORKSPACE_MOUNT_ROOT: "/workspaces"
+      # Room-scoped turns (#86 phase 4): the agents service joins spec rooms
+      # as a live Yjs peer through the in-network collab server.
+      AGENT_COLLAB_WS_URL: "ws://collab-server:3400"
     volumes:
       - aep-workspaces:/workspaces:ro
     networks:

--- a/packages/agent-stream/src/contracts/sse-events.ts
+++ b/packages/agent-stream/src/contracts/sse-events.ts
@@ -197,6 +197,33 @@ export interface McpConfig {
   token: string;
 }
 
+/**
+ * Caller-supplied collab-room reference for a room-scoped turn (#86 phase 4).
+ * Mirrors `McpConfig`: the BFF resolves the room and forwards the caller's
+ * bearer; the service never reads either from its own env (the ws URL alone
+ * comes from service config — the BFF doesn't know the agents-side route).
+ * Present → the agents service joins the room as a live Yjs peer, reads the
+ * file bundle FROM the doc, and applies file ops to it; nothing is committed
+ * to git (persistence is the #86 phase-3 committer). Omitted → the
+ * committed-truth snapshot turn, byte-identical to today.
+ */
+export interface CollabConfig {
+  /** The room id (`spec-<org>-<project>`), resolved by the BFF. */
+  roomId: string;
+  /**
+   * The caller's bearer, forwarded request-scoped (#86 decision 7): the
+   * collab server's BFF oracle validates it exactly like a browser join.
+   */
+  token: string;
+}
+
+/** Runtime guard for an untrusted `collab` value (the server's pre-stream 400 check). */
+export function isCollabConfig(v: unknown): v is CollabConfig {
+  if (typeof v !== "object" || v === null) return false;
+  const c = v as Record<string, unknown>;
+  return typeof c.roomId === "string" && c.roomId !== "" && typeof c.token === "string" && c.token !== "";
+}
+
 // --- The reviewable change (§7) ---------------------------------------------
 
 /**
@@ -280,6 +307,12 @@ export interface TurnRequest {
    * no fetch, no discovery tools (byte-identical to an mcp-free turn).
    */
   mcp?: McpConfig;
+  /**
+   * Room-scoped turn (#86 phase 4): join this collab room as a live Yjs peer,
+   * read files from the doc, apply ops to the doc, commit nothing. Omitted →
+   * the committed-truth snapshot turn (byte-identical to today).
+   */
+  collab?: CollabConfig;
 }
 
 /** The registrable tool sets a turn may request (`TurnRequest.toolset`). */

--- a/packages/agent-stream/src/index.ts
+++ b/packages/agent-stream/src/index.ts
@@ -46,11 +46,18 @@ export type {
   TurnRequest,
   WorkspaceRef,
   McpConfig,
+  CollabConfig,
   ManifestPart,
   Toolset,
   AgentSseEventType,
 } from "./contracts/sse-events.js";
-export { AGENT_SSE_EVENT_TYPES, SSE_DONE, TOOLSETS, isToolset } from "./contracts/sse-events.js";
+export {
+  AGENT_SSE_EVENT_TYPES,
+  SSE_DONE,
+  TOOLSETS,
+  isToolset,
+  isCollabConfig,
+} from "./contracts/sse-events.js";
 export type {
   ComponentDesign,
   Dependency,

--- a/packages/collab-doc/package.json
+++ b/packages/collab-doc/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@aep/collab-doc",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared collab-document plumbing (#86): the spec-room Y.Doc model (Y.Map path→Y.Text + Y.XmlFragment per md file), headless markdown ↔ ProseMirror conversion, and safe edit application (Y.Text diff-and-patch, fragment reparse). Used by services/collab (seeding/committer) and services/agents (agents as live peers).",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "tsx --test \"test/**/*.test.ts\"",
+    "dev": "echo \"@aep/collab-doc: no dev server\""
+  },
+  "dependencies": {
+    "@tiptap/core": "^3.27.2",
+    "@tiptap/markdown": "^3.27.2",
+    "@tiptap/starter-kit": "^3.27.2",
+    "fast-diff": "^1.3.0",
+    "y-prosemirror": "^1.3.7",
+    "yjs": "^13.6.31"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/packages/collab-doc/src/doc.ts
+++ b/packages/collab-doc/src/doc.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The spec-room document model (#86 decision 2 + phase 6) and safe edit
+// application for programmatic peers (#86 phase 4).
+//
+// Model: one Y.Doc per project. Markdown files are top-level Y.XmlFragments
+// keyed by path (Tiptap needs rich structure); everything else is a Y.Text
+// in Y.Map('files'). Paths are the repo path with the `specs/` prefix
+// stripped (requirements/prd.md) — #113 decision 2; every peer (console,
+// seeder, agents) uses the same scheme.
+//
+// Edit application (#86 phase-4 design note): whole-file replacement of a
+// Y.Text is forbidden — it destroys concurrent keystrokes and cursors.
+// Y.Text edits are DIFF-AND-PATCH against the text at APPLY time, in one
+// transaction tagged with the caller's origin. Markdown fragments get a
+// whole-fragment reparse in one transaction (v1 — step-level diffing is the
+// noted follow-up), which converges every peer to the new content.
+
+import diff from "fast-diff";
+import * as Y from "yjs";
+import {
+  fragmentToMarkdown,
+  isMarkdownPath,
+  markdownToFragment,
+} from "./markdown.js";
+
+/** The Y.Map holding non-markdown files (path → Y.Text). */
+export const FILES_MAP = "files";
+
+export function filesMap(doc: Y.Doc): Y.Map<Y.Text> {
+  return doc.getMap<Y.Text>(FILES_MAP);
+}
+
+/**
+ * Every file path present in the doc: the files-map keys plus every
+ * top-level markdown fragment. (In this model the only top-level shares are
+ * FILES_MAP and md fragments, so key shape decides the type.)
+ */
+export function listDocPaths(doc: Y.Doc): string[] {
+  const paths = new Set<string>();
+  for (const key of doc.share.keys()) {
+    if (key !== FILES_MAP && isMarkdownPath(key)) paths.add(key);
+  }
+  for (const key of filesMap(doc).keys()) paths.add(key);
+  return [...paths].sort();
+}
+
+/** One file's current content, or undefined when absent. */
+export function readDocFile(doc: Y.Doc, path: string): string | undefined {
+  if (isMarkdownPath(path)) {
+    if (!doc.share.has(path)) return undefined;
+    return fragmentToMarkdown(doc.getXmlFragment(path));
+  }
+  return filesMap(doc).get(path)?.toString();
+}
+
+/** The whole doc as path → content (a programmatic peer's read surface). */
+export function snapshotDoc(doc: Y.Doc): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const path of listDocPaths(doc)) {
+    const content = readDocFile(doc, path);
+    if (content !== undefined) out[path] = content;
+  }
+  return out;
+}
+
+/**
+ * Diff-and-patch a Y.Text to `next` in ONE transaction: diffed against the
+ * text at apply time (indices are valid now, not at generation time), so
+ * concurrent edits merge at the CRDT level instead of being overwritten.
+ */
+export function applyTextEdit(
+  ytext: Y.Text,
+  next: string,
+  origin?: unknown,
+): void {
+  const doc = ytext.doc;
+  if (!doc) throw new Error("collab-doc: Y.Text is not attached to a doc");
+  doc.transact(() => {
+    let pos = 0;
+    for (const [op, chunk] of diff(ytext.toString(), next)) {
+      if (op === diff.EQUAL) pos += chunk.length;
+      else if (op === diff.DELETE) ytext.delete(pos, chunk.length);
+      else {
+        ytext.insert(pos, chunk);
+        pos += chunk.length;
+      }
+    }
+  }, origin);
+}
+
+/**
+ * Write one file into the doc: markdown → whole-fragment reparse (v1),
+ * everything else → Y.Text diff-and-patch (created on first write). One
+ * transaction either way, tagged with `origin`.
+ */
+export function setDocFile(
+  doc: Y.Doc,
+  path: string,
+  content: string,
+  origin?: unknown,
+): void {
+  if (isMarkdownPath(path)) {
+    // getXmlFragment INSIDE the transaction: creating a top-level share
+    // integrates a new type, which is itself a transaction — outside it
+    // would carry no origin.
+    doc.transact(() => {
+      const fragment = doc.getXmlFragment(path);
+      fragment.delete(0, fragment.length);
+      markdownToFragment(content, fragment);
+    }, origin);
+    return;
+  }
+  const existing = doc.share.has(FILES_MAP)
+    ? filesMap(doc).get(path)
+    : undefined;
+  if (existing) {
+    applyTextEdit(existing, content, origin);
+    return;
+  }
+  doc.transact(() => {
+    const text = new Y.Text();
+    text.insert(0, content);
+    filesMap(doc).set(path, text);
+  }, origin);
+}
+
+/** Remove a file from the doc (fragment emptied — top-level shares cannot be deleted — or map entry removed). */
+export function deleteDocFile(doc: Y.Doc, path: string, origin?: unknown): void {
+  if (isMarkdownPath(path)) {
+    if (!doc.share.has(path)) return;
+    const fragment = doc.getXmlFragment(path);
+    doc.transact(() => fragment.delete(0, fragment.length), origin);
+    return;
+  }
+  doc.transact(() => filesMap(doc).delete(path), origin);
+}

--- a/packages/collab-doc/src/index.ts
+++ b/packages/collab-doc/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export {
+  isMarkdownPath,
+  markdownToFragment,
+  fragmentToMarkdown,
+} from "./markdown.js";
+export {
+  FILES_MAP,
+  filesMap,
+  listDocPaths,
+  readDocFile,
+  snapshotDoc,
+  applyTextEdit,
+  setDocFile,
+  deleteDocFile,
+} from "./doc.js";

--- a/packages/collab-doc/src/markdown.ts
+++ b/packages/collab-doc/src/markdown.ts
@@ -19,8 +19,8 @@
 // Headless markdown ↔ ProseMirror plumbing (#86 phase 6). Markdown files are
 // shared as Y.XmlFragments (Tiptap's collaboration binding needs rich
 // structure, not Y.Text); this module owns the conversion at the seams:
-// parse on seed here, serialize on flush when the committer lands (phase 3).
-// The extension set MUST match the console editor's, or content drifts.
+// parse on seed, serialize for committer/agent reads. The extension set MUST
+// match the console editor's, or content drifts.
 
 import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
@@ -48,7 +48,7 @@ export function markdownToFragment(
   prosemirrorJSONToYXmlFragment(schema, manager.parse(markdown), fragment);
 }
 
-/** Serialize a fragment back to markdown (committer seam, phase 3). */
+/** Serialize a fragment back to markdown (committer + agent-read seam). */
 export function fragmentToMarkdown(fragment: Y.XmlFragment): string {
   return manager.serialize(yXmlFragmentToProsemirrorJSON(fragment));
 }

--- a/packages/collab-doc/test/doc.test.ts
+++ b/packages/collab-doc/test/doc.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as Y from "yjs";
+import {
+  applyTextEdit,
+  deleteDocFile,
+  filesMap,
+  listDocPaths,
+  readDocFile,
+  setDocFile,
+  snapshotDoc,
+} from "../src/index.js";
+
+test("setDocFile creates and diff-patches Y.Text files", () => {
+  const doc = new Y.Doc();
+  setDocFile(doc, "design/arch.excalidraw", '{"v":1}');
+  assert.equal(readDocFile(doc, "design/arch.excalidraw"), '{"v":1}');
+
+  setDocFile(doc, "design/arch.excalidraw", '{"v":2}');
+  assert.equal(readDocFile(doc, "design/arch.excalidraw"), '{"v":2}');
+});
+
+test("applyTextEdit patches without destroying concurrent inserts elsewhere", () => {
+  const doc = new Y.Doc();
+  setDocFile(doc, "notes.txt", "alpha\nbeta\ngamma\n");
+  const ytext = filesMap(doc).get("notes.txt")!;
+
+  // Agent computes "beta" -> "BETA" against a snapshot; a user then edits
+  // gamma before it applies. Diff-and-patch runs against apply-time text.
+  ytext.insert(ytext.toString().indexOf("gamma"), "user-");
+  applyTextEdit(ytext, "alpha\nBETA\nuser-gamma\n", "agent");
+  assert.equal(ytext.toString(), "alpha\nBETA\nuser-gamma\n");
+});
+
+test("markdown files round-trip through fragments", () => {
+  const doc = new Y.Doc();
+  setDocFile(doc, "requirements/prd.md", "# Title\n\nSome body text.");
+  assert.match(doc.getXmlFragment("requirements/prd.md").toString(), /Title/);
+  assert.equal(
+    readDocFile(doc, "requirements/prd.md")?.trim(),
+    "# Title\n\nSome body text.",
+  );
+
+  setDocFile(doc, "requirements/prd.md", "# New\n\nReplaced.");
+  assert.equal(readDocFile(doc, "requirements/prd.md")?.trim(), "# New\n\nReplaced.");
+});
+
+test("fragment edits replicate to synced peers in one update", () => {
+  const server = new Y.Doc();
+  const client = new Y.Doc();
+  server.on("update", (u: Uint8Array) => Y.applyUpdate(client, u));
+  setDocFile(server, "requirements/prd.md", "# Seeded");
+  setDocFile(server, "requirements/prd.md", "# Agent rewrite");
+  assert.match(client.getXmlFragment("requirements/prd.md").toString(), /Agent rewrite/);
+});
+
+test("transactions carry the caller's origin", () => {
+  const doc = new Y.Doc();
+  const origins: unknown[] = [];
+  doc.on("afterTransaction", (tr: Y.Transaction) => origins.push(tr.origin));
+  setDocFile(doc, "requirements/prd.md", "# X", "agent:test");
+  setDocFile(doc, "data.json", "{}", "agent:test");
+  assert.ok(origins.every((o) => o === "agent:test"));
+});
+
+test("listDocPaths and snapshotDoc cover both shapes", () => {
+  const doc = new Y.Doc();
+  setDocFile(doc, "requirements/prd.md", "# P");
+  setDocFile(doc, "design/arch.excalidraw", "{}");
+  assert.deepEqual(listDocPaths(doc), [
+    "design/arch.excalidraw",
+    "requirements/prd.md",
+  ]);
+  const snap = snapshotDoc(doc);
+  assert.equal(snap["design/arch.excalidraw"], "{}");
+  assert.match(snap["requirements/prd.md"] ?? "", /# P/);
+});
+
+test("deleteDocFile removes text entries and empties fragments", () => {
+  const doc = new Y.Doc();
+  setDocFile(doc, "requirements/prd.md", "# P");
+  setDocFile(doc, "data.json", "{}");
+  deleteDocFile(doc, "data.json");
+  deleteDocFile(doc, "requirements/prd.md");
+  assert.equal(readDocFile(doc, "data.json"), undefined);
+  assert.equal(doc.getXmlFragment("requirements/prd.md").length, 0);
+});

--- a/packages/collab-doc/tsconfig.json
+++ b/packages/collab-doc/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1641,6 +1641,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        collab:
+          description: 'Room-scoped turn (#86 phase 4): the agent joins the project''s spec collab room as a live peer, reads and edits the shared doc, and commits nothing to git.'
+          type: boolean
         instruction:
           description: User message / generation directive
           type: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,31 @@ importers:
         specifier: ^4.21.0
         version: 4.22.4
 
+  packages/collab-doc:
+    dependencies:
+      '@tiptap/core':
+        specifier: ^3.27.2
+        version: 3.27.2(@tiptap/pm@3.27.2)
+      '@tiptap/markdown':
+        specifier: ^3.27.2
+        version: 3.27.2(@tiptap/core@3.27.2(@tiptap/pm@3.27.2))(@tiptap/pm@3.27.2)
+      '@tiptap/starter-kit':
+        specifier: ^3.27.2
+        version: 3.27.2
+      fast-diff:
+        specifier: ^1.3.0
+        version: 1.3.0
+      y-prosemirror:
+        specifier: ^1.3.7
+        version: 1.3.7(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-view@1.42.0)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
+
   packages/contracts: {}
 
   packages/design-projection:
@@ -189,9 +214,15 @@ importers:
       '@aep/agent-stream':
         specifier: workspace:*
         version: link:../../packages/agent-stream
+      '@aep/collab-doc':
+        specifier: workspace:*
+        version: link:../../packages/collab-doc
       '@ai-sdk/anthropic':
         specifier: ^4.0.0
         version: 4.0.0(zod@4.4.3)
+      '@hocuspocus/provider':
+        specifier: ^4.3.0
+        version: 4.3.0(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       ai:
         specifier: ^7.0.2
         version: 7.0.2(zod@4.4.3)
@@ -204,9 +235,15 @@ importers:
       pg:
         specifier: ^8.13.0
         version: 8.22.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
       yaml:
         specifier: ^2.8.4
         version: 2.9.0
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -220,6 +257,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.6.0
         version: 1.6.0
+      '@hocuspocus/server':
+        specifier: ^4.3.0
+        version: 4.3.0(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -229,27 +269,21 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
+      '@types/ws':
+        specifier: ^8.18.0
+        version: 8.18.1
       tsx:
         specifier: ^4.21.0
         version: 4.22.4
 
   services/collab:
     dependencies:
+      '@aep/collab-doc':
+        specifier: workspace:*
+        version: link:../../packages/collab-doc
       '@hocuspocus/server':
         specifier: ^4.3.0
         version: 4.3.0(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
-      '@tiptap/core':
-        specifier: ^3.27.2
-        version: 3.27.2(@tiptap/pm@3.27.2)
-      '@tiptap/markdown':
-        specifier: ^3.27.2
-        version: 3.27.2(@tiptap/core@3.27.2(@tiptap/pm@3.27.2))(@tiptap/pm@3.27.2)
-      '@tiptap/starter-kit':
-        specifier: ^3.27.2
-        version: 3.27.2
-      y-prosemirror:
-        specifier: ^1.3.7
-        version: 1.3.7(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-view@1.42.0)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       yjs:
         specifier: ^13.6.31
         version: 13.6.31
@@ -2096,6 +2130,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
@@ -5149,6 +5186,8 @@ snapshots:
       - supports-color
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-equals@5.4.0: {}
 

--- a/services/aep-api/internal/clients/agentsvc/client.go
+++ b/services/aep-api/internal/clients/agentsvc/client.go
@@ -86,6 +86,20 @@ type TurnRequest struct {
 	// without it). The wire shape is pinned by @aep/agent-stream's McpConfig
 	// (packages/agent-stream/src/contracts/sse-events.ts): `mcp: {url, token}`.
 	MCP *MCPBlock `json:"mcp,omitempty"`
+	// Collab, when set, makes this a room-scoped turn (#86 phase 4): the agents
+	// service joins the collab room as a live Yjs peer, reads its file bundle
+	// FROM the doc, and applies ops to the doc — nothing is committed to git.
+	// Wire shape pinned by @aep/agent-stream's CollabConfig.
+	Collab *CollabBlock `json:"collab,omitempty"`
+}
+
+// CollabBlock names the room and carries the prompting user's bearer,
+// forwarded request-scoped (#86 decision 7) — the collab server's oracle
+// validates it exactly like a browser join. JSON field names match
+// @aep/agent-stream's CollabConfig exactly.
+type CollabBlock struct {
+	RoomID string `json:"roomId"`
+	Token  string `json:"token"`
 }
 
 // MCPBlock is the caller-supplied MCP discovery config for a turn. URL is the

--- a/services/aep-api/internal/feature/genai/genai_component_test.go
+++ b/services/aep-api/internal/feature/genai/genai_component_test.go
@@ -770,6 +770,61 @@ func (r *genaiRig) waitTerminalOf(t *testing.T, turnID string) genai.TurnStatus 
 	return r.waitTerminal(t, turnID)
 }
 
+// TestCollabTurn_RoomScopedDispatchNoCommit pins #86 phase 4's BFF half: a
+// `collab: true` turn dispatches the agents service with the room + the
+// caller's bearer, relays the stream, and lands NOTHING on git — the doc is
+// the write surface (no fold, no manifest gate, no commit).
+func TestCollabTurn_RoomScopedDispatchNoCommit(t *testing.T) {
+	r := newGenaiRig(t, map[string]string{"specs/requirements/requirements.md": "# Reqs\n"})
+	base := r.fx.Origin.HeadSHA(t)
+	// Room-scheme (unprefixed) paths: in committed mode this would fail the
+	// fold; room mode never folds — pinning that the fold is bypassed.
+	r.fake.parts = []string{
+		textPart("editing the shared doc"),
+		editFilePart("requirements/requirements.md", "# Reqs\n", "# Requirements\n"),
+	}
+	m := manifestPart(map[string]string{"requirements/requirements.md": "# Requirements\n"}, nil)
+	r.fake.manifest = &m
+
+	body, _ := json.Marshal(map[string]any{
+		"useCase":     "requirements-chat",
+		"instruction": "edit the doc live",
+		"collab":      true,
+	})
+	rec := r.h.AsOrg(testOrg).Post(turnsPath(convUUID), string(body))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("POST collab turn: code %d (%s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || out.TurnID == "" {
+		t.Fatalf("202 body = %s (err %v)", rec.Body.String(), err)
+	}
+
+	st := r.waitTerminal(t, out.TurnID)
+	if st.Status != "completed" || !st.NoChanges {
+		t.Fatalf("terminal = %+v, want completed no-changes", st)
+	}
+	if st.CommitSHA != base {
+		t.Errorf("collab turn commitSha = %s, want base pin %s", st.CommitSHA, base)
+	}
+	if r.fx.Origin.HeadSHA(t) != base {
+		t.Error("collab turn must not commit — git is not the write surface")
+	}
+
+	sent := r.fake.sentTurn(t, 0)
+	if sent.req.Collab == nil {
+		t.Fatal("dispatch carried no collab block")
+	}
+	if want := "spec-" + testOrg + "-" + testProj; sent.req.Collab.RoomID != want {
+		t.Errorf("collab roomId = %q, want %q", sent.req.Collab.RoomID, want)
+	}
+	if sent.req.Collab.Token != componenttest.TestBearer {
+		t.Errorf("collab token = %q, want the caller's bearer", sent.req.Collab.Token)
+	}
+}
+
 // TestD15_ConcurrentBaseMovement pins disjoint→rebase, overlap→fail: an
 // unrelated commit landing mid-turn does not kill the generation; a commit
 // touching a folded path fails the turn with the conflicting path listed.

--- a/services/aep-api/internal/feature/genai/genai_huma.go
+++ b/services/aep-api/internal/feature/genai/genai_huma.go
@@ -65,6 +65,7 @@ type turnInput struct {
 		UseCase     string `json:"useCase" enum:"requirements-generate,requirements-chat,design-generate" doc:"Which generation/chat flow"`
 		Instruction string `json:"instruction" doc:"User message / generation directive"`
 		Target      string `json:"target,omitempty" doc:"Optional target (e.g. a doc type)"`
+		Collab      bool   `json:"collab,omitempty" doc:"Room-scoped turn (#86 phase 4): the agent joins the project's spec collab room as a live peer, reads and edits the shared doc, and commits nothing to git."`
 	}
 }
 
@@ -133,6 +134,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 			ConversationID: in.ConversationID,
 			Instruction:    in.Body.Instruction,
 			Target:         in.Body.Target,
+			Collab:         in.Body.Collab,
 		})
 		if err != nil {
 			return nil, mapTurnError(err)
@@ -303,6 +305,8 @@ func mapTurnError(err error) error {
 		return huma.Error400BadRequest("invalid conversation id")
 	case errors.Is(err, ErrEmptyInstruction):
 		return huma.Error400BadRequest(ErrEmptyInstruction.Error())
+	case errors.Is(err, ErrCollabNoToken):
+		return huma.Error400BadRequest(ErrCollabNoToken.Error())
 	case errors.Is(err, ErrNoAnthropicKey):
 		return huma.Error400BadRequest(ErrNoAnthropicKey.Error())
 	case errors.Is(err, ErrRequirementsNotApproved):

--- a/services/aep-api/internal/feature/genai/genai_service.go
+++ b/services/aep-api/internal/feature/genai/genai_service.go
@@ -62,6 +62,9 @@ var (
 	ErrInvalidUseCase          = errors.New("invalid use case")
 	ErrInvalidConversationID   = errors.New("invalid conversation id")
 	ErrEmptyInstruction        = errors.New("instruction must not be empty")
+	// ErrCollabNoToken rejects a room-scoped turn whose request carried no
+	// bearer — the agent joins the room with the caller's token (#86 d7).
+	ErrCollabNoToken = errors.New("collab turn requires a bearer token")
 	ErrNoAnthropicKey          = errors.New("organization has no Anthropic API key configured")
 	ErrRequirementsNotApproved = errors.New("design generation requires an approved (tagged) requirements version")
 	ErrConversationNotFound    = errors.New("conversation not found")
@@ -129,6 +132,10 @@ type TurnInput struct {
 	ConversationID string
 	Instruction    string
 	Target         string
+	// Collab makes this a room-scoped turn (#86 phase 4): the agents service
+	// joins the project's spec room as a live Yjs peer with the prompting
+	// user's bearer, edits the shared doc, and nothing is committed to git.
+	Collab bool
 }
 
 // TurnStatus is the read view of one turn (the status GET body).
@@ -284,6 +291,19 @@ func (s *service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	// = the org credential's save identity (the AEP bot fallback).
 	author, committer := s.captureIdentities(ctx, ref)
 
+	// Room-scoped turn (#86 phase 4): capture the room + the prompting user's
+	// bearer NOW (D20 — the runner has no request context). Access is
+	// request-scoped: the collab server's oracle validates this token exactly
+	// like a browser join; no token → the turn cannot join, fail pre-202.
+	collabRoomID, collabToken := "", ""
+	if in.Collab {
+		collabToken = auth.GetAuthToken(ctx)
+		if collabToken == "" {
+			return "", ErrCollabNoToken
+		}
+		collabRoomID = "spec-" + orgID + "-" + projectID
+	}
+
 	ws := s.git.Workspace()
 	baseRef, err := ws.Head(ctx, ref, "")
 	if err != nil {
@@ -339,6 +359,8 @@ func (s *service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 		anthropicKey:     key,
 		author:           author,
 		committer:        committer,
+		collabRoomID:     collabRoomID,
+		collabToken:      collabToken,
 	}
 	// Detached: the turn runs to completion (or a terminal failure) server-
 	// side regardless of the client connection (D16). runTurnSafe is the panic

--- a/services/aep-api/internal/feature/genai/turn_runner.go
+++ b/services/aep-api/internal/feature/genai/turn_runner.go
@@ -75,6 +75,12 @@ type turnJob struct {
 	anthropicKey     string
 	author           *gitrepo.GitIdentity
 	committer        *gitrepo.GitIdentity
+	// Room-scoped turn (#86 phase 4): non-empty collabRoomID makes the agents
+	// service a live peer of this room (joining with collabToken, the
+	// prompting user's bearer). The doc is the write surface — the runner
+	// relays frames but folds nothing and commits nothing.
+	collabRoomID string
+	collabToken  string
 }
 
 // baseMovedError is the D15 overlap conflict: main moved past the turn's base
@@ -168,6 +174,10 @@ func (s *service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		}
 	}
 
+	var collab *agentsvc.CollabBlock
+	if job.collabRoomID != "" {
+		collab = &agentsvc.CollabBlock{RoomID: job.collabRoomID, Token: job.collabToken}
+	}
 	body, err := s.client.Turn(ctx, job.nsConversationID, job.orgID, job.anthropicKey, agentsvc.TurnRequest{
 		Instruction: instruction,
 		Workspace: agentsvc.WorkspaceRef{
@@ -179,6 +189,7 @@ func (s *service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		},
 		FilesChangedExternally: filesChangedExternally,
 		MCP:                    s.mcpForTurn(ctx, job),
+		Collab:                 collab,
 	})
 	if err != nil {
 		slog.WarnContext(ctx, "genai: turn dispatch failed", "turn", job.turnID, "error", err)
@@ -233,6 +244,12 @@ func (s *service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		}
 	}()
 
+	// Room-scoped turn (#86 phase 4): the doc is the write surface — the fold
+	// would run against the SNAPSHOT while the agents-side bundle started from
+	// the DOC, so parity is undefined by construction. Relay frames only;
+	// nothing folds, nothing commits, no manifest gate.
+	roomMode := job.collabRoomID != ""
+
 	fold := agentfold.New(s.turnBaseReader(job.repoRef, job.baseRef))
 	var manifest *agentfold.Manifest
 	var foldErr error
@@ -246,12 +263,37 @@ func (s *service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 			return nil // backend integrity plumbing — never forwarded (D14)
 		}
 		s.broker.Append(job.turnID, raw)
+		if roomMode {
+			return nil // doc-applied on the agents side — nothing to fold
+		}
 		if _, err := fold.ApplyToolCall(ctx, part); err != nil {
 			foldErr = err
 			return err
 		}
 		return nil
 	})
+
+	if roomMode {
+		switch {
+		case readErr != nil:
+			msg := "agents stream read failed: " + readErr.Error()
+			if idleAborted.Load() {
+				msg = "agents stream idle past deadline"
+			}
+			return failedTerminal(turnReasonStreamDied, msg, nil)
+		case manifest == nil:
+			// Same severed/errored semantics as the committed path — the agents
+			// service vouched for nothing.
+			msg := "stream ended without a manifest"
+			if end == agentfold.StreamEOF {
+				msg = "stream severed before the manifest"
+			}
+			return failedTerminal(turnReasonStreamDied, msg, nil)
+		}
+		// Edits live in the room's doc; git is untouched (persistence is the
+		// #86 phase-3 committer). The base sha stays the "content as of" pin.
+		return TurnTerminal{Status: turnStatusCompleted, CommitSHA: job.baseRef, NoChanges: true}
+	}
 
 	switch {
 	case foldErr != nil:

--- a/services/aep-api/internal/platform/componenttest/auth.go
+++ b/services/aep-api/internal/platform/componenttest/auth.go
@@ -29,6 +29,11 @@ import (
 // request, so table tests with t.Parallel() don't race.
 const hdrClaims = "X-Componenttest-Claims"
 
+// TestBearer is the stand-in bearer fakeInboundAuth stores alongside the
+// claims (production: ExtractAuthToken). Tests asserting a forwarded caller
+// token compare against this.
+const TestBearer = "componenttest-bearer"
+
 // fakeInboundAuth is the component tier's stand-in for the production
 // JWKS-backed auth.Middleware (bff-component-testing.md §3). It does NOT verify a
 // token — it projects the harness-supplied claims into the request context at
@@ -41,7 +46,12 @@ func fakeInboundAuth(next http.Handler) http.Handler {
 		if raw := r.Header.Get(hdrClaims); raw != "" {
 			var c auth.Claims
 			if err := json.Unmarshal([]byte(raw), &c); err == nil {
-				r = r.WithContext(auth.WithClaims(r.Context(), &c))
+				ctx := auth.WithClaims(r.Context(), &c)
+				// Production's ExtractAuthToken stores the request bearer next
+				// to the verified claims; mirror it with a fixed stand-in so
+				// features that forward the caller's token (collab turns,
+				// OC user-JWT path) see one. TestBearer is the assertable value.
+				r = r.WithContext(auth.WithAuthToken(ctx, TestBearer))
 			}
 			r.Header.Del(hdrClaims)
 		}

--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -19,6 +19,11 @@ AGENT_MAX_OUTPUT_TOKENS=64000
 # an idle-timeout ingress.
 AGENT_KEEPALIVE_MS=15000
 
+# Collab server ws URL for room-scoped turns (#86 phase 4). Unset => turns
+# carrying a `collab` block are rejected pre-stream (503). Compose sets
+# ws://collab-server:3400.
+#AGENT_COLLAB_WS_URL=ws://localhost:3400
+
 # M2M gate (always on): set a JWKS URL (RS256) OR a shared secret (HS256) — the
 # service refuses to boot with neither. AGENT_JWT_SECRET must match the BFF's
 # AGENTS_SVC_JWT_SECRET, and AGENT_JWT_AUDIENCE its AGENTS_SVC_JWT_AUDIENCE.

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -39,10 +39,11 @@ COPY services/agents ./services/agents
 RUN pnpm install --frozen-lockfile --filter @aep/agents...
 
 # @aep/agents runs from TypeScript source via tsx (no build of its own), but it
-# imports @aep/agent-stream as a package whose `exports` resolve to ./dist — so
-# that package MUST be compiled before the service can start. Without this step
-# the container crashes at boot with "Cannot find module .../@aep/agent-stream/dist".
-RUN pnpm --filter @aep/agent-stream build
+# imports @aep/agent-stream and @aep/collab-doc as packages whose `exports`
+# resolve to ./dist — both MUST be compiled before the service can start.
+# Without this step the container crashes at boot with "Cannot find module
+# .../@aep/agent-stream/dist" (or the collab-doc analog).
+RUN pnpm --filter @aep/agent-stream build && pnpm --filter @aep/collab-doc build
 
 WORKDIR /repo/services/agents
 

--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -21,18 +21,24 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.0",
     "@aep/agent-stream": "workspace:*",
+    "@aep/collab-doc": "workspace:*",
+    "@hocuspocus/provider": "^4.3.0",
     "ai": "^7.0.2",
     "express": "^5.0.0",
     "jose": "^5.9.0",
     "pg": "^8.13.0",
+    "ws": "^8.18.0",
     "yaml": "^2.8.4",
+    "yjs": "^13.6.31",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@clack/prompts": "^1.6.0",
+    "@hocuspocus/server": "^4.3.0",
     "@types/express": "^5.0.0",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.11.0",
+    "@types/ws": "^8.18.0",
     "tsx": "^4.21.0",
     "@aep/excalidraw-dsl": "workspace:*",
     "@aep/design-projection": "workspace:*"

--- a/services/agents/src/collab/doc-bundle.ts
+++ b/services/agents/src/collab/doc-bundle.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FileBundle, type OpResult } from "@aep/agent-stream";
+import type { RoomPeer } from "./room-peer.js";
+
+/**
+ * A FileBundle that mirrors every APPLIED mutation onto the live collab doc
+ * (#86 phase 4). The bundle stays the LLM's plain-text working state (all
+ * validation — anchored edits, YAML gates, write-guards — runs in the
+ * superclass); only ops that actually changed content reach the doc, where
+ * @aep/collab-doc applies them safely (Y.Text diff-and-patch / md fragment
+ * reparse) as one agent-origin transaction per op — live typing for every
+ * peer in the room.
+ */
+export class DocFileBundle extends FileBundle {
+  constructor(
+    private readonly peer: RoomPeer,
+    initial: Record<string, string>,
+  ) {
+    super(initial);
+  }
+
+  override addFile(path: string, content: string): OpResult {
+    return this.mirror(super.addFile(path, content), path);
+  }
+
+  override editFile(path: string, oldString: string, newString: string): OpResult {
+    return this.mirror(super.editFile(path, oldString, newString), path);
+  }
+
+  override removeFile(path: string): OpResult {
+    const res = super.removeFile(path);
+    if (res.ok && res.status === "applied") this.peer.delete(path);
+    return res;
+  }
+
+  override setFrontmatterField(
+    path: string,
+    key: string,
+    value: string | number | boolean | string[],
+  ): OpResult {
+    return this.mirror(super.setFrontmatterField(path, key, value), path);
+  }
+
+  private mirror(res: OpResult, path: string): OpResult {
+    if (res.ok && res.status === "applied") {
+      const content = this.read(path);
+      if (content !== undefined) this.peer.set(path, content);
+    }
+    return res;
+  }
+}

--- a/services/agents/src/collab/room-peer.test.ts
+++ b/services/agents/src/collab/room-peer.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { Server } from "@hocuspocus/server";
+import type { Document } from "@hocuspocus/server";
+import { readDocFile, setDocFile } from "@aep/collab-doc";
+import { joinRoom, type RoomPeer } from "./room-peer.js";
+import { DocFileBundle } from "./doc-bundle.js";
+
+// A real Hocuspocus server (no auth hooks — auth is the collab service's
+// oracle, not this client's concern) with a seeded room, so the peer path is
+// exercised over an actual websocket: join, sync, read, mirror ops, leave.
+
+let server: Server;
+let url: string;
+const serverDocs = new Map<string, Document>();
+
+// Hocuspocus treats port 0 as unset (defaults to 80); pick a random high port.
+const PORT = 20000 + Math.floor(Math.random() * 20000);
+
+before(async () => {
+  server = new Server({
+    onLoadDocument: ({ document, documentName }) => {
+      serverDocs.set(documentName, document);
+      setDocFile(document, "requirements/prd.md", "# PRD\n\nSeeded body.");
+      setDocFile(document, "design/arch.excalidraw", '{"v":1}');
+      return Promise.resolve(document);
+    },
+  });
+  await server.listen(PORT);
+  url = `ws://127.0.0.1:${PORT}`;
+});
+
+after(async () => {
+  await server.destroy();
+});
+
+test("joins, snapshots the doc, mirrors bundle ops live, leaves", async () => {
+  const peer: RoomPeer = await joinRoom({
+    url,
+    roomId: "spec-acme-shop",
+    token: "any",
+  });
+  try {
+    const files = peer.files();
+    assert.match(files["requirements/prd.md"] ?? "", /# PRD/);
+    assert.equal(files["design/arch.excalidraw"], '{"v":1}');
+
+    const bundle = new DocFileBundle(peer, files);
+
+    // edit an md file → fragment reparse lands on the server doc
+    const edit = bundle.editFile("requirements/prd.md", "Seeded body.", "Agent-edited body.");
+    assert.equal(edit.ok, true);
+
+    // add a new text file → files-map entry lands on the server doc
+    const add = bundle.addFile("validation/plan.txt", "check things\n");
+    assert.equal(add.ok, true);
+
+    // let updates flush over the socket
+    await new Promise((r) => setTimeout(r, 300));
+
+    const serverDoc = serverDocs.get("spec-acme-shop");
+    assert.ok(serverDoc, "server holds the room doc");
+    assert.match(
+      readDocFile(serverDoc, "requirements/prd.md") ?? "",
+      /Agent-edited body\./,
+    );
+    assert.equal(readDocFile(serverDoc, "validation/plan.txt"), "check things\n");
+  } finally {
+    peer.leave();
+  }
+});
+
+test("a failed-op does not touch the doc", async () => {
+  const peer = await joinRoom({ url, roomId: "spec-acme-shop2", token: "any" });
+  try {
+    const bundle = new DocFileBundle(peer, peer.files());
+    const res = bundle.editFile("requirements/prd.md", "not-present-text", "x");
+    assert.equal(res.ok, false);
+    await new Promise((r) => setTimeout(r, 200));
+    const serverDoc = serverDocs.get("spec-acme-shop2");
+    assert.match(readDocFile(serverDoc!, "requirements/prd.md") ?? "", /Seeded body\./);
+  } finally {
+    peer.leave();
+  }
+});

--- a/services/agents/src/collab/room-peer.ts
+++ b/services/agents/src/collab/room-peer.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The agents service's side of #86 phase 4: join a spec room as a live Yjs
+// peer for the duration of one turn. The LLM only ever sees plain text — this
+// module owns the doc: snapshot for the turn's file bundle, per-op writes via
+// @aep/collab-doc (Y.Text diff-and-patch, md fragment reparse), presence as
+// an agent (`kind: "agent"` — the console renders square avatars, #86 d7).
+//
+// Access is REQUEST-SCOPED (#86 d7): the caller's bearer rides the turn
+// payload and the collab server's BFF oracle validates it exactly like a
+// browser join. The ws URL comes from service config (AGENT_COLLAB_WS_URL);
+// the caller names only the room.
+
+import {
+  HocuspocusProvider,
+  HocuspocusProviderWebsocket,
+} from "@hocuspocus/provider";
+import WebSocket from "ws";
+import type * as Y from "yjs";
+import {
+  deleteDocFile,
+  setDocFile,
+  snapshotDoc,
+} from "@aep/collab-doc";
+
+/** Transaction origin for every doc write this peer makes. */
+export const AGENT_ORIGIN = "aep-agent";
+
+const SYNC_TIMEOUT_MS = 10_000;
+
+export interface RoomPeer {
+  /** The synced doc's files (path → content) — the turn's initial bundle. */
+  files(): Record<string, string>;
+  /** Write one file into the live doc (agent-origin transaction). */
+  set(path: string, content: string): void;
+  /** Remove one file from the live doc. */
+  delete(path: string): void;
+  /** Detach presence and close the connection. Safe to call twice. */
+  leave(): void;
+}
+
+export interface JoinRoomInput {
+  /** Collab server ws URL (service config, e.g. ws://collab-server:3400). */
+  url: string;
+  /** Room id (`spec-<org>-<project>`), resolved by the BFF. */
+  roomId: string;
+  /** The caller's bearer, validated by the collab server's oracle. */
+  token: string;
+  /** Presence label (defaults to "Spec Agent"). */
+  agentName?: string;
+}
+
+/**
+ * Join a room and resolve once the doc has synced (or reject on auth
+ * failure / timeout — a room-scoped turn must not run against an empty
+ * unsynced replica).
+ */
+export async function joinRoom(input: JoinRoomInput): Promise<RoomPeer> {
+  // Explicit websocket sub-provider so the Node `ws` implementation is pinned
+  // (the polyfill knob lives on the websocket configuration, not the provider).
+  const socket = new HocuspocusProviderWebsocket({
+    url: input.url,
+    WebSocketPolyfill: WebSocket,
+  });
+  const provider = new HocuspocusProvider({
+    websocketProvider: socket,
+    name: input.roomId,
+    token: input.token,
+  });
+
+  provider.setAwarenessField("user", {
+    name: input.agentName ?? "Spec Agent",
+    color: "#b57edc",
+    kind: "agent",
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`collab: room ${input.roomId} did not sync within ${SYNC_TIMEOUT_MS}ms`));
+      }, SYNC_TIMEOUT_MS);
+      provider.on("synced", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      provider.on("authenticationFailed", () => {
+        clearTimeout(timer);
+        reject(new Error(`collab: room ${input.roomId} rejected the forwarded bearer`));
+      });
+      provider.attach();
+    });
+  } catch (err) {
+    provider.destroy();
+    socket.destroy();
+    throw err;
+  }
+
+  const doc: Y.Doc = provider.document;
+  let left = false;
+  return {
+    files: () => snapshotDoc(doc),
+    set: (path, content) => setDocFile(doc, path, content, AGENT_ORIGIN),
+    delete: (path) => deleteDocFile(doc, path, AGENT_ORIGIN),
+    leave: () => {
+      if (left) return;
+      left = true;
+      provider.destroy();
+      socket.destroy(); // we created the sub-provider, we close it
+    },
+  };
+}

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -31,6 +31,8 @@
 
 import { isStepCount, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { FileBundle, type McpConfig, type StreamPart, type Toolset } from "@aep/agent-stream";
+import { DocFileBundle } from "../collab/doc-bundle.js";
+import type { RoomPeer } from "../collab/room-peer.js";
 import { runTurn } from "../agents/main/run-turn.js";
 import { buildFileTools, ASK_QUESTION } from "../agents/main/tools/files.js";
 import { buildTaskPlanTools } from "../agents/main/tools/task-plan.js";
@@ -119,6 +121,14 @@ export interface RunConversationTurnInput {
    * merge (byte-identical to today).
    */
   mcp?: McpConfig;
+  /**
+   * Live collab-room peer for a room-scoped turn (#86 phase 4). Present (and
+   * toolset `files`) → the bundle mirrors every applied op onto the room's
+   * Y.Doc as it happens; `input.files` is the doc snapshot the SERVER read
+   * from the synced replica. The server owns the peer's lifecycle (join
+   * before, leave after); this function only writes through it.
+   */
+  collabPeer?: RoomPeer;
   /** Injected at the composition root (createModel is called ONCE there, not per turn). */
   model: LanguageModel;
   store: ConversationStore;
@@ -152,7 +162,9 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       tools = buildTaskPlanTools(new TaskPlan(input.files), skills);
       instructions = buildTaskPlanInstructions(skills);
     } else {
-      bundle = new FileBundle(input.files);
+      bundle = input.collabPeer
+        ? new DocFileBundle(input.collabPeer, input.files)
+        : new FileBundle(input.files);
       tools = buildFileTools(bundle, skills);
       instructions = buildInstructions(skills);
     }

--- a/services/agents/src/server.ts
+++ b/services/agents/src/server.ts
@@ -46,9 +46,19 @@
 import express from "express";
 import type { Express, Request, Response, NextFunction } from "express";
 import type { LanguageModel } from "ai";
-import { SSE_DONE, TOOLSETS, isToolset, type McpConfig, type StreamPart, type Toolset } from "@aep/agent-stream";
+import {
+  SSE_DONE,
+  TOOLSETS,
+  isToolset,
+  isCollabConfig,
+  type CollabConfig,
+  type McpConfig,
+  type StreamPart,
+  type Toolset,
+} from "@aep/agent-stream";
 import type { ConversationStore } from "./store/conversation-store.js";
 import { runConversationTurn, TurnGuard, ConcurrentTurnError } from "./conversation/run-conversation-turn.js";
+import { joinRoom, type RoomPeer } from "./collab/room-peer.js";
 import type { SkillSource } from "./agents/main/skill-source.js";
 import { readSnapshot, loadSkillsFromSnapshot } from "./conversation/load-workspace.js";
 import { resolveWorkspace, WorkspaceRefError } from "./shared/snapshot-path.js";
@@ -123,6 +133,7 @@ export function createApp(deps: CreateAppDeps): Express {
       skills?: unknown;
       toolset?: unknown;
       mcp?: unknown;
+      collab?: unknown;
     };
 
     // Pre-stream validation → HTTP status (no SSE headers sent yet).
@@ -193,6 +204,28 @@ export function createApp(deps: CreateAppDeps): Express {
       mcp = body.mcp;
     }
 
+    // collab (optional, #86 phase 4): a room-scoped turn. The room replaces
+    // the snapshot as the FILE source (skills + the org fence still come from
+    // the workspace); ops apply live to the doc; nothing commits. Reject a
+    // malformed block, an unsupported toolset combination, or a deployment
+    // with no collab server, pre-stream.
+    let collab: CollabConfig | undefined;
+    if (body.collab !== undefined) {
+      if (!isCollabConfig(body.collab)) {
+        res.status(400).json({ error: "collab must be { roomId: string, token: string }" });
+        return;
+      }
+      if (toolset !== undefined && toolset !== "files") {
+        res.status(400).json({ error: "collab turns support only the files toolset" });
+        return;
+      }
+      if (!config.collabWsUrl) {
+        res.status(503).json({ error: "collab is not configured on this deployment (AGENT_COLLAB_WS_URL)" });
+        return;
+      }
+      collab = body.collab;
+    }
+
     // Build the per-turn model from the request key (fail as a pre-stream 500).
     let model: LanguageModel;
     try {
@@ -234,6 +267,26 @@ export function createApp(deps: CreateAppDeps): Express {
       res.write(`data: ${JSON.stringify(part)}\n\n`);
     };
 
+    // Room-scoped turn (#86 phase 4): join as a live peer BEFORE streaming —
+    // an oracle denial or sync timeout is a clean pre-stream status. The
+    // synced doc replaces the snapshot as the turn's file source.
+    let roomPeer: RoomPeer | undefined;
+    if (collab) {
+      try {
+        roomPeer = await joinRoom({
+          url: config.collabWsUrl!,
+          roomId: collab.roomId,
+          token: collab.token,
+        });
+        files = roomPeer.files();
+      } catch (err) {
+        res.status(502).json({
+          error: err instanceof Error ? err.message : "collab room join failed",
+        });
+        return;
+      }
+    }
+
     try {
       await runConversationTurn({
         id,
@@ -243,6 +296,7 @@ export function createApp(deps: CreateAppDeps): Express {
         skillSource,
         ...(toolset ? { toolset } : {}),
         ...(mcp ? { mcp } : {}),
+        ...(roomPeer ? { collabPeer: roomPeer } : {}),
         model,
         store: deps.store,
         guard,
@@ -271,6 +325,10 @@ export function createApp(deps: CreateAppDeps): Express {
         res.write(`data: ${SSE_DONE}\n\n`);
         res.end();
       }
+    } finally {
+      // The agent peer never lingers in the room past its turn (presence
+      // honesty); runs on every exit path, including client-gone returns.
+      roomPeer?.leave();
     }
   });
 

--- a/services/agents/src/shared/config.ts
+++ b/services/agents/src/shared/config.ts
@@ -61,6 +61,11 @@ export const config = {
   // mount the volume :ro; nothing in this service ever writes it.
   workspaceMountRoot: process.env.WORKSPACE_MOUNT_ROOT || "/workspaces",
 
+  // Collab server ws URL for room-scoped turns (#86 phase 4). Unset → any
+  // turn carrying a `collab` block is rejected pre-stream (the deployment
+  // doesn't do live rooms). Compose: ws://collab-server:3400.
+  collabWsUrl: process.env.AGENT_COLLAB_WS_URL || undefined,
+
   // M2M gate (§12.3.2): a Bearer JWT with this audience, verified against a JWKS
   // (RS256) OR a shared secret (HS256) — whichever is configured. The gate is
   // ALWAYS ON; the composition root refuses to start if neither is set. No org

--- a/services/collab/Dockerfile
+++ b/services/collab/Dockerfile
@@ -16,9 +16,9 @@
 
 # Collab service (services/collab) — Yjs/Hocuspocus rooms with BFF-oracle auth
 # and Files-API seeding (#86 / #114). Built from the REPO ROOT context
-# (docker-compose sets `context: ..`) so pnpm resolves the workspace lockfile;
-# @aep/collab has no workspace-package dependencies, so only its own tree is
-# copied. Runs from TypeScript source via tsx, like @aep/agents.
+# (docker-compose sets `context: ..`) because @aep/collab depends on the
+# workspace package @aep/collab-doc (the shared doc model, #86 phase 4).
+# Runs from TypeScript source via tsx, like @aep/agents.
 FROM node:22-bookworm-slim
 
 RUN corepack enable
@@ -26,9 +26,13 @@ WORKDIR /repo
 
 # Workspace manifests first for install-layer caching.
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
+COPY packages ./packages
 COPY services/collab ./services/collab
 
 RUN pnpm install --frozen-lockfile --filter @aep/collab...
+
+# @aep/collab-doc resolves through its dist exports — build it before boot.
+RUN pnpm --filter @aep/collab-doc build
 
 WORKDIR /repo/services/collab
 

--- a/services/collab/package.json
+++ b/services/collab/package.json
@@ -13,11 +13,8 @@
     "start": "tsx src/main.ts"
   },
   "dependencies": {
+    "@aep/collab-doc": "workspace:*",
     "@hocuspocus/server": "^4.3.0",
-    "@tiptap/core": "^3.27.2",
-    "@tiptap/markdown": "^3.27.2",
-    "@tiptap/starter-kit": "^3.27.2",
-    "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.31"
   },
   "devDependencies": {

--- a/services/collab/src/seed.test.ts
+++ b/services/collab/src/seed.test.ts
@@ -20,7 +20,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as Y from "yjs";
 import { seedDocument, filesMap } from "./seed.js";
-import { fragmentToMarkdown } from "./markdown.js";
+import { fragmentToMarkdown } from "@aep/collab-doc";
 
 const bundle = [
   { path: "requirements/prd.md", content: "# PRD\n" },

--- a/services/collab/src/seed.ts
+++ b/services/collab/src/seed.ts
@@ -17,22 +17,18 @@
  */
 
 import * as Y from "yjs";
+import { filesMap, isMarkdownPath, markdownToFragment } from "@aep/collab-doc";
 import type { SpecFile } from "./bff.js";
-import { isMarkdownPath, markdownToFragment } from "./markdown.js";
 
-// Doc model (#86 decision 2 + phase 6): one Y.Doc per project. Markdown
-// files are Y.XmlFragments keyed by path (Tiptap's collaboration binding
-// needs rich structure); everything else is a Y.Text in Y.Map('files').
+// Doc model (#86 decision 2 + phase 6): one Y.Doc per project — the model
+// itself (Y.Map('files') + md fragments) lives in @aep/collab-doc, shared
+// with the agents service's live-peer path (#86 phase 4).
 //
 // KEY SCHEME INVARIANT (#113 decision 2 / #114): doc keys are the repo path
 // with the `specs/` prefix stripped (requirements/prd.md). The console's spec
-// feature strips identically at its API boundary; any future peer that writes
-// to rooms (agents, #86) must too. The strip lives in bff.ts (toRoomPath).
-export const FILES_MAP = "files";
-
-export function filesMap(doc: Y.Doc): Y.Map<Y.Text> {
-  return doc.getMap<Y.Text>(FILES_MAP);
-}
+// feature strips identically at its API boundary; agent peers (#86 phase 4)
+// inherit it via @aep/collab-doc. The strip lives in bff.ts (toRoomPath).
+export { FILES_MAP, filesMap } from "@aep/collab-doc";
 
 /**
  * Populate an (empty or partial) doc from a spec bundle. Existing entries are


### PR DESCRIPTION
Implements **#86 phase 4** (grilled 2026-07-08; decisions comment on the issue). Ephemeral slice by decision: room turns write the doc and nothing else — persistence remains the phase-3 committer.

## Flow

```
caller ── POST …/conversations/{id}/turns {collab: true} ──▶ aep-api (genai)
   │ captures room id + the CALLER's bearer at POST time (D20)
   │ dispatches agents svc with a CollabBlock; relays SSE; folds/commits NOTHING
   ▼
agents svc ──ws──▶ collab server: joins `spec-<org>-<project>` as a live peer
   presence {kind:"agent"} · bundle read FROM the synced doc ·
   every applied file op mirrored onto the doc (live typing) · leaves at turn end
```

## Pieces

- **`@aep/collab-doc`** (new workspace package): the shared spec-room doc model + safe edit application — `Y.Text` diff-and-patch against apply-time content in one origin-tagged transaction (per the #86 design note; whole-file replacement stays forbidden), md fragments whole-reparse v1 (step-level diffing = noted follow-up). `services/collab`'s markdown module moved here; both services now share one implementation.
- **agents svc**: `src/collab/` — Hocuspocus peer (sync gate, agent presence, forwarded-bearer auth so room access is request-scoped, #86 d7) and `DocFileBundle` (subclasses `FileBundle`: all anchored-edit/YAML validation stays upstream; only *applied* ops reach the doc). `collab` turn field (wire shape pinned in `@aep/agent-stream`, mirroring `mcp`); `AGENT_COLLAB_WS_URL` config (absent → clean 503).
- **aep-api**: `TurnInputBody.collab` (contract, frontend-first); room-mode runner branch — relay-only, no fold (parity is undefined by construction: the agents-side bundle starts from the doc, not the snapshot), no manifest gate on content, no commit; terminal = completed/noChanges pinned to base. `componenttest` fake auth now stores a stand-in bearer beside the claims (mirrors production `ExtractAuthToken`), asserted by the new component test.

## Verified

- Unit/integration: `@aep/collab-doc` 7 tests (patch-vs-concurrent-edit, md round-trip, origin tagging); agents `room-peer.test.ts` over a real Hocuspocus server (mirrored ops land on the server doc; failed ops don't); aep-api `TestCollabTurn_RoomScopedDispatchNoCommit` (dispatch carries room + caller bearer; origin head unmoved). Repo-wide typecheck + all suites green.
- **Live on the deployed stack** (all three images rebuilt): fired a `collab: true` turn via the API as a real Thunder user with the spec room open in a browser — the **agent avatar appeared**, the requested edit landed **keystroke-live in the open Tiptap editor**, the avatar left at turn end, and `git HEAD` does not contain the agent's edit (`completed`/`noChanges`). Screenshot: `86-agent-presence.png`.

## Out of scope (per grilling)

Phase 3 committer (room edits — user *and* agent — remain ephemeral); `agentInsertion` review marks (now unblocked by this PR); console chat UI for triggering room turns (future console-feature issue); ProseMirror step-diffing for md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
