### PR TITLE
feat(marketplace): endpoint spec discovery — agents discover org-service API contracts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^25.5.0

--- a/runners/remote-worker/package.json
+++ b/runners/remote-worker/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/oneshot.ts",
+    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },

--- a/runners/remote-worker/plugin/skills/aep/SKILL.md
+++ b/runners/remote-worker/plugin/skills/aep/SKILL.md
@@ -295,3 +295,34 @@ comment, your component has no consumer-side dependencies — add no
 `dependencies:` block. The build's `generate-workload-cr` step propagates
 this block into the OpenChoreo `Workload` CR, and OpenChoreo resolves +
 injects the addresses; you never hardcode an upstream URL.
+
+### Consuming an org-service's API contract
+
+The "Platform-resolved dependencies" comment may also carry one or more
+**"Consumed API contract — `<depName>`"** sections — one per `org-service`
+(cross-project) or same-project component dependency. When you see one,
+follow this procedure before writing any client code. Do not guess at
+request/response shapes or endpoint paths:
+
+1. Call the `list_org_component_endpoints` MCP tool (a tool the platform
+   provides alongside `get_remote_git_file_contents` and
+   `search_remote_git_code`) and find the entry matching the provider
+   component named in the issue's contract section.
+2. `spec.availability: inline` — the OpenAPI document is right there;
+   implement the client against `spec.inlineContent`.
+3. `spec.availability: repo` — the spec is a file in the provider's repo.
+   Use `search_remote_git_code` to locate an OpenAPI file (e.g.
+   `openapi.yaml`/`openapi.json`) and/or `get_remote_git_file_contents`
+   under the returned `subdir` to read it, then implement against it.
+4. `spec.availability: local` — a same-project sibling (the issue's
+   contract section is suffixed `(local)`). No MCP call needed: read
+   `specs/design/components/<sibling>/openapi.yaml` directly from your
+   own checked-out repo.
+5. `spec.availability: none` — there is no published contract. Implement
+   a minimal client against the injected address + `basePath` only. Do
+   NOT fabricate operations or paths.
+6. **Always:** implement the EXACT operations, parameters, and schemas
+   from the contract you found — never invent endpoints. Read
+   configuration via the injected env-var **names** only; never hardcode
+   or echo secret values — the pre-push guard scans for leaked secret
+   values.

--- a/runners/remote-worker/src/lib/runner.test.ts
+++ b/runners/remote-worker/src/lib/runner.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildMcpOptions } from "./runner.js";
+
+const BASE_TOOLS = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"];
+const MCP_TOOLS = [
+  "mcp__aep__list_org_component_endpoints",
+  "mcp__aep__get_remote_git_file_contents",
+  "mcp__aep__search_remote_git_code",
+];
+
+test("buildMcpOptions: registers the aep MCP server and tools when both envs are set", () => {
+  const result = buildMcpOptions("https://bff.example.com/internal/v1/mcp", "mcp-token-xyz");
+
+  assert.deepEqual(result.mcpServers, {
+    aep: {
+      type: "http",
+      url: "https://bff.example.com/internal/v1/mcp",
+      headers: { Authorization: "Bearer mcp-token-xyz" },
+    },
+  });
+  assert.deepEqual(result.allowedTools, [...BASE_TOOLS, ...MCP_TOOLS]);
+});
+
+test("buildMcpOptions: omits mcpServers and MCP tools when the token is missing", () => {
+  const result = buildMcpOptions("https://bff.example.com/internal/v1/mcp", undefined);
+
+  assert.equal(result.mcpServers, undefined);
+  assert.deepEqual(result.allowedTools, BASE_TOOLS);
+});
+
+test("buildMcpOptions: omits mcpServers and MCP tools when the url is missing", () => {
+  const result = buildMcpOptions(undefined, "mcp-token-xyz");
+
+  assert.equal(result.mcpServers, undefined);
+  assert.deepEqual(result.allowedTools, BASE_TOOLS);
+});
+
+test("buildMcpOptions: omits mcpServers and MCP tools when both are empty strings", () => {
+  const result = buildMcpOptions("", "");
+
+  assert.equal(result.mcpServers, undefined);
+  assert.deepEqual(result.allowedTools, BASE_TOOLS);
+});
+
+test("buildMcpOptions: omits mcpServers and MCP tools when both are undefined", () => {
+  const result = buildMcpOptions(undefined, undefined);
+
+  assert.equal(result.mcpServers, undefined);
+  assert.deepEqual(result.allowedTools, BASE_TOOLS);
+});

--- a/runners/remote-worker/src/lib/runner.ts
+++ b/runners/remote-worker/src/lib/runner.ts
@@ -18,7 +18,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
+import { query, type McpServerConfig, type Query } from "@anthropic-ai/claude-agent-sdk";
 import type { TaskLog } from "./logger.js";
 import type { DispatchRequest } from "./types.js";
 import type { WorkspaceLayout } from "./workspace.js";
@@ -29,8 +29,52 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_PATH = path.resolve(__dirname, "../../plugin");
 
 // Phase 0 allowed-tools: git, gh, build/test/lint via Bash; standard file
-// tools. MCP is retired.
-const ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"];
+// tools. Endpoint Spec Discovery (B2) re-introduces MCP — but only as an
+// in-process remote HTTP server (see buildMcpOptions below), never the
+// file-based .mcp.json that settingSources: [] deliberately blocks.
+const BASE_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash", "Glob", "Grep"];
+
+// The server key the BFF MCP endpoint is registered under. The SDK
+// namespaces MCP tools as `mcp__<serverKey>__<toolName>` (confirmed from
+// node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts, SDKControlMcpCallRequest
+// doc comment: "Fully-qualified MCP tool name, e.g. mcp__server__tool_name.").
+const MCP_SERVER_KEY = "aep";
+
+// The three read-only tools the BFF's aep-api-mcp server exposes (see
+// services/aep-api/internal/feature/dependencies/mcp_tools.go). Namespaced
+// per the SDK's mcp__<server>__<tool> convention above.
+const MCP_TOOL_NAMES = [
+  `mcp__${MCP_SERVER_KEY}__list_org_component_endpoints`,
+  `mcp__${MCP_SERVER_KEY}__get_remote_git_file_contents`,
+  `mcp__${MCP_SERVER_KEY}__search_remote_git_code`,
+];
+
+export interface McpQueryOptions {
+  mcpServers?: Record<string, McpServerConfig>;
+  allowedTools: string[];
+}
+
+// buildMcpOptions is a pure seam so the env-presence guard is unit-testable
+// without constructing a full query(). Both mcpUrl and mcpToken must be
+// present — the BFF's coding-agent Job template stamps AEP_MCP_URL
+// unconditionally but only stamps AEP_MCP_TOKEN when minting succeeded
+// (see job_template.go), so a URL-without-token dispatch must still omit
+// the server rather than register it unauthenticated.
+export function buildMcpOptions(mcpUrl: string | undefined, mcpToken: string | undefined): McpQueryOptions {
+  if (!mcpUrl || !mcpToken) {
+    return { allowedTools: BASE_ALLOWED_TOOLS };
+  }
+  return {
+    mcpServers: {
+      [MCP_SERVER_KEY]: {
+        type: "http",
+        url: mcpUrl,
+        headers: { Authorization: `Bearer ${mcpToken}` },
+      },
+    },
+    allowedTools: [...BASE_ALLOWED_TOOLS, ...MCP_TOOL_NAMES],
+  };
+}
 
 export interface RunResult {
   exitCode: number;
@@ -104,6 +148,12 @@ export function runClaudeQuery(
     }
   }
 
+  // Endpoint Spec Discovery (B2) — register the BFF's MCP server in-process
+  // when the dispatch carries both AEP_MCP_URL and AEP_MCP_TOKEN. Older
+  // dispatches (or a failed token mint) omit one or both, in which case the
+  // runner falls back to the base tool set unchanged.
+  const { mcpServers, allowedTools } = buildMcpOptions(req.mcpUrl, req.mcpToken);
+
   // SDK v0.2.126 auto-discovers the bundled native binary — no
   // pathToClaudeCodeExecutable needed. settingSources: [] ensures no
   // host filesystem settings leak into the container agent.
@@ -115,7 +165,8 @@ export function runClaudeQuery(
       // Force built-in skill bodies into context at startup. Do NOT
       // replace with 'all' — see docs/design/skills-system.md.
       skills: skillPreload as unknown as string[],
-      allowedTools: ALLOWED_TOOLS,
+      allowedTools,
+      ...(mcpServers ? { mcpServers } : {}),
       permissionMode: "bypassPermissions",
       allowDangerouslySkipPermissions: true,
       persistSession: false,

--- a/runners/remote-worker/src/lib/types.ts
+++ b/runners/remote-worker/src/lib/types.ts
@@ -48,4 +48,19 @@ export interface DispatchRequest {
    * and legacy Task-JWT bearers.
    */
   refreshUrl?: string;
+  /**
+   * Endpoint Spec Discovery (B1/B2) — the BFF's in-process MCP endpoint
+   * (`<platform>/internal/v1/mcp`), stamped unconditionally by the BFF's
+   * coding-agent Job template as AEP_MCP_URL. Paired with `mcpToken`; the
+   * runner only registers the MCP server when BOTH are present, since older
+   * dispatches (or a failed token mint) may render the URL without a token.
+   */
+  mcpUrl?: string;
+  /**
+   * Dedicated `aep-api-mcp`-audience identity token minted by the BFF for
+   * runner→BFF MCP calls (distinct from AEP_BEARER's git-service audience).
+   * Read from AEP_MCP_TOKEN; absent when minting failed or the dispatch
+   * predates Endpoint Spec Discovery.
+   */
+  mcpToken?: string;
 }

--- a/runners/remote-worker/src/oneshot.ts
+++ b/runners/remote-worker/src/oneshot.ts
@@ -67,6 +67,12 @@ function readDispatchFromEnv(): DispatchRequest {
   const identityEmail = requireEnv("AEP_IDENTITY_EMAIL");
   const identityLogin = process.env.AEP_IDENTITY_LOGIN || "";
   const correlationId = process.env.AEP_CORRELATION_ID || randomUUID();
+  // Endpoint Spec Discovery (B1/B2) — BFF MCP server coordinates. The BFF
+  // stamps AEP_MCP_URL unconditionally but only stamps AEP_MCP_TOKEN when
+  // minting succeeded, so both are optional here; runner.ts guards on BOTH
+  // being present before registering the in-process mcpServers entry.
+  const mcpUrl = process.env.AEP_MCP_URL || "";
+  const mcpToken = process.env.AEP_MCP_TOKEN || "";
 
   const publisherClientId = process.env.PUBLISHER_CLIENT_ID ?? "";
   const publisherClientSecret = process.env.PUBLISHER_CLIENT_SECRET ?? "";
@@ -97,6 +103,8 @@ function readDispatchFromEnv(): DispatchRequest {
     gitServiceUrl,
     prompt,
     correlationId,
+    mcpUrl: mcpUrl || undefined,
+    mcpToken: mcpToken || undefined,
   };
 }
 
@@ -150,7 +158,7 @@ async function main(): Promise<number> {
     }
   }
 
