### PR TITLE
fix: skills-repo failure observability + provision-gate execute feedback

### DIFF
--- a/services/aep-api/internal/contracts/taskmeta/labels.go
+++ b/services/aep-api/internal/contracts/taskmeta/labels.go
@@ -57,6 +57,14 @@ const (
 	// stale-vs-design, refused op, no executor).
 	LabelStatusPrefix = "aep:status/"
 	LabelAttention    = "aep:attention"
+
+	// LabelProvisionNoted is a platform-written marker stamped on an aep:provision
+	// gate issue the first (and only) time a stray aep:execute is consumed on it,
+	// so the funnel's one-time "use the design page's dependency panel" comment is
+	// not re-posted on every repeated Execute stamp. It is deliberately NOT in the
+	// Classify vocabulary (it classifies as KindOther) so the status-projection
+	// reconciler never strips it.
+	LabelProvisionNoted = "aep:provision-noted"
 )
 
 // ExecutorClass is the single routing dimension (§3): coding tasks are

--- a/services/aep-api/internal/feature/execution/funnel.go
+++ b/services/aep-api/internal/feature/execution/funnel.go
@@ -72,10 +72,16 @@ func (f *Funnel) OnExecuteIntent(ctx context.Context, repoFullName string, issue
 		return nil
 	}
 	if facts.Class == taskmeta.ClassProvision {
-		// aep:provision gate issues are driven by the drawer action + the
-		// readiness watcher (dependency-management §3.6), never by aep:execute.
-		// Consume a stray execute label so it does not linger; do not admit a row.
+		// aep:provision gate issues are fulfilled from the design page's
+		// dependency panel + the readiness watcher (dependency-management §3.6),
+		// never by aep:execute. Consume the stray execute label (so it does not
+		// linger), tell the user where to go — ONCE — and admit no row. Without
+		// this feedback a user clicking Execute (or "Execute all") on a provision
+		// gate got silence.
 		f.consumeExecute(ctx, orgID, projectID, issueNumber)
+		slog.InfoContext(ctx, "funnel: aep:execute consumed on a provision gate — provision gates are fulfilled from the design page's dependency panel",
+			"org", orgID, "project", projectID, "issue", issueNumber)
+		f.noteProvisionExecute(ctx, facts, view)
 		return nil
 	}
 
@@ -343,6 +349,41 @@ func (f *Funnel) depDeployed(ctx context.Context, view *projectView, key string)
 	return deriveStatus(depTask, execs) == taskmeta.StatusDeployed
 }
 
