### PR TITLE
fix(console): pre-build design-projection + excalidraw-dsl in the image

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -36,9 +36,14 @@ RUN pnpm install --frozen-lockfile --filter @aep/console...
 
 # Workspace deps whose exports resolve to ./dist must be compiled first
 # (@aep/agent-stream — the agent-chat panel's SSE contracts, #130;
-# @aep/collab-doc — the AgentInsertion mark shared with the editor, #86 ph6).
+# @aep/collab-doc — the AgentInsertion mark shared with the editor, #86 ph6;
+# @aep/design-projection + @aep/excalidraw-dsl — the rich design view's
+# projection + wireframe DSL, #149). The @aep/ui-* view packages resolve to
+# their src/ (types: src/index.ts) so tsc reads them directly — no pre-build.
 RUN pnpm --filter @aep/agent-stream build
 RUN pnpm --filter @aep/collab-doc build
+RUN pnpm --filter @aep/design-projection build
+RUN pnpm --filter @aep/excalidraw-dsl build
 RUN pnpm --filter @aep/console gen
 RUN pnpm --filter @aep/console build
 


### PR DESCRIPTION
## Problem

The console image's stage-0 pre-builds every workspace dep whose exports resolve to `./dist` before `pnpm --filter @aep/console build` — tsc can't find their type declarations until `dist/` is emitted. The rich design view (#149) added `@aep/design-projection` and `@aep/excalidraw-dsl` (both `"types": "./dist/index.d.ts"`) as console deps but left them off that pre-build list, so the console image build fails:

```
error TS2307: Cannot find module '@aep/design-projection' or its corresponding type declarations.
error TS2307: Cannot find module '@aep/excalidraw-dsl' or its corresponding type declarations.
```

`make build` / turbo builds the whole dependency graph, so this drift is **invisible outside the Docker image path** — only `docker compose build console` (or the deployment image) hits it.

## Fix

Add the two missing `RUN pnpm --filter … build` lines. The `@aep/ui-*` view packages resolve to their `src/` (`types: src/index.ts`), so tsc reads them directly and they need no pre-build (noted in the comment).

## Verification

- `pnpm --filter @aep/console build` (`tsc && vite build`) — green after building the four dist-resolved deps (agent-stream, collab-doc, design-projection, excalidraw-dsl).
- Full `docker compose up --build` of the local stack — console image builds; container `aep-console-new` healthy on :8091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)