### PR TITLE
feat(aep-api): RCA-agent alert reports backend

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -78,6 +78,17 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
+- Alerts — top-nav notification bell for RCA-agent alert reports
+  (org-wide, read-only, client-tracked unread state) —
+  [#154](https://github.com/wso2/labs-agentic-engineer/issues/154)
+  (BE handshake: [#156](https://github.com/wso2/labs-agentic-engineer/issues/156),
+  ADR-0008)
+- Alerts — dedicated left-nav section (cursor-paginated list + per-alert
+  Stepper progress view: Alert Received / Issue Created / Coding Handover
+  / Verify Fix) —
+  [#155](https://github.com/wso2/labs-agentic-engineer/issues/155)
+  (BE handshake: [#156](https://github.com/wso2/labs-agentic-engineer/issues/156),
+  ADR-0008)
 - Settings — org GitHub PAT + Anthropic key credentials, and skills catalogue
   (browse/search/import/sync; no in-console authoring) —
   [#96](https://github.com/wso2/labs-agentic-engineer/issues/96) (BE

--- a/apps/console/design/decisions/ADR-0008-alerts-surface-and-non-goal-narrowing.md
+++ b/apps/console/design/decisions/ADR-0008-alerts-surface-and-non-goal-narrowing.md
@@ -1,0 +1,59 @@
+# ADR-0008: Console gains an Alerts surface — non-goal narrowed, IA extended
+
+- **Status:** Accepted
+- **Date:** 2026-07-09 (grilling of the RCA-agent alert notification
+  features, [#154](https://github.com/wso2/labs-agentic-engineer/issues/154),
+  [#155](https://github.com/wso2/labs-agentic-engineer/issues/155))
+- **Context:** the PRD's non-goals stated "Dev-environment visibility only
+  (for now). No prod ops, alerting, or observability surface." Both #154
+  (a top-nav notification bell) and #155 (a dedicated global "Alerts"
+  left-nav section) surface RCA reports produced by the OpenChoreo
+  SRE/RCA-agent handoff (`docs/developer-guide/sre-handoff-runbook.md`) —
+  genuinely new alerting data flowing into the console, not a
+  reinterpretation of data it already had. That contradicts the blanket
+  non-goal as written. Separately, `docs/design/observability.md` is a
+  much larger, still-unapproved proposal (WS1–WS6: logs, metrics, traces,
+  agentic telemetry, alerting/incidents, platform self-observability);
+  #154/#155 are scoped narrowly to RCA-agent alerts only and are not part
+  of that proposal or its approval.
+
+## Decision
+
+Narrow the non-goal from a blanket "no alerting" to explicitly exclude
+**RCA-agent alert notifications** (issue/task/deploy-status surfaced from
+the SRE-agent handoff pipeline) from what's disallowed. General
+alerting/observability (metrics, logs, traces, alert-rule authoring,
+incident management) remains a non-goal and is out of scope for both
+#154 and #155; that ground stays with `docs/design/observability.md`'s
+own (separate, pending) design review.
+
+The console's information architecture gains two Alerts-related surfaces:
+- A global, org-wide **top-nav notification bell** (#154) — quick
+  awareness, read-only, client-tracked unread state, no dedicated page.
+- A global, org-wide **"Alerts" left-nav section** (#155), at the same
+  level as "Projects" — a browsable list + a per-alert Stepper progress
+  view (Alert Received / Issue Created / Coding Handover / Verify Fix),
+  entirely derived client-side from existing data (no new stored state
+  machine).
+
+Both are read-only from the console's side: no triage actions, no
+"mark verified"/acknowledge mutations, no alert-rule or incident
+management UI.
+
+## Consequences
+
+- `apps/console/PRD.md`'s non-goals section is amended when #154/#155
+  ship: the "no prod ops, alerting, or observability surface" line is
+  qualified to carve out RCA-agent alert notifications specifically.
+- The PRD's Information architecture section gains "Alerts" (global,
+  two entry points: top-nav bell + left-nav section) alongside Home,
+  Project view, and Admin.
+- Future alerting/observability work (metrics, logs, traces, alert-rule
+  authoring, incident management) still requires its own design review
+  and PRD change — this ADR does not pre-approve
+  `docs/design/observability.md`'s broader scope, and features must not
+  cite this ADR to justify building those pillars without that review.
+- Any future feature that wants to add mutation/triage actions to alerts
+  (acknowledge, dismiss, "mark verified," manual dispatch from the
+  console) must explicitly supersede the read-only stance recorded here
+  and in #154/#155's grilling decisions.

--- a/apps/console/src/features/alerts/api/keys.ts
+++ b/apps/console/src/features/alerts/api/keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const alertKeys = {
+  all: ["alerts"] as const,
+  lists: () => [...alertKeys.all, "list"] as const,
+  list: (limit?: number) => [...alertKeys.lists(), { limit }] as const,
+  recent: (limit: number) => [...alertKeys.all, "recent", limit] as const,
+  details: () => [...alertKeys.all, "detail"] as const,
+  detail: (id: string) => [...alertKeys.details(), id] as const,
+};

--- a/apps/console/src/features/alerts/api/queries.ts
+++ b/apps/console/src/features/alerts/api/queries.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { client } from "../../../api/client";
+import { alertKeys } from "./keys";
+
+// Bell badge poll interval (#154 decision: 60s, matches the ~3-4 min
+// RCA→handoff completion time from the SRE-handoff runbook).
+const BELL_POLL_MS = 60_000;
+
+// Last N reports the bell dropdown shows/counts (#154 decision: 50, no pagination).
+export const BELL_LIMIT = 50;
+
+// Top-nav bell (#154): last N reports, no pagination — a single page is the
+// entire surface the dropdown shows.
+export function useRecentAlerts(limit: number = BELL_LIMIT) {
+  return useQuery({
+    queryKey: alertKeys.recent(limit),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/rca-agent/reports", {
+        params: { query: { limit } },
+      });
+      if (error) {
+        throw new Error(error.detail ?? error.title ?? "Failed to load alerts");
+      }
+      return data.items ?? [];
+    },
+    refetchInterval: BELL_POLL_MS,
+  });
+}
+
+// Alerts list page (#155): cursor-based infinite scroll, mirrors
+// useProjectsList's pagination shape.
+export function useAlertsInfinite(limit?: number) {
+  return useInfiniteQuery({
+    queryKey: alertKeys.list(limit),
+    queryFn: async ({ pageParam }) => {
+      const { data, error } = await client.GET("/rca-agent/reports", {
+        params: {
+          query: {
+            ...(pageParam && { cursor: pageParam }),
+            ...(limit && { limit }),
+          },
+        },
+      });
+      if (error) {
+        throw new Error(error.detail ?? error.title ?? "Failed to load alerts");
+      }
+      return data;
+    },
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
+    staleTime: 30_000,
+  });
+}
+
+// Alert detail (#154's detail view, #155's stepper stages).
+export function useAlertReport(reportId: string) {
+  return useQuery({
+    queryKey: alertKeys.detail(reportId),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/rca-agent/reports/{reportId}", {
+        params: { path: { reportId } },
+      });
+      if (error) {
+        throw new Error(error.detail ?? error.title ?? "Failed to load the alert");
+      }
+      return data;
+    },
+  });
+}

--- a/apps/console/src/features/alerts/components/AlertDetail.tsx
+++ b/apps/console/src/features/alerts/components/AlertDetail.tsx
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Link,
+  PageContent,
+  PageTitle,
+  Step,
+  StepContent,
+  StepLabel,
+  Stepper,
+  Typography,
+  formatRelativeTime,
+} from "@wso2/oxygen-ui";
+import { ExternalLink } from "@wso2/oxygen-ui-icons-react";
+import { Link as RouterLink, useNavigate } from "@tanstack/react-router";
+import { useAlertReport } from "../api/queries";
+import { ClassificationChip } from "./ClassificationChip";
+import type { components } from "../../../generated/aep-api";
+
+type RcaAgentReport = components["schemas"]["RcaAgentReport"];
+type Stage = "received" | "issue-created" | "coding-handover" | "verify-fix";
+
+const STAGE_INDEX: Record<Stage, number> = {
+  received: 0,
+  "issue-created": 1,
+  "coding-handover": 2,
+  "verify-fix": 3,
+};
+
+// Derived client-side from existing report fields — no stored state machine
+// (#155 decision). "No issue" (config-level/none classifications) is
+// terminal at Alert Received; the remaining stages never apply.
+function deriveStage(report: RcaAgentReport): Stage {
+  if (!report.issueNumber) return "received";
+  if (report.deployed) return "verify-fix";
+  if (report.dispatched) return "coding-handover";
+  return "issue-created";
+}
+
+function AlertReceivedContent({ report }: { report: RcaAgentReport }) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <ClassificationChip classification={report.classification} />
+        {report.component && (
+          <Chip label={report.component} size="small" variant="outlined" />
+        )}
+        {report.createdAt && (
+          <Typography variant="caption" color="text.secondary">
+            {formatRelativeTime(new Date(report.createdAt))}
+          </Typography>
+        )}
+      </Box>
+      <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+        {report.diagnosis}
+      </Typography>
+    </Box>
+  );
+}
+
+function IssueCreatedContent({ report }: { report: RcaAgentReport }) {
+  if (!report.issueNumber) {
+    return (
+      <Alert severity="info">
+        No GitHub issue was created for this alert —{" "}
+        {report.classification === "config-level"
+          ? "the handoff resolved it via a config change, no code action needed."
+          : "the handoff found no actionable remediation."}
+      </Alert>
+    );
+  }
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="subtitle2">{report.issueTitle}</Typography>
+      <Typography variant="body2" color="text.secondary">
+        {report.issueExcerpt}
+      </Typography>
+      {report.issueUrl && (
+        <Box>
+          <Button
+            component={Link}
+            href={report.issueUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            variant="outlined"
+            endIcon={<ExternalLink size={14} />}
+          >
+            View issue #{report.issueNumber} on GitHub
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function CodingHandoverContent({ report }: { report: RcaAgentReport }) {
+  const navigate = useNavigate();
+  const goToBuild = () =>
+    void navigate({
+      to: "/projects/$projectName/builds",
+      params: { projectName: report.project! },
+    });
+
+  if (!report.issueNumber) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Not applicable — no issue was created.
+      </Typography>
+    );
+  }
+  if (!report.dispatched) {
+    return (
+      <Alert
+        severity="warning"
+        action={
+          <Button onClick={goToBuild} size="small">
+            Dispatch from Build
+          </Button>
+        }
+      >
+        Issue #{report.issueNumber} was created, but no coding agent has been
+        dispatched yet.
+      </Alert>
+    );
+  }
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="body2" color="text.secondary">
+        The coding agent has been dispatched for issue #{report.issueNumber}.
+      </Typography>
+      <Box>
+        <Button onClick={goToBuild} size="small" variant="outlined">
+          View build phase
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+function VerifyFixContent({ report }: { report: RcaAgentReport }) {
+  if (!report.issueNumber) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Not applicable — no issue was created.
+      </Typography>
+    );
+  }
+  if (!report.deployed) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Waiting for the fix to be built and deployed before it can be
+        verified.
+      </Typography>
+    );
+  }
+  return (
+    <Alert severity="success">
+      The fix was deployed
+      {report.deployedAt ? ` ${formatRelativeTime(new Date(report.deployedAt))}` : ""}.
+      Reproduce the original failure and confirm it's resolved.
+    </Alert>
+  );
+}
+
+export function AlertDetail({ alertId }: { alertId: string }) {
+  const { data: report, isPending, isError, error, refetch } = useAlertReport(alertId);
+
+  return (
+    <PageContent>
+      <Box sx={{ mb: 3 }}>
+        <PageTitle>
+          <PageTitle.BackButton component={<RouterLink to="/alerts" />} />
+          <PageTitle.Header>{report?.title ?? "Alert"}</PageTitle.Header>
+          {report?.project && (
+            <PageTitle.SubHeader>{report.project}</PageTitle.SubHeader>
+          )}
+        </PageTitle>
+      </Box>
+
+      {isPending ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
+          <CircularProgress aria-label="Loading alert" />
+        </Box>
+      ) : isError || !report ? (
+        <Alert
+          severity="error"
+          action={<Button onClick={() => void refetch()}>Retry</Button>}
+        >
+          Failed to load this alert
+          {error instanceof Error && error.message ? `: ${error.message}` : ""}
+        </Alert>
+      ) : (
+        <Stepper activeStep={STAGE_INDEX[deriveStage(report)]} orientation="vertical" nonLinear>
+          <Step completed={STAGE_INDEX[deriveStage(report)] > 0}>
+            <StepLabel>Alert Received</StepLabel>
+            <StepContent TransitionProps={{ in: true }}>
+              <AlertReceivedContent report={report} />
+            </StepContent>
+          </Step>
+          <Step completed={STAGE_INDEX[deriveStage(report)] > 1}>
+            <StepLabel>Issue Created</StepLabel>
+            <StepContent TransitionProps={{ in: true }}>
+              <IssueCreatedContent report={report} />
+            </StepContent>
+          </Step>
+          <Step completed={STAGE_INDEX[deriveStage(report)] > 2}>
+            <StepLabel>Coding Handover</StepLabel>
+            <StepContent TransitionProps={{ in: true }}>
+              <CodingHandoverContent report={report} />
+            </StepContent>
+          </Step>
+          <Step completed={false}>
+            <StepLabel>Verify Fix</StepLabel>
+            <StepContent TransitionProps={{ in: true }}>
+              <VerifyFixContent report={report} />
+            </StepContent>
+          </Step>
+        </Stepper>
+      )}
+    </PageContent>
+  );
+}

