### PR TITLE
feat(devflow): unique base36 run suffix on dev + task workflow ids

### DIFF
--- a/services/aep-api/internal/feature/devflow/devflow_huma.go
+++ b/services/aep-api/internal/feature/devflow/devflow_huma.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -177,7 +179,11 @@ func (s *HumaService) start(ctx context.Context, in *startInput) (*startOutput, 
 		}
 	}
 
-	workflowID := DevWorkflowID(in.OrgHandle, in.ProjectName, tag)
+	// One run suffix per start: it distinguishes each re-run of the same tag
+	// (own workflow id + timeline) and is threaded to task children so the dev
+	// run and its tasks share one lineage.
+	suffix := newRunSuffix(time.Now())
+	workflowID := DevWorkflowID(in.OrgHandle, in.ProjectName, tag, suffix)
 	run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		ID:                    workflowID,
 		TaskQueue:             s.rt.TaskQueue(),
@@ -188,6 +194,7 @@ func (s *HumaService) start(ctx context.Context, in *startInput) (*startOutput, 
 		Repo:      repo,
 		Tag:       tag,
 		Gates:     in.Body.Gates,
+		RunSuffix: suffix,
 	})
 	if err != nil {
 		return nil, huma.Error500InternalServerError("start workflow: " + err.Error())
@@ -276,10 +283,24 @@ func (s *HumaService) temporal() (client.Client, error) {
 	return c, nil
 }
 
-// DevWorkflowID builds the dev workflow id devflow-<org>-<project>-<tag>.
-// The tag (the spec version) makes it unique per build; concurrent builds for
-// a project are blocked at the API layer, and a completed version re-runs
-// under the same id (WorkflowIDReusePolicy AllowDuplicate).
-func DevWorkflowID(orgID, projectID, tag string) string {
-	return fmt.Sprintf("devflow-%s-%s-%s", orgID, projectID, tag)
+// DevWorkflowID builds the dev workflow id devflow-<org>-<project>-<tag>[-<suffix>].
+// The tag (the spec version) scopes it per build; the run suffix (base36 epoch,
+// see newRunSuffix) gives each re-run of the same tag its own distinct id and
+// Temporal timeline. An empty suffix keeps the legacy format. The suffix is
+// threaded to task children (DevFlowInput.RunSuffix) so a dev run and its tasks
+// share one lineage.
+func DevWorkflowID(orgID, projectID, tag, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("devflow-%s-%s-%s", orgID, projectID, tag)
+	}
+	return fmt.Sprintf("devflow-%s-%s-%s-%s", orgID, projectID, tag, suffix)
+}
+
+// newRunSuffix returns a compact, unique-per-run id: the base36 encoding of the
+// instant's epoch-millis. Charset [0-9a-z] is Temporal- and DNS-label-safe.
+// Millisecond resolution makes a collision between two re-runs of the same
+// (org, project, tag) effectively impossible. Computed in the API handler (never
+// inside workflow code, which must stay deterministic) and passed down as input.
+func newRunSuffix(t time.Time) string {
+	return strconv.FormatInt(t.UnixMilli(), 36)
 }

--- a/services/aep-api/internal/feature/devflow/id_test.go
+++ b/services/aep-api/internal/feature/devflow/id_test.go
@@ -18,14 +18,42 @@ package devflow
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestDevWorkflowID_Format(t *testing.T) {
-	require.Equal(t, "devflow-acme-shop-v3", DevWorkflowID("acme", "shop", "v3"))
+	// With a run suffix — each re-run gets its own workflow id / timeline.
+	require.Equal(t, "devflow-acme-shop-v3-abc", DevWorkflowID("acme", "shop", "v3", "abc"))
+}
+
+func TestDevWorkflowID_NoSuffix(t *testing.T) {
+	// Empty suffix keeps the legacy format (no trailing dash).
+	require.Equal(t, "devflow-acme-shop-v3", DevWorkflowID("acme", "shop", "v3", ""))
 }
 
 func TestTaskWorkflowID_Format(t *testing.T) {
-	require.Equal(t, "taskflow-acme-shop-v3-7", taskWorkflowID("acme", "shop", "v3", 7))
+	// The child inherits the parent's run suffix so a dev run and its tasks
+	// share one lineage: devflow-…-v3-abc → taskflow-…-v3-7-abc.
+	require.Equal(t, "taskflow-acme-shop-v3-7-abc", taskWorkflowID("acme", "shop", "v3", 7, "abc"))
+}
+
+func TestTaskWorkflowID_NoSuffix(t *testing.T) {
+	require.Equal(t, "taskflow-acme-shop-v3-7", taskWorkflowID("acme", "shop", "v3", 7, ""))
+}
+
+func TestNewRunSuffix_Base36(t *testing.T) {
+	// base36 of the epoch-millis: [0-9a-z], compact, Temporal/DNS-safe.
+	require.Equal(t, "0", newRunSuffix(time.UnixMilli(0)))
+	require.Equal(t, "z", newRunSuffix(time.UnixMilli(35)))  // 35 → 'z'
+	require.Equal(t, "10", newRunSuffix(time.UnixMilli(36))) // 36 → '10'
+}
+
+func TestNewRunSuffix_MonotonicDistinct(t *testing.T) {
+	// Distinct instants yield distinct suffixes (millisecond resolution).
+	a := newRunSuffix(time.UnixMilli(1783587000000))
+	b := newRunSuffix(time.UnixMilli(1783587000001))
+	require.NotEqual(t, a, b)
+	require.NotEmpty(t, a)
 }

--- a/services/aep-api/internal/feature/devflow/workflow_dev.go
+++ b/services/aep-api/internal/feature/devflow/workflow_dev.go
@@ -42,6 +42,10 @@ type DevFlowInput struct {
 	Repo  string     `json:"repo"`
 	Tag   string     `json:"tag"`
 	Gates GateConfig `json:"gates"`
+	// RunSuffix is the per-run id (base36 epoch, set by the API handler). It is
+	// carried into each task child's workflow id so a dev run and its tasks share
+	// one lineage. Empty on legacy runs — the id builders keep the old format.
+	RunSuffix string `json:"runSuffix,omitempty"`
 }
 
 // DevFlowStatus is the QueryStatus result for a dev workflow.
@@ -263,7 +267,7 @@ func scheduleTasks(ctx workflow.Context, in DevFlowInput, tag string, tasks []Pl
 			if !depsSatisfied(t, succeeded, present) {
 				continue
 			}
-			wid := taskWorkflowID(in.OrgID, in.ProjectID, tag, t.Issue)
+			wid := taskWorkflowID(in.OrgID, in.ProjectID, tag, t.Issue, in.RunSuffix)
 			cctx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 				WorkflowID:        wid,
 				ParentClosePolicy: enumsParentClosePolicyTerminate(),
@@ -375,7 +379,12 @@ func planActivityOpts(ctx workflow.Context) workflow.Context {
 }
 
 // taskWorkflowID builds the deterministic child workflow id
-// (taskflow-<org>-<project>-<tag>-<issueNumber>).
-func taskWorkflowID(orgID, projectID, tag string, issue int) string {
-	return fmt.Sprintf("taskflow-%s-%s-%s-%d", orgID, projectID, tag, issue)
+// (taskflow-<org>-<project>-<tag>-<issueNumber>[-<suffix>]). The suffix is the
+// parent dev run's RunSuffix, so re-running a tag yields fresh task ids too.
+// Deterministic given its inputs — safe to call from workflow code.
+func taskWorkflowID(orgID, projectID, tag string, issue int, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("taskflow-%s-%s-%s-%d", orgID, projectID, tag, issue)
+	}
+	return fmt.Sprintf("taskflow-%s-%s-%s-%d-%s", orgID, projectID, tag, issue, suffix)
 }


### PR DESCRIPTION
## What

Give every dev-flow run a unique **base36 epoch-millis suffix** on its workflow
id, and thread the same suffix into each child task workflow id.

```
devflow-<org>-<project>-<tag>-<suffix>
taskflow-<org>-<project>-<tag>-<issue>-<suffix>
```

## Why

Follow-up to the workflow-id discussion on #135
(https://github.com/wso2/labs-agentic-engineer/pull/135#discussion_r3549065420).
That thread flagged that the dev workflow id was deterministic on
`(org, project, tag)` and relied on `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE`,
which makes re-runs of the same tag **stack under one workflow id / Temporal
timeline** and leaves a residual race on the auto-tag path.

A unique per-run suffix fixes that: re-running the same tag (e.g. after a build
failure) now produces a **distinct workflow id with its own timeline**, which is
exactly what you want when debugging a failed run.

## How

- `newRunSuffix(time.Time)` = `strconv.FormatInt(t.UnixMilli(), 36)`. Charset
  `[0-9a-z]`, compact (~8 chars), Temporal/DNS-label-safe. Millisecond resolution
  makes a collision between two re-runs of the same `(org, project, tag)`
  effectively impossible.
- The suffix is computed **once in the API handler** (`start`) from
  `time.Now()` — never inside workflow code, which must stay deterministic — and
  passed down via `DevFlowInput.RunSuffix` so a dev run and all its task children
  **share one lineage**.
- Both id builders take a `suffix` param and keep the **legacy format when it is
  empty** (backward compatible).

## Notes

- **Concurrency guard unchanged.** With unique per-run ids, Temporal's same-id
  reuse policy is no longer the dedup mechanism; the existing
  `RunningDevByProject` 409 check in `start` remains the one-dev-run-per-project
  guard, so this does not widen the race that #135 discussed.
- **Signal routing unaffected.** Webhook signals resolve the target workflow via
  DB lookup (`RunningTaskByIssue` / `RunningDevByProject`), never by parsing the
  id, so the extra id segment is transparent.

## Tests

TDD — tests written first. `id_test.go` covers suffixed + legacy formats for both
ids and the base36 encoding contract. All devflow package tests pass; `go vet`
clean.
