### PR TITLE
feat(console): first-run onboarding wizard for the default org (#102)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -89,6 +89,12 @@ that's a stalled feature — investigate, don't ignore.
   [#150](https://github.com/wso2/labs-agentic-engineer/issues/150)
   (no contract change; duplicate-generation guard deferred to
   [#151](https://github.com/wso2/labs-agentic-engineer/issues/151))
+- Onboarding — first-time credentials wizard for the default org (hard gate on
+  incomplete `GET /config`): GitHub PAT + Anthropic key, then auto skills-repo
+  bootstrap via extended `/skills/sync` —
+  [#102](https://github.com/wso2/labs-agentic-engineer/issues/102)
+  (BE handshake [#171](https://github.com/wso2/labs-agentic-engineer/issues/171);
+  ADR-0009)
 - Spec view — rich design rendering: component-grouped file list, whole-architecture
   cell diagram, per-component wireframes, and Swagger-style API Spec view
   (client-derived, read-only; no committed artifacts) —

--- a/apps/console/design/decisions/ADR-0009-default-org-guarantee-and-config-keyed-onboarding.md
+++ b/apps/console/design/decisions/ADR-0009-default-org-guarantee-and-config-keyed-onboarding.md
@@ -1,0 +1,38 @@
+# ADR-0009: Default org is a platform guarantee; onboarding gates on config, not org existence
+
+- **Status:** Accepted
+- **Date:** 2026-07-10 (grilling of the onboarding feature,
+  [#102](https://github.com/wso2/labs-agentic-engineer/issues/102))
+- **Context:** the onboarding issue originally opened with a
+  create-organization wizard step and a `POST /organizations` contract
+  question (aep-api is deliberately read-only over OC namespaces). Phase 1
+  was refactored: every user gets a **default organization** provisioned
+  platform-side at signup. Console-side org creation was proposed and
+  rejected.
+
+## Decision
+
+The platform guarantees that by the time the console receives a token, the
+user's default org exists and the JWT carries its `ou*` claim. The console
+therefore **assumes `orgHandle` is non-null after sign-in** and keeps no
+zero-org state, no org-creation UI, and no lazy "ensure my org" call.
+
+First-run onboarding is keyed on **org configuration, not org existence**:
+if `GET /config` reports `gitProvider` or `llm` as `null`, the console hard-
+gates every route into the onboarding wizard (#102). Config is org-level,
+so resume-after-abandon and "later members of a configured org skip
+onboarding" need no extra bookkeeping.
+
+## Consequences
+
+- No console feature may introduce org-creation UI or a zero-org state;
+  supersede this ADR explicitly if multi-org creation becomes a product
+  goal.
+- `orgHandle ?? "default"`-style fallbacks in the codebase are legacy
+  defensiveness, not a supported state; new code must not add them.
+- The onboarding gate's trigger is `GET /config` completeness only — no
+  "is the org bootstrapped" contract signal exists or should be requested
+  for gating.
+- If the platform-side guarantee is ever weakened (JWTs without `ou*`
+  claims in some flow), that is a platform bug, not a state the console
+  handles.

--- a/apps/console/src/features/onboarding/components/AnthropicStep.tsx
+++ b/apps/console/src/features/onboarding/components/AnthropicStep.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ExternalLink, Eye, EyeOff, Key } from "@wso2/oxygen-ui-icons-react";
+import { useConnectAnthropic } from "../../settings/api/queries";
+
+// Same probe-before-persist pattern as the GitHub step: the BFF validates
+// the key against Anthropic before persisting (#96).
+export function AnthropicStep() {
+  const [apiKey, setApiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const connect = useConnectAnthropic();
+
+  const submit = () => {
+    if (!apiKey) return;
+    connect.mutate(apiKey);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Key size={22} />
+        <Typography variant="h6">Connect Anthropic</Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary">
+        The platform's agents call Claude with your organization's Anthropic
+        API key. The key is validated against Anthropic before it is saved,
+        and it can be replaced later in Settings.
+      </Typography>
+
+      <Button
+        variant="text"
+        size="small"
+        href="https://console.anthropic.com/settings/keys"
+        target="_blank"
+        rel="noreferrer"
+        endIcon={<ExternalLink size={14} />}
+        sx={{ alignSelf: "flex-start" }}
+      >
+        Get an API key from Anthropic
+      </Button>
+
+      <TextField
+        required
+        label="API key"
+        placeholder="sk-ant-..."
+        type={showKey ? "text" : "password"}
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        fullWidth
+        slotProps={{
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showKey ? "hide key" : "show key"}
+                  onClick={() => setShowKey((v) => !v)}
+                  edge="end"
+                >
+                  {showKey ? <EyeOff size={18} /> : <Eye size={18} />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+
+      {connect.isError && <Alert severity="error">{connect.error.message}</Alert>}
+
+      <Button
+        variant="contained"
+        onClick={submit}
+        disabled={!apiKey || connect.isPending}
+        sx={{ alignSelf: "flex-end" }}
+      >
+        {connect.isPending ? "Validating…" : "Connect Anthropic"}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/console/src/features/onboarding/components/GitHubStep.tsx
+++ b/apps/console/src/features/onboarding/components/GitHubStep.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import {
+  ExternalLink,
+  Eye,
+  EyeOff,
+  GitHub,
+  Lightbulb,
+} from "@wso2/oxygen-ui-icons-react";
+import { useConnectGitHubPat } from "../../settings/api/queries";
+
+// Classic-PAT URL preselecting the scopes the platform needs (#102 decision:
+// classic PAT, repo + read:org; exact set confirmed via the BE handshake
+// issue #171 — a correction here is copy-only).
+const TOKEN_URL =
+  "https://github.com/settings/tokens/new?scopes=repo,read:org&description=Agentic%20Engineer%20Platform";
+
+// Validation is the PATCH itself: the BFF probes the PAT against GitHub
+// before persisting (#96 pattern), so errors surface from the mutation.
+export function GitHubStep() {
+  const [pat, setPat] = useState("");
+  const [githubLogin, setGithubLogin] = useState("");
+  const [showPat, setShowPat] = useState(false);
+  const connect = useConnectGitHubPat();
+
+  const submit = () => {
+    const org = githubLogin.trim();
+    if (!pat || !org) return;
+    connect.mutate({ pat, githubLogin: org });
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <GitHub size={22} />
+        <Typography variant="h6">Connect GitHub</Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary">
+        The platform hosts your organization's skills catalogue and project
+        repos on GitHub. Create a <strong>classic personal access token</strong>{" "}
+        with the <code>repo</code> and <code>read:org</code> scopes, owned by a
+        member of the GitHub organization the platform should use.
+      </Typography>
+      <Alert severity="info" icon={<Lightbulb size={18} />}>
+        Pro tip: create a dedicated GitHub organization for this platform so
+        its agents' repos, tokens, and skills catalogue stay isolated from
+        your team's main org.
+      </Alert>
+
+      <Button
+        variant="text"
+        size="small"
+        href={TOKEN_URL}
+        target="_blank"
+        rel="noreferrer"
+        endIcon={<ExternalLink size={14} />}
+        sx={{ alignSelf: "flex-start" }}
+      >
+        Create a token on GitHub (scopes preselected)
+      </Button>
+
+      <TextField
+        required
+        label="GitHub organization name"
+        placeholder="octocat"
+        value={githubLogin}
+        onChange={(e) => setGithubLogin(e.target.value)}
+        helperText="The GitHub organization the platform reads and writes repos in."
+        fullWidth
+      />
+      <TextField
+        required
+        label="Personal access token"
+        placeholder="ghp_..."
+        type={showPat ? "text" : "password"}
+        value={pat}
+        onChange={(e) => setPat(e.target.value)}
+        fullWidth
+        slotProps={{
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showPat ? "hide token" : "show token"}
+                  onClick={() => setShowPat((v) => !v)}
+                  edge="end"
+                >
+                  {showPat ? <EyeOff size={18} /> : <Eye size={18} />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+
+      {connect.isError && <Alert severity="error">{connect.error.message}</Alert>}
+
+      <Button
+        variant="contained"
+        onClick={submit}
+        disabled={!pat || !githubLogin.trim() || connect.isPending}
+        sx={{ alignSelf: "flex-end" }}
+      >
+        {connect.isPending ? "Validating…" : "Connect GitHub"}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/console/src/features/onboarding/components/OnboardingGate.tsx
+++ b/apps/console/src/features/onboarding/components/OnboardingGate.tsx
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useRef, useState, type PropsWithChildren } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { useConfig } from "../../settings/api/queries";
+import { OnboardingWizard } from "./OnboardingWizard";
+
+// First-run hard gate (issue #102, ADR-0009): an org whose config is missing
+// gitProvider or llm is non-functional, so every route yields to the
+// onboarding wizard until both are connected. Keyed purely on GET /config —
+// the org itself always exists (default org, platform guarantee).
+export function OnboardingGate({ children }: PropsWithChildren) {
+  const config = useConfig();
+  // Once the wizard has been shown this session, keep it mounted past the
+  // moment config becomes complete — the skills-bootstrap step runs after
+  // the last credential lands, and only the wizard's own completion
+  // actions ("Go to console" / "Continue anyway") dismiss it.
+  const wizardShown = useRef(false);
+  const [completed, setCompleted] = useState(false);
+
+  if (config.isPending) {
+    return (
+      <FullScreen>
+        <CircularProgress size={32} />
+        <Typography variant="body2" color="text.secondary">
+          Loading your organization…
+        </Typography>
+      </FullScreen>
+    );
+  }
+
+  if (config.isError) {
+    return (
+      <FullScreen>
+        <Typography variant="h6">Couldn't load your organization</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {config.error.message}
+        </Typography>
+        <Button variant="contained" onClick={() => void config.refetch()}>
+          Try again
+        </Button>
+      </FullScreen>
+    );
+  }
+
+  const incomplete =
+    config.data.gitProvider === null || config.data.llm === null;
+  if (incomplete) wizardShown.current = true;
+
+  if (wizardShown.current && !completed) {
+    return (
+      <OnboardingWizard
+        config={config.data}
+        onComplete={() => setCompleted(true)}
+      />
+    );
+  }
+
+  return children;
+}
+
+// Full-viewport centering for the gate's own loading/error states,
+// mirroring auth/AuthScreen.tsx.
+function FullScreen({ children }: PropsWithChildren) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 2,
+        bgcolor: "background.default",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/apps/console/src/features/onboarding/components/OnboardingWizard.tsx
+++ b/apps/console/src/features/onboarding/components/OnboardingWizard.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Paper,
+  Step,
+  StepLabel,
+  Stepper,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type { components } from "../../../generated/aep-api";
+import { useSession } from "../../../auth/SessionContext";
+import { GitHubStep } from "./GitHubStep";
+import { AnthropicStep } from "./AnthropicStep";
+import { SkillsBootstrapStep } from "./SkillsBootstrapStep";
+
+type ConfigProjection = components["schemas"]["ConfigProjection"];
+
+const STEPS = ["Connect GitHub", "Connect Anthropic", "Set up skills"];
+
+// The active step derives from server state, not local navigation: each
+// successful PATCH /config updates the query cache and the wizard advances.
+// A partially-configured org therefore resumes at its first incomplete step
+// (issue #102 decisions comment).
+function activeStep(config: ConfigProjection): number {
+  if (config.gitProvider === null) return 0;
+  if (config.llm === null) return 1;
+  return 2;
+}
+
+export function OnboardingWizard({
+  config,
+  onComplete,
+}: {
+  config: ConfigProjection;
+  onComplete: () => void;
+}) {
+  const { user, signOut } = useSession();
+  const step = activeStep(config);
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 3,
+        p: 3,
+        bgcolor: "background.default",
+      }}
+    >
+      <Box sx={{ textAlign: "center" }}>
+        <Typography variant="h5" gutterBottom>
+          Welcome to Agentic Engineer
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Your organization needs a few connections before agents can work.
+        </Typography>
+      </Box>
+
+      <Paper variant="outlined" sx={{ p: 4, width: "100%", maxWidth: 640 }}>
+        <Stepper activeStep={step} sx={{ mb: 4 }}>
+          {STEPS.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+
+        {step === 0 && <GitHubStep />}
+        {step === 1 && <AnthropicStep />}
+        {step === 2 && <SkillsBootstrapStep onComplete={onComplete} />}
+      </Paper>
+
+      <Typography variant="body2" color="text.secondary">
+        Signed in as {user.name} ·{" "}
+        <Button variant="text" size="small" onClick={signOut}>
+          Sign out
+        </Button>
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/console/src/features/onboarding/components/SkillsBootstrapStep.tsx
+++ b/apps/console/src/features/onboarding/components/SkillsBootstrapStep.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Check, Sparkles } from "@wso2/oxygen-ui-icons-react";
+import { useSyncSkills } from "../../settings/api/queries";
+
+// Auto-runs the skills bootstrap the moment credentials complete (#102
+// decision): POST /skills/sync creates the org's skills repo if missing and
+// pushes the platform's built-in skills. Failure is non-blocking — sync is
+// idempotent (Retry) and Settings' Sync control is the standing fallback
+// (Continue anyway).
+export function SkillsBootstrapStep({ onComplete }: { onComplete: () => void }) {
+  const sync = useSyncSkills();
+  // Deferred one-shot, not a bare mutate() in the effect: firing a mutation
+  // synchronously inside the mount effect binds its result delivery to the
+  // StrictMode-doubled subscription React is about to tear down — the
+  // mutation succeeds in the cache but this component never re-renders
+  // (stuck spinner). The cleanup-cancelled timeout fires exactly once,
+  // after the subscription is stable, in both dev and prod.
+  const { mutate } = sync;
+  useEffect(() => {
+    const t = setTimeout(() => mutate(), 0);
+    return () => clearTimeout(t);
+  }, [mutate]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        py: 2,
+        textAlign: "center",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Sparkles size={22} />
+        <Typography variant="h6">Set up skills</Typography>
+      </Box>
+
+      {sync.isError ? (
+        <>
+          <Alert severity="error" sx={{ width: "100%", textAlign: "left" }}>
+            {sync.error.message}
+          </Alert>
+          <Typography variant="body2" color="text.secondary">
+            The skills catalogue couldn't be set up. You can retry now, or
+            continue and run <strong>Sync</strong> from Settings → Skills
+            later — agents won't have skills until it succeeds.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 1.5 }}>
+            <Button
+              variant="contained"
+              onClick={() => sync.mutate()}
+              disabled={sync.isPending}
+            >
+              Retry
+            </Button>
+            <Button variant="text" onClick={onComplete}>
+              Continue anyway
+            </Button>
+          </Box>
+        </>
+      ) : sync.isSuccess ? (
+        <>
+          <Check size={32} />
+          <Typography variant="body2" color="text.secondary">
+            Your skills catalogue is ready
+            {sync.data.updated > 0 ? ` — ${sync.data.updated} built-in skill${
+              sync.data.updated === 1 ? "" : "s"
+            } installed` : ""}
+            . Your organization is all set.
+          </Typography>
+          <Button variant="contained" onClick={onComplete}>
+            Go to console
+          </Button>
+        </>
+      ) : (
+        <>
+          <CircularProgress size={32} />
+          <Typography variant="body2" color="text.secondary">
+            Setting up your skills catalogue — creating the repository and
+            installing the platform's built-in skills…
+          </Typography>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/apps/console/src/mocks/fixtures/settings.ts
+++ b/apps/console/src/mocks/fixtures/settings.ts
@@ -24,13 +24,24 @@ type SkillDetailBody = components["schemas"]["SkillDetailBody"];
 type SkillUpdate = components["schemas"]["SkillUpdate"];
 type ErrorModel = components["schemas"]["ErrorModel"];
 
-// Scenario switch for the Settings feature (#96). Toggle in devtools:
-//   localStorage.setItem('aep:mock:settings', 'empty' | 'connected' | 'error')
-// "empty": nothing connected yet (the default — exercises the not-connected
-// and GitHub-not-connected-blocks-Skills states).
-// "connected": GitHub + Anthropic already connected.
+// Scenario switch for the Settings (#96) and Onboarding (#102) features.
+// Toggle in devtools:
+//   localStorage.setItem('aep:mock:settings',
+//     'empty' | 'partial' | 'connected' | 'error' | 'sync-error')
+// "empty": nothing connected yet (the default — triggers the onboarding
+// gate; also exercises Settings' not-connected states).
+// "partial": GitHub connected, Anthropic not — the onboarding wizard opens
+// at its first incomplete step (resume-after-abandon, #102).
+// "connected": GitHub + Anthropic already connected (no onboarding).
 // "error": GET /config and GET /skills fail (load-error state).
-export type SettingsScenario = "empty" | "connected" | "error";
+// "sync-error": config empty and POST /skills/sync fails — exercises the
+// wizard's bootstrap-failure step (Retry / Continue anyway, #102).
+export type SettingsScenario =
+  | "empty"
+  | "partial"
+  | "connected"
+  | "error"
+  | "sync-error";
 
 // Typing this exact value into a PAT/API-key field simulates the BFF's
 // synchronous probe-before-persist validation failing against the real
@@ -115,6 +126,15 @@ export const skillsLoadError: ErrorModel = {
   status: 500,
   title: "Internal Server Error",
   detail: "Failed to load skills",
+};
+
+// Bootstrap failure for the onboarding wizard (#102): repo creation or the
+// built-ins push failed. Sync is idempotent, so the remedy is retry.
+export const skillsSyncError: ErrorModel = {
+  type: "about:blank",
+  status: 502,
+  title: "Bad Gateway",
+  detail: "Failed to create the skills repository on GitHub",
 };
 
 // Covers all four kinds (org | platform | custom | imported — the BE's real

--- a/apps/console/src/mocks/handlers/settings.ts
+++ b/apps/console/src/mocks/handlers/settings.ts
@@ -33,6 +33,7 @@ import {
   seedSkillUpdates,
   seedSkills,
   skillsLoadError,
+  skillsSyncError,
   skillsRepoUrl,
   type SettingsScenario,
 } from "../fixtures/settings";
@@ -75,6 +76,10 @@ function ensureInitialized() {
   if (scenario() === "connected") {
     gitProvider = { ...githubConnectedFixture };
     llm = { ...llmConnectedFixture };
+  } else if (scenario() === "partial") {
+    // Onboarding resume-after-abandon (#102): GitHub landed, Anthropic
+    // didn't — the wizard must open at its first incomplete step.
+    gitProvider = { ...githubConnectedFixture };
   }
   skills = seedSkills.map((s) => ({ ...s }));
   skillUpdates = seedSkillUpdates.map((u) => ({ ...u }));
@@ -236,8 +241,11 @@ export const settingsHandlers = [
   }),
 
   // All-or-nothing, mirroring the BE: no request body, reconcile everything.
+  // Per #102 the BE creates the org's skills repo first when it's missing;
+  // the mock treats that as part of the same opaque call.
   http.post("*/api/v1/skills/sync", () => {
     ensureInitialized();
+    if (scenario() === "sync-error") return problem(skillsSyncError, 502);
     const targets = skillUpdates;
 
     for (const t of targets) {

--- a/apps/console/src/routes/__root.tsx
+++ b/apps/console/src/routes/__root.tsx
@@ -19,13 +19,17 @@
 import { createRootRoute } from "@tanstack/react-router";
 import { AppLayout } from "../layouts/AppLayout";
 import { AuthGuard } from "../auth/AuthGuard";
+import { OnboardingGate } from "../features/onboarding/components/OnboardingGate";
 
 // Everything renders behind the auth gate (issue #91): routes only ever
-// see a signed-in session.
+// see a signed-in session. Behind it, the onboarding gate (issue #102,
+// ADR-0009) holds every route until the org's config is complete.
 export const Route = createRootRoute({
   component: () => (
     <AuthGuard>
-      <AppLayout />
+      <OnboardingGate>
+        <AppLayout />
+      </OnboardingGate>
     </AuthGuard>
   ),
 });

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -3558,7 +3558,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: Sync built-in skills
+      summary: Sync built-in skills (creates the org's skills repo if missing)
       tags:
         - Skills
   /skills/updates:


### PR DESCRIPTION
Closes-when-shipped: #102 · BE handshake: #171 · ADR: `ADR-0009`

First-run onboarding for the default org, per the decisions comment on #102.

## What

- **Config-keyed hard gate** (`OnboardingGate`, wired in `__root.tsx` behind `AuthGuard`): if `GET /config` has `gitProvider` or `llm` null, every route yields to the wizard. The org itself always exists — default org is a platform guarantee (ADR-0009); there is no zero-org state and no org-creation UI.
- **Wizard** (`features/onboarding/`): GitHub PAT step (classic token, `repo` + `read:org`, scope-preselected creation link) → Anthropic key step → auto-run skills bootstrap. Credential steps reuse #96's mutation hooks (`PATCH /config` probe-before-persist); the wizard owns its own lean step UI. Active step derives from server state, so a partially-configured org resumes at its first incomplete step.
- **Skills bootstrap**: auto-fires `POST /skills/sync` when credentials complete (contract summary extended: create-repo-if-missing — the behavioral ask on #171). Failure is non-blocking: Retry (sync is idempotent) or Continue anyway (Settings → Skills → Sync is the standing fallback).
- **Mocks**: `partial` and `sync-error` scenarios added to the existing `aep:mock:settings` switch, typed against the contract.
- **PRD**: In-flight line added.

## Notable

The bootstrap step defers its auto-`mutate()` by a cleanup-cancelled timeout. Firing a mutation synchronously in the mount effect binds result delivery to the StrictMode-doubled subscription React immediately tears down — the mutation succeeds in the mutation cache but the component never re-renders (permanent spinner). Found via mock-mode verification; the constraint is documented in `SkillsBootstrapStep.tsx`.

## Verified (mock mode, all decided states)

Full Playwright walk: gate → GitHub step (incl. probe error) → Anthropic step (incl. probe error) → bootstrap success → into console; resume-at-step-2 (`partial`); bootstrap failure with Retry/Continue-anyway (`sync-error`); configured org never sees the wizard (`connected`); gate load-error state. `pnpm test` 45/45, `tsc` and `eslint` clean.

Screenshots attached below (drag-and-drop; never pushed to the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