--- a/apps/console/src/features/alerts/components/AlertsList.tsx
+++ b/apps/console/src/features/alerts/components/AlertsList.tsx
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  ListingTable,
+  PageContent,
+  PageTitle,
+  Typography,
+  formatRelativeTime,
+} from "@wso2/oxygen-ui";
+import { BellOff } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import { useAlertsInfinite } from "../api/queries";
+import { ClassificationChip } from "./ClassificationChip";
+
+function EmptyState() {
+  return (
+    <Box sx={{ textAlign: "center", py: 8 }}>
+      <BellOff size={48} style={{ opacity: 0.3, marginBottom: 16 }} />
+      <Typography variant="h6" gutterBottom>
+        No alerts yet
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        RCA reports from the SRE-agent handoff will show up here.
+      </Typography>
+    </Box>
+  );
+}
+
+export function AlertsList() {
+  const navigate = useNavigate();
+  const {
+    data,
+    isPending,
+    isError,
+    error,
+    refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useAlertsInfinite();
+
+  const items = data?.pages.flatMap((page) => page.items ?? []) ?? [];
+
+  return (
+    <PageContent>
+      <PageTitle>
+        <PageTitle.Header>Alerts</PageTitle.Header>
+        <PageTitle.SubHeader>
+          RCA reports from the OpenChoreo SRE-agent handoff, across every
+          project.
+        </PageTitle.SubHeader>
+      </PageTitle>
+
+      {isPending ? (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
+          <CircularProgress aria-label="Loading alerts" />
+        </Box>
+      ) : isError ? (
+        <Alert
+          severity="error"
+          action={<Button onClick={() => void refetch()}>Retry</Button>}
+        >
+          Failed to load alerts
+          {error instanceof Error && error.message ? `: ${error.message}` : ""}
+        </Alert>
+      ) : items.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <ListingTable.Container sx={{ width: "100%" }} disablePaper>
+            <ListingTable variant="card" density="standard">
+              <ListingTable.Body>
+                {items.map((report) => (
+                  <ListingTable.Row
+                    key={report.id}
+                    variant="card"
+                    hover
+                    clickable
+                    onClick={() =>
+                      void navigate({
+                        to: "/alerts/$alertId",
+                        params: { alertId: report.id! },
+                      })
+                    }
+                  >
+                    <ListingTable.Cell>
+                      <Box
+                        display="flex"
+                        alignItems="flex-start"
+                        justifyContent="space-between"
+                        gap={2}
+                      >
+                        <Box minWidth={0} flexGrow={1}>
+                          <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
+                            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                              {report.title}
+                            </Typography>
+                            <ClassificationChip classification={report.classification} />
+                          </Box>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{
+                              mt: 0.5,
+                              display: "-webkit-box",
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: "vertical",
+                              overflow: "hidden",
+                            }}
+                          >
+                            {report.summary}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                            {report.project}
+                          </Typography>
+                        </Box>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ whiteSpace: "nowrap", flexShrink: 0 }}
+                        >
+                          {report.createdAt
+                            ? formatRelativeTime(new Date(report.createdAt))
+                            : ""}
+                        </Typography>
+                      </Box>
+                    </ListingTable.Cell>
+                  </ListingTable.Row>
+                ))}
+              </ListingTable.Body>
+            </ListingTable>
+          </ListingTable.Container>
+          {hasNextPage && (
+            <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+              <Button
+                variant="outlined"
+                onClick={() => void fetchNextPage()}
+                loading={isFetchingNextPage}
+              >
+                Load more
+              </Button>
+            </Box>
+          )}
+        </>
+      )}
+    </PageContent>
+  );
+}

--- a/apps/console/src/features/alerts/components/ClassificationChip.tsx
+++ b/apps/console/src/features/alerts/components/ClassificationChip.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Chip } from "@wso2/oxygen-ui";
+import type { components } from "../../../generated/aep-api";
+
+type RcaAgentReport = components["schemas"]["RcaAgentReport"];
+
+const LABEL: Record<string, string> = {
+  "code-level": "Code-level",
+  "config-level": "Config-level",
+  mixed: "Mixed",
+  none: "No action",
+};
+
+const COLOR: Record<string, "warning" | "success" | "default"> = {
+  "code-level": "warning",
+  "config-level": "success",
+  mixed: "warning",
+  none: "default",
+};
+
+// Plain-text label — for contexts where a Chip (a <div>) can't be nested,
+// e.g. inside NotificationPanel.ItemMessage, which MUI renders as a <p>.
+export function classificationLabel(
+  classification?: RcaAgentReport["classification"],
+): string {
+  if (!classification) return "";
+  return LABEL[classification] ?? classification;
+}
+
+export function ClassificationChip({
+  classification,
+}: {
+  classification?: RcaAgentReport["classification"];
+}) {
+  if (!classification) return null;
+  return (
+    <Chip
+      label={LABEL[classification] ?? classification}
+      color={COLOR[classification] ?? "default"}
+      size="small"
+      variant="outlined"
+    />
+  );
+}

--- a/apps/console/src/features/alerts/hooks/useAlertsUnread.test.ts
+++ b/apps/console/src/features/alerts/hooks/useAlertsUnread.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { components } from "../../../generated/aep-api";
+import { countUnread, nextSeenUntil } from "./useAlertsUnread";
+
+type RcaAgentReport = components["schemas"]["RcaAgentReport"];
+
+// createdAt is required by the contract, but the pure functions under test
+// defensively fall back to "" when it's absent — cast to simulate a
+// malformed/legacy response the type system otherwise wouldn't allow.
+function report(id: string, createdAt?: string): RcaAgentReport {
+  return {
+    id,
+    project: "demo-shop",
+    title: `report ${id}`,
+    summary: "summary",
+    classification: "code-level",
+    diagnosis: "diagnosis",
+    deployed: false,
+    ...(createdAt !== undefined && { createdAt }),
+  } as RcaAgentReport;
+}
+
+describe("countUnread", () => {
+  it("counts every timestamped report as unread when there is no watermark yet", () => {
+    const reports = [report("a", "2026-07-09T10:00:00Z"), report("b", "2026-07-09T11:00:00Z")];
+    expect(countUnread(reports, "")).toBe(2);
+  });
+
+  it("excludes reports without a createdAt when there is no watermark", () => {
+    const reports = [report("a", "2026-07-09T10:00:00Z"), report("b")];
+    expect(countUnread(reports, "")).toBe(1);
+  });
+
+  it("counts only reports newer than the watermark", () => {
+    const reports = [
+      report("a", "2026-07-09T09:00:00Z"),
+      report("b", "2026-07-09T11:00:00Z"),
+      report("c", "2026-07-09T12:00:00Z"),
+    ];
+    expect(countUnread(reports, "2026-07-09T10:00:00Z")).toBe(2);
+  });
+
+  it("never counts a report missing createdAt, even past a watermark", () => {
+    const reports = [report("a", "2026-07-09T12:00:00Z"), report("b")];
+    expect(countUnread(reports, "2026-07-09T10:00:00Z")).toBe(1);
+  });
+
+  it("returns 0 for an empty list regardless of watermark", () => {
+    expect(countUnread([], "")).toBe(0);
+    expect(countUnread([], "2026-07-09T10:00:00Z")).toBe(0);
+  });
+});
+
+describe("nextSeenUntil", () => {
+  it("advances to the newest report's createdAt", () => {
+    const reports = [report("a", "2026-07-09T09:00:00Z"), report("b", "2026-07-09T12:00:00Z")];
+    expect(nextSeenUntil(reports, "")).toBe("2026-07-09T12:00:00Z");
+  });
+
+  it("never regresses the watermark when reports are older than it", () => {
+    const reports = [report("a", "2026-07-09T09:00:00Z")];
+    expect(nextSeenUntil(reports, "2026-07-09T12:00:00Z")).toBe("2026-07-09T12:00:00Z");
+  });
+
+  it("ignores reports without a createdAt", () => {
+    const reports = [report("a"), report("b")];
+    expect(nextSeenUntil(reports, "2026-07-09T10:00:00Z")).toBe("2026-07-09T10:00:00Z");
+  });
+
+  it("returns the existing watermark unchanged for an empty list", () => {
+    expect(nextSeenUntil([], "2026-07-09T10:00:00Z")).toBe("2026-07-09T10:00:00Z");
+  });
+});

