### PR TITLE
feat(console): guide credential setup on the GitHub + Anthropic cards (#96)

### DIFF
--- a/apps/console/src/features/settings/components/AnthropicCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/AnthropicCredentialCard.tsx
@@ -73,8 +73,10 @@ export function AnthropicCredentialCard({
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
           <Key size={22} />
           <Typography variant="h6">Anthropic</Typography>
-          {connected && (
+          {connected ? (
             <Chip label={llm.status} size="small" color="success" />
+          ) : (
+            <Chip label="not connected" size="small" color="warning" />
           )}
         </Box>
         <Divider sx={{ mb: 3 }} />

--- a/apps/console/src/features/settings/components/AnthropicCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/AnthropicCredentialCard.tsx
@@ -35,7 +35,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Eye, EyeOff, Key } from "@wso2/oxygen-ui-icons-react";
+import { ExternalLink, Eye, EyeOff, Key } from "@wso2/oxygen-ui-icons-react";
 import type { components } from "../../../generated/aep-api";
 import { useConnectAnthropic, useDisconnectAnthropic } from "../api/queries";
 
@@ -79,7 +79,14 @@ export function AnthropicCredentialCard({
         </Box>
         <Divider sx={{ mb: 3 }} />
 
-        {connected ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          Configure an Anthropic API key to dispatch the remote coding agent
+          for this organization. Requirements, architecture, and task
+          generation use the platform-provided key as a fallback if you don't
+          configure one here.
+        </Typography>
+
+        {connected && (
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 3 }}>
             <Typography variant="body2" fontFamily="monospace">
               {llm.keyPrefix}•••••••••{llm.keyLast4}
@@ -93,11 +100,6 @@ export function AnthropicCredentialCard({
               <Alert severity="warning">{llm.validationError}</Alert>
             )}
           </Box>
-        ) : (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            Not connected. An Anthropic API key is needed for the platform and
-            coding agents to call Claude.
-          </Typography>
         )}
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -124,6 +126,17 @@ export function AnthropicCredentialCard({
               },
             }}
           />
+          <Button
+            variant="text"
+            size="small"
+            href="https://console.anthropic.com/settings/keys"
+            target="_blank"
+            rel="noreferrer"
+            endIcon={<ExternalLink size={14} />}
+            sx={{ alignSelf: "flex-start" }}
+          >
+            Get an API key
+          </Button>
           {connect.isError && (
             <Alert severity="error">{connect.error.message}</Alert>
           )}

--- a/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
@@ -37,7 +37,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Eye, EyeOff, GitHub } from "@wso2/oxygen-ui-icons-react";
+import { ExternalLink, Eye, EyeOff, GitHub, Lightbulb } from "@wso2/oxygen-ui-icons-react";
 import type { components } from "../../../generated/aep-api";
 import { useConnectGitHubPat, useDisconnectGitProvider } from "../api/queries";
 
@@ -91,6 +91,14 @@ export function GitHubCredentialCard({
 
         {connected ? (
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 3 }}>
+            {(gitProvider.githubLogin ?? gitProvider.identityLogin) && (
+              <Typography variant="body2">
+                Organization:{" "}
+                <strong>
+                  {gitProvider.githubLogin ?? gitProvider.identityLogin}
+                </strong>
+              </Typography>
+            )}
             <Typography variant="body2">
               Connected as{" "}
               <strong>
@@ -109,11 +117,21 @@ export function GitHubCredentialCard({
             </Typography>
           </Box>
         ) : (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            Not connected. A GitHub personal access token is needed to read and
-            write project spec and code repos, and to host the org's skills
-            catalogue.
-          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mb: 3 }}>
+            <Typography variant="body2" color="text.secondary">
+              Connect a GitHub personal access token with{" "}
+              <strong>organization-level access</strong> so the platform can
+              read and write this org's spec and code repos and host its skills
+              catalogue. Use a fine-grained token with the organization set as
+              the resource owner, or a classic token with the{" "}
+              <code>repo</code> scope owned by a member of the org.
+            </Typography>
+            <Alert severity="info" icon={<Lightbulb size={18} />}>
+              Pro tip: create a dedicated GitHub organization for this platform
+              so its agents' repos, tokens, and skills catalogue stay isolated
+              from your team's main org.
+            </Alert>
+          </Box>
         )}
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -151,6 +169,17 @@ export function GitHubCredentialCard({
             onChange={(e) => setGithubLogin(e.target.value)}
             fullWidth
           />
+          <Button
+            variant="text"
+            size="small"
+            href="https://github.com/settings/personal-access-tokens/new"
+            target="_blank"
+            rel="noreferrer"
+            endIcon={<ExternalLink size={14} />}
+            sx={{ alignSelf: "flex-start" }}
+          >
+            Create a token on GitHub
+          </Button>
           {connect.isError && (
             <Alert severity="error">{connect.error.message}</Alert>
           )}

--- a/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
@@ -49,7 +49,9 @@ export function GitHubCredentialCard({
   gitProvider: GitProviderProjection | null;
 }) {
   const [pat, setPat] = useState("");
-  const [githubLogin, setGithubLogin] = useState("");
+  // Pre-fill the org when already connected so a token rotation is PAT-only;
+  // the field is required (below), so an empty org can't reach the BE.
+  const [githubLogin, setGithubLogin] = useState(gitProvider?.githubLogin ?? "");
   const [showPat, setShowPat] = useState(false);
   const [disconnectOpen, setDisconnectOpen] = useState(false);
   const [uninstall, setUninstall] = useState(true);
@@ -60,14 +62,11 @@ export function GitHubCredentialCard({
   const connected = gitProvider !== null;
 
   const submit = () => {
+    const org = githubLogin.trim();
+    if (!pat || !org) return;
     connect.mutate(
-      { pat, ...(githubLogin ? { githubLogin } : {}) },
-      {
-        onSuccess: () => {
-          setPat("");
-          setGithubLogin("");
-        },
-      },
+      { pat, githubLogin: org },
+      { onSuccess: () => setPat("") },
     );
   };
 
@@ -163,10 +162,12 @@ export function GitHubCredentialCard({
             }}
           />
           <TextField
+            required
             label="GitHub organization name"
             placeholder="octocat"
             value={githubLogin}
             onChange={(e) => setGithubLogin(e.target.value)}
+            helperText="The GitHub organization the platform reads and writes repos in."
             fullWidth
           />
           <Button
@@ -194,7 +195,7 @@ export function GitHubCredentialCard({
             <Button
               variant="contained"
               onClick={submit}
-              disabled={!pat || connect.isPending}
+              disabled={!pat || !githubLogin.trim() || connect.isPending}
             >
               {connect.isPending
                 ? "Validating…"

--- a/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
@@ -82,8 +82,10 @@ export function GitHubCredentialCard({
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
           <GitHub size={22} />
           <Typography variant="h6">GitHub</Typography>
-          {connected && (
+          {connected ? (
             <Chip label={gitProvider.status} size="small" color="success" />
+          ) : (
+            <Chip label="not connected" size="small" color="warning" />
           )}
         </Box>
         <Divider sx={{ mb: 3 }} />


### PR DESCRIPTION
Post-#103 UX refinement of the Settings **Credentials** cards (#96). Guidance/links only — no contract change; verified in mock mode across connected and not-connected states.

## GitHub Integration
- **Shows the org** — the connected `githubLogin` now renders as its own "Organization" line.
- **Link to create a PAT** — "Create a token on GitHub" → the fine-grained token page (present in both connect and replace flows).
- **Setup instructions emphasising org-level access** — a fine-grained token with the organization set as the resource owner, or a classic token with the `repo` scope owned by an org member.
- **Pro tip** — create a dedicated GitHub org for the platform so its agents' repos, tokens, and skills catalogue stay isolated from your team's main org.

## Anthropic Integration
- **Purpose + fallback description** (shown always): "Configure an Anthropic API key to dispatch the remote coding agent for this organization. Requirements, architecture, and task generation use the platform-provided key as a fallback if you don't configure one here."
- **Link to get a key** — "Get an API key" → the Anthropic console.

Typecheck + eslint clean on both files. Screenshots (not-connected, Anthropic, connected) to drag in below.

Refs #96