+// provisionExecuteNotice is the one-time comment posted when a user stamps
+// aep:execute on a provisioning gate — telling them where provisioning is
+// actually driven from (the design page's dependency panel), since the funnel
+// deliberately admits no execution row for a provision gate.
+const provisionExecuteNotice = "ℹ️ **`aep:execute` doesn't apply to a provisioning gate.** " +
+	"Provisioning is fulfilled from the design page's dependency panel (provide the required values / provision the resource there); " +
+	"the platform's readiness watcher then closes this gate automatically. The Execute button has no effect here, so nothing was dispatched."
+
+// noteProvisionExecute posts the one-time provisioning-gate guidance comment and
+// stamps aep:provision-noted so it is never re-posted on a repeated Execute
+// stamp. Best-effort: if the comment fails the marker is NOT stamped, so a later
+// stamp retries the notice rather than silently swallowing it again.
+func (f *Funnel) noteProvisionExecute(ctx context.Context, facts TaskFacts, view *projectView) {
+	if view.provisionNoted[facts.IssueNumber] {
+		return // already informed once — don't spam
+	}
+	if err := f.issues.CommentIssue(ctx, facts.OrgID, facts.ProjectID, facts.IssueNumber, provisionExecuteNotice); err != nil {
+		slog.WarnContext(ctx, "funnel: provision-gate execute notice failed", "issue", facts.IssueNumber, "error", err)
+		return
+	}
+	if err := f.issues.AddLabels(ctx, facts.OrgID, facts.ProjectID, facts.IssueNumber, []string{taskmeta.LabelProvisionNoted}); err != nil {
+		slog.WarnContext(ctx, "funnel: stamp aep:provision-noted failed", "issue", facts.IssueNumber, "error", err)
+	}
+}
+
+// containsLabel reports whether labels contains want.
+func containsLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
 // consumeExecute removes the edge-triggered aep:execute label (best-effort).
 func (f *Funnel) consumeExecute(ctx context.Context, orgID, projectID string, number int) {
 	if err := f.issues.RemoveLabel(ctx, orgID, projectID, number, taskmeta.LabelExecute); err != nil {
@@ -375,6 +416,9 @@ type projectView struct {
 	latestByComponent        map[string]TaskFacts
 	provisionByDep           map[string]TaskFacts
 	provisionDepsByComponent map[string][]string
+	// provisionNoted marks issues already carrying aep:provision-noted — the
+	// one-time-comment guard for a stray aep:execute on a provision gate.
+	provisionNoted map[int]bool
 }
 
 // TaskFactsFor resolves one Task's live facts by repo full name + issue number
@@ -404,6 +448,7 @@ func (f *Funnel) loadProject(ctx context.Context, orgID, projectID, repoFullName
 		byNumber:          map[int]TaskFacts{},
 		latestByComponent: map[string]TaskFacts{},
 		provisionByDep:    map[string]TaskFacts{},
+		provisionNoted:    map[int]bool{},
 	}
 	for _, issue := range issues {
 		facts, _, ok := factsFromIssue(issue, orgID, projectID, repoFullName)
@@ -411,6 +456,9 @@ func (f *Funnel) loadProject(ctx context.Context, orgID, projectID, repoFullName
 			continue
 		}
 		v.byNumber[facts.IssueNumber] = facts
+		if containsLabel(issue.Labels, taskmeta.LabelProvisionNoted) {
+			v.provisionNoted[facts.IssueNumber] = true
+		}
 		key := strings.ToLower(facts.Component)
 		if key == "" {
 			continue

--- a/services/aep-api/internal/feature/execution/funnel_provision_test.go
+++ b/services/aep-api/internal/feature/execution/funnel_provision_test.go
@@ -19,6 +19,7 @@ package execution
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
@@ -206,5 +207,50 @@ func TestFunnel_ExecuteOnProvisionIssue_NoOp(t *testing.T) {
 	// The stray label is consumed.
 	if got := issues.removed[1]; len(got) == 0 || got[0] != taskmeta.LabelExecute {
 		t.Errorf("expected aep:execute consumed on the provision issue, got %v", got)
+	}
+	// A one-time guidance comment is posted, pointing at the design page.
+	if got := issues.comments[1]; len(got) != 1 {
+		t.Fatalf("expected exactly one provision-gate notice comment, got %d: %v", len(got), got)
+	} else if !strings.Contains(got[0], "dependency panel") {
+		t.Errorf("notice comment does not point at the dependency panel: %q", got[0])
+	}
+	// ...and the one-time marker is stamped so a repeat stamp stays quiet.
+	if got := issues.added[1]; len(got) != 1 || got[0] != taskmeta.LabelProvisionNoted {
+		t.Errorf("expected aep:provision-noted stamped, got %v", got)
+	}
+}
+
+// TestFunnel_ExecuteOnProvisionIssue_NoDuplicateNotice pins the one-time
+// guarantee: a provision gate already carrying aep:provision-noted (a prior
+// Execute stamp already explained it) does not get a second comment — the label
+// is still consumed and no row is admitted.
+func TestFunnel_ExecuteOnProvisionIssue_NoDuplicateNotice(t *testing.T) {
+	store := newFakeStore()
+	issues := newFakeIssues([]gitrepo.IssueInfo{
+		provisionIssue(1, "stripe", taskmeta.GateConfigCollection, "open"),
+	})
+	// A repeated stray aep:execute on a gate that was already explained once.
+	issues.list[0].Labels = append(issues.list[0].Labels, taskmeta.LabelExecute, taskmeta.LabelProvisionNoted)
+	exec := &fakeExecutor{store: store, startOK: true}
+	f := newTestFunnelP(store, issues, map[string]bool{}, nil, exec)
+
+	if err := f.OnExecuteIntent(context.Background(), "o/r", 1); err != nil {
+		t.Fatalf("OnExecuteIntent: %v", err)
+	}
+	if len(exec.got) != 0 {
+		t.Fatalf("aep:execute on a provision issue must not dispatch, got %d", len(exec.got))
+	}
+	// No duplicate comment on the already-noted gate.
+	if got := issues.comments[1]; len(got) != 0 {
+		t.Errorf("expected no duplicate notice on an already-noted gate, got %v", got)
+	}
+	// The stray label is still consumed.
+	if got := issues.removed[1]; len(got) == 0 || got[0] != taskmeta.LabelExecute {
+		t.Errorf("expected aep:execute consumed, got %v", got)
+	}
+	// No execution row admitted.
+	rows, _ := store.ListByIssue(context.Background(), "o/r", 1)
+	if len(rows) != 0 {
+		t.Fatalf("no execution row must be admitted, got %d", len(rows))
 	}
 }

--- a/services/aep-api/internal/feature/execution/sweep_test.go
+++ b/services/aep-api/internal/feature/execution/sweep_test.go
@@ -100,15 +100,7 @@ func TestSweep_PRReconcile_SettledTaskNoAPICall(t *testing.T) {
 }
 
 // --- aep:attention clearing authority ----------------------------------------
-
-func containsLabel(labels []string, want string) bool {
-	for _, l := range labels {
-		if l == want {
-			return true
-		}
-	}
-	return false
-}
+// (containsLabel now lives in funnel.go — the sweep tests share it.)
 
 func attnSweep(t *testing.T, store *fakeStore, issues *fakeIssues) *Sweep {
 	t.Helper()

--- a/services/aep-api/internal/feature/genai/genai_component_test.go
+++ b/services/aep-api/internal/feature/genai/genai_component_test.go
@@ -413,13 +413,20 @@ type genaiRig struct {
 type rigOption func(*rigConfig)
 
 type rigConfig struct {
-	client agentsvc.Client // overrides the default real-over-fake-HTTP client
+	client     agentsvc.Client // overrides the default real-over-fake-HTTP client
+	skillsRepo genai.SkillsRepoResolver
 }
 
 // withAgentsClient swaps the agents client (e.g. a panicking fake) — everything
 // else in the rig stays real.
 func withAgentsClient(c agentsvc.Client) rigOption {
 	return func(rc *rigConfig) { rc.client = c }
+}
+
+// withSkillsRepo overrides the skills-repo resolver (e.g. to hand back a row
+// whose backing repo is gone, exercising the skills-unavailable 503 path).
+func withSkillsRepo(fn genai.SkillsRepoResolver) rigOption {
+	return func(rc *rigConfig) { rc.skillsRepo = fn }
 }
 
 // newGenaiRig wires the real genai service over a real engine + origins and
@@ -461,17 +468,21 @@ func newGenaiRig(t *testing.T, seed map[string]string, opts ...rigOption) *genai
 	if cfg.client != nil {
 		client = cfg.client
 	}
+	skillsRepo := genai.SkillsRepoResolver(func(context.Context, string) (*models.GitRepository, error) {
+		return skillsRow, nil
+	})
+	if cfg.skillsRepo != nil {
+		skillsRepo = cfg.skillsRepo
+	}
 	svc := genai.NewService(genai.ServiceDeps{
-		Repos:     stubRepoResolver{rec: rec},
-		Git:       gitrepo.NewGitOpsService(stubResolver{}, fx.Engine),
-		Keys:      func(context.Context, string) (string, error) { return rig.key, nil },
-		Client:    client,
-		Turns:     turns,
-		Broker:    broker,
-		Snapshots: fx.Engine,
-		SkillsRepo: func(context.Context, string) (*models.GitRepository, error) {
-			return skillsRow, nil
-		},
+		Repos:      stubRepoResolver{rec: rec},
+		Git:        gitrepo.NewGitOpsService(stubResolver{}, fx.Engine),
+		Keys:       func(context.Context, string) (string, error) { return rig.key, nil },
+		Client:     client,
+		Turns:      turns,
+		Broker:     broker,
+		Snapshots:  fx.Engine,
+		SkillsRepo: skillsRepo,
 	})
 	rig.h = componenttest.New(t, componenttest.Options{Deps: api.HumaDeps{GenAISvc: svc}})
 	return rig

--- a/services/aep-api/internal/feature/genai/genai_huma.go
+++ b/services/aep-api/internal/feature/genai/genai_huma.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -135,7 +136,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 			Target:         in.Body.Target,
 		})
 		if err != nil {
-			return nil, mapTurnError(err)
+			return nil, mapTurnError(ctx, err)
 		}
 		out := &turnOutput{}
 		out.Body.TurnID = turnID
@@ -152,7 +153,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 	}, func(ctx context.Context, in *turnStatusInput) (*turnStatusOutput, error) {
 		st, err := svc.TurnStatus(ctx, in.OrgHandle, in.ProjectName, in.TurnID)
 		if err != nil {
-			return nil, mapTurnError(err)
+			return nil, mapTurnError(ctx, err)
 		}
 		return &turnStatusOutput{Body: st}, nil
 	})
@@ -167,7 +168,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 	}, func(ctx context.Context, in *activeTurnInput) (*huma.StreamResponse, error) {
 		st, err := svc.ActiveTurn(ctx, in.OrgHandle, in.ProjectName)
 		if err != nil {
-			return nil, mapTurnError(err)
+			return nil, mapTurnError(ctx, err)
 		}
 		// Manual body write: 200 with the status JSON, or a bodyless 204 —
 		// a typed output cannot express the 204-no-body arm.
@@ -203,7 +204,7 @@ func RegisterGenAI(api huma.API, svc GenAIService) {
 		}
 		sub, err := svc.AttachTurn(ctx, in.OrgHandle, in.ProjectName, in.TurnID, from)
 		if err != nil {
-			return nil, mapTurnError(err) // pre-stream 404 / 409
+			return nil, mapTurnError(ctx, err) // pre-stream 404 / 409
 		}
 		return &huma.StreamResponse{Body: humakit.SSEBody(func(w io.Writer, flush func()) {
 			defer sub.Cancel()
@@ -284,7 +285,7 @@ func streamSubscription(ctx context.Context, w io.Writer, flush func(), sub *Tur
 // bodies are the pinned {"code": …} shapes; upstream statuses map per the
 // shared edge policy (dispatch happens post-202 now, so upstream errors here
 // are limited to rehydrate-like paths).
-func mapTurnError(err error) error {
+func mapTurnError(ctx context.Context, err error) error {
 	var inProgress *TurnInProgressError
 	if errors.As(err, &inProgress) {
 		return &turnConflictError{Code: "turn_in_progress", ActiveTurnID: inProgress.ActiveTurnID}
@@ -309,12 +310,23 @@ func mapTurnError(err error) error {
 		return &turnConflictError{Code: "requirements_not_approved"}
 	case errors.Is(err, ErrTurnBufferTruncated):
 		return huma.Error409Conflict(ErrTurnBufferTruncated.Error())
+	case errors.Is(err, ErrSkillsRepoUnavailable):
+		// The org's _skills repo is unusable (row missing/unprovisionable or
+		// backing repo gone — e.g. deleted externally under a lingering row).
+		// A platform-side failure, not a client error: 503 with a clear
+		// message, cause in the logs. Recovery is a manual operator action
+		// today (drop the stale `_skills` row; the next resolve re-provisions).
+		slog.ErrorContext(ctx, "genai turn: org skills repository unavailable", "error", err)
+		return huma.Error503ServiceUnavailable("org skills repository unavailable — contact your platform admin")
 	default:
-		return huma.Error500InternalServerError("internal error")
+		return internalError(ctx, "genai turn", err)
 	}
 }
 
 func mapRehydrateError(err error) error {
+	// The rehydrate handler does not thread its request ctx into the mapper;
+	// the internal-error log carries the cause, which is what matters here.
+	ctx := context.Background()
 	switch {
 	case errors.Is(err, ErrConversationNotFound):
 		return huma.Error404NotFound("conversation not found")
@@ -326,6 +338,15 @@ func mapRehydrateError(err error) error {
 		if mapped, ok := humakit.MapAgentsUpstreamError(err, nil); ok {
 			return mapped
 		}
-		return huma.Error500InternalServerError("internal error")
+		return internalError(ctx, "genai rehydrate", err)
 	}
+}
+
+// internalError is the single opaque-500 exit for the genai edge: it logs the
+// underlying cause (nothing else in the default branch does — the client sees
+// only "internal error") and returns the pinned 500. Every default-500 path
+// routes through here so a swallowed cause can never reach production again.
+func internalError(ctx context.Context, scope string, err error) error {
+	slog.ErrorContext(ctx, "genai: unmapped internal error", "scope", scope, "error", err)
+	return huma.Error500InternalServerError("internal error")
 }

--- a/services/aep-api/internal/feature/genai/genai_huma_test.go
+++ b/services/aep-api/internal/feature/genai/genai_huma_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package genai
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// statusOf extracts the HTTP status a mapped error renders as.
+func statusOf(t *testing.T, err error) int {
+	t.Helper()
+	var se huma.StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("mapped error %v is not a huma.StatusError", err)
+	}
+	return se.GetStatus()
+}
+
+// TestMapTurnError_Table pins the turn error mapping table — including the new
+// 503 arm for an unusable org skills repo and the opaque-500 default. The table
+// must stay intact as arms are added.
+func TestMapTurnError_Table(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"project repo not found", ErrProjectRepoNotFound, 404},
+		{"turn not found", ErrTurnNotFound, 404},
+		{"invalid use case", ErrInvalidUseCase, 400},
+		{"invalid conversation id", ErrInvalidConversationID, 400},
+		{"empty instruction", ErrEmptyInstruction, 400},
+		{"no anthropic key", ErrNoAnthropicKey, 400},
+		{"buffer truncated", ErrTurnBufferTruncated, 409},
+		{"skills repo unavailable", fmt.Errorf("%w: resolve head: boom", ErrSkillsRepoUnavailable), 503},
+		{"wrapped skills unavailable", fmt.Errorf("start turn: %w", ErrSkillsRepoUnavailable), 503},
+		{"unmapped default", errors.New("some unexpected failure"), 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusOf(t, mapTurnError(ctx, tc.err)); got != tc.want {
+				t.Errorf("mapTurnError(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+
+	// The in-progress guard renders its pinned 409 conflict body.
+	if got := statusOf(t, mapTurnError(ctx, &TurnInProgressError{ActiveTurnID: "t1"})); got != 409 {
+		t.Errorf("turn-in-progress = %d, want 409", got)
+	}
+	// The design gate renders its pinned 409 conflict body.
+	if got := statusOf(t, mapTurnError(ctx, ErrRequirementsNotApproved)); got != 409 {
+		t.Errorf("requirements-not-approved = %d, want 409", got)
+	}
+}
+
+// captureLogs redirects slog to a buffer for the test's duration.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestInternalError_LogsCause proves the opaque-500 exit logs the underlying
+// cause (the whole point of the helper — the client sees only "internal error",
+// so the cause must reach the logs). Both default-500 mapper branches route
+// through internalError.
+func TestInternalError_LogsCause(t *testing.T) {
+	buf := captureLogs(t)
+
+	cause := errors.New("workspace exploded")
+	if got := statusOf(t, mapTurnError(context.Background(), cause)); got != 500 {
+		t.Fatalf("default arm status = %d, want 500", got)
+	}
+	if !strings.Contains(buf.String(), "workspace exploded") {
+		t.Errorf("internal-error log did not carry the cause; log = %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "genai turn") {
+		t.Errorf("internal-error log did not carry the scope; log = %q", buf.String())
+	}
+
+	// The rehydrate mapper's default arm logs too.
+	buf.Reset()
+	if got := statusOf(t, mapRehydrateError(errors.New("rehydrate blew up"))); got != 500 {
+		t.Fatalf("rehydrate default arm status = %d, want 500", got)
+	}
+	if !strings.Contains(buf.String(), "rehydrate blew up") {
+		t.Errorf("rehydrate internal-error log did not carry the cause; log = %q", buf.String())
+	}
+}
+
+// TestSkillsUnavailable_LogsCause proves the 503 arm logs the wrapped cause —
+// the incident's observability gap was exactly a skills failure with no log.
+func TestSkillsUnavailable_LogsCause(t *testing.T) {
+	buf := captureLogs(t)
+	err := fmt.Errorf("%w: resolve head: git ref not found", ErrSkillsRepoUnavailable)
+	if got := statusOf(t, mapTurnError(context.Background(), err)); got != 503 {
+		t.Fatalf("skills-unavailable status = %d, want 503", got)
+	}
+	if !strings.Contains(buf.String(), "git ref not found") {
+		t.Errorf("503 log did not carry the cause; log = %q", buf.String())
+	}
+}

--- a/services/aep-api/internal/feature/genai/genai_service.go
+++ b/services/aep-api/internal/feature/genai/genai_service.go
@@ -66,6 +66,16 @@ var (
 	ErrRequirementsNotApproved = errors.New("design generation requires an approved (tagged) requirements version")
 	ErrConversationNotFound    = errors.New("conversation not found")
 	ErrTurnNotFound            = errors.New("turn not found")
+	// ErrSkillsRepoUnavailable means the org's _skills repo (the turn's
+	// SkillsRef source) could not be resolved — its row is missing or
+	// unprovisionable, or the backing repo is gone/unreachable (live incident:
+	// the GitHub repo was deleted externally while its git_repositories row
+	// lingered). Mapped to a LOGGED 503 with a clear message instead of the
+	// generic 500 that previously swallowed the cause. Wraps the underlying
+	// error for the logs. Recovery is a manual operator action today: delete
+	// the stale `_skills` git_repositories row — the next resolve re-provisions
+	// and re-seeds the repo.
+	ErrSkillsRepoUnavailable = errors.New("org skills repository unavailable")
 )
 
 // TurnInProgressError is the D18 guard rejection: another turn holds the
@@ -289,14 +299,18 @@ func (s *service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	if err != nil {
 		return "", fmt.Errorf("resolve base ref: %w", err)
 	}
+	// Skills resolve failures are typed: both arms mean the org's _skills repo
+	// is unusable right now (row missing/unprovisionable, or the backing repo
+	// gone/unreachable — e.g. deleted externally under a lingering row). The
+	// edge maps this to a logged 503 rather than the old opaque 500.
 	skillsRow, err := s.skillsRepo(ctx, orgID)
 	if err != nil {
-		return "", fmt.Errorf("resolve skills repo: %w", err)
+		return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
 	}
 	skillsRepoRef := gitrepo.WorkspaceRefFor(orgID, skillsRow, ref.Cred)
 	skillsRef, err := ws.Head(ctx, skillsRepoRef, "")
 	if err != nil {
-		return "", fmt.Errorf("resolve skills ref: %w", err)
+		return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
 	}
 	if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
 		return "", fmt.Errorf("ensure repo snapshot: %w", err)

--- a/services/aep-api/internal/feature/genai/genai_skills_unavailable_test.go
+++ b/services/aep-api/internal/feature/genai/genai_skills_unavailable_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package genai_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// TestSkillsRepoGone_Clear503 reproduces the live incident's failure shape: the
+// org's _skills git_repositories row lingers but the backing repo is gone, so
+// the turn's skills-ref resolve fails. The user must get a clear 503 ("org
+// skills repository unavailable"), NOT the old opaque unlogged 500 — and agents
+// must never be dispatched, no turn row created.
+func TestSkillsRepoGone_Clear503(t *testing.T) {
+	staleRow := &models.GitRepository{
+		OrgID:         testOrg,
+		ProjectID:     models.SkillsRepoSentinelProjectID,
+		RepoURL:       "file:///nonexistent/skills-repo-gone.git",
+		DefaultBranch: "main",
+		Status:        "ready",
+		RepoSlug:      "org-skills",
+	}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/requirements.md": "# Reqs\n"},
+		withSkillsRepo(func(context.Context, string) (*models.GitRepository, error) {
+			return staleRow, nil
+		}))
+
+	rec := r.post(t, convUUID, "requirements-chat", "x")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("gone-skills-repo POST: code %d, want 503 (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "org skills repository unavailable") {
+		t.Errorf("503 body must carry the clear message, got %s", rec.Body.String())
+	}
+	if r.fake.turns(t) != 0 {
+		t.Error("agents dispatched despite an unavailable skills repo")
+	}
+	if rec := r.h.AsOrg(testOrg).Get(turnPath("active")); rec.Code != http.StatusNoContent {
+		t.Errorf("no turn row should exist: active = %d, want 204", rec.Code)
+	}
+}

--- a/services/aep-api/internal/feature/task/errors.go
+++ b/services/aep-api/internal/feature/task/errors.go
@@ -51,4 +51,13 @@ var (
 	// ErrNoAnthropicKey is returned pre-stream when the org has no Anthropic key.
 	// Mapped to 400.
 	ErrNoAnthropicKey = errors.New("organization has no Anthropic API key configured")
+	// ErrSkillsRepoUnavailable means the org's _skills repo (the plan turn's
+	// SkillsRef source) could not be resolved — its row is missing or
+	// unprovisionable, or the backing repo is gone/unreachable (live incident:
+	// the GitHub repo was deleted externally while its git_repositories row
+	// lingered). Mapped to a LOGGED 503 with a clear message instead of an
+	// opaque 500. Recovery is a manual operator action today: delete the stale
+	// `_skills` git_repositories row — the next resolve re-provisions and
+	// re-seeds the repo.
+	ErrSkillsRepoUnavailable = errors.New("org skills repository unavailable")
 )

--- a/services/aep-api/internal/feature/task/plan.go
+++ b/services/aep-api/internal/feature/task/plan.go
@@ -169,14 +169,18 @@ func (s *PlanService) startPlanLocked(ctx context.Context, orgID, projectID stri
 	if err != nil {
 		return nil, fmt.Errorf("resolve base ref: %w", err)
 	}
+	// Skills resolve failures are typed: both arms mean the org's _skills repo
+	// is unusable right now (row missing/unprovisionable, or the backing repo
+	// gone/unreachable — e.g. deleted externally under a lingering row). The
+	// edge maps this to a logged 503 rather than an opaque 500.
 	skillsRow, err := s.skillsRepo(ctx, orgID)
 	if err != nil {
-		return nil, fmt.Errorf("resolve skills repo: %w", err)
+		return nil, fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
 	}
 	skillsRepoRef := gitrepo.WorkspaceRefFor(orgID, skillsRow, ref.Cred)
 	skillsRef, err := ws.Head(ctx, skillsRepoRef, "")
 	if err != nil {
-		return nil, fmt.Errorf("resolve skills ref: %w", err)
+		return nil, fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
 	}
 	if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
 		return nil, fmt.Errorf("ensure repo snapshot: %w", err)

--- a/services/aep-api/internal/feature/task/plan_test.go
+++ b/services/aep-api/internal/feature/task/plan_test.go
@@ -18,6 +18,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -210,5 +211,41 @@ func TestStartPlan_InstructionCarriesExistingTasksAndLineageDiff(t *testing.T) {
 	// The diff carries real hunks (the gitfs Diff Patch extension).
 	if !strings.Contains(instr, "```diff") || !strings.Contains(instr, "+# design v1 CHANGED") {
 		t.Errorf("lineage diff patch hunks missing: %q", instr)
+	}
+}
+
+// TestStartPlan_SkillsRepoGone_TypedError pins the incident's plan-turn failure
+// shape: a stale _skills row over a gone repo must surface as the typed
+// ErrSkillsRepoUnavailable (mapped to a logged 503 at the edge), never an
+// anonymous wrap that falls into the opaque 500 — and the turn must not start.
+func TestStartPlan_SkillsRepoGone_TypedError(t *testing.T) {
+	fx := workspacetest.New(t, map[string]string{
+		"specs/design/design.md":                              "# design",
+		"specs/design/components/hello-world-api/design.json": `{"name":"hello-world-api"}`,
+		"specs/requirements/requirements.md":                  "# reqs",
+	})
+	repoRow := &models.GitRepository{OrgID: "org1", ProjectID: "proj1", RepoURL: fx.Origin.URL(),
+		DefaultBranch: "main", RepoSlug: workspacetest.DefaultSlug, Status: "ready"}
+	staleSkills := &models.GitRepository{OrgID: "org1", ProjectID: models.SkillsRepoSentinelProjectID,
+		RepoURL: "file:///nonexistent/skills-repo-gone.git", DefaultBranch: "main", RepoSlug: "org-skills", Status: "ready"}
+
+	turn := &capturingTurn{}
+	svc := NewPlanService(
+		fakeRepos{repo: repoRow},
+		planVersions{designTag: "design-v1"},
+		gitrepo.NewGitOpsService(nilResolver{}, fx.Engine),
+		func(context.Context, string) (string, error) { return "sk-test", nil },
+		turn,
+		newFakeIssues(),
+		fx.Engine,
+		func(context.Context, string) (*models.GitRepository, error) { return staleSkills, nil },
+	)
+
+	_, err := svc.StartPlan(context.Background(), "org1", "proj1")
+	if !errors.Is(err, ErrSkillsRepoUnavailable) {
+		t.Fatalf("StartPlan error = %v, want ErrSkillsRepoUnavailable", err)
+	}
+	if turn.req != nil {
+		t.Error("plan turn dispatched despite an unavailable skills repo")
 	}
 }

--- a/services/aep-api/internal/feature/task/task_huma.go
+++ b/services/aep-api/internal/feature/task/task_huma.go
@@ -19,6 +19,7 @@ package task
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -199,6 +200,12 @@ func mapPlanError(err error) error {
 		return huma.Error400BadRequest(ErrNoAnthropicKey.Error())
 	case errors.Is(err, ErrProjectRepoNotFound):
 		return huma.Error404NotFound(ErrProjectRepoNotFound.Error())
+	case errors.Is(err, ErrSkillsRepoUnavailable):
+		// Platform-side dependency down (see ErrSkillsRepoUnavailable) — a clear
+		// 503 with the cause logged. (This mapper is not ctx-threaded yet; a
+		// broader mapper ctx-threading + default-500-logging pass is a follow-up.)
+		slog.ErrorContext(context.Background(), "task plan: org skills repository unavailable", "error", err)
+		return huma.Error503ServiceUnavailable("org skills repository unavailable — contact your platform admin")
 	default:
 		return huma.Error500InternalServerError("internal error")
 	}


### PR DESCRIPTION
Two small, independent fixes found during live testing.

## 1. Deleted `org-skills` repo → every generation turn failed with an unlogged 500

**Symptom.** After an org's `org-skills` GitHub repo was deleted externally, every requirements/design generation turn (and task-plan turn) failed with a generic `500 internal error` — and nothing about the cause reached the logs.

**Cause.** The `git_repositories` row for the skills repo (project_id `_skills`) outlived the repo itself, so the turn flow failed downstream at the skills-ref resolve (`Head` on a gone repo) — and the genai error mapper's default branch swallowed the error into an opaque, unlogged 500.

**Fix (observability + a clear error — no automatic mutation).**
- **No more silent 500s in genai**: the genai error mappers' default-500 branches now route through a single `internalError(ctx, scope, err)` helper that logs the underlying cause before returning the opaque 500; `mapTurnError` is ctx-threaded from the handlers.
- **Typed, clear failure for this class**: genai `StartTurn` and task-plan `StartPlan` wrap skills-resolve failures (row missing/unprovisionable, or backing repo gone/unreachable) in `ErrSkillsRepoUnavailable`, mapped to a **logged 503** — `org skills repository unavailable — contact your platform admin` — instead of the generic 500.

**Recovery is a manual operator action for now**: delete the stale `_skills` row from `git_repositories`; the next skills resolve re-provisions the repo and re-seeds the embedded skill library (repo creation adopts a still-present repo at its stable name, so this is safe to run even on a false alarm). An automatic self-heal (drop stale row + re-provision + retry once on the turn path) was prototyped and deliberately deferred — mutating rows/repos from a resolve-failure path carries more risk than this incident justifies today.

**Tests.** Component-tier test reproducing the incident shape (stale row over a gone repo → clear 503 body, no agents dispatch, no turn row), a task-plan test pinning the typed error, and mapper unit tests pinning the full status table plus the logged-cause guarantees for both the 503 arm and the default-500 arm.

**Follow-ups:**
- Automatic self-heal of a stale `_skills` row (drop + re-provision under the per-org provisioning lock) — possible future improvement once the manual runbook proves out.
- The skills catalog read path and the runner skills S2S endpoint degrade to an *empty* catalog on repo failure (by design); worth revisiting whether they should surface the same 503 class.
- The task feature's other default-500 mappers (`mapPlanError`/`mapReadError`/`mapCommandError`) still swallow unmapped causes, and the task mappers are not ctx-threaded yet (the new 503 arm logs with a background context) — the same `internalError` + ctx-threading treatment could be applied there.

## 2. Execute on a provisioning gate was silently swallowed

**Symptom.** Clicking **Execute** (or "Execute all") on an `aep:provision` gate issue did nothing — no log, no comment, no execution.

**Cause.** Provision gates are fulfilled from the design page's dependency panel + the readiness watcher, never by `aep:execute`. The funnel correctly consumed the stray label and admitted no row — but gave no feedback at all.

**Fix.** The funnel now logs the consume (org/project/issue) and posts a **one-time** comment on the issue explaining that provisioning is driven from the design page's dependency panel and Execute has no effect there. One-time is enforced with an `aep:provision-noted` marker label (outside the status-projection vocabulary so it is never reconciled away); the marker is stamped only after the comment posts, so a failed post retries on the next stamp rather than being lost.

**Tests.** The provision funnel tests now assert: label consumed, no row admitted (existing behavior preserved), notice posted exactly once, and a repeat Execute stamp on an already-noted gate posts no duplicate.

## Verification

- `go build ./... && go test ./... && go vet ./...` green across services/aep-api
- `golangci-lint run` clean on all touched packages
- license headers verified on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)