--- a/apps/console/src/features/alerts/hooks/useAlertsUnread.ts
+++ b/apps/console/src/features/alerts/hooks/useAlertsUnread.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { components } from "../../../generated/aep-api";
+
+type RcaAgentReport = components["schemas"]["RcaAgentReport"];
+
+// Client-side only — no server read-state, per #154's grilling decision
+// (no triage actions / mutations). Opening the bell dropdown clears the
+// whole badge by moving this watermark to the newest report seen.
+const SEEN_UNTIL_KEY = "aep:alerts:seenUntil";
+
+function readSeenUntil(): string {
+  try {
+    return localStorage.getItem(SEEN_UNTIL_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function useAlertsUnread(reports: RcaAgentReport[]) {
+  const [seenUntil, setSeenUntil] = useState<string>(readSeenUntil);
+
+  const unreadCount = useMemo(() => {
+    if (!seenUntil) return reports.length;
+    return reports.filter((r) => (r.createdAt ?? "") > seenUntil).length;
+  }, [reports, seenUntil]);
+
+  const markAllSeen = useCallback(() => {
+    const newest = reports.reduce(
+      (max, r) => ((r.createdAt ?? "") > max ? (r.createdAt ?? "") : max),
+      seenUntil,
+    );
+    if (newest && newest !== seenUntil) {
+      try {
+        localStorage.setItem(SEEN_UNTIL_KEY, newest);
+      } catch {
+        // Storage unavailable (e.g. private browsing) — badge just won't persist across reloads.
+      }
+      setSeenUntil(newest);
+    }
+  }, [reports, seenUntil]);
+
+  return { unreadCount, markAllSeen };
+}

--- a/apps/console/src/features/alerts/hooks/useAlertsUnread.ts
+++ b/apps/console/src/features/alerts/hooks/useAlertsUnread.ts
@@ -34,19 +34,27 @@ function readSeenUntil(): string {
   }
 }
 
+// Pure logic, exported for unit testing (see useAlertsUnread.test.ts) —
+// reports without a createdAt are treated as already-seen (never counted
+// unread, never advance the watermark), since there's no timestamp to
+// compare against seenUntil.
+
+export function countUnread(reports: RcaAgentReport[], seenUntil: string): number {
+  if (!seenUntil) return reports.filter((r) => Boolean(r.createdAt)).length;
+  return reports.filter((r) => (r.createdAt ?? "") > seenUntil).length;
+}
+
+export function nextSeenUntil(reports: RcaAgentReport[], seenUntil: string): string {
+  return reports.reduce((max, r) => ((r.createdAt ?? "") > max ? (r.createdAt ?? "") : max), seenUntil);
+}
+
 export function useAlertsUnread(reports: RcaAgentReport[]) {
   const [seenUntil, setSeenUntil] = useState<string>(readSeenUntil);
 
-  const unreadCount = useMemo(() => {
-    if (!seenUntil) return reports.length;
-    return reports.filter((r) => (r.createdAt ?? "") > seenUntil).length;
-  }, [reports, seenUntil]);
+  const unreadCount = useMemo(() => countUnread(reports, seenUntil), [reports, seenUntil]);
 
   const markAllSeen = useCallback(() => {
-    const newest = reports.reduce(
-      (max, r) => ((r.createdAt ?? "") > max ? (r.createdAt ?? "") : max),
-      seenUntil,
-    );
+    const newest = nextSeenUntil(reports, seenUntil);
     if (newest && newest !== seenUntil) {
       try {
         localStorage.setItem(SEEN_UNTIL_KEY, newest);

--- a/apps/console/src/layouts/AppLayout.tsx
+++ b/apps/console/src/layouts/AppLayout.tsx
@@ -26,19 +26,28 @@ import {
   UserMenu,
   version as OXYGEN_UI_VERSION,
 } from "@wso2/oxygen-ui";
-import { FolderOpen, LogOut, Settings, User as UserIcon, WSO2 } from "@wso2/oxygen-ui-icons-react";
+import {
+  FolderOpen,
+  LogOut,
+  Settings,
+  Siren,
+  User as UserIcon,
+  WSO2,
+} from "@wso2/oxygen-ui-icons-react";
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { useSession } from "../auth/SessionContext";
 import { OrgSwitcher, ProjectSwitcher } from "./HeaderSwitchers";
+import { AlertsNotificationPanel, NotificationButton } from "./NotificationBell";
 
 // Sidebar highlight follows the route; grows one mapping per top-level route.
 function activeItemFor(pathname: string): string {
   if (pathname.startsWith("/settings")) return "settings";
+  if (pathname.startsWith("/alerts")) return "alerts";
   return "projects";
 }
 
 // App shell per the oxygen-ui skill's canonical AppLayout: Header + Sidebar +
-// Main(Outlet) + Footer. NotificationPanel arrives with its feature.
+// Main(Outlet) + Footer + NotificationPanel (Alerts, #154/#155).
 export function AppLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activeItem = activeItemFor(pathname);
@@ -73,6 +82,7 @@ export function AppLayout() {
           <Header.Spacer />
           <Header.Actions>
             <ColorSchemeToggle />
+            <NotificationButton />
             <Divider orientation="vertical" flexItem sx={{ mx: 2 }} />
             <UserMenu>
               <UserMenu.Trigger name={user.name} />
@@ -99,6 +109,13 @@ export function AppLayout() {
                   <FolderOpen />
                 </Sidebar.ItemIcon>
                 <Sidebar.ItemLabel>Projects</Sidebar.ItemLabel>
+              </Sidebar.Item>
+              {/* Global Alerts section (#155) — RCA-agent reports across every project. */}
+              <Sidebar.Item id="alerts" link={<Link to="/alerts" />}>
+                <Sidebar.ItemIcon>
+                  <Siren />
+                </Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>Alerts</Sidebar.ItemLabel>
               </Sidebar.Item>
             </Sidebar.Category>
           </Sidebar.Nav>
@@ -130,6 +147,10 @@ export function AppLayout() {
           <Footer.Version>oxygen-ui-v{OXYGEN_UI_VERSION}</Footer.Version>
         </Footer>
       </AppShell.Footer>
+
+      <AppShell.NotificationPanel>
+        <AlertsNotificationPanel />
+      </AppShell.NotificationPanel>
     </AppShell>
   );
 }

--- a/apps/console/src/layouts/NotificationBell.tsx
+++ b/apps/console/src/layouts/NotificationBell.tsx
@@ -18,9 +18,12 @@
 
 import {
   Badge,
+  Box,
+  Button,
   IconButton,
   NotificationPanel,
   Tooltip,
+  Typography,
   formatRelativeTime,
   useAppShell,
 } from "@wso2/oxygen-ui";
@@ -62,7 +65,7 @@ export function NotificationButton() {
 export function AlertsNotificationPanel() {
   const navigate = useNavigate();
   const { actions } = useAppShell();
-  const { data: reports = [], isPending } = useRecentAlerts();
+  const { data: reports = [], isPending, isError, error, refetch } = useRecentAlerts();
 
   const openAlert = (alertId: string) => {
     // Close the overlay so it doesn't linger over the destination page.
@@ -79,7 +82,22 @@ export function AlertsNotificationPanel() {
         <NotificationPanel.HeaderTitle>Alerts</NotificationPanel.HeaderTitle>
         <NotificationPanel.HeaderClose />
       </NotificationPanel.Header>
-      {isPending || reports.length === 0 ? (
+      {isPending ? (
+        <NotificationPanel.EmptyState />
+      ) : isError && reports.length === 0 ? (
+        // Initial load failed with no last-known data to fall back on —
+        // surface it distinctly from "no alerts yet" (api-guidelines: every
+        // view ships an error state, not just empty/loading).
+        <Box sx={{ px: 3, py: 4, textAlign: "center" }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+            Failed to load alerts
+            {error instanceof Error && error.message ? `: ${error.message}` : ""}
+          </Typography>
+          <Button size="small" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </Box>
+      ) : reports.length === 0 ? (
         <NotificationPanel.EmptyState />
       ) : (
         <NotificationPanel.List>

--- a/apps/console/src/layouts/NotificationBell.tsx
+++ b/apps/console/src/layouts/NotificationBell.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Badge,
+  IconButton,
+  NotificationPanel,
+  Tooltip,
+  formatRelativeTime,
+  useAppShell,
+} from "@wso2/oxygen-ui";
+import { Bell } from "@wso2/oxygen-ui-icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import { useRecentAlerts } from "../features/alerts/api/queries";
+import { useAlertsUnread } from "../features/alerts/hooks/useAlertsUnread";
+import { classificationLabel } from "../features/alerts/components/ClassificationChip";
+
+// Top-nav notification bell (#154) — global, read-only, client-tracked
+// unread state (no server read-state; see the issue's grilling decisions).
+// Must be a child of AppShell to reach useAppShell()'s panel toggle.
+export function NotificationButton() {
+  const { actions } = useAppShell();
+  const { data: reports = [] } = useRecentAlerts();
+  const { unreadCount, markAllSeen } = useAlertsUnread(reports);
+
+  return (
+    <Tooltip title="Alerts">
+      <IconButton
+        onClick={() => {
+          actions.toggleNotificationPanel();
+          markAllSeen();
+        }}
+        size="small"
+        sx={{ color: "text.secondary" }}
+        aria-label="Alerts"
+      >
+        <Badge badgeContent={unreadCount} color="error" max={99} invisible={unreadCount === 0}>
+          <Bell size={20} />
+        </Badge>
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+// Panel body — no per-item read state (the badge clears as a whole on open,
+// per #154's decision), so this only needs the report list itself.
+export function AlertsNotificationPanel() {
+  const navigate = useNavigate();
+  const { actions } = useAppShell();
+  const { data: reports = [], isPending } = useRecentAlerts();
+
+  const openAlert = (alertId: string) => {
+    // Close the overlay so it doesn't linger over the destination page.
+    actions.toggleNotificationPanel();
+    void navigate({ to: "/alerts/$alertId", params: { alertId } });
+  };
+
+  return (
+    <NotificationPanel>
+      <NotificationPanel.Header>
+        <NotificationPanel.HeaderIcon>
+          <Bell size={20} />
+        </NotificationPanel.HeaderIcon>
+        <NotificationPanel.HeaderTitle>Alerts</NotificationPanel.HeaderTitle>
+        <NotificationPanel.HeaderClose />
+      </NotificationPanel.Header>
+      {isPending || reports.length === 0 ? (
+        <NotificationPanel.EmptyState />
+      ) : (
+        <NotificationPanel.List>
+          {reports.map((report) => (
+            <NotificationPanel.Item key={report.id} id={report.id!} type="info" read>
+              <NotificationPanel.ItemTitle>{report.title}</NotificationPanel.ItemTitle>
+              <NotificationPanel.ItemMessage>
+                {report.project} · {classificationLabel(report.classification)}
+              </NotificationPanel.ItemMessage>
+              <NotificationPanel.ItemTimestamp>
+                {report.createdAt ? formatRelativeTime(new Date(report.createdAt)) : ""}
+              </NotificationPanel.ItemTimestamp>
+              <NotificationPanel.ItemAction onClick={() => openAlert(report.id!)}>
+                View
+              </NotificationPanel.ItemAction>
+            </NotificationPanel.Item>
+          ))}
+        </NotificationPanel.List>
+      )}
+    </NotificationPanel>
+  );
+}

--- a/apps/console/src/mocks/browser.ts
+++ b/apps/console/src/mocks/browser.ts
@@ -3,6 +3,7 @@ import { projectHandlers } from "./handlers/project";
 import { projectsHandlers } from "./handlers/projects";
 import { organizationsHandlers } from "./handlers/organizations";
 import { settingsHandlers } from "./handlers/settings";
+import { alertsHandlers } from "./handlers/alerts";
 
 // Order matters: project-scoped routes (/projects/:name/...) are more
 // specific than /projects/:name, so they register first.
@@ -11,4 +12,5 @@ export const worker = setupWorker(
   ...projectsHandlers,
   ...organizationsHandlers,
   ...settingsHandlers,
+  ...alertsHandlers,
 );

--- a/apps/console/src/mocks/fixtures/alerts.ts
+++ b/apps/console/src/mocks/fixtures/alerts.ts
@@ -1,0 +1,268 @@
+import type { components } from "../../generated/aep-api";
+
+type RcaAgentReport = components["schemas"]["RcaAgentReport"];
+type RcaAgentReportList = components["schemas"]["RcaAgentReportList"];
+type ErrorModel = components["schemas"]["ErrorModel"];
+
+// Scenario switch (api-guidelines: mocks must produce empty AND error
+// states). Toggle in the browser devtools:
+//   localStorage.setItem('aep:mock:alerts', 'empty' | 'some' | 'error')
+export type AlertsScenario = "empty" | "some" | "error";
+
+export const emptyAlerts: RcaAgentReportList = { items: [] };
+
+// Mirrors seedProjects: fixed content so screenshots/tests are deterministic.
+export const seedAlerts: RcaAgentReport[] = [
+  {
+    id: "rca-1021",
+    project: "demo-shop",
+    component: "checkout-service",
+    createdAt: "2026-07-09T14:02:00Z",
+    title: "Checkout requests failing with 500 after payment-gateway timeout",
+    summary:
+      "Repeated ERROR logs show unhandled timeout exceptions from the payment-gateway client during checkout submission.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe payment-gateway client has no timeout/retry policy, so a slow upstream response propagates as an unhandled exception, returning a 500 to the caller.\n\n## Remediation\n\nSuggested: wrap the payment-gateway client call with a bounded timeout and a single retry, and return a typed 502 on exhaustion instead of an unhandled 500.",
+    issueNumber: 201,
+    issueUrl: "https://github.com/acme-dev/demo-shop/issues/201",
+    issueTitle: "checkout-service: add timeout/retry around payment-gateway client",
+    issueExcerpt:
+      "The payment-gateway client call in CheckoutController has no timeout, causing unhandled 500s under upstream latency...",
+    dispatched: true,
+    deployed: false,
+  },
+  {
+    id: "rca-1020",
+    project: "demo-shop",
+    component: "checkout-service",
+    createdAt: "2026-07-09T09:40:00Z",
+    title: "Cart total miscalculated when a discount code is combined with tax",
+    summary:
+      "Discount is applied after tax instead of before, producing an incorrect total for orders using a discount code.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nOrder-total calculation applies the discount after tax is computed, rather than before, inflating totals whenever a discount code is present.\n\n## Remediation\n\nSuggested: reorder the pricing pipeline so discounts apply before tax.",
+    issueNumber: 198,
+    issueUrl: "https://github.com/acme-dev/demo-shop/issues/198",
+    issueTitle: "checkout-service: apply discount before tax in order-total calculation",
+    issueExcerpt:
+      "OrderTotalCalculator computes tax first, then discount, which is backwards from the pricing spec...",
+    dispatched: true,
+    deployed: true,
+    deployedAt: "2026-07-09T12:15:00Z",
+  },
+  {
+    id: "rca-1019",
+    project: "demo-shop",
+    component: "inventory-service",
+    createdAt: "2026-07-08T22:10:00Z",
+    title: "Inventory pod restarting on OOM under nightly batch sync",
+    summary:
+      "Memory usage climbs steadily during the nightly inventory sync job until the pod is OOMKilled.",
+    classification: "config-level",
+    diagnosis:
+      "## Diagnosis\n\nThe inventory-service pod's memory limit (256Mi) is undersized for the nightly batch sync job's peak working set (~420Mi).\n\n## Remediation\n\nApplied: raised the pod's memory limit to 512Mi via a ResourceChange. No code change needed.",
+    deployed: false,
+  },
+  {
+    id: "rca-1018",
+    project: "gym-tracker",
+    component: "workout-api",
+    createdAt: "2026-07-08T17:55:00Z",
+    title: "Workout history endpoint returns stale data after a delete",
+    summary:
+      "GET /workouts continues returning a deleted entry for up to two minutes after DELETE succeeds.",
+    classification: "mixed",
+    diagnosis:
+      "## Diagnosis\n\nThe read path serves from a cache with a 2-minute TTL that isn't invalidated on delete; a secondary config issue also left cache invalidation disabled in this environment.\n\n## Remediation\n\nApplied: re-enabled cache invalidation in config. Suggested: invalidate the specific cache key synchronously on delete, rather than relying on TTL expiry alone.",
+    issueNumber: 189,
+    issueUrl: "https://github.com/acme-dev/gym-tracker/issues/189",
+    issueTitle: "workout-api: invalidate workout-history cache entry synchronously on delete",
+    issueExcerpt:
+      "DeleteWorkoutHandler removes the row but never calls cache.invalidate(key), leaving stale reads until TTL expiry...",
+    dispatched: true,
+    deployed: false,
+  },
+  {
+    id: "rca-1017",
+    project: "gym-tracker",
+    component: "workout-api",
+    createdAt: "2026-07-07T11:20:00Z",
+    title: "Intermittent 502s from workout-api under load",
+    summary:
+      "Handoff classified this as code-level and created an issue; the coding agent hasn't been dispatched yet.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe connection pool to the primary datastore is sized for steady-state load and exhausts under the observed traffic spike, causing upstream 502s.\n\n## Remediation\n\nSuggested: size the connection pool from load-test data and add a bounded queue instead of failing fast.",
+    issueNumber: 185,
+    issueUrl: "https://github.com/acme-dev/gym-tracker/issues/185",
+    issueTitle: "workout-api: size the datastore connection pool for peak load",
+    issueExcerpt:
+      "ConnectionPoolConfig.maxSize is set to the steady-state estimate (10) with no headroom for traffic spikes...",
+    // Not dispatched yet — issue-only/manual-dispatch mode gap (#155 decision).
+    dispatched: false,
+    deployed: false,
+  },
+  {
+    id: "rca-1016",
+    project: "invoice-hub",
+    component: "pdf-export",
+    createdAt: "2026-07-06T08:30:00Z",
+    title: "PDF export times out for invoices with more than 200 line items",
+    summary:
+      "Export duration grows non-linearly with line-item count; large invoices exceed the request timeout.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe PDF renderer re-lays-out the full document on every line item appended (O(n²)), rather than appending incrementally.\n\n## Remediation\n\nSuggested: switch to incremental page layout in the PDF renderer.",
+    issueNumber: 172,
+    issueUrl: "https://github.com/acme-dev/invoice-hub/issues/172",
+    issueTitle: "pdf-export: fix O(n²) layout re-computation for large invoices",
+    issueExcerpt:
+      "PdfDocumentBuilder.appendLineItem() triggers a full relayout() call on every invocation...",
+    dispatched: true,
+    deployed: true,
+    deployedAt: "2026-07-06T19:05:00Z",
+  },
+  {
+    id: "rca-1015",
+    project: "salon-booking",
+    component: "booking-api",
+    createdAt: "2026-07-04T13:45:00Z",
+    title: "Double-booking possible when two requests race the same slot",
+    summary:
+      "Two concurrent booking requests for the same slot can both succeed due to a missing unique constraint.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe bookings table has no unique constraint on (staff_id, slot_start), so two concurrent inserts can both commit.\n\n## Remediation\n\nSuggested: add a unique constraint and handle the resulting conflict as a 409.",
+    issueNumber: 160,
+    issueUrl: "https://github.com/acme-dev/salon-booking/issues/160",
+    issueTitle: "booking-api: prevent double-booking with a unique slot constraint",
+    issueExcerpt:
+      "BookingRepository.create() has no uniqueness check before insert, allowing a race between concurrent requests...",
+    dispatched: true,
+    deployed: false,
+  },
+  {
+    id: "rca-1014",
+    project: "pet-adoption",
+    component: "listings-api",
+    createdAt: "2026-07-02T10:05:00Z",
+    title: "Shelter search ignores the radius filter above 50 results",
+    summary:
+      "Pagination applied before the radius filter, so later pages include out-of-radius shelters.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe query pipeline paginates before applying the radius filter, rather than after, so filtered-out shelters still occupy page slots.\n\n## Remediation\n\nSuggested: reorder the pipeline to filter by radius before paginating.",
+    issueNumber: 151,
+    issueUrl: "https://github.com/acme-dev/pet-adoption/issues/151",
+    issueTitle: "listings-api: apply radius filter before pagination",
+    issueExcerpt:
+      "ShelterSearchQuery.execute() paginates the raw result set, then filters by radius on the current page only...",
+    dispatched: true,
+    deployed: true,
+    deployedAt: "2026-07-02T20:40:00Z",
+  },
+  {
+    id: "rca-1013",
+    project: "recipe-box",
+    component: "recipe-api",
+    createdAt: "2026-06-29T09:15:00Z",
+    title: "Recipe images occasionally served with the wrong content-type",
+    summary:
+      "A misconfigured storage bucket setting served a stale default content-type for a subset of uploads.",
+    classification: "config-level",
+    diagnosis:
+      "## Diagnosis\n\nThe storage bucket's default content-type was left at its pre-migration value (application/octet-stream) for objects uploaded without an explicit content-type header.\n\n## Remediation\n\nApplied: corrected the bucket's default content-type policy. No code change needed.",
+    deployed: false,
+  },
+  {
+    id: "rca-1012",
+    project: "event-radar",
+    component: "events-api",
+    createdAt: "2026-06-26T15:50:00Z",
+    title: "Reminder notifications sent twice for events with a timezone offset",
+    summary:
+      "The reminder scheduler double-counts events crossing a DST boundary, sending duplicate notifications.",
+    classification: "mixed",
+    diagnosis:
+      "## Diagnosis\n\nThe scheduler's DST-boundary handling double-schedules affected events; a stale feature flag also re-enabled the legacy scheduler path in this environment.\n\n## Remediation\n\nApplied: disabled the legacy scheduler flag. Suggested: fix DST-boundary handling in the reminder scheduler itself.",
+    issueNumber: 140,
+    issueUrl: "https://github.com/acme-dev/event-radar/issues/140",
+    issueTitle: "events-api: fix duplicate reminders across a DST boundary",
+    issueExcerpt:
+      "ReminderScheduler.scheduleFor() computes the reminder window using local time, double-counting the repeated hour...",
+    dispatched: true,
+    deployed: false,
+  },
+  {
+    id: "rca-1011",
+    project: "fleet-watch",
+    component: "tracking-api",
+    createdAt: "2026-06-24T07:25:00Z",
+    title: "Vehicle location updates delayed by up to 10 minutes under peak load",
+    summary:
+      "Handoff found no actionable remediation — the delay matches expected behavior for the current fleet size.",
+    classification: "none",
+    diagnosis:
+      "## Diagnosis\n\nLocation-update latency during the observed window matches expected queuing behavior for the current fleet size and ingest rate; no defect found.\n\n## Remediation\n\nNone — informational only.",
+    deployed: false,
+  },
+  {
+    id: "rca-1010",
+    project: "study-buddy",
+    component: "flashcards-api",
+    createdAt: "2026-06-20T12:00:00Z",
+    title: "Spaced-repetition scheduling skips cards marked 'hard' twice in a row",
+    summary:
+      "A boundary condition in the scheduling algorithm skips re-queuing a card marked hard on consecutive reviews.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe scheduler's interval-reset logic has an off-by-one boundary condition when a card is marked 'hard' on two consecutive reviews, skipping the re-queue.\n\n## Remediation\n\nSuggested: fix the boundary condition in the interval-reset calculation.",
+    issueNumber: 122,
+    issueUrl: "https://github.com/acme-dev/study-buddy/issues/122",
+    issueTitle: "flashcards-api: fix consecutive-'hard' scheduling boundary condition",
+    issueExcerpt:
+      "SchedulingAlgorithm.onReview() resets the interval only when previousGrade !== 'hard', missing the consecutive case...",
+    dispatched: true,
+    deployed: true,
+    deployedAt: "2026-06-21T09:30:00Z",
+  },
+  {
+    id: "rca-1009",
+    project: "plant-care",
+    component: "care-api",
+    createdAt: "2026-06-16T18:40:00Z",
+    title: "Watering reminders not sent for plants added via bulk import",
+    summary:
+      "Bulk-imported plants skip the reminder-scheduling hook that runs on individual plant creation.",
+    classification: "code-level",
+    diagnosis:
+      "## Diagnosis\n\nThe bulk-import path writes rows directly, bypassing the ORM hook that schedules the first watering reminder on create.\n\n## Remediation\n\nSuggested: call the reminder-scheduling hook explicitly at the end of bulk import.",
+    issueNumber: 108,
+    issueUrl: "https://github.com/acme-dev/plant-care/issues/108",
+    issueTitle: "care-api: schedule watering reminders for bulk-imported plants",
+    issueExcerpt:
+      "BulkImportService.importPlants() uses a raw batch insert, which never invokes Plant.afterCreate()...",
+    dispatched: true,
+    deployed: false,
+  },
+];
+
+// Mock server-side default page size when the client omits `limit`
+// (#155's list). The bell (#154) always passes its own limit explicitly.
+export const ALERTS_PAGE_SIZE = 6;
+
+export const alertsError: ErrorModel = {
+  type: "about:blank",
+  status: 500,
+  title: "Internal Server Error",
+  detail: "Mock error scenario for RCA-agent alert reports",
+};
+
+export const alertNotFoundError = (id: string): ErrorModel => ({
+  type: "about:blank",
+  status: 404,
+  title: "Not Found",
+  detail: `RCA report ${id} not found`,
+});

--- a/apps/console/src/mocks/handlers/alerts.ts
+++ b/apps/console/src/mocks/handlers/alerts.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from "msw";
+import {
+  ALERTS_PAGE_SIZE,
+  alertNotFoundError,
+  alertsError,
+  emptyAlerts,
+  seedAlerts,
+  type AlertsScenario,
+} from "../fixtures/alerts";
+
+function scenario(): AlertsScenario {
+  return (
+    (localStorage.getItem("aep:mock:alerts") as AlertsScenario | null) ?? "some"
+  );
+}
+
+// Newest first, matching the contract's "list ... newest first" ordering.
+function currentAlerts() {
+  if (scenario() === "empty") return [];
+  return [...seedAlerts].sort((a, b) => (a.createdAt! < b.createdAt! ? 1 : -1));
+}
+
+export const alertsHandlers = [
+  http.get("*/api/v1/rca-agent/reports", ({ request }) => {
+    if (scenario() === "error") {
+      return HttpResponse.json(alertsError, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    const all = currentAlerts();
+    if (all.length === 0) {
+      return HttpResponse.json(emptyAlerts);
+    }
+    const params = new URL(request.url).searchParams;
+    // The cursor is opaque to the client; the mock's is a plain offset.
+    const offset = Number(params.get("cursor") ?? 0) || 0;
+    const limit = Number(params.get("limit")) || ALERTS_PAGE_SIZE;
+    const items = all.slice(offset, offset + limit);
+    const next = offset + limit;
+    return HttpResponse.json({
+      items,
+      ...(next < all.length && { nextCursor: String(next) }),
+    });
+  }),
+
+  http.get("*/api/v1/rca-agent/reports/:reportId", ({ params }) => {
+    if (scenario() === "error") {
+      return HttpResponse.json(alertsError, {
+        status: 500,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    const report = currentAlerts().find((r) => r.id === params.reportId);
+    if (!report) {
+      return HttpResponse.json(alertNotFoundError(String(params.reportId)), {
+        status: 404,
+        headers: { "Content-Type": "application/problem+json" },
+      });
+    }
+    return HttpResponse.json(report);
+  }),
+];

--- a/apps/console/src/mocks/handlers/settings.ts
+++ b/apps/console/src/mocks/handlers/settings.ts
@@ -324,7 +324,7 @@ export const settingsHandlers = [
       editable: true,
       description: extractDescription(body.skillMd),
       skillMd: body.skillMd,
-      references: body.references,
+      references: body.references ?? {},
       version: 1,
       contentSha: `sha-${body.name}-1`,
       updatedAt: new Date().toISOString(),
@@ -366,7 +366,7 @@ export const settingsHandlers = [
     }
     const body = (await request.json()) as UpdateSkillInput;
     skill.skillMd = body.skillMd;
-    skill.references = body.references;
+    skill.references = body.references ?? {};
     skill.description = extractDescription(body.skillMd);
     skill.version += 1;
     skill.updatedAt = new Date().toISOString();

--- a/apps/console/src/routes/alerts.tsx
+++ b/apps/console/src/routes/alerts.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createFileRoute } from "@tanstack/react-router";
+import { AlertsList } from "../features/alerts/components/AlertsList";
+
+export const Route = createFileRoute("/alerts")({
+  component: AlertsList,
+});

--- a/apps/console/src/routes/alerts_.$alertId.tsx
+++ b/apps/console/src/routes/alerts_.$alertId.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createFileRoute } from "@tanstack/react-router";
+import { AlertDetail } from "../features/alerts/components/AlertDetail";
+
+export const Route = createFileRoute("/alerts_/$alertId")({
+  component: AlertDetailRoute,
+});
+
+function AlertDetailRoute() {
+  const { alertId } = Route.useParams();
+  return <AlertDetail alertId={alertId} />;
+}

--- a/deployments/scripts/setup-observability.sh
+++ b/deployments/scripts/setup-observability.sh
@@ -126,6 +126,14 @@ observer:
   # to it via in-cluster DNS instead of the chart default
   # (api.openchoreo.localhost, which only resolves on the host).
   controlPlaneApiUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
+  # Required for the alert->RCA pipeline (see sre-handoff-runbook.md §2.3) —
+  # without it rules sync as Ready but log-based alerts are never evaluated.
+  # Set here (not via a manual `kubectl patch`) so Helm's server-side apply
+  # owns the field; a kubectl-owned field of the same name causes every
+  # subsequent `helm upgrade` to fail with a Server-Side Apply field-manager
+  # conflict on observer-config's .data.LOGS_ADAPTER_ENABLED.
+  logsAdapter:
+    enabled: true
 security:
   enabled: true
   oidc:

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1216,6 +1216,87 @@ components:
           description: Provisioning parameters (override the design defaults)
           type: object
       type: object
+    RcaAgentReport:
+      additionalProperties: false
+      description: An RCA report from the OpenChoreo SRE/RCA-agent handoff (console issues #154, #155).
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/RcaAgentReport.json
+          format: uri
+          readOnly: true
+          type: string
+        classification:
+          description: "code-level, config-level, mixed, or none — set by the handoff agent"
+          type: string
+        component:
+          type: string
+        createdAt:
+          type: string
+        deployed:
+          description: Whether the resulting fix has been deployed (Verify Fix threshold, not merely PR-merged)
+          type: boolean
+        deployedAt:
+          type: string
+        diagnosis:
+          description: Full RCA diagnosis + remediation content (markdown)
+          type: string
+        dispatched:
+          description: Whether the coding agent has been dispatched for the linked issue (false in issue-only/manual-dispatch mode until a human dispatches)
+          type: boolean
+        id:
+          type: string
+        issueExcerpt:
+          description: Short excerpt of the linked GitHub issue; absent when no issue was created
+          type: string
+        issueNumber:
+          description: GitHub issue number created by the handoff; also the Task key (see /projects/{projectName}/tasks/{issueNumber}); absent when the handoff was config-only
+          format: int64
+          type: integer
+        issueTitle:
+          type: string
+        issueUrl:
+          type: string
+        project:
+          type: string
+        summary:
+          description: Short RCA summary; the console truncates this further for list rows
+          type: string
+        title:
+          type: string
+      required:
+        - id
+        - project
+        - createdAt
+        - title
+        - summary
+        - classification
+        - diagnosis
+        - deployed
+      type: object
+    RcaAgentReportList:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/RcaAgentReportList.json
+          format: uri
+          readOnly: true
+          type: string
+        items:
+          items:
+            $ref: "#/components/schemas/RcaAgentReport"
+          type:
+            - array
+            - "null"
+        nextCursor:
+          description: Cursor for the next page; absent on the last page.
+          type: string
+      required:
+        - items
+      type: object
     SaveValuesBody:
       additionalProperties: false
       properties:
@@ -3339,6 +3420,71 @@ paths:
       summary: Stream a Task's live state (status + executions + unified timeline) as SSE
       tags:
         - Tasks
+  /rca-agent/reports:
+    get:
+      operationId: list-rca-agent-reports
+      parameters:
+        - description: Opaque pagination cursor
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor
+            type: string
+        - description: Maximum number of items to return (server default when absent)
+          explode: false
+          in: query
+          name: limit
+          schema:
+            description: Maximum number of items to return (server default when absent)
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RcaAgentReportList"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: List RCA-agent alert reports across the caller's org, newest first
+      tags:
+        - RcaAgentReports
+  /rca-agent/reports/{reportId}:
+    get:
+      operationId: get-rca-agent-report
+      parameters:
+        - description: RCA report id
+          in: path
+          name: reportId
+          required: true
+          schema:
+            description: RCA report id
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RcaAgentReport"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Get a single RCA-agent alert report
+      tags:
+        - RcaAgentReports
   /skills:
     get:
       operationId: list-skills

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1399,6 +1399,9 @@ components:
         updatedAt:
           format: date-time
           type: string
+        version:
+          format: int64
+          type: integer
       required:
         - editable
         - orgId
@@ -1409,6 +1412,7 @@ components:
         - references
         - contentSha
         - updatedAt
+        - version
       type: object
     SkillSummary:
       additionalProperties: false

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -569,6 +569,53 @@ components:
       required:
         - name
       type: object
+    CreateRcaAgentReportRequest:
+      additionalProperties: false
+      description: Write-side request for a new RCA-agent alert report (issue #156). Server assigns id and createdAt.
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/CreateRcaAgentReportRequest.json
+          format: uri
+          readOnly: true
+          type: string
+        classification:
+          description: "code-level, config-level, mixed, or none — set by the handoff agent"
+          type: string
+        component:
+          type: string
+        deployed:
+          type: boolean
+        deployedAt:
+          type: string
+        diagnosis:
+          description: Full RCA diagnosis + remediation content (markdown)
+          type: string
+        dispatched:
+          type: boolean
+        issueExcerpt:
+          type: string
+        issueNumber:
+          format: int64
+          type: integer
+        issueTitle:
+          type: string
+        issueUrl:
+          type: string
+        project:
+          type: string
+        summary:
+          type: string
+        title:
+          type: string
+      required:
+        - project
+        - title
+        - summary
+        - classification
+        - diagnosis
+      type: object
     CreateSkillInput:
       additionalProperties: false
       properties:
@@ -3454,6 +3501,32 @@ paths:
       security:
         - userJWT: []
       summary: List RCA-agent alert reports across the caller's org, newest first
+      tags:
+        - RcaAgentReports
+    post:
+      operationId: create-rca-agent-report
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRcaAgentReportRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RcaAgentReport"
+          description: Created
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: Record a new RCA-agent alert report (internal/service-authenticated writer; issue #156)
       tags:
         - RcaAgentReports
   /rca-agent/reports/{reportId}:

--- a/services/aep-api/internal/api/huma_register.go
+++ b/services/aep-api/internal/api/huma_register.go
@@ -38,6 +38,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/feature/orgcreds"
 	"github.com/wso2/aep/aep-api/internal/feature/project"
 	"github.com/wso2/aep/aep-api/internal/feature/provisioning"
+	"github.com/wso2/aep/aep-api/internal/feature/rcaagent"
 	"github.com/wso2/aep/aep-api/internal/feature/requirements"
 	"github.com/wso2/aep/aep-api/internal/feature/skills"
 	"github.com/wso2/aep/aep-api/internal/feature/task"
@@ -76,6 +77,7 @@ type HumaDeps struct {
 	ArtifactSvc       artifacts.ArtifactService
 	GenAISvc          genai.GenAIService
 	BuildSvc          *build.Service
+	RcaAgentReportSvc rcaagent.RcaAgentReportService
 	GitHubAppSlug     string
 	BFFPublicURL      string
 	GitHubAppClientID string
@@ -101,6 +103,7 @@ func RegisterAllHuma(api huma.API, d HumaDeps) {
 	artifacts.RegisterTags(api, d.ArtifactSvc)
 	genai.RegisterGenAI(api, d.GenAISvc)
 	build.RegisterBuild(api, d.BuildSvc)
+	rcaagent.RegisterRcaAgentReports(api, d.RcaAgentReportSvc)
 }
 
 // GenerateOpenAPIYAML builds the full OpenAPI document (all migrated features)

--- a/services/aep-api/internal/api/huma_registration_test.go
+++ b/services/aep-api/internal/api/huma_registration_test.go
@@ -45,6 +45,8 @@ func TestHumaRegistration_NoDupAndComplete(t *testing.T) {
 		"get-config", "update-config", "list-skills",
 		// Single-tag build surface (the contract's build-project/get-project-build).
 		"build-project", "get-project-build", "list-project-tags",
+		// Alerts (console issues #154, #155, BE handshake #156).
+		"list-rca-agent-reports", "create-rca-agent-report", "get-rca-agent-report",
 	}
 	for _, op := range wantOps {
 		if !strings.Contains(s, op) {

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -63,6 +63,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/feature/orgcreds"
 	"github.com/wso2/aep/aep-api/internal/feature/project"
 	"github.com/wso2/aep/aep-api/internal/feature/provisioning"
+	"github.com/wso2/aep/aep-api/internal/feature/rcaagent"
 	"github.com/wso2/aep/aep-api/internal/feature/requirements"
 	"github.com/wso2/aep/aep-api/internal/feature/runtimeconfig"
 	"github.com/wso2/aep/aep-api/internal/feature/skills"
@@ -826,6 +827,12 @@ func Build(cfg config.Config, db *gorm.DB) (*App, error) {
 	)
 	externalResourceRepo := repositories.NewExternalResourceRepository(db)
 	params.MCPExternalResources = externalResourceRepo
+	// Alerts (console issues #154, #155, BE handshake #156): org-scoped store
+	// for RCA-agent reports the console's notification bell and Alerts
+	// list/stepper read. Write side is a plain userJWT-secured endpoint (no
+	// separate service-auth scheme yet) — see rcaagent_huma.go.
+	rcaAgentReportRepo := repositories.NewRcaAgentReportRepository(db)
+	params.HumaDeps.RcaAgentReportSvc = rcaagent.NewRcaAgentReportService(rcaAgentReportRepo)
 	params.MCPOrgEndpoints = orgEndpointCatalog
 	resourceTypeCatalog := resources.NewResourceTypeCatalog(resourceClient)
 	params.MCPResourceTypes = resourceTypeCatalog

--- a/services/aep-api/internal/arch/arch_test.go
+++ b/services/aep-api/internal/arch/arch_test.go
@@ -118,6 +118,9 @@ var featureEdgeAllowlist = map[string][]string{
 	// Reevaluate hook, the design reader, the repo locator — is a consumer-side port
 	// wired at the composition root, so it holds only these two feature edges.
 	"provisioning": {"dependencies/resources", "gitrepo"},
+	// rcaagent (console issues #154, #155, BE handshake #156) is a
+	// self-contained CRUD feature — no cross-feature imports.
+	"rcaagent":     {},
 	"requirements": {"artifacts"},
 	// runtimeconfig reads the thunder-app dependency's binding outputs (OIDC
 	// config) and patches its redirect URIs declaratively; it reuses the

--- a/services/aep-api/internal/database/migrations/phase10_rca_agent_reports.go
+++ b/services/aep-api/internal/database/migrations/phase10_rca_agent_reports.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// RunPhase10RcaAgentReports creates rca_agent_reports (models.RcaAgentReport)
+// — the store backing the console's Alerts notification bell and Alerts
+// list/stepper (issues #154, #155, BE handshake #156). Raw SQL per the house
+// migration rule; idempotent via the existence guard.
+func RunPhase10RcaAgentReports(ctx context.Context, db *gorm.DB) error {
+	if hasTable(db, "rca_agent_reports") {
+		return nil
+	}
+	if err := db.WithContext(ctx).Exec(`
+		CREATE TABLE rca_agent_reports (
+			id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			org_id          TEXT NOT NULL,
+			project         TEXT NOT NULL,
+			component       TEXT,
+			title           TEXT NOT NULL,
+			summary         TEXT NOT NULL,
+			classification  TEXT NOT NULL,
+			diagnosis       TEXT NOT NULL,
+			issue_number    BIGINT,
+			issue_url       TEXT,
+			issue_title     TEXT,
+			issue_excerpt   TEXT,
+			dispatched      BOOLEAN NOT NULL DEFAULT false,
+			deployed        BOOLEAN NOT NULL DEFAULT false,
+			deployed_at     TIMESTAMPTZ,
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+		)
+	`).Error; err != nil {
+		return fmt.Errorf("phase10_rca_agent_reports: create rca_agent_reports: %w", err)
+	}
+	if err := db.WithContext(ctx).Exec(`
+		CREATE INDEX idx_rca_agent_reports_org_created
+			ON rca_agent_reports (org_id, created_at DESC)
+	`).Error; err != nil {
+		return fmt.Errorf("phase10_rca_agent_reports: create idx_rca_agent_reports_org_created: %w", err)
+	}
+	return nil
+}

--- a/services/aep-api/internal/database/migrations/run_all.go
+++ b/services/aep-api/internal/database/migrations/run_all.go
@@ -104,6 +104,11 @@ func RunAll(ctx context.Context, db *gorm.DB, deploymentTier string) error {
 		// `tasks_github_native` (cascade-drops any legacy component_tasks-keyed
 		// table). Supersedes the guarded phase3_coding_agent_logs no-op above.
 		ctxStep("coding_agent_logs", RunCodingAgentLogs),
+		// rca_agent_reports (models.RcaAgentReport): the store backing the
+		// console's Alerts notification bell and Alerts list/stepper
+		// (issues #154, #155, BE handshake #156). One idempotent CREATE TABLE
+		// + its (org_id, created_at) list index.
+		ctxStep("phase10_rca_agent_reports", RunPhase10RcaAgentReports),
 	}
 
 	for _, s := range steps {

--- a/services/aep-api/internal/feature/rcaagent/ports.go
+++ b/services/aep-api/internal/feature/rcaagent/ports.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rcaagent
+
+import (
+	"context"
+
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// Repository is the storage port RcaAgentService depends on — narrow enough
+// to fake in unit tests without a database.
+type Repository interface {
+	Create(ctx context.Context, orgID string, in *models.CreateRcaAgentReportRequest) (*models.RcaAgentReport, error)
+	Get(ctx context.Context, orgID, id string) (*models.RcaAgentReport, error)
+	List(ctx context.Context, orgID string, cursor string, limit int) ([]models.RcaAgentReport, string, error)
+}

--- a/services/aep-api/internal/feature/rcaagent/rcaagent_huma.go
+++ b/services/aep-api/internal/feature/rcaagent/rcaagent_huma.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rcaagent
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/wso2/aep/aep-api/internal/platform/humakit"
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// --- Inputs / Outputs ------------------------------------------------------
+// Inputs embed humakit.OrgScopedInput, whose Resolve binds the active org
+// from the verified token (no {orgHandle} path param) and applies the tenant
+// gate (the IDOR fence) by construction. Per BE handshake #156, the caller is
+// any userJWT holder scoped to the org — including a widened-audience
+// service-account token (see docs/developer-guide/sre-handoff-runbook.md
+// §1.2 for the precedent) — there is no separate service-auth scheme.
+
+type listReportsInput struct {
+	humakit.OrgScopedInput
+	Cursor string `query:"cursor" doc:"Opaque pagination cursor"`
+	Limit  int    `query:"limit" doc:"Maximum number of items to return (server default when absent)"`
+}
+
+type getReportInput struct {
+	humakit.OrgScopedInput
+	ReportID string `path:"reportId" doc:"RCA report id"`
+}
+
+type createReportInput struct {
+	humakit.OrgScopedInput
+	Body models.CreateRcaAgentReportRequest
+}
+
+type reportListOutput struct{ Body *models.RcaAgentReportList }
+type reportOutput struct{ Body *models.RcaAgentReport }
+
+// RegisterRcaAgentReports registers the RCA-agent report feature's HTTP
+// operations on the Huma API (issues #154, #155, BE handshake #156).
+func RegisterRcaAgentReports(api huma.API, svc RcaAgentReportService) {
+	const prefix = "/rca-agent/reports"
+
+	huma.Register(api, huma.Operation{
+		OperationID: "list-rca-agent-reports",
+		Method:      http.MethodGet,
+		Path:        prefix,
+		Summary:     "List RCA-agent alert reports across the caller's org, newest first",
+		Tags:        []string{"RcaAgentReports"},
+		Security:    humakit.SecurityUserJWT,
+	}, func(ctx context.Context, in *listReportsInput) (*reportListOutput, error) {
+		out, err := svc.ListReports(ctx, in.OrgHandle, in.Cursor, in.Limit)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to list rca-agent reports")
+		}
+		return &reportListOutput{Body: out}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "create-rca-agent-report",
+		Method:        http.MethodPost,
+		Path:          prefix,
+		Summary:       "Record a new RCA-agent alert report (internal/service-authenticated writer; issue #156)",
+		Tags:          []string{"RcaAgentReports"},
+		Security:      humakit.SecurityUserJWT,
+		DefaultStatus: http.StatusCreated,
+	}, func(ctx context.Context, in *createReportInput) (*reportOutput, error) {
+		out, err := svc.CreateReport(ctx, in.OrgHandle, &in.Body)
+		if err != nil {
+			if errors.Is(err, ErrInvalidReport) {
+				return nil, huma.Error400BadRequest(err.Error())
+			}
+			return nil, huma.Error500InternalServerError("failed to create rca-agent report")
+		}
+		return &reportOutput{Body: out}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-rca-agent-report",
+		Method:      http.MethodGet,
+		Path:        prefix + "/{reportId}",
+		Summary:     "Get a single RCA-agent alert report",
+		Tags:        []string{"RcaAgentReports"},
+		Security:    humakit.SecurityUserJWT,
+	}, func(ctx context.Context, in *getReportInput) (*reportOutput, error) {
+		out, err := svc.GetReport(ctx, in.OrgHandle, in.ReportID)
+		if err != nil {
+			if errors.Is(err, ErrReportNotFound) {
+				return nil, huma.Error404NotFound("rca-agent report not found")
+			}
+			return nil, huma.Error500InternalServerError("failed to get rca-agent report")
+		}
+		return &reportOutput{Body: out}, nil
+	})
+}

--- a/services/aep-api/internal/feature/rcaagent/rcaagent_service.go
+++ b/services/aep-api/internal/feature/rcaagent/rcaagent_service.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rcaagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// ErrReportNotFound is returned by GetReport when no report exists for the
+// given (org, id) — the huma handler maps it to a 404.
+var ErrReportNotFound = errors.New("rca agent report not found")
+
+// ErrInvalidReport is returned by CreateReport when the request fails
+// validation — the huma handler maps it to a 400.
+var ErrInvalidReport = errors.New("invalid rca agent report")
+
+// defaultListLimit matches the console bell's own default (issue #154:
+// "last 50, no pagination") when the caller omits limit.
+const defaultListLimit = 50
+
+// maxListLimit caps a single page regardless of what the caller asks for.
+const maxListLimit = 200
+
+var validClassifications = map[string]bool{
+	"code-level":   true,
+	"config-level": true,
+	"mixed":        true,
+	"none":         true,
+}
+
+// RcaAgentReportService is the read + write surface backing the console's
+// Alerts notification bell and Alerts list/stepper (issues #154, #155, BE
+// handshake #156).
+type RcaAgentReportService interface {
+	CreateReport(ctx context.Context, orgID string, in *models.CreateRcaAgentReportRequest) (*models.RcaAgentReport, error)
+	GetReport(ctx context.Context, orgID, id string) (*models.RcaAgentReport, error)
+	ListReports(ctx context.Context, orgID, cursor string, limit int) (*models.RcaAgentReportList, error)
+}
+
+type rcaAgentReportService struct {
+	repo Repository
+}
+
+// NewRcaAgentReportService returns a service backed by repo.
+func NewRcaAgentReportService(repo Repository) RcaAgentReportService {
+	return &rcaAgentReportService{repo: repo}
+}
+
+// CreateReport validates and persists a new report. Fields the contract
+// marks required are enforced here (not left to a DB NOT NULL 500) so the
+// caller gets a precise 400.
+func (s *rcaAgentReportService) CreateReport(ctx context.Context, orgID string, in *models.CreateRcaAgentReportRequest) (*models.RcaAgentReport, error) {
+	if err := validateCreate(in); err != nil {
+		return nil, err
+	}
+	report, err := s.repo.Create(ctx, orgID, in)
+	if err != nil {
+		return nil, fmt.Errorf("create report: %w", err)
+	}
+	return report, nil
+}
+
+func validateCreate(in *models.CreateRcaAgentReportRequest) error {
+	if in == nil {
+		return fmt.Errorf("%w: request body is required", ErrInvalidReport)
+	}
+	missing := []string{}
+	if in.Project == "" {
+		missing = append(missing, "project")
+	}
+	if in.Title == "" {
+		missing = append(missing, "title")
+	}
+	if in.Summary == "" {
+		missing = append(missing, "summary")
+	}
+	if in.Diagnosis == "" {
+		missing = append(missing, "diagnosis")
+	}
+	if in.Classification == "" {
+		missing = append(missing, "classification")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: missing required field(s): %v", ErrInvalidReport, missing)
+	}
+	if !validClassifications[in.Classification] {
+		return fmt.Errorf("%w: classification %q must be one of code-level, config-level, mixed, none", ErrInvalidReport, in.Classification)
+	}
+	return nil
+}
+
+// GetReport returns a single report, or ErrReportNotFound when absent.
+func (s *rcaAgentReportService) GetReport(ctx context.Context, orgID, id string) (*models.RcaAgentReport, error) {
+	report, err := s.repo.Get(ctx, orgID, id)
+	if err != nil {
+		return nil, fmt.Errorf("get report %q: %w", id, err)
+	}
+	if report == nil {
+		return nil, ErrReportNotFound
+	}
+	return report, nil
+}
+
+// ListReports returns a page of reports, newest first.
+func (s *rcaAgentReportService) ListReports(ctx context.Context, orgID, cursor string, limit int) (*models.RcaAgentReportList, error) {
+	switch {
+	case limit <= 0:
+		limit = defaultListLimit
+	case limit > maxListLimit:
+		limit = maxListLimit
+	}
+	reports, nextCursor, err := s.repo.List(ctx, orgID, cursor, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list reports: %w", err)
+	}
+	return &models.RcaAgentReportList{Items: reports, NextCursor: nextCursor}, nil
+}

--- a/services/aep-api/internal/feature/rcaagent/rcaagent_service_test.go
+++ b/services/aep-api/internal/feature/rcaagent/rcaagent_service_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rcaagent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// fakeRepo is an in-memory Repository fake — enough to test the service's
+// validation and default/cap logic without a database.
+type fakeRepo struct {
+	created []models.RcaAgentReport
+	byID    map[string]*models.RcaAgentReport
+
+	// listCalls records the (cursor, limit) the service actually passed
+	// through, so tests can assert default/cap behavior.
+	listLimit int
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{byID: map[string]*models.RcaAgentReport{}}
+}
+
+func (f *fakeRepo) Create(_ context.Context, orgID string, in *models.CreateRcaAgentReportRequest) (*models.RcaAgentReport, error) {
+	report := &models.RcaAgentReport{
+		ID:             "generated-id",
+		OrgID:          orgID,
+		Project:        in.Project,
+		Title:          in.Title,
+		Summary:        in.Summary,
+		Classification: in.Classification,
+		Diagnosis:      in.Diagnosis,
+	}
+	f.created = append(f.created, *report)
+	f.byID[report.ID] = report
+	return report, nil
+}
+
+func (f *fakeRepo) Get(_ context.Context, _, id string) (*models.RcaAgentReport, error) {
+	return f.byID[id], nil
+}
+
+func (f *fakeRepo) List(_ context.Context, _ string, _ string, limit int) ([]models.RcaAgentReport, string, error) {
+	f.listLimit = limit
+	return nil, "", nil
+}
+
+func validCreateRequest() *models.CreateRcaAgentReportRequest {
+	return &models.CreateRcaAgentReportRequest{
+		Project:        "demo-shop",
+		Title:          "Checkout requests failing",
+		Summary:        "summary",
+		Classification: "code-level",
+		Diagnosis:      "diagnosis",
+	}
+}
+
+func TestCreateReport_Valid(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	report, err := svc.CreateReport(context.Background(), "acme", validCreateRequest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.OrgID != "acme" {
+		t.Errorf("orgID = %q, want acme", report.OrgID)
+	}
+	if len(repo.created) != 1 {
+		t.Errorf("expected 1 created report, got %d", len(repo.created))
+	}
+}
+
+func TestCreateReport_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*models.CreateRcaAgentReportRequest)
+	}{
+		{"missing project", func(r *models.CreateRcaAgentReportRequest) { r.Project = "" }},
+		{"missing title", func(r *models.CreateRcaAgentReportRequest) { r.Title = "" }},
+		{"missing summary", func(r *models.CreateRcaAgentReportRequest) { r.Summary = "" }},
+		{"missing diagnosis", func(r *models.CreateRcaAgentReportRequest) { r.Diagnosis = "" }},
+		{"missing classification", func(r *models.CreateRcaAgentReportRequest) { r.Classification = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newFakeRepo()
+			svc := NewRcaAgentReportService(repo)
+			in := validCreateRequest()
+			tt.mutate(in)
+
+			_, err := svc.CreateReport(context.Background(), "acme", in)
+			if !errors.Is(err, ErrInvalidReport) {
+				t.Fatalf("error = %v, want ErrInvalidReport", err)
+			}
+			if len(repo.created) != 0 {
+				t.Errorf("expected no report to be created, got %d", len(repo.created))
+			}
+		})
+	}
+}
+
+func TestCreateReport_InvalidClassification(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+	in := validCreateRequest()
+	in.Classification = "urgent"
+
+	_, err := svc.CreateReport(context.Background(), "acme", in)
+	if !errors.Is(err, ErrInvalidReport) {
+		t.Fatalf("error = %v, want ErrInvalidReport", err)
+	}
+}
+
+func TestCreateReport_NilRequest(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	_, err := svc.CreateReport(context.Background(), "acme", nil)
+	if !errors.Is(err, ErrInvalidReport) {
+		t.Fatalf("error = %v, want ErrInvalidReport", err)
+	}
+}
+
+func TestGetReport_Found(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+	created, _ := svc.CreateReport(context.Background(), "acme", validCreateRequest())
+
+	got, err := svc.GetReport(context.Background(), "acme", created.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("got ID %q, want %q", got.ID, created.ID)
+	}
+}
+
+func TestGetReport_NotFound(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	_, err := svc.GetReport(context.Background(), "acme", "does-not-exist")
+	if !errors.Is(err, ErrReportNotFound) {
+		t.Fatalf("error = %v, want ErrReportNotFound", err)
+	}
+}
+
+func TestListReports_DefaultsLimitWhenAbsentOrZero(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	if _, err := svc.ListReports(context.Background(), "acme", "", 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.listLimit != defaultListLimit {
+		t.Errorf("limit passed to repo = %d, want default %d", repo.listLimit, defaultListLimit)
+	}
+}
+
+func TestListReports_CapsExcessiveLimit(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	if _, err := svc.ListReports(context.Background(), "acme", "", 10_000); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.listLimit != maxListLimit {
+		t.Errorf("limit passed to repo = %d, want cap %d", repo.listLimit, maxListLimit)
+	}
+}
+
+func TestListReports_PassesThroughReasonableLimit(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewRcaAgentReportService(repo)
+
+	if _, err := svc.ListReports(context.Background(), "acme", "", 20); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.listLimit != 20 {
+		t.Errorf("limit passed to repo = %d, want 20", repo.listLimit)
+	}
+}

--- a/services/aep-api/models/rca_agent_report.go
+++ b/services/aep-api/models/rca_agent_report.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package models
+
+import "time"
+
+// RcaAgentReport is an RCA report from the OpenChoreo SRE/RCA-agent handoff
+// (console issues #154, #155). Written once via create-rca-agent-report and
+// read back by the console's notification bell and Alerts list/stepper —
+// see packages/contracts/api/v1/openapi.yaml for the full field contract.
+type RcaAgentReport struct {
+	ID        string `gorm:"primaryKey;type:uuid;default:gen_random_uuid()" json:"id"`
+	OrgID     string `gorm:"index:idx_rca_agent_reports_org_created,priority:1;not null" json:"-"`
+	Project   string `gorm:"not null" json:"project"`
+	Component string `json:"component,omitempty"`
+	Title     string `gorm:"not null" json:"title"`
+	Summary   string `gorm:"not null;type:text" json:"summary"`
+	// Classification: code-level, config-level, mixed, or none.
+	Classification string `gorm:"not null" json:"classification"`
+	Diagnosis      string `gorm:"not null;type:text" json:"diagnosis"`
+
+	IssueNumber  *int64 `json:"issueNumber,omitempty"`
+	IssueURL     string `json:"issueUrl,omitempty"`
+	IssueTitle   string `json:"issueTitle,omitempty"`
+	IssueExcerpt string `gorm:"type:text" json:"issueExcerpt,omitempty"`
+
+	// Dispatched: whether the coding agent has been dispatched for
+	// IssueNumber (false in issue-only/manual-dispatch mode until a human
+	// dispatches — console issue #155's "Coding Handover" stage).
+	Dispatched bool `gorm:"not null;default:false" json:"dispatched"`
+	// Deployed: whether the resulting fix has been deployed — the
+	// "Verify Fix" threshold, not merely PR-merged.
+	Deployed   bool       `gorm:"not null;default:false" json:"deployed"`
+	DeployedAt *time.Time `json:"deployedAt,omitempty"`
+
+	CreatedAt time.Time `gorm:"index:idx_rca_agent_reports_org_created,priority:2;not null;default:now()" json:"createdAt"`
+}
+
+// TableName pins the table name explicitly (matches GORM's default
+// pluralization, kept stable per house convention).
+func (RcaAgentReport) TableName() string { return "rca_agent_reports" }
+
+// RcaAgentReportList is the paginated list envelope served by
+// list-rca-agent-reports.
+type RcaAgentReportList struct {
+	Items []RcaAgentReport `json:"items"`
+	// NextCursor is the opaque continuation token for the next page;
+	// empty/absent on the last page.
+	NextCursor string `json:"nextCursor,omitempty" doc:"Cursor for the next page; absent on the last page."`
+}
+
+// CreateRcaAgentReportRequest is the write-side payload for
+// create-rca-agent-report. Server assigns ID and CreatedAt.
+type CreateRcaAgentReportRequest struct {
+	Project        string `json:"project"`
+	Component      string `json:"component,omitempty"`
+	Title          string `json:"title"`
+	Summary        string `json:"summary"`
+	Classification string `json:"classification"`
+	Diagnosis      string `json:"diagnosis"`
+
+	IssueNumber  *int64 `json:"issueNumber,omitempty"`
+	IssueURL     string `json:"issueUrl,omitempty"`
+	IssueTitle   string `json:"issueTitle,omitempty"`
+	IssueExcerpt string `json:"issueExcerpt,omitempty"`
+
+	Dispatched bool       `json:"dispatched,omitempty"`
+	Deployed   bool       `json:"deployed,omitempty"`
+	DeployedAt *time.Time `json:"deployedAt,omitempty"`
+}

--- a/services/aep-api/repositories/rca_agent_report_repository.go
+++ b/services/aep-api/repositories/rca_agent_report_repository.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/wso2/aep/aep-api/models"
+)
+
+// ErrRcaAgentReportNotFound is returned when no report exists for the given
+// (org, id).
+var ErrRcaAgentReportNotFound = errors.New("rca agent report not found")
+
+// RcaAgentReportRepository is the org-scoped store backing the console's
+// Alerts notification bell and Alerts list/stepper (issues #154, #155).
+type RcaAgentReportRepository struct {
+	db *gorm.DB
+}
+
+// NewRcaAgentReportRepository returns a repository backed by db.
+func NewRcaAgentReportRepository(db *gorm.DB) *RcaAgentReportRepository {
+	return &RcaAgentReportRepository{db: db}
+}
+
+// Create inserts a new report for orgID, returning it with its
+// server-assigned ID and CreatedAt populated.
+func (r *RcaAgentReportRepository) Create(ctx context.Context, orgID string, in *models.CreateRcaAgentReportRequest) (*models.RcaAgentReport, error) {
+	if orgID == "" {
+		return nil, fmt.Errorf("rca_agent_reports: orgID is required")
+	}
+	report := &models.RcaAgentReport{
+		OrgID:          orgID,
+		Project:        in.Project,
+		Component:      in.Component,
+		Title:          in.Title,
+		Summary:        in.Summary,
+		Classification: in.Classification,
+		Diagnosis:      in.Diagnosis,
+		IssueNumber:    in.IssueNumber,
+		IssueURL:       in.IssueURL,
+		IssueTitle:     in.IssueTitle,
+		IssueExcerpt:   in.IssueExcerpt,
+		Dispatched:     in.Dispatched,
+		Deployed:       in.Deployed,
+		DeployedAt:     in.DeployedAt,
+	}
+	if err := r.db.WithContext(ctx).Create(report).Error; err != nil {
+		return nil, fmt.Errorf("rca_agent_reports: create: %w", err)
+	}
+	return report, nil
+}
+
+// Get returns a single report by (org, id), or (nil, nil) when absent.
+func (r *RcaAgentReportRepository) Get(ctx context.Context, orgID, id string) (*models.RcaAgentReport, error) {
+	var report models.RcaAgentReport
+	err := r.db.WithContext(ctx).Where("org_id = ? AND id = ?", orgID, id).First(&report).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("rca_agent_reports: get %q: %w", id, err)
+	}
+	return &report, nil
+}
+
+// List returns up to limit reports for orgID, newest first, optionally
+// continuing after cursor (an opaque RFC3339Nano CreatedAt watermark from a
+// previous page's NextCursor). Returns the page plus the cursor for the next
+// page, or "" on the last page.
+func (r *RcaAgentReportRepository) List(ctx context.Context, orgID string, cursor string, limit int) ([]models.RcaAgentReport, string, error) {
+	if orgID == "" {
+		return nil, "", fmt.Errorf("rca_agent_reports: orgID is required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	q := r.db.WithContext(ctx).Where("org_id = ?", orgID)
+	if cursor != "" {
+		q = q.Where("created_at < ?", cursor)
+	}
+	var reports []models.RcaAgentReport
+	// Fetch one extra row to detect whether a next page exists without a
+	// separate COUNT query.
+	if err := q.Order("created_at DESC").Limit(limit + 1).Find(&reports).Error; err != nil {
+		return nil, "", fmt.Errorf("rca_agent_reports: list org %q: %w", orgID, err)
+	}
+	nextCursor := ""
+	if len(reports) > limit {
+		nextCursor = reports[limit-1].CreatedAt.Format(rfc3339NanoLayout)
+		reports = reports[:limit]
+	}
+	return reports, nextCursor, nil
+}
+
+const rfc3339NanoLayout = "2006-01-02T15:04:05.999999999Z07:00"


### PR DESCRIPTION
## Summary
Implements BE handshake #156 for the console Alerts features (#154, #155):

- `GET /rca-agent/reports` — cursor-paginated list, org-scoped, newest first
- `GET /rca-agent/reports/{reportId}` — single report
- `POST /rca-agent/reports` — new write endpoint (not in the original handshake proposal, added here): creates a report. Decoupled from any specific ingestion mechanism — whatever eventually calls it (a future SRE-agent handoff integration, a script, etc.) is a separate concern. Auth is the same `userJWT` scheme as the reads; no new service-auth scheme was introduced (see decision notes below).
- New `rca_agent_reports` table (migration `phase10_rca_agent_reports`), model, repository, and `internal/feature/rcaagent` service + huma registration.

## Decisions (answering #156's open questions)
- **Ingestion mechanism**: left open on purpose. This PR only adds the write endpoint; nothing in this repo calls it yet. A future integration (e.g. an SRE-agent handoff MCP tool) is separate follow-up work.
- **Auth**: reuses the existing `userJWT` scheme (org-scoped via `humakit.OrgScopedInput`), same as the two read endpoints. No new service/internal auth scheme — the codebase's only precedent for a non-end-user caller (widened `JWT_AUDIENCE` accepting a service-account token, per `docs/developer-guide/sre-handoff-runbook.md` §1.2) still verifies against the same `userJWT` scheme, just with a different allow-listed audience — so this needs no code changes, only ops-side audience configuration whenever a specific service caller is wired up.
- **Data correlation** (linked task/PR/deploy status for the console's Coding Handover / Verify Fix stepper stages): stored directly on the report row (`dispatched`, `deployed`, `deployedAt`, `issueNumber`/`issueUrl`/etc.) per #156's recommendation — one round-trip, no cross-referencing the tasks API from the console.

## Test plan
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./... -short` — passes (only a pre-existing, unrelated `internal/arch` failure remains: `clients/openchoreo/gen/` legacy layout, present on `aep-rewrite` before this branch)
- [x] `make openapi-check` — served spec matches the committed contract for the new endpoints (cosmetic-only diff: Huma's auto `format: int64` on the `limit` query param)
- [x] Unit tests for the service layer (validation, default/cap limit logic) — `internal/feature/rcaagent/rcaagent_service_test.go`

Closes the BE side of #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)