-  primeScrubber([process.env.ANTHROPIC_API_KEY, req.bearer, publisherClientSecret]);
+  primeScrubber([process.env.ANTHROPIC_API_KEY, req.bearer, publisherClientSecret, req.mcpToken]);
 
   emit({
     kind: "phase",

--- a/services/aep-api/internal/api/app.go
+++ b/services/aep-api/internal/api/app.go
@@ -102,6 +102,10 @@ type AppParams struct {
 	MCPExternalResources dependencies.ExternalResourceReader
 	MCPOrgEndpoints      dependencies.OrgEndpointLister
 	MCPResourceTypes     dependencies.ResourceTypeLister
+	// MCPRemoteGit backs the read-only remote-git MCP tools (endpoint spec
+	// discovery). Nil makes get_remote_git_file_contents/search_remote_git_code
+	// return a tool error; it never affects the other tools.
+	MCPRemoteGit dependencies.RemoteGitReader
 }
 
 // NewHandler assembles the full HTTP handler with middleware and routes.

--- a/services/aep-api/internal/api/surfaces.go
+++ b/services/aep-api/internal/api/surfaces.go
@@ -140,7 +140,7 @@ func mountSurfaces(params AppParams) *http.ServeMux {
 	if params.HumaDeps.TaskTokens != nil {
 		mcpVerifier := auth.NewAgentsScopedVerifier(params.HumaDeps.TaskTokens)
 		mcpHandler := dependencies.NewMCPHandler(
-			params.MCPExternalResources, params.MCPOrgEndpoints, params.MCPResourceTypes)
+			params.MCPExternalResources, params.MCPOrgEndpoints, params.MCPResourceTypes, params.MCPRemoteGit)
 		mux.Handle("POST "+internalV1+"/mcp", mcpVerifier.Middleware(mcpHandler))
 
 		// ── playground-token mint (POST /internal/v1/mcp/playground-token) ────

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -47,6 +47,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/feature/artifacts"
 	"github.com/wso2/aep/aep-api/internal/feature/codingagent"
 	"github.com/wso2/aep/aep-api/internal/feature/component"
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies"
 	"github.com/wso2/aep/aep-api/internal/feature/dependencies/endpoints"
 	"github.com/wso2/aep/aep-api/internal/feature/dependencies/resources"
 	"github.com/wso2/aep/aep-api/internal/feature/design"
@@ -791,6 +792,11 @@ func Build(cfg config.Config, db *gorm.DB) (*App, error) {
 	params.MCPOrgEndpoints = orgEndpointCatalog
 	resourceTypeCatalog := resources.NewResourceTypeCatalog(resourceClient)
 	params.MCPResourceTypes = resourceTypeCatalog
+	// Endpoint spec discovery: the read-only remote-git reader an agent uses to
+	// read a provider's OpenAPI file from its own repo (Contents + Code Search,
+	// no clone). It resolves the org's credential (token + owner) from
+	// credResolver and refuses any owner that is not the org's GitHub account.
+	params.MCPRemoteGit = dependencies.NewRemoteGitClient(credResolver)
 	// design-save keys end-user-auth derivation on the CRT role marker read from
 	// this catalog (thunder-app generalization); wired consumer-side so design
 	// holds only a narrow MarkersByName port. When the design declares a

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -778,7 +778,14 @@ func Build(cfg config.Config, db *gorm.DB) (*App, error) {
 	// The provisioning surface (value/param collection + the aep:provision issue
 	// funnel) is wired in the Phase-6 block further below.
 	resourceClient := openchoreo.NewResourceClient(ocConfig)
-	orgEndpointCatalog := endpoints.NewCatalog(resourceClient)
+	// The resolver collaborators (repo locator + design reader) let the endpoint
+	// catalog discover each org-service's real OpenAPI contract + repo coords
+	// (endpoint spec discovery). Wired here so the A3 MCP tool projects them;
+	// the read-only List/Resolve* surface degrades gracefully if either is nil.
+	orgEndpointCatalog := endpoints.NewCatalog(resourceClient,
+		endpoints.WithRepoLocator(repoRepo),
+		endpoints.WithDesignReader(artifactStore),
+	)
 	externalResourceRepo := repositories.NewExternalResourceRepository(db)
 	params.MCPExternalResources = externalResourceRepo
 	params.MCPOrgEndpoints = orgEndpointCatalog

--- a/services/aep-api/internal/arch/arch_test.go
+++ b/services/aep-api/internal/arch/arch_test.go
@@ -61,12 +61,16 @@ var featureEdgeAllowlist = map[string][]string{
 	"codingagent": {"execution"},
 	"component":   {"artifacts", "gitrepo"},
 	// dependencies is the dependency-management feature: the parent package (MCP
-	// discovery server + endpoints catalog) composes its own resources subpackage
-	// (external/platform provisioner cores). endpoints/ and resources/ hold no
+	// discovery server + endpoints catalog) composes its own resources and
+	// endpoints subpackages (external/platform provisioner cores; the org
+	// endpoint catalog). ports.go's OrgEndpointLister.ListResolved return type is
+	// endpoints.OrgComponentEndpoint (A3's list_org_component_endpoints MCP
+	// tool), so the parent package names its own child package's type — the same
+	// shape as the resources edge below. endpoints/ and resources/ hold no
 	// cross-feature edges of their own — every other collaborator (OC client,
 	// external-resource repo, secret writer, design reader) is a consumer-side
 	// port wired at the composition root, keeping the feature edge surface minimal.
-	"dependencies": {"dependencies/resources"},
+	"dependencies": {"dependencies/resources", "dependencies/endpoints"},
 	// design imports dependencies/resources for the CRT metadata vocabulary
 	// (resources.TypeMarkers + the marker catalog port): design-save keys
 	// end-user-auth derivation on the PE-authored role marker instead of a

--- a/services/aep-api/internal/clients/openchoreo/resource_client.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client.go
@@ -132,6 +132,12 @@ type WorkloadEndpointInfo struct {
 	Port       int32    // endpoint port
 	BasePath   string   // optional root path
 	Visibility []string // explicit extra visibilities: namespace | internal | external
+
+	// Schema is the endpoint's inline API definition, if the Workload declares one
+	// (OpenChoreo populates spec.endpoints[].schema from workload.yaml `schemaFile:`,
+	// or a directly-authored Workload CR). Empty for app-factory BYO-image workloads.
+	SchemaType    string // e.g. "openapi", "proto", "graphql" (endpoint.Schema.Type)
+	SchemaContent string // the inlined spec document (endpoint.Schema.Content)
 }
 
 // NamespaceVisible reports whether this endpoint is consumable cross-project
@@ -651,6 +657,10 @@ type workloadItem struct {
 			Port       int32    `json:"port"`
 			BasePath   string   `json:"basePath"`
 			Visibility []string `json:"visibility"`
+			Schema     struct {
+				Type    string `json:"type"`
+				Content string `json:"content"`
+			} `json:"schema"`
 		} `json:"endpoints"`
 	} `json:"spec"`
 }
@@ -664,14 +674,16 @@ func (c *resourceClient) ListWorkloadEndpoints(ctx context.Context, orgHandle st
 	for _, w := range out.Items {
 		for name, ep := range w.Spec.Endpoints {
 			infos = append(infos, WorkloadEndpointInfo{
-				Project:    w.Spec.Owner.ProjectName,
-				Component:  w.Spec.Owner.ComponentName,
-				Workload:   w.Metadata.Name,
-				Name:       name,
-				Type:       ep.Type,
-				Port:       ep.Port,
-				BasePath:   ep.BasePath,
-				Visibility: ep.Visibility,
+				Project:       w.Spec.Owner.ProjectName,
+				Component:     w.Spec.Owner.ComponentName,
+				Workload:      w.Metadata.Name,
+				Name:          name,
+				Type:          ep.Type,
+				Port:          ep.Port,
+				BasePath:      ep.BasePath,
+				Visibility:    ep.Visibility,
+				SchemaType:    ep.Schema.Type,
+				SchemaContent: ep.Schema.Content,
 			})
 		}
 	}

--- a/services/aep-api/internal/clients/openchoreo/resource_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client_test.go
@@ -645,7 +645,7 @@ func TestListWorkloadEndpoints_Success(t *testing.T) {
 				"spec":{
 					"owner":{"projectName":"orders","componentName":"orders-api"},
 					"endpoints":{
-						"http":{"type":"HTTP","port":8080,"basePath":"/","visibility":["namespace"]},
+						"http":{"type":"HTTP","port":8080,"basePath":"/","visibility":["namespace"],"schema":{"type":"openapi","content":"openapi: 3.0.0"}},
 						"admin":{"type":"HTTP","port":9090,"basePath":"/admin","visibility":[]}
 					}
 				}
@@ -673,12 +673,18 @@ func TestListWorkloadEndpoints_Success(t *testing.T) {
 	if httpEP.Project != "orders" || httpEP.Component != "orders-api" || httpEP.Port != 8080 || !httpEP.NamespaceVisible() {
 		t.Errorf("unexpected http endpoint: %+v", httpEP)
 	}
+	if httpEP.SchemaType != "openapi" || httpEP.SchemaContent != "openapi: 3.0.0" {
+		t.Errorf("expected schema decoded onto http endpoint, got SchemaType=%q SchemaContent=%q", httpEP.SchemaType, httpEP.SchemaContent)
+	}
 	adminEP, ok := byName["admin"]
 	if !ok {
 		t.Fatalf("missing admin endpoint in %+v", got)
 	}
 	if adminEP.NamespaceVisible() {
 		t.Errorf("admin endpoint should not be namespace-visible: %+v", adminEP)
+	}
+	if adminEP.SchemaType != "" || adminEP.SchemaContent != "" {
+		t.Errorf("expected admin endpoint (no schema in payload) to have empty schema fields, got SchemaType=%q SchemaContent=%q", adminEP.SchemaType, adminEP.SchemaContent)
 	}
 }
 

--- a/services/aep-api/internal/feature/codingagent/coding_executor.go
+++ b/services/aep-api/internal/feature/codingagent/coding_executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
 	"github.com/wso2/aep/aep-api/internal/feature/execution"
+	"github.com/wso2/aep/aep-api/internal/platform/auth"
 	"github.com/wso2/aep/aep-api/models"
 	"github.com/wso2/aep/aep-api/repositories"
 )
@@ -258,6 +259,15 @@ func (e *CodingExecutor) runCoding(ctx context.Context, req execution.DispatchRe
 	if err != nil {
 		return fmt.Errorf("mint runner bearer: %w", err)
 	}
+	// Dedicated MCP identity token (aud aep-api-mcp): the runner bearer above
+	// (aud git-service) is pinned-rejected by the MCP verifier, so the pod needs
+	// a separate token to call the BFF's internal MCP surface (list endpoints /
+	// read remote file / search remote code). One token stamped at dispatch,
+	// TTL matching the runner bearer's 24h Job lifetime — no refresh route.
+	mcpToken, err := e.tokens.IssueServiceToken(auth.AudienceMCP, t.OrgID, 24*time.Hour)
+	if err != nil {
+		return fmt.Errorf("mint MCP token: %w", err)
+	}
 	// Resolve the org's skills repo URL (provisioning on first touch) so the
 	// runner can clone it and resolve applied skills locally. Best-effort — ""
 	// on any failure, the runner then degrades to the base plugin.
@@ -277,7 +287,7 @@ func (e *CodingExecutor) runCoding(ctx context.Context, req execution.DispatchRe
 
 	// Proxy path first (what local uses). Falls back to ClusterWorkflow when the
 	// proxy dispatcher / SM-API triplets are not fully configured.
-	used, runName, perr := e.dispatchViaProxy(ctx, req, repo, prompt, name, email, login, bearer, skillsRepoURL)
+	used, runName, perr := e.dispatchViaProxy(ctx, req, repo, prompt, name, email, login, bearer, mcpToken, skillsRepoURL)
 	if perr != nil {
 		return perr
 	}
@@ -330,7 +340,7 @@ func (e *CodingExecutor) runCoding(ctx context.Context, req execution.DispatchRe
 // configured for the proxy path (fall back). The runner env AEP_TASK_ID carries
 // the EXECUTION id (JobInputs.TaskID) and the bearer's task claim is the
 // execution id — the re-keyed runner contract (§9.2).
-func (e *CodingExecutor) dispatchViaProxy(ctx context.Context, req execution.DispatchRequest, repo *models.GitRepository, prompt, name, email, login, bearer, skillsRepoURL string) (bool, string, error) {
+func (e *CodingExecutor) dispatchViaProxy(ctx context.Context, req execution.DispatchRequest, repo *models.GitRepository, prompt, name, email, login, bearer, mcpToken, skillsRepoURL string) (bool, string, error) {
 	t := req.Task
 	if e.proxy == nil || e.db == nil || e.runnerImage == "" || e.clusterSecretStore == "" {
 		return false, "", nil
@@ -406,6 +416,7 @@ func (e *CodingExecutor) dispatchViaProxy(ctx context.Context, req execution.Dis
 		GitServiceURL:     e.gitServiceURL,
 		CallbackURL:       e.platformURL,
 		Bearer:            bearer,
+		MCPToken:          mcpToken,
 		SkillsRepoURL:     skillsRepoURL,
 		PublisherTokenURL: publisherTokenURL,
 	}

--- a/services/aep-api/internal/feature/codingagent/fakes_test.go
+++ b/services/aep-api/internal/feature/codingagent/fakes_test.go
@@ -19,6 +19,7 @@ package codingagent
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
 	"github.com/wso2/aep/aep-api/models"
@@ -107,6 +108,10 @@ func (fakeIdentities) IdentityFor(context.Context, string) (string, string, stri
 type fakeTokens struct{}
 
 func (fakeTokens) Issue(string, string, string) (string, error) { return "bearer-xyz", nil }
+
+func (fakeTokens) IssueServiceToken(string, string, time.Duration) (string, error) {
+	return "mcp-token-xyz", nil
+}
 
 // fakeReeval records Reevaluate calls (the build-success release path).
 type fakeReeval struct {

--- a/services/aep-api/internal/feature/codingagent/job_template.go
+++ b/services/aep-api/internal/feature/codingagent/job_template.go
@@ -117,6 +117,16 @@ type JobInputs struct {
 	// and uses Bearer only as a fallback.
 	Bearer string
 
+	// MCPToken is a dedicated BFF-signed identity token (aud aep-api-mcp,
+	// minted via auth.IssueServiceToken — see coding_executor.go) that
+	// authenticates the runner pod to the BFF's internal MCP discovery surface
+	// (POST /internal/v1/mcp: list_org_component_endpoints,
+	// get_remote_git_file_contents, search_remote_git_code). Bearer's audience
+	// (git-service) is rejected by the MCP verifier, hence this separate token.
+	// Optional: empty (minting failed / not wired) stamps no AEP_MCP_TOKEN env,
+	// mirroring the Bearer contract — the runner then skips MCP-backed tools.
+	MCPToken string
+
 	// ActiveDeadlineSeconds bounds the agent run. Zero falls back to 1h.
 	ActiveDeadlineSeconds int64
 }
@@ -143,6 +153,10 @@ func Build(in JobInputs) (map[string]any, error) {
 		{"name": "AEP_PROMPT", "value": in.Prompt},
 		{"name": "AEP_GIT_SERVICE_URL", "value": in.GitServiceURL},
 		{"name": "AEP_PLATFORM_URL", "value": in.CallbackURL},
+		// AEP_MCP_URL is the BFF's internal MCP discovery endpoint, derived from
+		// the same callback URL as AEP_PLATFORM_URL — always rendered (parity
+		// with AEP_PLATFORM_URL) since CallbackURL is a required field.
+		{"name": "AEP_MCP_URL", "value": strings.TrimRight(in.CallbackURL, "/") + "/internal/v1/mcp"},
 		{"name": "AEP_IDENTITY_NAME", "value": in.IdentityName},
 		{"name": "AEP_IDENTITY_EMAIL", "value": in.IdentityEmail},
 		{"name": "AEP_IDENTITY_LOGIN", "value": in.IdentityLogin},
@@ -152,6 +166,11 @@ func Build(in JobInputs) (map[string]any, error) {
 	if in.Bearer != "" {
 		envVars = append(envVars, map[string]any{
 			"name": "AEP_BEARER", "value": in.Bearer,
+		})
+	}
+	if in.MCPToken != "" {
+		envVars = append(envVars, map[string]any{
+			"name": "AEP_MCP_TOKEN", "value": in.MCPToken,
 		})
 	}
 	// Optional: only stamped when the org's skills repo resolved. Absent → the

--- a/services/aep-api/internal/feature/codingagent/job_template_test.go
+++ b/services/aep-api/internal/feature/codingagent/job_template_test.go
@@ -92,3 +92,47 @@ func TestBuild_OmitsSkillsRepoURLWhenEmpty(t *testing.T) {
 		t.Errorf("AEP_SKILLS_REPO_URL must be absent when SkillsRepoURL is empty, got %q", env["AEP_SKILLS_REPO_URL"])
 	}
 }
+
+// TestBuild_StampsMCPTokenAndURL pins the coding-agent MCP wiring (task B1):
+// the rendered Job carries a dedicated AEP_MCP_TOKEN (aud aep-api-mcp, distinct
+// from AEP_BEARER's git-service audience) and an AEP_MCP_URL derived from the
+// BFF callback URL, so the runner pod can call the BFF's internal MCP surface
+// (POST /internal/v1/mcp) for endpoint discovery / remote-file / code-search.
+func TestBuild_StampsMCPTokenAndURL(t *testing.T) {
+	in := validJobInputs()
+	in.CallbackURL = "http://aep-api:9090"
+	in.MCPToken = "mcp-token-xyz"
+
+	job, err := Build(in)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := jobEnv(t, job)
+	if got, want := env["AEP_MCP_TOKEN"], "mcp-token-xyz"; got != want {
+		t.Errorf("AEP_MCP_TOKEN = %q, want %q", got, want)
+	}
+	if got, want := env["AEP_MCP_URL"], "http://aep-api:9090/internal/v1/mcp"; got != want {
+		t.Errorf("AEP_MCP_URL = %q, want %q", got, want)
+	}
+}
+
+// TestBuild_OmitsMCPTokenWhenEmpty mirrors the AEP_BEARER contract: an empty
+// MCPToken (minting failed / not wired) stamps no AEP_MCP_TOKEN env, but
+// AEP_MCP_URL still renders unconditionally (parity with AEP_PLATFORM_URL) —
+// the runner can then tell "no MCP token" apart from "empty token value".
+func TestBuild_OmitsMCPTokenWhenEmpty(t *testing.T) {
+	in := validJobInputs() // MCPToken left empty
+	in.CallbackURL = "http://aep-api:9090"
+
+	job, err := Build(in)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := jobEnv(t, job)
+	if _, present := env["AEP_MCP_TOKEN"]; present {
+		t.Errorf("AEP_MCP_TOKEN must be absent when MCPToken is empty, got %q", env["AEP_MCP_TOKEN"])
+	}
+	if got, want := env["AEP_MCP_URL"], "http://aep-api:9090/internal/v1/mcp"; got != want {
+		t.Errorf("AEP_MCP_URL = %q, want %q (must render even without a token)", got, want)
+	}
+}

--- a/services/aep-api/internal/feature/codingagent/ports.go
+++ b/services/aep-api/internal/feature/codingagent/ports.go
@@ -31,6 +31,7 @@ package codingagent
 
 import (
 	"context"
+	"time"
 
 	"github.com/wso2/aep/aep-api/models"
 )
@@ -85,6 +86,13 @@ type AnthropicProvisioner interface {
 // auth.TaskTokenManager (Issue(id, ocOrgID, projectID)).
 type TokenIssuer interface {
 	Issue(id, ocOrgID, projectID string) (string, error)
+
+	// IssueServiceToken mints a dedicated BFF-signed identity token for a given
+	// audience (e.g. auth.AudienceMCP) — used to mint the coding runner's
+	// AEP_MCP_TOKEN, since the runner bearer above (aud git-service) is
+	// rejected by the MCP verifier. ttl <= 0 falls back to the manager's
+	// configured task TTL. Wired from auth.TaskTokenManager.IssueServiceToken.
+	IssueServiceToken(audience, ocOrgID string, ttl time.Duration) (string, error)
 }
 
 // ProjectRepos resolves a project's git repo row (RepoURL/RepoSlug). Wired from

--- a/services/aep-api/internal/feature/dependencies/endpoints/catalog.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/catalog.go
@@ -34,13 +34,24 @@ import (
 // added, is uniform across dependencies, not special-cased here.)
 type Catalog struct {
 	rc openchoreo.ResourceClient
+	// repos/design are optional resolver collaborators (see resolve.go). Nil
+	// when a caller wires only the raw catalog reads; the resolver then degrades
+	// its availability computation rather than panicking.
+	repos  RepoLocator
+	design DesignReader
 }
 
 // NewCatalog wires a Catalog over the given OC resource client. A nil rc
 // leaves the Catalog "not wired" — every read then degrades to a documented
-// no-op (nil, nil) rather than a nil-pointer panic.
-func NewCatalog(rc openchoreo.ResourceClient) *Catalog {
-	return &Catalog{rc: rc}
+// no-op (nil, nil) rather than a nil-pointer panic. Optional CatalogOptions
+// wire the spec-discovery resolver's collaborators (repo locator, design
+// reader); omit them for the read-only catalog surface.
+func NewCatalog(rc openchoreo.ResourceClient, opts ...CatalogOption) *Catalog {
+	c := &Catalog{rc: rc}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // List returns every provider-side endpoint across the org's Workloads (one

--- a/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
@@ -241,7 +241,11 @@ func TestResolve_InlineFromSchema(t *testing.T) {
 		Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080,
 		Visibility: []string{"namespace"}, SchemaType: "openapi", SchemaContent: "openapi: 3.0.3\ninfo: {}\n",
 	}
-	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}))
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}),
+		WithRepoLocator(fakeRepoLocator{byProject: map[string]*models.GitRepository{
+			"hr": {RepoURL: "https://github.com/acme/hr.git", DefaultBranch: "main"},
+		}}),
+	)
 
 	got := cat.Resolve(context.Background(), "org", e)
 	if got.Spec.Availability != "inline" {
@@ -252,6 +256,11 @@ func TestResolve_InlineFromSchema(t *testing.T) {
 	}
 	if !got.NamespaceVisible {
 		t.Fatalf("expected NamespaceVisible=true")
+	}
+	// Repo coords resolve independently of the CR-schema inline spec — the two
+	// sources are orthogonal, so availability=inline must not suppress coords.
+	if got.Owner != "acme" || got.Repo != "hr" || got.Branch != "main" {
+		t.Fatalf("repo coords: want acme/hr@main, got %s/%s@%s", got.Owner, got.Repo, got.Branch)
 	}
 }
 
@@ -287,6 +296,33 @@ func TestResolve_InlineFromDesignBundle(t *testing.T) {
 	// repo coords still resolved for provenance even though availability=inline.
 	if got.Owner != "acme" || got.Repo != "hr" {
 		t.Fatalf("repo coords: want acme/hr, got %s/%s", got.Owner, got.Repo)
+	}
+}
+
+// (b2) The design-bundle component is matched case-insensitively against the
+// endpoint's OC component name — the provenance Path's folder segment must
+// use the MATCHED component's actual committed Name/casing, not the
+// endpoint's (possibly differently-cased) Component.
+func TestResolve_InlineFromDesignBundle_ProvenancePathUsesMatchedComponentCasing(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "hr", Component: "Employee-API", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"},
+	}
+	spec := "openapi: 3.0.3\ninfo:\n  title: Employee API\n"
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}),
+		WithDesignReader(fakeDesignReader{byProject: map[string]*artifacts.DesignFile{
+			// Committed folder casing differs from the endpoint's Component field.
+			"hr": designWith(models.DesignComponent{Name: "employee-api", AppPath: "svc", OpenAPISpec: spec}),
+		}}),
+	)
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "inline" {
+		t.Fatalf("availability: want inline, got %q", got.Spec.Availability)
+	}
+	if got.Spec.Path != "specs/design/components/employee-api/openapi.yaml" {
+		t.Fatalf("provenance path: want matched design component's casing (employee-api), got %q", got.Spec.Path)
 	}
 }
 
@@ -376,6 +412,45 @@ func TestListResolved_NilSafety(t *testing.T) {
 	got, err := nilCatalog.ListResolved(context.Background(), "org")
 	if got != nil || err != nil {
 		t.Fatalf("nil receiver: want (nil, nil), got (%v, %v)", got, err)
+	}
+}
+
+// countingDesignReader tracks how many times ReadDesign was called per
+// project — used to assert ListResolved's per-pass design-bundle memoization
+// (a project publishing several endpoints must trigger at most one remote
+// read per project for the whole pass).
+type countingDesignReader struct {
+	byProject map[string]*artifacts.DesignFile
+	calls     map[string]int
+}
+
+func (f *countingDesignReader) ReadDesign(_ context.Context, _, projectID string) (*artifacts.DesignFile, error) {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[projectID]++
+	return f.byProject[projectID], nil
+}
+
+func TestListResolved_MemoizesDesignReadPerProject(t *testing.T) {
+	t.Parallel()
+	// Three endpoints owned by the same provider project ("hr") — a naive
+	// per-endpoint resolve would read the design bundle 3 times in this pass.
+	eps := []openchoreo.WorkloadEndpointInfo{
+		{Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080, Visibility: []string{"namespace"}},
+		{Project: "hr", Component: "payroll-api", Name: "http", Type: "HTTP", Port: 8081, Visibility: []string{"namespace"}},
+		{Project: "hr", Component: "benefits-api", Name: "http", Type: "HTTP", Port: 8082, Visibility: []string{"namespace"}},
+	}
+	reader := &countingDesignReader{byProject: map[string]*artifacts.DesignFile{
+		"hr": designWith(models.DesignComponent{Name: "employee-api", OpenAPISpec: "openapi: 3.0.3\n"}),
+	}}
+	cat := NewCatalog(fakeRC(eps), WithDesignReader(reader))
+
+	if _, err := cat.ListResolved(context.Background(), "org"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := reader.calls["hr"]; got != 1 {
+		t.Fatalf("ReadDesign(hr): want 1 call across 3 endpoints in one ListResolved pass, got %d", got)
 	}
 }
 

--- a/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	ocmocks "github.com/wso2/aep/aep-api/internal/clients/openchoreo/mocks"
 	"github.com/wso2/aep/aep-api/internal/feature/artifacts"
+	"github.com/wso2/aep/aep-api/models"
 )
 
 // Structural compile-time check (dependency-management Phase 5): *Catalog is the
@@ -205,6 +206,176 @@ func TestCatalog_FindByComponent(t *testing.T) {
 	// Unknown component must not resolve (the not-found case).
 	if _, ok, _ := cat.FindByComponent(context.Background(), "ns", "nope"); ok {
 		t.Fatalf("unknown component must not resolve")
+	}
+}
+
+// ---- Resolve / ListResolved (Task A2: per-endpoint spec discovery) ---------
+
+// fakeRepoLocator resolves an app-factory provider's git repo row by project id.
+type fakeRepoLocator struct {
+	byProject map[string]*models.GitRepository
+}
+
+func (f fakeRepoLocator) GetByOrgAndProjectID(_ context.Context, _, projectID string) (*models.GitRepository, error) {
+	return f.byProject[projectID], nil
+}
+
+// fakeDesignReader returns a provider project's assembled design bundle.
+type fakeDesignReader struct {
+	byProject map[string]*artifacts.DesignFile
+}
+
+func (f fakeDesignReader) ReadDesign(_ context.Context, _, projectID string) (*artifacts.DesignFile, error) {
+	return f.byProject[projectID], nil
+}
+
+func designWith(comp models.DesignComponent) *artifacts.DesignFile {
+	return &artifacts.DesignFile{Components: []models.DesignComponent{comp}}
+}
+
+// (a) An endpoint whose deployed Workload CR already carries an inline schema
+// resolves to availability=inline straight from the CR — no repo/design probe.
+func TestResolve_InlineFromSchema(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"}, SchemaType: "openapi", SchemaContent: "openapi: 3.0.3\ninfo: {}\n",
+	}
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}))
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "inline" {
+		t.Fatalf("availability: want inline, got %q", got.Spec.Availability)
+	}
+	if got.Spec.InlineContent != e.SchemaContent {
+		t.Fatalf("inline content: want CR schema, got %q", got.Spec.InlineContent)
+	}
+	if !got.NamespaceVisible {
+		t.Fatalf("expected NamespaceVisible=true")
+	}
+}
+
+// (b) No CR schema, but the app-factory provider committed a design-bundle
+// openapi.yaml → read it server-side → inline, with Path set for provenance.
+// Repo coords are also resolved but step 2 wins over step 3.
+func TestResolve_InlineFromDesignBundle(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"},
+	}
+	spec := "openapi: 3.0.3\ninfo:\n  title: Employee API\n"
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}),
+		WithDesignReader(fakeDesignReader{byProject: map[string]*artifacts.DesignFile{
+			"hr": designWith(models.DesignComponent{Name: "employee-api", AppPath: "svc", OpenAPISpec: spec}),
+		}}),
+		WithRepoLocator(fakeRepoLocator{byProject: map[string]*models.GitRepository{
+			"hr": {RepoURL: "https://github.com/acme/hr.git", DefaultBranch: "main"},
+		}}),
+	)
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "inline" {
+		t.Fatalf("availability: want inline, got %q", got.Spec.Availability)
+	}
+	if got.Spec.InlineContent != spec {
+		t.Fatalf("inline content: want design-bundle spec, got %q", got.Spec.InlineContent)
+	}
+	if got.Spec.Path != "specs/design/components/employee-api/openapi.yaml" {
+		t.Fatalf("provenance path: got %q", got.Spec.Path)
+	}
+	// repo coords still resolved for provenance even though availability=inline.
+	if got.Owner != "acme" || got.Repo != "hr" {
+		t.Fatalf("repo coords: want acme/hr, got %s/%s", got.Owner, got.Repo)
+	}
+}
+
+// (c) No schema anywhere, but repo coords resolve (git_repositories row) →
+// availability=repo with the component subdir as the hint.
+func TestResolve_RepoCoords(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"},
+	}
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}),
+		// design bundle present but component has NO openapi.yaml → not inline.
+		WithDesignReader(fakeDesignReader{byProject: map[string]*artifacts.DesignFile{
+			"hr": designWith(models.DesignComponent{Name: "employee-api", AppPath: "services/employee"}),
+		}}),
+		WithRepoLocator(fakeRepoLocator{byProject: map[string]*models.GitRepository{
+			"hr": {RepoURL: "https://github.com/acme/hr", DefaultBranch: "main"},
+		}}),
+	)
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "repo" {
+		t.Fatalf("availability: want repo, got %q", got.Spec.Availability)
+	}
+	if got.Spec.InlineContent != "" {
+		t.Fatalf("repo availability must not carry inline content, got %q", got.Spec.InlineContent)
+	}
+	if got.Owner != "acme" || got.Repo != "hr" || got.Branch != "main" {
+		t.Fatalf("repo coords: want acme/hr@main, got %s/%s@%s", got.Owner, got.Repo, got.Branch)
+	}
+	if got.Subdir != "services/employee" || got.Spec.Path != "services/employee" {
+		t.Fatalf("subdir hint: got Subdir=%q Path=%q", got.Subdir, got.Spec.Path)
+	}
+}
+
+// (d) BYO-image provider: no CR schema, no design bundle, no repo coords →
+// availability=none.
+func TestResolve_None(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "hr", Component: "byo", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"},
+	}
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}))
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "none" {
+		t.Fatalf("availability: want none, got %q", got.Spec.Availability)
+	}
+	if got.Owner != "" || got.Repo != "" || got.Spec.InlineContent != "" {
+		t.Fatalf("none case must carry no coords/content, got %+v", got)
+	}
+}
+
+func TestListResolved(t *testing.T) {
+	t.Parallel()
+	eps := []openchoreo.WorkloadEndpointInfo{
+		{Project: "hr", Component: "employee-api", Name: "http", Type: "HTTP", Port: 8080,
+			Visibility: []string{"namespace"}, SchemaContent: "openapi: 3.0.3\n"},
+		{Project: "hr", Component: "byo", Name: "http", Type: "HTTP", Port: 8081},
+	}
+	cat := NewCatalog(fakeRC(eps))
+
+	got, err := cat.ListResolved(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 resolved endpoints, got %d", len(got))
+	}
+	byComp := map[string]OrgComponentEndpoint{}
+	for _, r := range got {
+		byComp[r.Component] = r
+	}
+	if byComp["employee-api"].Spec.Availability != "inline" {
+		t.Fatalf("employee-api: want inline, got %q", byComp["employee-api"].Spec.Availability)
+	}
+	if byComp["byo"].Spec.Availability != "none" {
+		t.Fatalf("byo: want none, got %q", byComp["byo"].Spec.Availability)
+	}
+}
+
+func TestListResolved_NilSafety(t *testing.T) {
+	t.Parallel()
+	var nilCatalog *Catalog
+	got, err := nilCatalog.ListResolved(context.Background(), "org")
+	if got != nil || err != nil {
+		t.Fatalf("nil receiver: want (nil, nil), got (%v, %v)", got, err)
 	}
 }
 

--- a/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/catalog_test.go
@@ -326,6 +326,37 @@ func TestResolve_InlineFromDesignBundle_ProvenancePathUsesMatchedComponentCasing
 	}
 }
 
+// (b3) app-factory OC components are project-prefixed
+// (spec.owner.componentName = "<project>-<design-component-name>"), but the
+// design bundle stores components under their unprefixed authored name. The
+// design-component lookup must retry with the project prefix stripped so the
+// inline-from-design-bundle path still fires for app-factory providers.
+func TestResolve_InlineFromDesignBundle_ProjectPrefixedComponentName(t *testing.T) {
+	t.Parallel()
+	e := openchoreo.WorkloadEndpointInfo{
+		Project: "myproj", Component: "myproj-svc", Name: "http", Type: "HTTP", Port: 8080,
+		Visibility: []string{"namespace"},
+	}
+	spec := "openapi: 3.0.3\ninfo:\n  title: Svc\n"
+	cat := NewCatalog(fakeRC([]openchoreo.WorkloadEndpointInfo{e}),
+		WithDesignReader(fakeDesignReader{byProject: map[string]*artifacts.DesignFile{
+			// Design bundle stores the component under its UNPREFIXED authored name.
+			"myproj": designWith(models.DesignComponent{Name: "svc", OpenAPISpec: spec}),
+		}}),
+	)
+
+	got := cat.Resolve(context.Background(), "org", e)
+	if got.Spec.Availability != "inline" {
+		t.Fatalf("availability: want inline, got %q", got.Spec.Availability)
+	}
+	if got.Spec.InlineContent != spec {
+		t.Fatalf("inline content: want design-bundle spec, got %q", got.Spec.InlineContent)
+	}
+	if got.Spec.Path != "specs/design/components/svc/openapi.yaml" {
+		t.Fatalf("provenance path: want unprefixed design component name (svc), got %q", got.Spec.Path)
+	}
+}
+
 // (c) No schema anywhere, but repo coords resolve (git_repositories row) →
 // availability=repo with the component subdir as the hint.
 func TestResolve_RepoCoords(t *testing.T) {

--- a/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
@@ -116,6 +116,12 @@ func WithDesignReader(d DesignReader) CatalogOption {
 // ListWorkloadEndpoints error; per-endpoint resolution is fail-open (a repo /
 // design lookup error degrades that one row's availability, never the list).
 // Returns nil when the catalog is not wired (nil receiver or nil client).
+//
+// A project publishing K endpoints would otherwise trigger K redundant
+// ArtifactStore.ReadDesign calls (a remote git-bundle read) in a single pass,
+// so this method memoizes the design-bundle read per provider project in a
+// map scoped to THIS call only — it is never a long-lived/global cache (no
+// staleness risk) and does not affect the single-endpoint Resolve below.
 func (c *Catalog) ListResolved(ctx context.Context, orgHandle string) ([]OrgComponentEndpoint, error) {
 	if c == nil || c.rc == nil {
 		return nil, nil
@@ -124,9 +130,10 @@ func (c *Catalog) ListResolved(ctx context.Context, orgHandle string) ([]OrgComp
 	if err != nil {
 		return nil, err
 	}
+	designCache := make(map[string]*artifacts.DesignFile)
 	out := make([]OrgComponentEndpoint, 0, len(infos))
 	for i := range infos {
-		out = append(out, c.Resolve(ctx, orgHandle, infos[i]))
+		out = append(out, c.resolve(ctx, orgHandle, infos[i], designCache))
 	}
 	return out, nil
 }
@@ -143,7 +150,20 @@ func (c *Catalog) ListResolved(ctx context.Context, orgHandle string) ([]OrgComp
 //
 // All collaborator lookups are fail-open: an error leaves that source
 // unresolved (logged) rather than failing the whole resolution.
+//
+// Resolve always reads the design bundle directly (no memoization) — the
+// per-project cache is a ListResolved-pass-only optimization (see
+// designCache in ListResolved); this single-endpoint entry point's behavior
+// is unchanged.
 func (c *Catalog) Resolve(ctx context.Context, orgHandle string, e openchoreo.WorkloadEndpointInfo) OrgComponentEndpoint {
+	return c.resolve(ctx, orgHandle, e, nil)
+}
+
+// resolve is the shared implementation behind Resolve and ListResolved.
+// designCache, when non-nil, memoizes the provider project's design-bundle
+// read for the duration of one ListResolved pass; nil (the public Resolve's
+// case) means "always read".
+func (c *Catalog) resolve(ctx context.Context, orgHandle string, e openchoreo.WorkloadEndpointInfo, designCache map[string]*artifacts.DesignFile) OrgComponentEndpoint {
 	oce := OrgComponentEndpoint{
 		Project:          e.Project,
 		Component:        e.Component,
@@ -156,7 +176,7 @@ func (c *Catalog) Resolve(ctx context.Context, orgHandle string, e openchoreo.Wo
 
 	// Read the provider's design bundle once — it feeds both the step-2 inline
 	// spec and the component subdir hint used on the repo path.
-	comp := c.providerComponent(ctx, orgHandle, e.Project, e.Component)
+	comp := c.providerComponent(ctx, orgHandle, e.Project, e.Component, designCache)
 
 	// Resolve repo coords (step-3 source + provenance on the inline paths).
 	c.resolveRepoCoords(ctx, orgHandle, e.Project, comp, &oce)
@@ -169,7 +189,10 @@ func (c *Catalog) Resolve(ctx context.Context, orgHandle string, e openchoreo.Wo
 		oce.Spec = EndpointSpec{
 			Availability:  availabilityInline,
 			InlineContent: comp.OpenAPISpec,
-			Path:          designOpenAPIPath(e.Component),
+			// comp is matched case-insensitively (see providerComponent), so use
+			// its actual committed Name — not e.Component — for the folder
+			// segment, matching the real design-bundle path casing.
+			Path: designOpenAPIPath(comp.Name),
 		}
 	case oce.Repo != "":
 		oce.Spec = EndpointSpec{Availability: availabilityRepo, Path: oce.Subdir}
@@ -183,12 +206,13 @@ func (c *Catalog) Resolve(ctx context.Context, orgHandle string, e openchoreo.Wo
 // component named `component` (case-insensitive, mirroring
 // artifacts.ResolveDesignComponent), or nil when the reader is unwired, the
 // project has no design bundle, or the component is absent. Fail-open: a read
-// error is logged and returns nil.
-func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, component string) *models.DesignComponent {
+// error is logged and returns nil. designCache is forwarded to readDesign
+// (see its doc) — nil for the public single-endpoint Resolve.
+func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, component string, designCache map[string]*artifacts.DesignFile) *models.DesignComponent {
 	if c.design == nil {
 		return nil
 	}
-	design, err := c.design.ReadDesign(ctx, orgHandle, project)
+	design, err := c.readDesign(ctx, orgHandle, project, designCache)
 	if err != nil {
 		slog.WarnContext(ctx, "endpoint resolver: design read failed",
 			"org", orgHandle, "project", project, "component", component, "error", err)
@@ -203,6 +227,29 @@ func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, com
 		}
 	}
 	return nil
+}
+
+// readDesign reads a provider project's design bundle, memoizing the result
+// in designCache when it is non-nil (the ListResolved-pass-scoped cache — see
+// ListResolved's doc). A nil designCache (the public Resolve's case) always
+// reads through. Only successful reads (including a genuinely absent design
+// bundle, i.e. a nil *DesignFile) are cached; a read error is neither cached
+// nor swallowed here — it is returned for the caller (providerComponent) to
+// log and fail open on, so a transient error doesn't poison the pass.
+func (c *Catalog) readDesign(ctx context.Context, orgHandle, project string, designCache map[string]*artifacts.DesignFile) (*artifacts.DesignFile, error) {
+	if designCache != nil {
+		if design, ok := designCache[project]; ok {
+			return design, nil
+		}
+	}
+	design, err := c.design.ReadDesign(ctx, orgHandle, project)
+	if err != nil {
+		return nil, err
+	}
+	if designCache != nil {
+		designCache[project] = design
+	}
+	return design, nil
 }
 
 // resolveRepoCoords fills oce.Owner/Repo/Subdir/Branch from the app-factory

--- a/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
@@ -208,6 +208,14 @@ func (c *Catalog) resolve(ctx context.Context, orgHandle string, e openchoreo.Wo
 // project has no design bundle, or the component is absent. Fail-open: a read
 // error is logged and returns nil. designCache is forwarded to readDesign
 // (see its doc) — nil for the public single-endpoint Resolve.
+//
+// The raw component name is tried first. An app-factory-created component's
+// OC name (spec.owner.componentName, carried on the endpoint's Component
+// field) is project-prefixed — e.g. "myproj-svc" — but the design bundle
+// stores it under its unprefixed authored name ("svc"), so a raw-name miss on
+// a "<project>-" prefixed component retries once with the prefix stripped.
+// Hand-applied / non-app-factory components (unprefixed to begin with) are
+// unaffected: the raw-name lookup already finds them.
 func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, component string, designCache map[string]*artifacts.DesignFile) *models.DesignComponent {
 	if c.design == nil {
 		return nil
@@ -221,8 +229,20 @@ func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, com
 	if design == nil {
 		return nil
 	}
+	if comp := findDesignComponent(design, component); comp != nil {
+		return comp
+	}
+	if prefix := project + "-"; strings.HasPrefix(component, prefix) {
+		return findDesignComponent(design, strings.TrimPrefix(component, prefix))
+	}
+	return nil
+}
+
+// findDesignComponent returns the design bundle component named `name`
+// (case-insensitive), or nil when absent.
+func findDesignComponent(design *artifacts.DesignFile, name string) *models.DesignComponent {
 	for i := range design.Components {
-		if strings.EqualFold(design.Components[i].Name, component) {
+		if strings.EqualFold(design.Components[i].Name, name) {
 			return &design.Components[i]
 		}
 	}

--- a/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
+++ b/services/aep-api/internal/feature/dependencies/endpoints/resolve.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package endpoints
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/feature/artifacts"
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// OrgComponentEndpoint is a catalog row enriched with the provider's repo
+// coordinates and a discovered OpenAPI contract — the material an architect (or
+// a coding agent, via the A3 MCP tool) needs to consume an `org-service` by its
+// real spec instead of guessing. It is the resolved projection of a single
+// WorkloadEndpointInfo.
+type OrgComponentEndpoint struct {
+	Project   string // owner project NAME (== the app-factory project id; see resolveRepoCoords)
+	Component string // owner component NAME (the org-service key)
+	Endpoint  string // endpoint name (spec.endpoints key)
+	Type      string // HTTP | gRPC | GraphQL | Websocket | TCP | UDP
+	Port      int32
+	BasePath  string
+	// NamespaceVisible mirrors the raw row: whether the provider published this
+	// endpoint for cross-project (org-service) consumption.
+	NamespaceVisible bool
+	// Owner/Repo/Subdir/Branch are the provider's repo coordinates, "" when
+	// unknown (a BYO-image provider with no git_repositories row and no
+	// off-platform repo coords surfaced by the OC client — see resolve.go's
+	// package note on the Workflow.Parameters gap).
+	Owner, Repo, Subdir, Branch string
+	Spec                        EndpointSpec
+}
+
+// EndpointSpec tags how the endpoint's OpenAPI contract is available.
+//
+//	inline — InlineContent holds the spec document verbatim (from the deployed
+//	         Workload CR schema, or a provider's committed design-bundle
+//	         openapi.yaml). Path names the design-bundle source for provenance.
+//	repo   — no inline spec, but the provider's repo coords are known; Path is
+//	         the subdir hint where an agent should look for the contract.
+//	none   — neither a spec nor repo coords are resolvable (BYO-image provider).
+//
+// `local` is deliberately NOT produced here — it is a coding-agent-side
+// classification for same-project deps (Part C), which never appear in this
+// org-wide list.
+type EndpointSpec struct {
+	Availability  string // inline | repo | none
+	InlineContent string // set iff Availability == inline
+	Path          string // provenance (inline from design bundle) or subdir hint (repo)
+}
+
+const (
+	availabilityInline = "inline"
+	availabilityRepo   = "repo"
+	availabilityNone   = "none"
+)
+
+// RepoLocator resolves an app-factory provider's provisioned git repo row by
+// its (org, project-id) tuple. Satisfied structurally by
+// repositories.RepoRepository. The provider project NAME carried on a workload
+// endpoint (spec.owner.projectName) IS the app-factory project id: project
+// creation seeds git_repositories.project_id from the OC project name
+// (project_service → repoSvc.CreateRepo(orgName, project.Name, …)), so the
+// endpoint's Project field keys these lookups directly — no name→id mapping
+// table is needed.
+type RepoLocator interface {
+	GetByOrgAndProjectID(ctx context.Context, ocOrgID, projectID string) (*models.GitRepository, error)
+}
+
+// DesignReader reads a provider project's committed design bundle (assembled
+// per-component design.json + sibling openapi.yaml). Satisfied structurally by
+// *artifacts.ArtifactStore. Keyed by the same (org, project-id) tuple as
+// RepoLocator (see its note).
+type DesignReader interface {
+	ReadDesign(ctx context.Context, orgID, projectID string) (*artifacts.DesignFile, error)
+}
+
+// CatalogOption configures the optional resolver collaborators on a Catalog.
+// Absent options degrade gracefully: without a RepoLocator/DesignReader the
+// resolver simply can't reach the repo/design-bundle sources and availability
+// falls back accordingly (inline-from-CR still works; everything else → none).
+type CatalogOption func(*Catalog)
+
+// WithRepoLocator wires the git-repository lookup used for step-3 repo coords
+// (and provenance on the inline/repo paths).
+func WithRepoLocator(r RepoLocator) CatalogOption {
+	return func(c *Catalog) { c.repos = r }
+}
+
+// WithDesignReader wires the design-bundle reader used for step-2 inline specs
+// (a provider's committed openapi.yaml) and the component subdir hint.
+func WithDesignReader(d DesignReader) CatalogOption {
+	return func(c *Catalog) { c.design = d }
+}
+
+// ListResolved returns every provider-side endpoint enriched with repo coords
+// and a discovered spec (see Resolve). It propagates the underlying
+// ListWorkloadEndpoints error; per-endpoint resolution is fail-open (a repo /
+// design lookup error degrades that one row's availability, never the list).
+// Returns nil when the catalog is not wired (nil receiver or nil client).
+func (c *Catalog) ListResolved(ctx context.Context, orgHandle string) ([]OrgComponentEndpoint, error) {
+	if c == nil || c.rc == nil {
+		return nil, nil
+	}
+	infos, err := c.rc.ListWorkloadEndpoints(ctx, orgHandle)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]OrgComponentEndpoint, 0, len(infos))
+	for i := range infos {
+		out = append(out, c.Resolve(ctx, orgHandle, infos[i]))
+	}
+	return out, nil
+}
+
+// Resolve enriches one raw endpoint into an OrgComponentEndpoint: it resolves
+// the provider's repo coordinates and computes the spec availability in the
+// fixed order
+//
+//  1. the deployed Workload CR already carries an inline schema  → inline (CR);
+//  2. the app-factory provider committed a design-bundle openapi.yaml → inline
+//     (read server-side; Path = the design-bundle path, for provenance);
+//  3. repo coords resolved (git_repositories) → repo (Path = subdir hint);
+//  4. otherwise → none.
+//
+// All collaborator lookups are fail-open: an error leaves that source
+// unresolved (logged) rather than failing the whole resolution.
+func (c *Catalog) Resolve(ctx context.Context, orgHandle string, e openchoreo.WorkloadEndpointInfo) OrgComponentEndpoint {
+	oce := OrgComponentEndpoint{
+		Project:          e.Project,
+		Component:        e.Component,
+		Endpoint:         e.Name,
+		Type:             e.Type,
+		Port:             e.Port,
+		BasePath:         e.BasePath,
+		NamespaceVisible: e.NamespaceVisible(),
+	}
+
+	// Read the provider's design bundle once — it feeds both the step-2 inline
+	// spec and the component subdir hint used on the repo path.
+	comp := c.providerComponent(ctx, orgHandle, e.Project, e.Component)
+
+	// Resolve repo coords (step-3 source + provenance on the inline paths).
+	c.resolveRepoCoords(ctx, orgHandle, e.Project, comp, &oce)
+
+	// Compute spec availability in the fixed resolution order.
+	switch {
+	case e.SchemaContent != "":
+		oce.Spec = EndpointSpec{Availability: availabilityInline, InlineContent: e.SchemaContent}
+	case comp != nil && strings.TrimSpace(comp.OpenAPISpec) != "":
+		oce.Spec = EndpointSpec{
+			Availability:  availabilityInline,
+			InlineContent: comp.OpenAPISpec,
+			Path:          designOpenAPIPath(e.Component),
+		}
+	case oce.Repo != "":
+		oce.Spec = EndpointSpec{Availability: availabilityRepo, Path: oce.Subdir}
+	default:
+		oce.Spec = EndpointSpec{Availability: availabilityNone}
+	}
+	return oce
+}
+
+// providerComponent reads the provider project's design bundle and returns the
+// component named `component` (case-insensitive, mirroring
+// artifacts.ResolveDesignComponent), or nil when the reader is unwired, the
+// project has no design bundle, or the component is absent. Fail-open: a read
+// error is logged and returns nil.
+func (c *Catalog) providerComponent(ctx context.Context, orgHandle, project, component string) *models.DesignComponent {
+	if c.design == nil {
+		return nil
+	}
+	design, err := c.design.ReadDesign(ctx, orgHandle, project)
+	if err != nil {
+		slog.WarnContext(ctx, "endpoint resolver: design read failed",
+			"org", orgHandle, "project", project, "component", component, "error", err)
+		return nil
+	}
+	if design == nil {
+		return nil
+	}
+	for i := range design.Components {
+		if strings.EqualFold(design.Components[i].Name, component) {
+			return &design.Components[i]
+		}
+	}
+	return nil
+}
+
+// resolveRepoCoords fills oce.Owner/Repo/Subdir/Branch from the app-factory
+// provider's git_repositories row, using the design-bundle component's appPath
+// as the subdir hint. Fail-open: no row (or a lookup error) leaves the coords
+// empty, and availability then falls to repo-if-coords-known-else-none.
+//
+// The off-platform-with-build fallback (repo coords from the OC Component's
+// Workflow.Parameters) is intentionally NOT wired: the aep-api OC client's
+// GetComponent projects the CR onto models.Component, which drops the workflow
+// spec, so those coords are not reachable without extending the client. Left
+// best-effort per the Task A2 brief; app-factory providers resolve fully via
+// the git_repositories path above.
+func (c *Catalog) resolveRepoCoords(ctx context.Context, orgHandle, project string, comp *models.DesignComponent, oce *OrgComponentEndpoint) {
+	if c.repos == nil {
+		return
+	}
+	gr, err := c.repos.GetByOrgAndProjectID(ctx, orgHandle, project)
+	if err != nil {
+		slog.WarnContext(ctx, "endpoint resolver: repo lookup failed",
+			"org", orgHandle, "project", project, "error", err)
+		return
+	}
+	if gr == nil {
+		return
+	}
+	owner, repo := models.OwnerRepoFromURL(gr.RepoURL)
+	oce.Owner, oce.Repo, oce.Branch = owner, repo, gr.DefaultBranch
+	if comp != nil {
+		oce.Subdir = comp.AppPath
+	}
+}
+
+// designOpenAPIPath is the repo-relative path of a component's committed
+// OpenAPI contract in the design bundle — the provenance recorded on a
+// step-2 inline spec.
+func designOpenAPIPath(component string) string {
+	return "specs/design/components/" + component + "/openapi.yaml"
+}

--- a/services/aep-api/internal/feature/dependencies/mcp_server.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_server.go
@@ -33,10 +33,11 @@ import (
 // that ALREADY exist in the org instead of inventing names/shapes.
 //
 // Read-only tools (see mcp_tools.go):
-//   - list_external_resources       → every registered external resource + its config-key schema
-//   - get_external_resource_schema  → one external resource's config-key schema
-//   - list_org_endpoints            → every service endpoint published across the org
-//   - list_platform_resource_types  → the platform-provisioned resource types on the cluster
+//   - list_external_resources        → every registered external resource + its config-key schema
+//   - get_external_resource_schema   → one external resource's config-key schema
+//   - list_org_endpoints             → every service endpoint published across the org
+//   - list_org_component_endpoints   → list_org_endpoints resolved with repo coords + discovered OpenAPI spec
+//   - list_platform_resource_types   → the platform-provisioned resource types on the cluster
 //
 // Mounted at POST /internal/v1/mcp behind auth.AgentsScopedVerifier, which binds
 // the acting org onto the request context from a verified BFF-signed token

--- a/services/aep-api/internal/feature/dependencies/mcp_server.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_server.go
@@ -71,16 +71,19 @@ type mcpHandler struct {
 	resources     ExternalResourceReader
 	orgEndpoints  OrgEndpointLister
 	resourceTypes ResourceTypeLister
+	remoteGit     RemoteGitReader
 }
 
 // NewMCPHandler returns the JSON-RPC MCP handler over the external-resource
-// reader, the org endpoint lister, and the platform resource-type lister. The
-// acting org is resolved from the request context (bound by the auth
-// middleware), never from the request itself. A nil external-resource reader
-// makes the surface unavailable (503 — it is the surface's core catalog). A nil
-// orgEndpoints/resourceTypes degrades that one tool to an empty result.
-func NewMCPHandler(er ExternalResourceReader, ep OrgEndpointLister, rt ResourceTypeLister) http.Handler {
-	h := &mcpHandler{resources: er, orgEndpoints: ep, resourceTypes: rt}
+// reader, the org endpoint lister, the platform resource-type lister, and the
+// read-only remote-git reader (endpoint spec discovery). The acting org is
+// resolved from the request context (bound by the auth middleware), never from
+// the request itself. A nil external-resource reader makes the surface
+// unavailable (503 — it is the surface's core catalog). A nil
+// orgEndpoints/resourceTypes degrades that one tool to an empty result; a nil
+// remoteGit makes the two remote-git tools return a tool error.
+func NewMCPHandler(er ExternalResourceReader, ep OrgEndpointLister, rt ResourceTypeLister, rg RemoteGitReader) http.Handler {
+	h := &mcpHandler{resources: er, orgEndpoints: ep, resourceTypes: rt, remoteGit: rg}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if h.resources == nil {
 			http.Error(w, "external resource registry not configured", http.StatusServiceUnavailable)

--- a/services/aep-api/internal/feature/dependencies/mcp_server_test.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_server_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies/endpoints"
 	"github.com/wso2/aep/aep-api/internal/feature/dependencies/resources"
 	"github.com/wso2/aep/aep-api/internal/platform/auth"
 	"github.com/wso2/aep/aep-api/models"
@@ -69,12 +70,26 @@ type fakeEndpointLister struct {
 	// the OC transport treats the request's MCP bearer as a forwardable user
 	// JWT and OC 401s every catalog read (caught live in E2E S3).
 	lastCtxServiceIdentity bool
+
+	// resolved/resolvedErr back ListResolved (the A3 list_org_component_endpoints
+	// tool). lastResolvedOrg/lastResolvedCtxServiceIdentity mirror the List
+	// fields above for the resolved path.
+	resolved                       []endpoints.OrgComponentEndpoint
+	resolvedErr                    error
+	lastResolvedOrg                string
+	lastResolvedCtxServiceIdentity bool
 }
 
 func (f *fakeEndpointLister) List(ctx context.Context, orgHandle string) ([]openchoreo.WorkloadEndpointInfo, error) {
 	f.lastOrg = orgHandle
 	f.lastCtxServiceIdentity = auth.IsServiceIdentity(ctx)
 	return f.items, f.err
+}
+
+func (f *fakeEndpointLister) ListResolved(ctx context.Context, orgHandle string) ([]endpoints.OrgComponentEndpoint, error) {
+	f.lastResolvedOrg = orgHandle
+	f.lastResolvedCtxServiceIdentity = auth.IsServiceIdentity(ctx)
+	return f.resolved, f.resolvedErr
 }
 
 type fakeTypeLister struct {
@@ -157,10 +172,28 @@ func sampleHandler() (http.Handler, *fakeResourceReader, *fakeEndpointLister) {
 			{Key: "SALESFORCE_TOKEN", Secret: true},
 		},
 	}}}
-	ep := &fakeEndpointLister{items: []openchoreo.WorkloadEndpointInfo{
-		{Project: "billing", Component: "invoice-api", Name: "rest", Type: "HTTP", Visibility: []string{"namespace"}},
-		{Project: "crm", Component: "leads-api", Name: "grpc", Type: "gRPC"}, // not published cross-project
-	}}
+	ep := &fakeEndpointLister{
+		items: []openchoreo.WorkloadEndpointInfo{
+			{Project: "billing", Component: "invoice-api", Name: "rest", Type: "HTTP", Visibility: []string{"namespace"}},
+			{Project: "crm", Component: "leads-api", Name: "grpc", Type: "gRPC"}, // not published cross-project
+		},
+		resolved: []endpoints.OrgComponentEndpoint{
+			{
+				Project: "billing", Component: "invoice-api", Endpoint: "rest", Type: "HTTP",
+				Port: 8080, BasePath: "/api", NamespaceVisible: true,
+				Owner: "wso2", Repo: "billing-svc", Subdir: "services/invoice-api", Branch: "main",
+				Spec: endpoints.EndpointSpec{
+					Availability:  "inline",
+					InlineContent: "openapi: 3.0.0\ninfo:\n  title: invoice-api\n",
+					Path:          "specs/design/components/invoice-api/openapi.yaml",
+				},
+			},
+			{
+				Project: "crm", Component: "leads-api", Endpoint: "grpc", Type: "gRPC",
+				Spec: endpoints.EndpointSpec{Availability: "none"},
+			},
+		},
+	}
 	rt := &fakeTypeLister{items: []resources.PlatformResourceType{
 		{Name: "postgres", Description: "A dedicated PostgreSQL database cluster.", Outputs: []string{"host", "port"}},
 	}}
@@ -220,6 +253,7 @@ func TestMCP_ToolsList_RenamedTools(t *testing.T) {
 		"list_external_resources",
 		"get_external_resource_schema",
 		"list_org_endpoints",
+		"list_org_component_endpoints",
 		"list_platform_resource_types",
 	}
 	if len(names) != len(want) {
@@ -399,6 +433,55 @@ func TestMCP_ListOrgEndpoints_NilLister_Empty(t *testing.T) {
 	er := &fakeResourceReader{}
 	h := NewMCPHandler(er, nil, nil)
 	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_org_endpoints", `{}`)))
+	text := toolText(t, resp, false)
+	if text != `{"endpoints":[]}` {
+		t.Errorf("payload = %q, want empty endpoints", text)
+	}
+}
+
+func TestMCP_ListOrgComponentEndpoints(t *testing.T) {
+	h, _, ep := sampleHandler()
+	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_org_component_endpoints", `{}`)))
+	text := toolText(t, resp, false)
+
+	var payload struct {
+		Endpoints []orgComponentEndpointView `json:"endpoints"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if len(payload.Endpoints) != 2 {
+		t.Fatalf("endpoints = %+v, want 2 entries", payload.Endpoints)
+	}
+	first := payload.Endpoints[0]
+	if first.Project != "billing" || first.Component != "invoice-api" || first.Endpoint != "rest" ||
+		first.Type != "HTTP" || first.Port != 8080 || first.BasePath != "/api" || !first.NamespaceVisible ||
+		first.Owner != "wso2" || first.Repo != "billing-svc" || first.Subdir != "services/invoice-api" ||
+		first.Branch != "main" {
+		t.Errorf("unexpected first endpoint view: %+v", first)
+	}
+	if first.Spec.Availability != "inline" {
+		t.Errorf("first.Spec.Availability = %q, want inline", first.Spec.Availability)
+	}
+	if first.Spec.InlineContent == "" {
+		t.Errorf("first.Spec.InlineContent must be populated for the inline case")
+	}
+	second := payload.Endpoints[1]
+	if second.Spec.Availability != "none" {
+		t.Errorf("second.Spec.Availability = %q, want none", second.Spec.Availability)
+	}
+	if ep.lastResolvedOrg != "org-1" {
+		t.Errorf("resolver called with org %q, want org-1", ep.lastResolvedOrg)
+	}
+	if !ep.lastResolvedCtxServiceIdentity {
+		t.Errorf("tool-call context must be marked service identity — otherwise the OC transport forwards the MCP bearer as a user JWT and every catalog read 401s")
+	}
+}
+
+func TestMCP_ListOrgComponentEndpoints_NilLister_Empty(t *testing.T) {
+	er := &fakeResourceReader{}
+	h := NewMCPHandler(er, nil, nil)
+	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_org_component_endpoints", `{}`)))
 	text := toolText(t, resp, false)
 	if text != `{"endpoints":[]}` {
 		t.Errorf("payload = %q, want empty endpoints", text)

--- a/services/aep-api/internal/feature/dependencies/mcp_server_test.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_server_test.go
@@ -197,7 +197,34 @@ func sampleHandler() (http.Handler, *fakeResourceReader, *fakeEndpointLister) {
 	rt := &fakeTypeLister{items: []resources.PlatformResourceType{
 		{Name: "postgres", Description: "A dedicated PostgreSQL database cluster.", Outputs: []string{"host", "port"}},
 	}}
-	return NewMCPHandler(er, ep, rt), er, ep
+	return NewMCPHandler(er, ep, rt, &fakeRemoteGit{}), er, ep
+}
+
+// fakeRemoteGit is a stub RemoteGitReader for the handler-dispatch tests. It
+// records the org + owner the handler passed down (proving org flows from the
+// verified context, not a tool param) and returns canned results or errors.
+type fakeRemoteGit struct {
+	file      *RemoteGitFile
+	hits      []RemoteGitSearchHit
+	err       error
+	lastOrg   string
+	lastOwner string
+}
+
+func (f *fakeRemoteGit) GetFileContents(_ context.Context, ocOrgID, owner, _, _, _ string) (*RemoteGitFile, error) {
+	f.lastOrg, f.lastOwner = ocOrgID, owner
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.file, nil
+}
+
+func (f *fakeRemoteGit) SearchCode(_ context.Context, ocOrgID, owner, _, _ string) ([]RemoteGitSearchHit, error) {
+	f.lastOrg, f.lastOwner = ocOrgID, owner
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.hits, nil
 }
 
 // ---- protocol ----------------------------------------------------------------
@@ -255,6 +282,8 @@ func TestMCP_ToolsList_RenamedTools(t *testing.T) {
 		"list_org_endpoints",
 		"list_org_component_endpoints",
 		"list_platform_resource_types",
+		"get_remote_git_file_contents",
+		"search_remote_git_code",
 	}
 	if len(names) != len(want) {
 		t.Fatalf("tools = %v, want %v", names, want)
@@ -304,7 +333,7 @@ func TestMCP_UnknownTool(t *testing.T) {
 // ---- guards ------------------------------------------------------------------
 
 func TestMCP_NilResourceReader_503(t *testing.T) {
-	h := NewMCPHandler(nil, &fakeEndpointLister{}, &fakeTypeLister{})
+	h := NewMCPHandler(nil, &fakeEndpointLister{}, &fakeTypeLister{}, &fakeRemoteGit{})
 	w := postRPC(t, h, "org-1", `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", w.Code)
@@ -349,7 +378,7 @@ func TestMCP_ListExternalResources(t *testing.T) {
 
 func TestMCP_ListExternalResources_PortError(t *testing.T) {
 	er := &fakeResourceReader{listErr: fmt.Errorf("db down")}
-	h := NewMCPHandler(er, nil, nil)
+	h := NewMCPHandler(er, nil, nil, nil)
 	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_external_resources", `{}`)))
 	text := toolText(t, resp, true)
 	if !strings.Contains(text, "db down") {
@@ -431,7 +460,7 @@ func TestMCP_ListOrgEndpoints(t *testing.T) {
 
 func TestMCP_ListOrgEndpoints_NilLister_Empty(t *testing.T) {
 	er := &fakeResourceReader{}
-	h := NewMCPHandler(er, nil, nil)
+	h := NewMCPHandler(er, nil, nil, nil)
 	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_org_endpoints", `{}`)))
 	text := toolText(t, resp, false)
 	if text != `{"endpoints":[]}` {
@@ -480,7 +509,7 @@ func TestMCP_ListOrgComponentEndpoints(t *testing.T) {
 
 func TestMCP_ListOrgComponentEndpoints_NilLister_Empty(t *testing.T) {
 	er := &fakeResourceReader{}
-	h := NewMCPHandler(er, nil, nil)
+	h := NewMCPHandler(er, nil, nil, nil)
 	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_org_component_endpoints", `{}`)))
 	text := toolText(t, resp, false)
 	if text != `{"endpoints":[]}` {
@@ -515,10 +544,128 @@ func TestMCP_ListPlatformResourceTypes(t *testing.T) {
 
 func TestMCP_ListPlatformResourceTypes_NilLister_Empty(t *testing.T) {
 	er := &fakeResourceReader{}
-	h := NewMCPHandler(er, nil, nil)
+	h := NewMCPHandler(er, nil, nil, nil)
 	resp := decodeRPC(t, postRPC(t, h, "org-1", callBody("list_platform_resource_types", `{}`)))
 	text := toolText(t, resp, false)
 	if text != `{"resourceTypes":[]}` {
 		t.Errorf("payload = %q, want empty resourceTypes", text)
+	}
+}
+
+// ---- remote-git tools (endpoint spec discovery) --------------------------------
+
+func TestMCP_GetRemoteGitFileContents(t *testing.T) {
+	rg := &fakeRemoteGit{file: &RemoteGitFile{Content: "openapi: 3.0.0\n", SHA: "abc"}}
+	h := NewMCPHandler(&fakeResourceReader{}, nil, nil, rg)
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("get_remote_git_file_contents", `{"owner":"acme","repo":"billing-svc","path":"specs/openapi.yaml","ref":"main"}`)))
+	text := toolText(t, resp, false)
+
+	var payload remoteGitFileView
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Content != "openapi: 3.0.0\n" || payload.SHA != "abc" || payload.IsDirectory {
+		t.Errorf("unexpected payload: %+v", payload)
+	}
+	// The org MUST be the verified context claim, never a tool arg.
+	if rg.lastOrg != "org-1" {
+		t.Errorf("reader saw org %q, want org-1 (from the verified claim)", rg.lastOrg)
+	}
+	if rg.lastOwner != "acme" {
+		t.Errorf("reader saw owner %q, want acme", rg.lastOwner)
+	}
+}
+
+func TestMCP_GetRemoteGitFileContents_Directory(t *testing.T) {
+	rg := &fakeRemoteGit{file: &RemoteGitFile{IsDirectory: true, Entries: []RemoteGitEntry{
+		{Path: "specs/openapi.yaml", Type: "file", SHA: "a"},
+	}}}
+	h := NewMCPHandler(&fakeResourceReader{}, nil, nil, rg)
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("get_remote_git_file_contents", `{"owner":"acme","repo":"billing-svc","path":"specs"}`)))
+	text := toolText(t, resp, false)
+	var payload remoteGitFileView
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if !payload.IsDirectory || len(payload.Entries) != 1 || payload.Entries[0].Path != "specs/openapi.yaml" {
+		t.Errorf("unexpected directory payload: %+v", payload)
+	}
+}
+
+func TestMCP_GetRemoteGitFileContents_OwnerMismatch_ToolError(t *testing.T) {
+	// The reader refuses a cross-org owner; the handler must surface it as a
+	// tool-level error (isError=true), not data.
+	rg := &fakeRemoteGit{err: ErrOwnerNotInOrg}
+	h := NewMCPHandler(&fakeResourceReader{}, nil, nil, rg)
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("get_remote_git_file_contents", `{"owner":"evilcorp","repo":"secret","path":"x"}`)))
+	text := toolText(t, resp, true) // wantErr = true
+	if !strings.Contains(text, "owner") {
+		t.Errorf("tool error = %q, want it to mention the owner refusal", text)
+	}
+}
+
+func TestMCP_GetRemoteGitFileContents_MissingArgs_ToolError(t *testing.T) {
+	h, _, _ := sampleHandler()
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("get_remote_git_file_contents", `{"repo":"billing-svc","path":"x"}`))) // no owner
+	toolText(t, resp, true)
+}
+
+func TestMCP_GetRemoteGitFileContents_NilReader_ToolError(t *testing.T) {
+	h := NewMCPHandler(&fakeResourceReader{}, nil, nil, nil)
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("get_remote_git_file_contents", `{"owner":"acme","repo":"r","path":"x"}`)))
+	toolText(t, resp, true)
+}
+
+func TestMCP_SearchRemoteGitCode(t *testing.T) {
+	rg := &fakeRemoteGit{hits: []RemoteGitSearchHit{
+		{Path: "specs/openapi.yaml", SHA: "a"},
+		{Path: "api/openapi.yaml", SHA: "b"},
+	}}
+	h := NewMCPHandler(&fakeResourceReader{}, nil, nil, rg)
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("search_remote_git_code", `{"owner":"acme","repo":"billing-svc","query":"openapi"}`)))
+	text := toolText(t, resp, false)
+	var payload struct {
+		Items []remoteGitSearchHitView `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if len(payload.Items) != 2 || payload.Items[0].Path != "specs/openapi.yaml" {
+		t.Errorf("unexpected payload: %+v", payload)
+	}
+	if rg.lastOrg != "org-1" {
+		t.Errorf("reader saw org %q, want org-1", rg.lastOrg)
+	}
+}
+
+func TestMCP_SearchRemoteGitCode_MissingQuery_ToolError(t *testing.T) {
+	h, _, _ := sampleHandler()
+	resp := decodeRPC(t, postRPC(t, h, "org-1",
+		callBody("search_remote_git_code", `{"owner":"acme","repo":"billing-svc"}`)))
+	toolText(t, resp, true)
+}
+
+// The two remote-git tools must be advertised by tools/list.
+func TestMCP_ToolsList_IncludesRemoteGitTools(t *testing.T) {
+	h, _, _ := sampleHandler()
+	resp := decodeRPC(t, postRPC(t, h, "org-1", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	result := resp.Result.(map[string]any)
+	tools, _ := result["tools"].([]any)
+	names := map[string]bool{}
+	for _, tr := range tools {
+		if m, ok := tr.(map[string]any); ok {
+			names[m["name"].(string)] = true
+		}
+	}
+	for _, want := range []string{"get_remote_git_file_contents", "search_remote_git_code"} {
+		if !names[want] {
+			t.Errorf("tools/list missing %q (got %v)", want, names)
+		}
 	}
 }

--- a/services/aep-api/internal/feature/dependencies/mcp_tools.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_tools.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies/endpoints"
 	"github.com/wso2/aep/aep-api/models"
 )
 
@@ -55,6 +56,33 @@ type orgEndpointView struct {
 	NamespaceVisible bool   `json:"namespaceVisible"` // consumable cross-project as an org-service
 }
 
+// orgComponentEndpointView is the JSON shape returned to the agent for one
+// resolved org-wide component endpoint — list_org_endpoints's rows enriched
+// with the provider's repo coordinates and a discovered OpenAPI contract
+// (endpoint spec discovery). Mirrors endpoints.OrgComponentEndpoint.
+type orgComponentEndpointView struct {
+	Project          string           `json:"project"`
+	Component        string           `json:"component"`
+	Endpoint         string           `json:"endpoint"`
+	Type             string           `json:"type"`
+	Port             int32            `json:"port,omitempty"`
+	BasePath         string           `json:"basePath,omitempty"`
+	NamespaceVisible bool             `json:"namespaceVisible"`
+	Owner            string           `json:"owner,omitempty"`
+	Repo             string           `json:"repo,omitempty"`
+	Subdir           string           `json:"subdir,omitempty"`
+	Branch           string           `json:"branch,omitempty"`
+	Spec             endpointSpecView `json:"spec"`
+}
+
+// endpointSpecView is the JSON shape for an OrgComponentEndpoint's discovered
+// OpenAPI contract availability (see endpoints.EndpointSpec).
+type endpointSpecView struct {
+	Availability  string `json:"availability"`
+	InlineContent string `json:"inlineContent,omitempty"`
+	Path          string `json:"path,omitempty"`
+}
+
 // mcpTools returns the read-only tool descriptors advertised by tools/list.
 func mcpTools() []mcpTool {
 	return []mcpTool{
@@ -85,6 +113,18 @@ func mcpTools() []mcpTool {
 				"endpoint, type, and `namespaceVisible`. Only propose an `org-service` dependency when " +
 				"`namespaceVisible` is true; a row with namespaceVisible=false exists but the provider has NOT " +
 				"published it cross-project, so it cannot be consumed yet.",
+			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		},
+		{
+			Name: "list_org_component_endpoints",
+			Description: "List every org-wide component endpoint published across this organization, each " +
+				"resolved with the provider's real OpenAPI contract (when discoverable) and repo coordinates. " +
+				"Use this INSTEAD of list_org_endpoints when you need the endpoint's actual request/response " +
+				"contract to integrate against it — not just its name and type. Each row's `spec.availability` " +
+				"is `inline` (spec.inlineContent carries the OpenAPI document verbatim — read it directly), " +
+				"`repo` (no inline spec, but owner/repo/subdir/branch locate the provider's source so you can " +
+				"read the contract from there), or `none` (neither is resolvable — treat the integration as " +
+				"undocumented).",
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
 		},
 		{
@@ -161,6 +201,21 @@ func handleToolCall(w http.ResponseWriter, r *http.Request, h *mcpHandler, orgHa
 			})
 		}
 		writeToolText(w, req.ID, mustJSON(map[string]any{"endpoints": views}))
+	case "list_org_component_endpoints":
+		if h.orgEndpoints == nil {
+			writeToolText(w, req.ID, mustJSON(map[string]any{"endpoints": []any{}}))
+			return
+		}
+		resolved, err := h.orgEndpoints.ListResolved(r.Context(), orgHandle)
+		if err != nil {
+			writeToolError(w, req.ID, fmt.Sprintf("list org component endpoints: %v", err))
+			return
+		}
+		views := make([]orgComponentEndpointView, 0, len(resolved))
+		for i := range resolved {
+			views = append(views, toOrgComponentEndpointView(&resolved[i]))
+		}
+		writeToolText(w, req.ID, mustJSON(map[string]any{"endpoints": views}))
 	case "list_platform_resource_types":
 		if h.resourceTypes == nil {
 			writeToolText(w, req.ID, mustJSON(map[string]any{"resourceTypes": []any{}}))
@@ -185,4 +240,27 @@ func toExternalResourceView(er *models.ExternalResource) externalResourceView {
 		keys = append(keys, configKeyDTO{Key: k.Key, Secret: k.Secret})
 	}
 	return externalResourceView{Name: er.Name, Description: er.Description, ConfigKeys: keys}
+}
+
+// toOrgComponentEndpointView projects a resolved OrgComponentEndpoint to the
+// agent-facing shape (coords + discovered spec availability).
+func toOrgComponentEndpointView(e *endpoints.OrgComponentEndpoint) orgComponentEndpointView {
+	return orgComponentEndpointView{
+		Project:          e.Project,
+		Component:        e.Component,
+		Endpoint:         e.Endpoint,
+		Type:             e.Type,
+		Port:             e.Port,
+		BasePath:         e.BasePath,
+		NamespaceVisible: e.NamespaceVisible,
+		Owner:            e.Owner,
+		Repo:             e.Repo,
+		Subdir:           e.Subdir,
+		Branch:           e.Branch,
+		Spec: endpointSpecView{
+			Availability:  e.Spec.Availability,
+			InlineContent: e.Spec.InlineContent,
+			Path:          e.Spec.Path,
+		},
+	}
 }

--- a/services/aep-api/internal/feature/dependencies/mcp_tools.go
+++ b/services/aep-api/internal/feature/dependencies/mcp_tools.go
@@ -83,6 +83,28 @@ type endpointSpecView struct {
 	Path          string `json:"path,omitempty"`
 }
 
+// remoteGitFileView is the JSON shape returned by get_remote_git_file_contents —
+// a file's decoded content + sha, or a directory's entries (folded like
+// github-mcp-server's get_file_contents).
+type remoteGitFileView struct {
+	Content     string               `json:"content,omitempty"`
+	SHA         string               `json:"sha,omitempty"`
+	IsDirectory bool                 `json:"isDirectory"`
+	Entries     []remoteGitEntryView `json:"entries,omitempty"`
+}
+
+type remoteGitEntryView struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+	SHA  string `json:"sha"`
+}
+
+// remoteGitSearchHitView is one item of search_remote_git_code's result.
+type remoteGitSearchHitView struct {
+	Path string `json:"path"`
+	SHA  string `json:"sha"`
+}
+
 // mcpTools returns the read-only tool descriptors advertised by tools/list.
 func mcpTools() []mcpTool {
 	return []mcpTool{
@@ -136,6 +158,43 @@ func mcpTools() []mcpTool {
 				"matches the need. Read-only — you never author these.",
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
 		},
+		{
+			Name: "get_remote_git_file_contents",
+			Description: "Read a file (or list a directory) from a repository in THIS organization over the " +
+				"GitHub API — no clone. Use this AFTER list_org_component_endpoints reports a provider whose " +
+				"`spec.availability` is `repo`: pass that row's owner/repo plus the spec path to read the real " +
+				"OpenAPI document. A file returns decoded `content` + `sha`; a directory returns `entries[]` " +
+				"(each with path/type/sha) so you can drill down. `ref` is optional (branch/tag/commit; " +
+				"defaults to the repo's default branch). Read-only, and restricted to your own organization's " +
+				"repos — a request for any other owner is refused.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"owner": map[string]any{"type": "string", "description": "repo owner — MUST be your organization's GitHub account"},
+					"repo":  map[string]any{"type": "string", "description": "repository name"},
+					"path":  map[string]any{"type": "string", "description": "repo-relative file or directory path (empty = repo root)"},
+					"ref":   map[string]any{"type": "string", "description": "optional branch/tag/commit"},
+				},
+				"required": []string{"owner", "repo", "path"},
+			},
+		},
+		{
+			Name: "search_remote_git_code",
+			Description: "Search code in a repository in THIS organization over the GitHub API to LOCATE a " +
+				"file when you do not know its exact path (e.g. find where an `openapi.yaml` lives before " +
+				"reading it with get_remote_git_file_contents). Returns matching `items[]` of {path, sha}. " +
+				"Read-only, and restricted to your own organization's repos — a request for any other owner " +
+				"is refused.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"owner": map[string]any{"type": "string", "description": "repo owner — MUST be your organization's GitHub account"},
+					"repo":  map[string]any{"type": "string", "description": "repository name"},
+					"query": map[string]any{"type": "string", "description": "code search query (the repo scope is added for you)"},
+				},
+				"required": []string{"owner", "repo", "query"},
+			},
+		},
 	}
 }
 
@@ -144,7 +203,12 @@ func handleToolCall(w http.ResponseWriter, r *http.Request, h *mcpHandler, orgHa
 	var call struct {
 		Name      string `json:"name"`
 		Arguments struct {
-			Name string `json:"name"`
+			Name  string `json:"name"`
+			Owner string `json:"owner"`
+			Repo  string `json:"repo"`
+			Path  string `json:"path"`
+			Ref   string `json:"ref"`
+			Query string `json:"query"`
 		} `json:"arguments"`
 	}
 	if err := json.Unmarshal(req.Params, &call); err != nil {
@@ -227,6 +291,45 @@ func handleToolCall(w http.ResponseWriter, r *http.Request, h *mcpHandler, orgHa
 			return
 		}
 		writeToolText(w, req.ID, mustJSON(map[string]any{"resourceTypes": types}))
+	case "get_remote_git_file_contents":
+		if h.remoteGit == nil {
+			writeToolError(w, req.ID, "remote git reader not configured")
+			return
+		}
+		if call.Arguments.Owner == "" || call.Arguments.Repo == "" {
+			writeToolError(w, req.ID, "missing required arguments: owner and repo")
+			return
+		}
+		// orgHandle is the verified ocOrgId claim — the reader resolves the org's
+		// credential from it and refuses any owner that is not the org's own
+		// GitHub account. The owner is NEVER trusted to name the org.
+		file, err := h.remoteGit.GetFileContents(r.Context(), orgHandle,
+			call.Arguments.Owner, call.Arguments.Repo, call.Arguments.Path, call.Arguments.Ref)
+		if err != nil {
+			writeToolError(w, req.ID, fmt.Sprintf("get remote git file contents: %v", err))
+			return
+		}
+		writeToolText(w, req.ID, mustJSON(toRemoteGitFileView(file)))
+	case "search_remote_git_code":
+		if h.remoteGit == nil {
+			writeToolError(w, req.ID, "remote git reader not configured")
+			return
+		}
+		if call.Arguments.Owner == "" || call.Arguments.Repo == "" || call.Arguments.Query == "" {
+			writeToolError(w, req.ID, "missing required arguments: owner, repo and query")
+			return
+		}
+		hits, err := h.remoteGit.SearchCode(r.Context(), orgHandle,
+			call.Arguments.Owner, call.Arguments.Repo, call.Arguments.Query)
+		if err != nil {
+			writeToolError(w, req.ID, fmt.Sprintf("search remote git code: %v", err))
+			return
+		}
+		items := make([]remoteGitSearchHitView, 0, len(hits))
+		for _, hit := range hits {
+			items = append(items, remoteGitSearchHitView{Path: hit.Path, SHA: hit.SHA})
+		}
+		writeToolText(w, req.ID, mustJSON(map[string]any{"items": items}))
 	default:
 		writeRPCError(w, req.ID, -32602, "unknown tool: "+call.Name)
 	}
@@ -240,6 +343,22 @@ func toExternalResourceView(er *models.ExternalResource) externalResourceView {
 		keys = append(keys, configKeyDTO{Key: k.Key, Secret: k.Secret})
 	}
 	return externalResourceView{Name: er.Name, Description: er.Description, ConfigKeys: keys}
+}
+
+// toRemoteGitFileView projects a Contents API read to the agent-facing shape.
+func toRemoteGitFileView(f *RemoteGitFile) remoteGitFileView {
+	v := remoteGitFileView{
+		Content:     f.Content,
+		SHA:         f.SHA,
+		IsDirectory: f.IsDirectory,
+	}
+	if len(f.Entries) > 0 {
+		v.Entries = make([]remoteGitEntryView, 0, len(f.Entries))
+		for _, e := range f.Entries {
+			v.Entries = append(v.Entries, remoteGitEntryView{Path: e.Path, Type: e.Type, SHA: e.SHA})
+		}
+	}
+	return v
 }
 
 // toOrgComponentEndpointView projects a resolved OrgComponentEndpoint to the

--- a/services/aep-api/internal/feature/dependencies/ports.go
+++ b/services/aep-api/internal/feature/dependencies/ports.go
@@ -31,6 +31,7 @@ import (
 	"context"
 
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies/endpoints"
 	"github.com/wso2/aep/aep-api/internal/feature/dependencies/resources"
 	"github.com/wso2/aep/aep-api/models"
 )
@@ -44,9 +45,13 @@ type ExternalResourceReader interface {
 }
 
 // OrgEndpointLister is the read slice of the org endpoint catalog — the
-// published-service targets an `org-service` dependency can point at.
+// published-service targets an `org-service` dependency can point at (List),
+// plus each one resolved with the provider's repo coordinates and a
+// discovered OpenAPI contract (ListResolved) for the A3 MCP tool
+// (list_org_component_endpoints).
 type OrgEndpointLister interface {
 	List(ctx context.Context, orgHandle string) ([]openchoreo.WorkloadEndpointInfo, error)
+	ListResolved(ctx context.Context, orgHandle string) ([]endpoints.OrgComponentEndpoint, error)
 }
 
 // ResourceTypeLister is the read slice of the platform resource-type catalog —

--- a/services/aep-api/internal/feature/dependencies/ports.go
+++ b/services/aep-api/internal/feature/dependencies/ports.go
@@ -59,3 +59,15 @@ type OrgEndpointLister interface {
 type ResourceTypeLister interface {
 	List(ctx context.Context) ([]resources.PlatformResourceType, error)
 }
+
+// RemoteGitReader reads an org's OWN GitHub repos over the REST API (Contents +
+// Code Search, no clone) for endpoint spec discovery — the two MCP tools an
+// agent uses to read a provider's OpenAPI file straight from its repo. Both
+// methods take ocOrgID (the verified MCP claim, never a tool parameter) and
+// MUST refuse (ErrOwnerNotInOrg) any `owner` that is not the org credential's
+// GitHub account, so a caller in one org can never read another org's repos.
+// Satisfied by *RemoteGitClient (remote_git.go).
+type RemoteGitReader interface {
+	GetFileContents(ctx context.Context, ocOrgID, owner, repo, path, ref string) (*RemoteGitFile, error)
+	SearchCode(ctx context.Context, ocOrgID, owner, repo, query string) ([]RemoteGitSearchHit, error)
+}

--- a/services/aep-api/internal/feature/dependencies/remote_git.go
+++ b/services/aep-api/internal/feature/dependencies/remote_git.go
@@ -1,0 +1,339 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dependencies
+
+// remote_git.go is a thin, READ-ONLY GitHub REST client backing the two MCP
+// tools an agent uses to read a provider's OpenAPI contract straight out of its
+// repo (endpoint spec discovery) — no local clone. It exposes exactly two
+// GitHub reads:
+//
+//   - Contents API GET /repos/{owner}/{repo}/contents/{path}?ref=  (file or dir)
+//   - Code Search GET /search/code?q=<query>+repo:{owner}/{repo}
+//
+// There is deliberately NO create/update/delete/branch/PR surface here — the
+// agent can read the org's own repos and nothing else. Two guardrails bound it:
+//
+//  1. Org from the verified MCP claim only. The caller passes ocOrgID (the
+//     ocOrgId claim bound by the auth middleware, never a tool parameter); the
+//     org's credential — token AND owner — is resolved from it.
+//  2. Owner-must-match-org. Every read REFUSES (ErrOwnerNotInOrg) any `owner`
+//     that is not the resolved credential's RepoOwner(), BEFORE any network
+//     call. This stops an agent in org A from reading org B's / arbitrary repos.
+//
+// The read is bounded: a fixed GitHub API base host (a test seam overrides it
+// for the httptest stub), a short HTTP timeout, and a cap on decoded content
+// size.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/credentials"
+)
+
+// ErrOwnerNotInOrg is returned when a requested repo owner is not the GitHub
+// account the caller's org credential is installed on. This is the cross-org
+// read guard — it fires before any GitHub request is issued.
+var ErrOwnerNotInOrg = errors.New("dependencies: repo owner is not owned by the caller's organization")
+
+const (
+	// defaultRemoteGitAPIBase is the real GitHub REST API root (matches the
+	// clients/github default). Overridable only via WithRemoteGitAPIBase.
+	defaultRemoteGitAPIBase = "https://api.github.com"
+	// defaultRemoteGitTimeout bounds a single Contents/Search read.
+	defaultRemoteGitTimeout = 15 * time.Second
+	// defaultMaxContentBytes caps decoded file content (GitHub's own inline
+	// Contents limit is 1 MiB; a larger file must be fetched some other way).
+	defaultMaxContentBytes = 1 << 20
+	// maxSearchItems caps how many code-search hits we surface.
+	maxSearchItems = 30
+	// per_page bound sent to the Code Search API.
+	searchPerPage = 30
+)
+
+// RemoteGitFile is one Contents API read: a file (decoded Content + SHA,
+// IsDirectory=false) or a directory (IsDirectory=true, Entries populated,
+// Content empty).
+type RemoteGitFile struct {
+	Content     string
+	SHA         string
+	IsDirectory bool
+	Entries     []RemoteGitEntry
+}
+
+// RemoteGitEntry is one child listed when a Contents read resolves a directory.
+type RemoteGitEntry struct {
+	Path string
+	Type string // "file" | "dir"
+	SHA  string
+}
+
+// RemoteGitSearchHit is one Code Search result: the path and blob SHA.
+type RemoteGitSearchHit struct {
+	Path string
+	SHA  string
+}
+
+// RemoteGitClient reads files and searches code in an org's OWN GitHub repos
+// over the REST API. It resolves the org's credential (token + owner) from the
+// credential resolver and enforces the owner-must-match-org guard on every read.
+type RemoteGitClient struct {
+	resolver        credentials.Resolver
+	httpClient      *http.Client
+	apiBase         string
+	maxContentBytes int64
+}
+
+// RemoteGitOption configures a RemoteGitClient. Production wiring passes none;
+// WithRemoteGitAPIBase/WithRemoteGitMaxContentBytes are test seams.
+type RemoteGitOption func(*RemoteGitClient)
+
+// WithRemoteGitAPIBase overrides the GitHub REST API base URL — a TEST SEAM
+// pointing the client at an httptest fake. Not wired in production.
+func WithRemoteGitAPIBase(base string) RemoteGitOption {
+	return func(c *RemoteGitClient) { c.apiBase = strings.TrimRight(base, "/") }
+}
+
+// WithRemoteGitMaxContentBytes overrides the decoded-content cap (test seam).
+func WithRemoteGitMaxContentBytes(n int64) RemoteGitOption {
+	return func(c *RemoteGitClient) { c.maxContentBytes = n }
+}
+
+// NewRemoteGitClient builds the read-only GitHub client over the org credential
+// resolver. Production wiring passes no options.
+func NewRemoteGitClient(resolver credentials.Resolver, opts ...RemoteGitOption) *RemoteGitClient {
+	c := &RemoteGitClient{
+		resolver:        resolver,
+		httpClient:      &http.Client{Timeout: defaultRemoteGitTimeout},
+		apiBase:         defaultRemoteGitAPIBase,
+		maxContentBytes: defaultMaxContentBytes,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Compile-time proof the concrete client satisfies the consumer port.
+var _ RemoteGitReader = (*RemoteGitClient)(nil)
+
+// authorize resolves the org credential and enforces the owner-must-match-org
+// guard. It returns the fresh token on success, or ErrOwnerNotInOrg when owner
+// is not the credential's RepoOwner(). No network call to GitHub happens until
+// this passes.
+func (c *RemoteGitClient) authorize(ctx context.Context, ocOrgID, owner string) (token string, err error) {
+	cred, err := c.resolver.Resolve(ctx, ocOrgID)
+	if err != nil {
+		return "", fmt.Errorf("resolve org credential: %w", err)
+	}
+	orgOwner := cred.RepoOwner()
+	// Case-insensitive compare: GitHub logins are case-insensitive, so treat
+	// "Acme" and "acme" as the same owner. Empty owners never match.
+	if owner == "" || orgOwner == "" || !strings.EqualFold(owner, orgOwner) {
+		return "", fmt.Errorf("%w: %q (org owns %q)", ErrOwnerNotInOrg, owner, orgOwner)
+	}
+	tok, _, err := cred.Token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve token: %w", err)
+	}
+	return tok, nil
+}
+
+// setHeaders applies the standard read-only GitHub API headers + bearer auth.
+func setHeaders(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+}
+
+// GetFileContents reads one path via the Contents API. A file returns decoded
+// Content + SHA; a directory returns Entries (IsDirectory=true). REFUSES a
+// cross-org owner before any network call.
+func (c *RemoteGitClient) GetFileContents(ctx context.Context, ocOrgID, owner, repo, path, ref string) (*RemoteGitFile, error) {
+	token, err := c.authorize(ctx, ocOrgID, owner)
+	if err != nil {
+		return nil, err
+	}
+
+	// Path-escape each segment so a path like "specs/openapi.yaml" maps to
+	// .../contents/specs/openapi.yaml (slashes preserved, other reserved
+	// characters encoded). Empty path = repo root.
+	u := fmt.Sprintf("%s/repos/%s/%s/contents/%s", c.apiBase,
+		url.PathEscape(owner), url.PathEscape(repo), escapePath(path))
+	if ref != "" {
+		u += "?ref=" + url.QueryEscape(ref)
+	}
+
+	body, err := c.get(ctx, u, token, "contents")
+	if err != nil {
+		return nil, err
+	}
+
+	// The Contents API returns a JSON array for a directory and a JSON object
+	// for a file. Peek the first non-space byte to fold both.
+	trimmed := strings.TrimLeftFunc(string(body), func(r rune) bool {
+		return r == ' ' || r == '\n' || r == '\t' || r == '\r'
+	})
+	if strings.HasPrefix(trimmed, "[") {
+		var dir []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+		}
+		if err := json.Unmarshal(body, &dir); err != nil {
+			return nil, fmt.Errorf("decode directory listing: %w", err)
+		}
+		entries := make([]RemoteGitEntry, 0, len(dir))
+		for _, e := range dir {
+			entries = append(entries, RemoteGitEntry{Path: e.Path, Type: e.Type, SHA: e.SHA})
+		}
+		return &RemoteGitFile{IsDirectory: true, Entries: entries}, nil
+	}
+
+	var file struct {
+		Type     string `json:"type"`
+		SHA      string `json:"sha"`
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(body, &file); err != nil {
+		return nil, fmt.Errorf("decode file contents: %w", err)
+	}
+
+	content, err := decodeContent(file.Content, file.Encoding, c.maxContentBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteGitFile{Content: content, SHA: file.SHA, IsDirectory: false}, nil
+}
+
+// SearchCode runs a code search scoped to the org's repo. REFUSES a cross-org
+// owner before any network call.
+func (c *RemoteGitClient) SearchCode(ctx context.Context, ocOrgID, owner, repo, query string) ([]RemoteGitSearchHit, error) {
+	token, err := c.authorize(ctx, ocOrgID, owner)
+	if err != nil {
+		return nil, err
+	}
+
+	// Scope the query to the org's repo. The repo: qualifier is appended
+	// server-side so the search can NEVER escape the authorized repo, no matter
+	// what the agent-supplied query contains.
+	q := strings.TrimSpace(query) + fmt.Sprintf(" repo:%s/%s", owner, repo)
+	u := fmt.Sprintf("%s/search/code?q=%s&per_page=%d", c.apiBase, url.QueryEscape(q), searchPerPage)
+
+	body, err := c.get(ctx, u, token, "code search")
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Items []struct {
+			Path string `json:"path"`
+			SHA  string `json:"sha"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode search results: %w", err)
+	}
+	hits := make([]RemoteGitSearchHit, 0, len(out.Items))
+	for _, it := range out.Items {
+		if len(hits) >= maxSearchItems {
+			break
+		}
+		hits = append(hits, RemoteGitSearchHit{Path: it.Path, SHA: it.SHA})
+	}
+	return hits, nil
+}
+
+// get performs an authenticated GET requiring 200 and returns the (bounded)
+// response body. Reads at most maxContentBytes+overhead so a hostile/oversized
+// response cannot exhaust memory.
+func (c *RemoteGitClient) get(ctx context.Context, u, token, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	setHeaders(req, token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github %s request: %w", label, err)
+	}
+	defer resp.Body.Close()
+
+	// Bound the read. Base64 inflates ~4/3, plus JSON envelope; a generous
+	// headroom over the content cap keeps well-formed responses intact while
+	// still refusing an unbounded body.
+	limit := c.maxContentBytes*2 + (1 << 16)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, fmt.Errorf("read github %s response: %w", label, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github %s failed (status %d): %s", label, resp.StatusCode, truncateForError(body))
+	}
+	return body, nil
+}
+
+// decodeContent base64-decodes the Contents API `content` field, enforcing the
+// size cap. GitHub only inlines base64; any other encoding (or an over-cap
+// file) is refused rather than returned partial/undecoded.
+func decodeContent(content, encoding string, cap int64) (string, error) {
+	if content == "" {
+		return "", nil
+	}
+	if encoding != "" && encoding != "base64" {
+		return "", fmt.Errorf("unsupported content encoding %q", encoding)
+	}
+	// GitHub wraps the base64 payload at 60 cols with newlines.
+	clean := strings.NewReplacer("\n", "", "\r", "").Replace(content)
+	decoded, err := base64.StdEncoding.DecodeString(clean)
+	if err != nil {
+		return "", fmt.Errorf("decode base64 content: %w", err)
+	}
+	if int64(len(decoded)) > cap {
+		return "", fmt.Errorf("file content %d bytes exceeds cap %d", len(decoded), cap)
+	}
+	return string(decoded), nil
+}
+
+// escapePath path-escapes each segment of a repo-relative path while preserving
+// the separating slashes.
+func escapePath(p string) string {
+	segs := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	for i, s := range segs {
+		segs[i] = url.PathEscape(s)
+	}
+	return strings.Join(segs, "/")
+}
+
+// truncateForError bounds an error body so a large failure response is not
+// echoed wholesale into logs/errors.
+func truncateForError(b []byte) string {
+	const max = 512
+	if len(b) > max {
+		return string(b[:max]) + "…"
+	}
+	return string(b)
+}

--- a/services/aep-api/internal/feature/dependencies/remote_git.go
+++ b/services/aep-api/internal/feature/dependencies/remote_git.go
@@ -47,6 +47,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -57,6 +58,26 @@ import (
 // account the caller's org credential is installed on. This is the cross-org
 // read guard — it fires before any GitHub request is issued.
 var ErrOwnerNotInOrg = errors.New("dependencies: repo owner is not owned by the caller's organization")
+
+// ErrQueryScopeQualifier is returned when an agent-supplied SearchCode query
+// embeds its own repo/org/user/fork scope qualifier. GitHub OR-combines
+// multiple `repo:` (and `org:`/`user:`) qualifiers in one search, so an
+// embedded qualifier would widen the search beyond the authorized repo (e.g.
+// query `"secret repo:acme/other-private"` searches BOTH repos). REFUSED
+// before any network call so the appended `repo:{owner}/{repo}` is always the
+// query's sole scope.
+var ErrQueryScopeQualifier = errors.New("dependencies: query must not contain a repo/org/user/fork scope qualifier")
+
+// ErrFileTooLargeToInline is returned when the Contents API reports a file it
+// cannot inline as base64 (encoding "none" — GitHub's signal for a file over
+// its ~1 MiB inline limit, typically sized 1-100 MiB). This client is
+// deliberately read-only/simple and has no blob-API fallback, so such a file
+// is refused rather than silently surfaced as empty content.
+var ErrFileTooLargeToInline = errors.New("dependencies: file too large to inline (GitHub reported encoding=none)")
+
+// scopeQualifierPattern matches a GitHub code-search scope qualifier
+// (repo:, org:, user:, fork:) anywhere in a query, case-insensitively.
+var scopeQualifierPattern = regexp.MustCompile(`(?i)\b(repo|org|user|fork):`)
 
 const (
 	// defaultRemoteGitAPIBase is the real GitHub REST API root (matches the
@@ -237,9 +258,18 @@ func (c *RemoteGitClient) SearchCode(ctx context.Context, ocOrgID, owner, repo, 
 		return nil, err
 	}
 
-	// Scope the query to the org's repo. The repo: qualifier is appended
-	// server-side so the search can NEVER escape the authorized repo, no matter
-	// what the agent-supplied query contains.
+	// Reject an agent-supplied scope qualifier BEFORE building q. Without this,
+	// a query like "secret repo:acme/other-private" would hand GitHub two
+	// repo: qualifiers, which it OR-combines — widening the search to any repo
+	// the token can see, not just the authorized one.
+	if scopeQualifierPattern.MatchString(query) {
+		return nil, fmt.Errorf("%w: %q", ErrQueryScopeQualifier, query)
+	}
+
+	// Scope the query to the org's repo. The sanitizer above guarantees query
+	// carries no scope qualifier of its own, so the repo: qualifier appended
+	// here is the query's SOLE scope — it cannot be OR-combined with another
+	// repo:/org:/user: qualifier to escape the authorized repo.
 	q := strings.TrimSpace(query) + fmt.Sprintf(" repo:%s/%s", owner, repo)
 	u := fmt.Sprintf("%s/search/code?q=%s&per_page=%d", c.apiBase, url.QueryEscape(q), searchPerPage)
 
@@ -299,7 +329,16 @@ func (c *RemoteGitClient) get(ctx context.Context, u, token, label string) ([]by
 // decodeContent base64-decodes the Contents API `content` field, enforcing the
 // size cap. GitHub only inlines base64; any other encoding (or an over-cap
 // file) is refused rather than returned partial/undecoded.
-func decodeContent(content, encoding string, cap int64) (string, error) {
+//
+// encoding "none" is GitHub's explicit "too large to inline" signal (files
+// roughly 1-100 MiB come back with content:"" and encoding:"none"): that is
+// refused via ErrFileTooLargeToInline rather than treated as a genuinely
+// empty file. A real empty file still comes back as encoding:"base64" with
+// content:"" and is returned as an empty string, unaffected by this check.
+func decodeContent(content, encoding string, maxBytes int64) (string, error) {
+	if encoding == "none" {
+		return "", ErrFileTooLargeToInline
+	}
 	if content == "" {
 		return "", nil
 	}
@@ -312,8 +351,8 @@ func decodeContent(content, encoding string, cap int64) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("decode base64 content: %w", err)
 	}
-	if int64(len(decoded)) > cap {
-		return "", fmt.Errorf("file content %d bytes exceeds cap %d", len(decoded), cap)
+	if int64(len(decoded)) > maxBytes {
+		return "", fmt.Errorf("file content %d bytes exceeds cap %d", len(decoded), maxBytes)
 	}
 	return string(decoded), nil
 }

--- a/services/aep-api/internal/feature/dependencies/remote_git_test.go
+++ b/services/aep-api/internal/feature/dependencies/remote_git_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dependencies
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/credentials"
+)
+
+// ---- test doubles for the credential resolver ------------------------------
+
+// fakeCred is a minimal credentials.Credential: a fixed token + repo owner.
+type fakeCred struct {
+	token string
+	owner string
+}
+
+func (c fakeCred) Token(context.Context) (string, time.Time, error) { return c.token, time.Time{}, nil }
+func (c fakeCred) Identity() credentials.Identity                   { return credentials.Identity{} }
+func (c fakeCred) RepoOwner() string                                { return c.owner }
+func (c fakeCred) WebhookStrategy() credentials.WebhookStrategy     { return credentials.WebhookPerRepo }
+
+// fakeResolver returns cred for orgID, or err.
+type fakeResolver struct {
+	cred    credentials.Credential
+	err     error
+	lastOrg string
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, ocOrgID string) (credentials.Credential, error) {
+	r.lastOrg = ocOrgID
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.cred, nil
+}
+
+// newTestClient wires a RemoteGitClient at the stub's base URL with a resolver
+// that maps every org to owner "acme" (token "t0k3n").
+func newTestClient(t *testing.T, base string) (*RemoteGitClient, *fakeResolver) {
+	t.Helper()
+	res := &fakeResolver{cred: fakeCred{token: "t0k3n", owner: "acme"}}
+	c := NewRemoteGitClient(res, WithRemoteGitAPIBase(base))
+	return c, res
+}
+
+// ---- (a) file read → decoded content ---------------------------------------
+
+func TestRemoteGit_GetFileContents_File(t *testing.T) {
+	const raw = "openapi: 3.0.0\ninfo:\n  title: invoice\n"
+	var gotAuth, gotAccept, gotPath, gotRef string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		gotPath = r.URL.Path
+		gotRef = r.URL.Query().Get("ref")
+		fmt.Fprintf(w, `{"type":"file","name":"openapi.yaml","path":"specs/openapi.yaml","sha":"abc123","content":%q,"encoding":"base64"}`,
+			base64.StdEncoding.EncodeToString([]byte(raw)))
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	got, err := c.GetFileContents(context.Background(), "org-1", "acme", "billing-svc", "specs/openapi.yaml", "main")
+	if err != nil {
+		t.Fatalf("GetFileContents: %v", err)
+	}
+	if got.IsDirectory {
+		t.Errorf("IsDirectory = true, want false")
+	}
+	if got.Content != raw {
+		t.Errorf("Content = %q, want %q", got.Content, raw)
+	}
+	if got.SHA != "abc123" {
+		t.Errorf("SHA = %q, want abc123", got.SHA)
+	}
+	if gotAuth != "Bearer t0k3n" {
+		t.Errorf("Authorization = %q, want Bearer t0k3n", gotAuth)
+	}
+	if !strings.Contains(gotAccept, "vnd.github") {
+		t.Errorf("Accept = %q, want github media type", gotAccept)
+	}
+	if gotPath != "/repos/acme/billing-svc/contents/specs/openapi.yaml" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotRef != "main" {
+		t.Errorf("ref = %q, want main", gotRef)
+	}
+}
+
+// ---- (b) directory path → entries ------------------------------------------
+
+func TestRemoteGit_GetFileContents_Directory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[
+			{"type":"file","name":"openapi.yaml","path":"specs/openapi.yaml","sha":"aaa"},
+			{"type":"dir","name":"schemas","path":"specs/schemas","sha":"bbb"}
+		]`)
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	got, err := c.GetFileContents(context.Background(), "org-1", "acme", "billing-svc", "specs", "")
+	if err != nil {
+		t.Fatalf("GetFileContents: %v", err)
+	}
+	if !got.IsDirectory {
+		t.Fatalf("IsDirectory = false, want true")
+	}
+	if got.Content != "" {
+		t.Errorf("Content = %q, want empty for a directory", got.Content)
+	}
+	if len(got.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(got.Entries))
+	}
+	if got.Entries[0].Path != "specs/openapi.yaml" || got.Entries[0].Type != "file" {
+		t.Errorf("entry[0] = %+v", got.Entries[0])
+	}
+	if got.Entries[1].Type != "dir" {
+		t.Errorf("entry[1].Type = %q, want dir", got.Entries[1].Type)
+	}
+}
+
+// ---- (c) search → matching paths -------------------------------------------
+
+func TestRemoteGit_SearchCode(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("q")
+		fmt.Fprint(w, `{"total_count":2,"items":[
+			{"path":"specs/openapi.yaml","sha":"aaa"},
+			{"path":"api/openapi.yaml","sha":"bbb"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	hits, err := c.SearchCode(context.Background(), "org-1", "acme", "billing-svc", "openapi filename:openapi.yaml")
+	if err != nil {
+		t.Fatalf("SearchCode: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("hits = %d, want 2", len(hits))
+	}
+	if hits[0].Path != "specs/openapi.yaml" || hits[0].SHA != "aaa" {
+		t.Errorf("hit[0] = %+v", hits[0])
+	}
+	if !strings.Contains(gotQuery, "repo:acme/billing-svc") {
+		t.Errorf("q = %q, want it to scope repo:acme/billing-svc", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "openapi") {
+		t.Errorf("q = %q, want it to include the caller query", gotQuery)
+	}
+}
+
+// ---- (d) owner outside the caller's org is REFUSED -------------------------
+
+func TestRemoteGit_GetFileContents_OwnerMismatchRefused(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		fmt.Fprint(w, `{"type":"file","content":"","encoding":"base64"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL) // resolver owner = "acme"
+	_, err := c.GetFileContents(context.Background(), "org-1", "evilcorp", "secret-repo", "x", "")
+	if !errors.Is(err, ErrOwnerNotInOrg) {
+		t.Fatalf("err = %v, want ErrOwnerNotInOrg", err)
+	}
+	if called {
+		t.Fatalf("GitHub was called for a cross-org owner — the guard must refuse BEFORE any network read")
+	}
+}
+
+func TestRemoteGit_SearchCode_OwnerMismatchRefused(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	_, err := c.SearchCode(context.Background(), "org-1", "evilcorp", "secret-repo", "openapi")
+	if !errors.Is(err, ErrOwnerNotInOrg) {
+		t.Fatalf("err = %v, want ErrOwnerNotInOrg", err)
+	}
+	if called {
+		t.Fatalf("GitHub search was called for a cross-org owner — the guard must refuse first")
+	}
+}
+
+// ---- content size cap ------------------------------------------------------
+
+func TestRemoteGit_GetFileContents_ContentTooLarge(t *testing.T) {
+	big := strings.Repeat("a", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"type":"file","sha":"x","content":%q,"encoding":"base64"}`,
+			base64.StdEncoding.EncodeToString([]byte(big)))
+	}))
+	defer srv.Close()
+
+	res := &fakeResolver{cred: fakeCred{token: "t", owner: "acme"}}
+	c := NewRemoteGitClient(res, WithRemoteGitAPIBase(srv.URL), WithRemoteGitMaxContentBytes(1024))
+	_, err := c.GetFileContents(context.Background(), "org-1", "acme", "billing-svc", "big.yaml", "")
+	if err == nil {
+		t.Fatalf("expected an error for content over the cap")
+	}
+}

--- a/services/aep-api/internal/feature/dependencies/remote_git_test.go
+++ b/services/aep-api/internal/feature/dependencies/remote_git_test.go
@@ -229,3 +229,73 @@ func TestRemoteGit_GetFileContents_ContentTooLarge(t *testing.T) {
 		t.Fatalf("expected an error for content over the cap")
 	}
 }
+
+// ---- GitHub "too large to inline" (encoding=none) is refused, not silent --
+
+func TestRemoteGit_GetFileContents_EncodingNoneRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// GitHub's Contents API returns this shape for a file it cannot inline
+		// (roughly 1-100 MiB): content is empty and encoding is "none".
+		fmt.Fprint(w, `{"type":"file","sha":"toolarge","content":"","encoding":"none"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	_, err := c.GetFileContents(context.Background(), "org-1", "acme", "billing-svc", "huge.bin", "")
+	if !errors.Is(err, ErrFileTooLargeToInline) {
+		t.Fatalf("err = %v, want ErrFileTooLargeToInline", err)
+	}
+}
+
+func TestRemoteGit_GetFileContents_GenuinelyEmptyFileStillOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A real empty file: encoding is still "base64", content is "".
+		fmt.Fprint(w, `{"type":"file","sha":"empty","content":"","encoding":"base64"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	got, err := c.GetFileContents(context.Background(), "org-1", "acme", "billing-svc", "empty.txt", "")
+	if err != nil {
+		t.Fatalf("GetFileContents: %v", err)
+	}
+	if got.Content != "" {
+		t.Errorf("Content = %q, want empty string for a genuinely empty file", got.Content)
+	}
+}
+
+// ---- SearchCode rejects an agent-embedded scope qualifier ------------------
+
+func TestRemoteGit_SearchCode_EmbeddedRepoQualifierRefused(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	_, err := c.SearchCode(context.Background(), "org-1", "acme", "billing-svc", "secret repo:acme/other-private")
+	if !errors.Is(err, ErrQueryScopeQualifier) {
+		t.Fatalf("err = %v, want ErrQueryScopeQualifier", err)
+	}
+	if called {
+		t.Fatalf("GitHub search was called for a query embedding its own repo: qualifier — the sanitizer must refuse before any network read")
+	}
+}
+
+func TestRemoteGit_SearchCode_EmbeddedOrgQualifierRefused(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c, _ := newTestClient(t, srv.URL)
+	_, err := c.SearchCode(context.Background(), "org-1", "acme", "billing-svc", "secret org:evilcorp")
+	if !errors.Is(err, ErrQueryScopeQualifier) {
+		t.Fatalf("err = %v, want ErrQueryScopeQualifier", err)
+	}
+	if called {
+		t.Fatalf("GitHub search was called for a query embedding its own org: qualifier — the sanitizer must refuse before any network read")
+	}
+}

--- a/services/aep-api/internal/feature/provisioning/wiring.go
+++ b/services/aep-api/internal/feature/provisioning/wiring.go
@@ -85,7 +85,7 @@ func (w *WiringResolver) PostResolvedDeps(ctx context.Context, orgID, projectID 
 	if w.issues == nil || issueNumber == 0 {
 		return nil
 	}
-	block, err := w.resolveDependenciesYAML(ctx, orgID, projectID, component)
+	block, contracts, err := w.resolveDependenciesYAML(ctx, orgID, projectID, component)
 	if err != nil {
 		return err
 	}
@@ -96,23 +96,33 @@ func (w *WiringResolver) PostResolvedDeps(ctx context.Context, orgID, projectID 
 		"`workload.yaml` (merge into any existing `dependencies:`). The platform has " +
 		"already resolved the targets + env-var bindings; copy it verbatim. OpenChoreo " +
 		"injects these addresses/outputs into your pod env at runtime:\n\n```yaml\n" + block + "```"
+	if contracts != "" {
+		body += "\n\n---\n\n**Consumed API contracts** — before writing any client code, fetch " +
+			"the exact contract for each provider below. Do not guess at request/response shapes " +
+			"or endpoint paths:\n\n" + contracts
+	}
 	return w.issues.CommentIssue(ctx, orgID, projectID, issueNumber, body)
 }
 
 // resolveDependenciesYAML resolves a component's consumer deps — cross-project
 // org-service endpoints, same-project component siblings, bound external-resource
 // outputs, and platform-resource outputs — into the workload.yaml dependencies
-// block. Returns "" when nothing resolves. orgID is the OC namespace (orgHandle).
-func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, projectID, component string) (string, error) {
+// block, plus a human-readable "Consumed API contract" section (one per
+// org-service/same-project endpoint dep) instructing the coding agent to fetch
+// the provider's real contract instead of guessing at endpoints. Returns ""
+// for the yaml block when nothing resolves. orgID is the OC namespace
+// (orgHandle).
+func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, projectID, component string) (yamlBlock, contracts string, err error) {
 	comp, ok, err := w.findComponent(ctx, orgID, projectID, component)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !ok {
-		return "", nil
+		return "", "", nil
 	}
 
 	var deps workloadDeps
+	var contractSections []string
 
 	if w.endpoints != nil {
 		// org-service endpoints (cross-project, visibility namespace). Skip any
@@ -120,7 +130,7 @@ func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, pro
 		for _, name := range comp.OrgServiceDependsOn() {
 			target, ok, rerr := w.endpoints.ResolveNamespaceVisible(ctx, orgID, name)
 			if rerr != nil {
-				return "", fmt.Errorf("resolve org-service %q: %w", name, rerr)
+				return "", "", fmt.Errorf("resolve org-service %q: %w", name, rerr)
 			}
 			if !ok {
 				continue
@@ -132,6 +142,7 @@ func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, pro
 				Visibility:  "namespace",
 				EnvBindings: map[string]string{"address": orgServiceURLEnv(name)},
 			})
+			contractSections = append(contractSections, orgServiceContractSection(name, target))
 		}
 		// same-project component siblings (visibility project). The sibling's OC
 		// component name is `<project>-<logicalName>`; the env var keys on the
@@ -140,7 +151,7 @@ func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, pro
 			ocComponent := projectID + "-" + depName
 			target, ok, rerr := w.endpoints.ResolveProjectEndpoint(ctx, orgID, projectID, ocComponent)
 			if rerr != nil {
-				return "", fmt.Errorf("resolve same-project component %q: %w", depName, rerr)
+				return "", "", fmt.Errorf("resolve same-project component %q: %w", depName, rerr)
 			}
 			if !ok {
 				continue
@@ -151,6 +162,7 @@ func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, pro
 				Visibility:  "project",
 				EnvBindings: map[string]string{"address": orgServiceURLEnv(depName)},
 			})
+			contractSections = append(contractSections, localComponentContractSection(depName))
 		}
 	}
 
@@ -191,13 +203,52 @@ func (w *WiringResolver) resolveDependenciesYAML(ctx context.Context, orgID, pro
 	}
 
 	if len(deps.Endpoints) == 0 && len(deps.Resources) == 0 {
-		return "", nil
+		return "", "", nil
 	}
 	out, err := yaml.Marshal(map[string]workloadDeps{"dependencies": deps})
 	if err != nil {
-		return "", fmt.Errorf("marshal dependencies yaml: %w", err)
+		return "", "", fmt.Errorf("marshal dependencies yaml: %w", err)
 	}
-	return string(out), nil
+	return string(out), strings.Join(contractSections, "\n\n"), nil
+}
+
+// orgServiceContractSection renders the "Consumed API contract" guidance for
+// a resolved cross-project org-service dependency: names the provider (from
+// the already-resolved openchoreo.WorkloadEndpointInfo) and tells the coding
+// agent to fetch the real contract via MCP rather than guessing at endpoints.
+//
+// Owner/repo/subdir are intentionally omitted here: WorkloadEndpointInfo (the
+// EndpointResolver DTO used at this dispatch-time call site) carries only
+// Project/Component/Name/Type/Port/BasePath/Schema — no repo coordinates.
+// Those live on the separate endpoints.OrgComponentEndpoint DTO behind
+// list_org_component_endpoints, which the agent calls anyway and which
+// returns owner/repo/subdir directly — wiring in that enriched resolver here
+// too would duplicate a lookup the agent is about to make itself.
+func orgServiceContractSection(depName string, target openchoreo.WorkloadEndpointInfo) string {
+	return fmt.Sprintf(
+		"### Consumed API contract — %s\n"+
+			"Provider: project `%s`, component `%s`, endpoint `%s`.\n"+
+			"Call the `list_org_component_endpoints` MCP tool to get this provider's API "+
+			"contract (inline spec, or via `get_remote_git_file_contents`/`search_remote_git_code` "+
+			"when the spec lives in the repo). Implement the client against the EXACT operations. "+
+			"Do NOT invent endpoints.",
+		depName, target.Project, target.Component, target.Name,
+	)
+}
+
+// localComponentContractSection renders the "local" variant of the
+// "Consumed API contract" guidance for a same-project component dependency:
+// the sibling's OpenAPI contract is checked out alongside this component's
+// own code (same repo), so no MCP round-trip is needed.
+func localComponentContractSection(depName string) string {
+	return fmt.Sprintf(
+		"### Consumed API contract — %s (local)\n"+
+			"Provider: sibling component `%s` in this same project — no MCP call needed, its "+
+			"contract is in your own checked-out repo.\n"+
+			"Read `specs/design/components/%s/openapi.yaml` and implement the client against the "+
+			"EXACT operations. Do NOT invent endpoints.",
+		depName, depName, depName,
+	)
 }
 
 func (w *WiringResolver) findComponent(ctx context.Context, orgID, projectID, component string) (models.DesignComponent, bool, error) {

--- a/services/aep-api/internal/feature/provisioning/wiring_test.go
+++ b/services/aep-api/internal/feature/provisioning/wiring_test.go
@@ -107,6 +107,33 @@ func TestWiring_PostsResolvedDependencies(t *testing.T) {
 	if strings.Contains(body, "password") {
 		t.Errorf("unexpected token in wiring comment (no values should appear):\n%s", body)
 	}
+	// Consumed API contract guidance: org-service dep names the resolved
+	// provider + instructs the agent to fetch the real contract via MCP.
+	for _, want := range []string{
+		"### Consumed API contract — employee-api",
+		"project `hr`, component `hr-employee-api`, endpoint `http`",
+		"list_org_component_endpoints",
+		"Do NOT invent endpoints.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("wiring comment missing consumed-contract text %q:\n%s", want, body)
+		}
+	}
+	// Same-project component dep gets the "local" variant: read the sibling's
+	// checked-out openapi.yaml, no MCP round-trip needed.
+	for _, want := range []string{
+		"### Consumed API contract — orders (local)",
+		"specs/design/components/orders/openapi.yaml",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("wiring comment missing local consumed-contract text %q:\n%s", want, body)
+		}
+	}
+	// External/platform-resource deps are untouched by this feature — no
+	// contract section is rendered for them.
+	if strings.Contains(body, "Consumed API contract — stripe") || strings.Contains(body, "Consumed API contract — orders-db") {
+		t.Errorf("unexpected consumed-contract section for a non-endpoint dep:\n%s", body)
+	}
 }
 
 func TestWiring_EmptyResolutionPostsNothing(t *testing.T) {

--- a/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
+++ b/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
@@ -170,6 +170,17 @@ tools, USE them before authoring an `external`, `org-service`, or
   rather than inventing a parallel one.
 - `list_org_endpoints` — find the real provider component name for an
   `org-service` before referencing it.
+- `list_org_component_endpoints` — once you have the provider's name, call this
+  to read its REAL contract before writing the dependency's `description`:
+  each row resolves to a `spec.availability` of `inline` (read
+  `spec.inlineContent` directly — it IS the OpenAPI document), `repo` (no
+  inline spec, but the row's `owner`/`repo`/`subdir`/`branch` locate the
+  provider's source — use `search_remote_git_code` under that `subdir` to find
+  the spec file if you don't know its exact path, then
+  `get_remote_git_file_contents` to read it), or `none` (no contract is
+  resolvable). Base the dependency's `description` on the ACTUAL
+  operations/paths/schemas the contract exposes; on `none`, say so plainly in
+  the `description` instead of inventing a shape.
 - `list_platform_resource_types` — get a valid `resourceType` (and its
   parameters) before declaring a `platform-resource`. Read each type's
   `description` and pick the type whose description matches the need; when
@@ -192,7 +203,9 @@ least one `config` key — the value-collection gate needs something to collect.
 
 Every dependency carries a one-line `description`: what the target is and how
 the component uses it (for an `external`, which endpoints/SDK and auth scheme;
-for a `platform-resource`, what it stores). The console shows it in the
+for an `org-service`, the specific operations/paths it calls from the
+provider's discovered contract — or that no contract was resolvable, never a
+guess; for a `platform-resource`, what it stores). The console shows it in the
 dependency drawer and the coding agent relies on it to integrate correctly.
 
 One component per directory. Every `service` gets an `openapi.yaml`

--- a/services/agents/evals/main/fixtures/mcp-org-service-hit.json
+++ b/services/agents/evals/main/fixtures/mcp-org-service-hit.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-org-service-hit",
-  "description": "MCP discovery (Task E2): the org already publishes an `employee-api` endpoint from project `hr-directory` (mock catalog). The agent should call list_org_endpoints and reuse the exact provider component name for the org-service dependency instead of inventing one.",
+  "description": "MCP discovery (Task E2, extended by Task C3): the org already publishes an `employee-api` endpoint from project `hr-directory` (mock catalog), and the mock also resolves that endpoint's real (inline) OpenAPI contract via list_org_component_endpoints. The agent should call list_org_endpoints to reuse the exact provider component name, then list_org_component_endpoints to read its actual contract before writing the org-service dependency's description — never inventing either the name or the API shape.",
   "difficulty": "medium",
   "turns": [
     {
@@ -8,7 +8,7 @@
     }
   ],
   "expect": {
-    "toolsUsed": ["list_org_endpoints"],
+    "toolsUsed": ["list_org_endpoints", "list_org_component_endpoints"],
     "fileMatches": [
       {
         "path": "specs/design/components/onboarding-api/design.json",

--- a/services/agents/evals/mocks/mcp-server.test.ts
+++ b/services/agents/evals/mocks/mcp-server.test.ts
@@ -28,13 +28,21 @@ import assert from "node:assert/strict";
 import { loadMcpTools } from "../../src/shared/mcp-client.js";
 import { startMockMcpServer } from "./mcp-server.js";
 
-test("tools/list advertises the four read-only dependency-discovery tools", async () => {
+test("tools/list advertises the seven read-only dependency-discovery tools", async () => {
   const mock = await startMockMcpServer();
   try {
     const tools = await loadMcpTools({ url: mock.baseUrl, token: mock.token });
     assert.deepEqual(
       Object.keys(tools).sort(),
-      ["get_external_resource_schema", "list_external_resources", "list_org_endpoints", "list_platform_resource_types"].sort(),
+      [
+        "get_external_resource_schema",
+        "get_remote_git_file_contents",
+        "list_external_resources",
+        "list_org_component_endpoints",
+        "list_org_endpoints",
+        "list_platform_resource_types",
+        "search_remote_git_code",
+      ].sort(),
     );
   } finally {
     await mock.close();
@@ -83,6 +91,68 @@ test("list_org_endpoints returns the namespace-visible employee-api endpoint", a
     assert.equal(parsed.endpoints[0]?.name, "employee-api");
     assert.equal(parsed.endpoints[0]?.project, "hr-directory");
     assert.equal(parsed.endpoints[0]?.namespaceVisible, true);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("list_org_component_endpoints returns employee-api's resolved (inline) contract + repo coords", async () => {
+  const mock = await startMockMcpServer();
+  try {
+    const tools = await loadMcpTools({ url: mock.baseUrl, token: mock.token });
+    const raw = await tools.list_org_component_endpoints!.execute!({}, {} as never);
+    const parsed = JSON.parse(String(raw)) as {
+      endpoints: {
+        component: string;
+        project: string;
+        owner: string;
+        repo: string;
+        subdir: string;
+        spec: { availability: string; inlineContent: string };
+      }[];
+    };
+    assert.equal(parsed.endpoints.length, 1);
+    const ep = parsed.endpoints[0]!;
+    assert.equal(ep.component, "employee-api");
+    assert.equal(ep.project, "hr-directory");
+    assert.equal(ep.owner, "acme-org");
+    assert.equal(ep.repo, "hr-directory");
+    assert.equal(ep.subdir, "employee-api");
+    assert.equal(ep.spec.availability, "inline");
+    assert.match(ep.spec.inlineContent, /getEmployee/);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("get_remote_git_file_contents returns the file for a known coordinate, errors for an unknown one", async () => {
+  const mock = await startMockMcpServer();
+  try {
+    const tools = await loadMcpTools({ url: mock.baseUrl, token: mock.token });
+    const exec = tools.get_remote_git_file_contents!.execute!;
+
+    const hit = JSON.parse(
+      String(await exec({ owner: "acme-org", repo: "hr-directory", path: "employee-api/openapi.yaml" }, {} as never)),
+    ) as { content: string; sha: string; isDirectory: boolean };
+    assert.match(hit.content, /getEmployee/);
+    assert.equal(hit.isDirectory, false);
+
+    await assert.rejects(exec({ owner: "acme-org", repo: "hr-directory", path: "nope.yaml" }, {} as never), /not found/);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("search_remote_git_code returns the matching file's path + sha", async () => {
+  const mock = await startMockMcpServer();
+  try {
+    const tools = await loadMcpTools({ url: mock.baseUrl, token: mock.token });
+    const raw = await tools.search_remote_git_code!.execute!(
+      { owner: "acme-org", repo: "hr-directory", query: "openapi" },
+      {} as never,
+    );
+    const parsed = JSON.parse(String(raw)) as { items: { path: string; sha: string }[] };
+    assert.deepEqual(parsed.items, [{ path: "employee-api/openapi.yaml", sha: "deadbeef" }]);
   } finally {
     await mock.close();
   }

--- a/services/agents/evals/mocks/mcp-server.ts
+++ b/services/agents/evals/mocks/mcp-server.ts
@@ -21,12 +21,15 @@
  * (`aep-api/internal/feature/dependencies/mcp_server.go` + `mcp_tools.go`) for
  * the eval tree. Speaks the same JSON-RPC subset (`initialize` accepted but not
  * required, `tools/list`, `tools/call` with `{ name, arguments }`, text-content
- * JSON results) and the same four read-only tools, over a DETERMINISTIC catalog:
+ * JSON results) and the same read-only tools, over a DETERMINISTIC catalog:
  *
- *   - one external resource  `openweather`  (config key `OPENWEATHER_API_KEY`, secret)
- *   - one org endpoint       `employee-api` (project `hr-directory`, namespace-visible)
- *   - one resource type      `postgres-cnpg` (params version/storageGB/instances;
- *                                              outputs host/port/username/password/database)
+ *   - one external resource        `openweather`  (config key `OPENWEATHER_API_KEY`, secret)
+ *   - one org endpoint             `employee-api` (project `hr-directory`, namespace-visible)
+ *   - one resource type            `postgres-cnpg` (params version/storageGB/instances;
+ *                                                    outputs host/port/username/password/database)
+ *   - one resolved component endpoint `employee-api` (endpoint-spec-discovery: an `inline`
+ *     OpenAPI contract + repo coordinates, so `list_org_component_endpoints` /
+ *     `get_remote_git_file_contents` / `search_remote_git_code` have something real to return)
  *
  * Used by both the deterministic eval tree (`test:eval` — proves the mock +
  * `loadMcpTools` client plumbing without a live model) and the live-model `eval`
@@ -62,6 +65,36 @@ export interface ResourceTypeView {
   outputs: string[];
 }
 
+/** Mirrors aep-api's `endpointSpecView` (mcp_tools.go). */
+export interface EndpointSpecView {
+  availability: "inline" | "repo" | "none";
+  inlineContent?: string;
+  path?: string;
+}
+
+/** Mirrors aep-api's `orgComponentEndpointView` — `list_org_component_endpoints`'s row shape. */
+export interface OrgComponentEndpointView {
+  project: string;
+  component: string;
+  endpoint: string;
+  type: string;
+  namespaceVisible: boolean;
+  owner?: string;
+  repo?: string;
+  subdir?: string;
+  branch?: string;
+  spec: EndpointSpecView;
+}
+
+/** One file a mock "repo" exposes to `get_remote_git_file_contents` / `search_remote_git_code`. */
+interface RemoteGitFile {
+  owner: string;
+  repo: string;
+  path: string;
+  content: string;
+  sha: string;
+}
+
 // --- The deterministic catalog -----------------------------------------------
 
 export const EXTERNAL_RESOURCES: ExternalResourceView[] = [
@@ -82,6 +115,41 @@ export const RESOURCE_TYPES: ResourceTypeView[] = [
     params: { version: "string", storageGB: "number", instances: "number" },
     outputs: ["host", "port", "username", "password", "database"],
   },
+];
+
+/** The employee-api provider's real (mock) OpenAPI contract — resolvable `inline`. */
+const EMPLOYEE_API_OPENAPI = `openapi: 3.0.3
+info:
+  title: Employee API
+  version: 1.0.0
+paths:
+  /employees/{id}:
+    get:
+      operationId: getEmployee
+      summary: Look up an employee by id
+      responses:
+        '200':
+          description: Employee record
+`;
+
+export const ORG_COMPONENT_ENDPOINTS: OrgComponentEndpointView[] = [
+  {
+    project: "hr-directory",
+    component: "employee-api",
+    endpoint: "employee-api",
+    type: "HTTP",
+    namespaceVisible: true,
+    owner: "acme-org",
+    repo: "hr-directory",
+    subdir: "employee-api",
+    branch: "main",
+    spec: { availability: "inline", inlineContent: EMPLOYEE_API_OPENAPI, path: "employee-api/openapi.yaml" },
+  },
+];
+
+/** Backs `get_remote_git_file_contents` / `search_remote_git_code` for the `repo`-availability path. */
+export const REMOTE_GIT_FILES: RemoteGitFile[] = [
+  { owner: "acme-org", repo: "hr-directory", path: "employee-api/openapi.yaml", content: EMPLOYEE_API_OPENAPI, sha: "deadbeef" },
 ];
 
 // --- tools/list descriptors (mirrors mcpTools() in mcp_tools.go) ------------
@@ -112,9 +180,52 @@ function mcpTools(): { name: string; description: string; inputSchema: unknown }
       inputSchema: { type: "object", properties: {} },
     },
     {
+      name: "list_org_component_endpoints",
+      description:
+        "List every org-wide component endpoint published across this organization, each resolved with the " +
+        "provider's real OpenAPI contract (when discoverable) and repo coordinates. Use this AFTER " +
+        "list_org_endpoints when you need the endpoint's actual request/response contract to integrate " +
+        "against it. Each row's `spec.availability` is `inline` (`spec.inlineContent` carries the OpenAPI " +
+        "document verbatim — read it directly), `repo` (no inline spec, but owner/repo/subdir/branch locate " +
+        "the provider's source so you can read the contract from there), or `none` (neither is resolvable).",
+      inputSchema: { type: "object", properties: {} },
+    },
+    {
       name: "list_platform_resource_types",
       description: "List the platform-provisioned resource types (databases, caches, queues) on the cluster.",
       inputSchema: { type: "object", properties: {} },
+    },
+    {
+      name: "get_remote_git_file_contents",
+      description:
+        "Read a file (or list a directory) from a repository in THIS organization — no clone. Use this AFTER " +
+        "list_org_component_endpoints reports a provider whose `spec.availability` is `repo`: pass that " +
+        "row's owner/repo plus the spec path to read the real OpenAPI document.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          owner: { type: "string", description: "repo owner" },
+          repo: { type: "string", description: "repository name" },
+          path: { type: "string", description: "repo-relative file or directory path" },
+          ref: { type: "string", description: "optional branch/tag/commit" },
+        },
+        required: ["owner", "repo", "path"],
+      },
+    },
+    {
+      name: "search_remote_git_code",
+      description:
+        "Search code in a repository in THIS organization to LOCATE a file when you do not know its exact " +
+        "path (e.g. find where an `openapi.yaml` lives before reading it with get_remote_git_file_contents).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          owner: { type: "string", description: "repo owner" },
+          repo: { type: "string", description: "repository name" },
+          query: { type: "string", description: "code search query" },
+        },
+        required: ["owner", "repo", "query"],
+      },
     },
   ];
 }
@@ -148,8 +259,31 @@ function callTool(name: string, args: Record<string, unknown>): ToolCallResult {
     }
     case "list_org_endpoints":
       return textResult({ endpoints: ORG_ENDPOINTS });
+    case "list_org_component_endpoints":
+      return textResult({ endpoints: ORG_COMPONENT_ENDPOINTS });
     case "list_platform_resource_types":
       return textResult({ resourceTypes: RESOURCE_TYPES });
+    case "get_remote_git_file_contents": {
+      const owner = typeof args.owner === "string" ? args.owner : "";
+      const repo = typeof args.repo === "string" ? args.repo : "";
+      const path = typeof args.path === "string" ? args.path : "";
+      if (!owner || !repo) return errorResult("missing required arguments: owner and repo");
+      const found = REMOTE_GIT_FILES.find((f) => f.owner === owner && f.repo === repo && f.path === path);
+      return found
+        ? textResult({ content: found.content, sha: found.sha, isDirectory: false })
+        : errorResult(`not found: ${owner}/${repo}/${path}`);
+    }
+    case "search_remote_git_code": {
+      const owner = typeof args.owner === "string" ? args.owner : "";
+      const repo = typeof args.repo === "string" ? args.repo : "";
+      const query = typeof args.query === "string" ? args.query : "";
+      if (!owner || !repo || !query) return errorResult("missing required arguments: owner, repo and query");
+      const items = REMOTE_GIT_FILES.filter((f) => f.owner === owner && f.repo === repo).map((f) => ({
+        path: f.path,
+        sha: f.sha,
+      }));
+      return textResult({ items });
+    }
     default:
       return errorResult(`unknown tool: ${name}`);
   }

--- a/skills/high-level-architecture/SKILL.md
+++ b/skills/high-level-architecture/SKILL.md
@@ -170,6 +170,17 @@ tools, USE them before authoring an `external`, `org-service`, or
   rather than inventing a parallel one.
 - `list_org_endpoints` — find the real provider component name for an
   `org-service` before referencing it.
+- `list_org_component_endpoints` — once you have the provider's name, call this
+  to read its REAL contract before writing the dependency's `description`:
+  each row resolves to a `spec.availability` of `inline` (read
+  `spec.inlineContent` directly — it IS the OpenAPI document), `repo` (no
+  inline spec, but the row's `owner`/`repo`/`subdir`/`branch` locate the
+  provider's source — use `search_remote_git_code` under that `subdir` to find
+  the spec file if you don't know its exact path, then
+  `get_remote_git_file_contents` to read it), or `none` (no contract is
+  resolvable). Base the dependency's `description` on the ACTUAL
+  operations/paths/schemas the contract exposes; on `none`, say so plainly in
+  the `description` instead of inventing a shape.
 - `list_platform_resource_types` — get a valid `resourceType` (and its
   parameters) before declaring a `platform-resource`. Read each type's
   `description` and pick the type whose description matches the need; when
@@ -192,7 +203,9 @@ least one `config` key — the value-collection gate needs something to collect.
 
 Every dependency carries a one-line `description`: what the target is and how
 the component uses it (for an `external`, which endpoints/SDK and auth scheme;
-for a `platform-resource`, what it stores). The console shows it in the
+for an `org-service`, the specific operations/paths it calls from the
+provider's discovered contract — or that no contract was resolvable, never a
+guess; for a `platform-resource`, what it stores). The console shows it in the
 dependency drawer and the coding agent relies on it to integrate correctly.
 
 One component per directory. Every `service` gets an `openapi.yaml`


### PR DESCRIPTION
## What & why

Consumers of a **cross-project org-service** previously got only an *address* env var — no API contract — so the design and coding agents **guessed** the provider's endpoints. This adds contract discovery so both agents figure out the real API from a prompt that contains **no endpoint details**.

## How

Two read-only MCP tools on the BFF `dependencies` MCP server, consumed by **both** the design agent and the coding-agent runner:

- **`list_org_component_endpoints`** — enriches the org-endpoint catalog with repo coords + the provider's spec, tagged `availability: inline | repo | local | none`. Resolves the contract from **(a)** the provider's design-bundle `openapi.yaml` *or* **(b)** the inline `Schema.content` on the deployed OpenChoreo Workload endpoint (the only source for services deployed outside app-factory).
- **`get_remote_git_file_contents` / `search_remote_git_code`** — BFF-mediated GitHub reads (org credential, **org-scoped, read-only**, size/timeout-bounded; `SearchCode` strips embedded scope qualifiers) for specs that live as a repo file.

Wiring:
- The BFF mints a dedicated `aep-api-mcp`-audience token at coding-agent dispatch and ships `AEP_MCP_URL`/`AEP_MCP_TOKEN` to the runner; the runner registers the BFF MCP server in-process (Claude Agent SDK `mcpServers`) and allow-lists the `mcp__aep__*` tools.
- The dispatch comment gains a **"Consumed API contracts"** section; the runner `aep` SKILL.md + the design skill carry the deterministic *how* (procedure in the skill, per-dep data in the issue).

No spec copy is written into the consumer repo (avoids drift). `list_org_endpoints` and existing resolution/wiring are untouched (additive).

## Verification

- Every task TDD'd + reviewed; **final whole-branch review: READY** (chain integrity + security sound, no Critical/Important).
- **Live E2E, both spec sources, both agents, from endpoint-free prompts:**
  - **Source (a)** app-factory provider `test-auth-2/habit-api` → consumer coded `GET /habits?page=&page_size=` (spec-specific params), provider URL via `os.Getenv(TEST_AUTH_2_HABIT_API_URL)`, no invented paths.
  - **Source (b)** off-platform compliance `employee`/`product-service` → consumer coded `GET /employees/{id}`, `GET /products?owningTeam=`, no invented paths.
  - In both, the design agent and the coding-agent runner each called `list_org_component_endpoints` and implemented against the exact discovered operations.

## Notes

- Local dev-env setup gap surfaced while testing (Thunder console app missing the `ouHandle` claim → BFF namespace resolution) is tracked separately in **#140** — not part of this change.
- The `get_remote_git_*` SSRF/authz surface is flagged for `platform-design-expert` review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CZD5e4TC56qRcMVXPKbgv
