### PR TITLE
Settings → Skills: flat paginated catalogue (inline kind chips, keep row cards + search)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -78,6 +78,11 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
+- Settings → Skills — flat paginated catalogue: alphabetical list with inline
+  kind chips (blurb tooltips) replacing the four group sections; numbered
+  client-side pagination (10/page) + retained search —
+  [#172](https://github.com/wso2/labs-agentic-engineer/issues/172)
+  (no contract change)
 - Spec view — Build button invokes the build resource: commit-then-build
   (collab flush-on-demand → `POST /build`), lands on the overview; Build
   disabled with a tooltip while an agent turn runs —

--- a/apps/console/src/features/settings/components/SkillsSection.tsx
+++ b/apps/console/src/features/settings/components/SkillsSection.tsx
@@ -32,11 +32,12 @@ import {
   DialogContentText,
   DialogTitle,
   Divider,
+  Pagination,
   SearchBar,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { Eye, FolderGit2, Pencil, Trash2, Upload } from "@wso2/oxygen-ui-icons-react";
-import type { components } from "../../../generated/aep-api";
 import {
   useConfig,
   useDeleteSkill,
@@ -44,13 +45,14 @@ import {
   useSkills,
   useSyncSkills,
 } from "../api/queries";
-import { SKILL_GROUPS, kindLabel, normalizeKind } from "../skillKind";
+import { kindBlurb, kindChipColor, kindLabel, normalizeKind } from "../skillKind";
+import { paginateSkills } from "../skillsList";
 import { EditSkillDialog } from "./EditSkillDialog";
 import { ImportSkillDialog } from "./ImportSkillDialog";
 import { SkillViewerDialog } from "./SkillViewerDialog";
 import { SyncUpdatesControl } from "./SyncUpdatesControl";
 
-type SkillSummary = components["schemas"]["SkillSummary"];
+const PAGE_SIZE = 10;
 
 export function SkillsSection() {
   const {
@@ -65,6 +67,7 @@ export function SkillsSection() {
 
   const [importOpen, setImportOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [requestedPage, setRequestedPage] = useState(1);
   const [viewTarget, setViewTarget] = useState<string | null>(null);
   const [editTarget, setEditTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -134,24 +137,16 @@ export function SkillsSection() {
   const updatable = new Set((updates ?? []).map((u) => u.name));
   const syncedCount = syncSkills.data?.updated ?? 0;
 
-  // Client-side filter (issue #96 re-grill): the catalogue is fully loaded and
-  // tens of skills at most. Match the displayed kind label as well as the raw
-  // value — the chip reads "Organization", so that is what people will type.
-  const query = search.trim().toLowerCase();
-  const matches = (skill: SkillSummary) =>
-    !query ||
-    [
-      skill.name,
-      skill.description,
-      skill.kind,
-      kindLabel(normalizeKind(skill.kind)),
-    ].some((field) => (field ?? "").toLowerCase().includes(query));
-
-  const visible = skills.filter(matches);
-  const grouped = SKILL_GROUPS.map((group) => ({
-    ...group,
-    rows: visible.filter((s) => normalizeKind(s.kind) === group.kind),
-  }));
+  // Filter → sort → clamp → slice as one pure derivation: a list that shrinks
+  // underneath the current page (delete, sync) lands on the nearest still-
+  // valid page without any effect re-syncing state.
+  const query = search.trim();
+  const { rows, page, pageCount, total } = paginateSkills(
+    skills,
+    query,
+    requestedPage,
+    PAGE_SIZE,
+  );
 
   const confirmDelete = () => {
     if (!deleteTarget) return;
@@ -182,7 +177,12 @@ export function SkillsSection() {
         <Box sx={{ width: { xs: "100%", sm: 320 } }}>
           <SearchBar
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              // A new query re-filters from scratch — page 1 is the only
+              // page that is meaningful for it.
+              setRequestedPage(1);
+            }}
             placeholder="Search skills..."
           />
         </Box>
@@ -221,127 +221,121 @@ export function SkillsSection() {
         </Alert>
       )}
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-        {grouped.map(({ kind, heading, blurb, rows }) => (
-          <Box key={kind}>
-            <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 0.5 }}>
-              {heading}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {blurb}
-            </Typography>
-
-            {rows.length === 0 ? (
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ mt: 1, fontStyle: "italic" }}
-              >
-                {query ? "No matches." : "None yet."}
-              </Typography>
-            ) : (
-              <Card variant="outlined" sx={{ mt: 1 }}>
-                <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
-                  {rows.map((skill, idx) => {
-                    return (
-                      <Box key={skill.name}>
-                        {idx > 0 && <Divider />}
+      {total === 0 ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ fontStyle: "italic" }}
+        >
+          {query ? "No matches." : "None yet."}
+        </Typography>
+      ) : (
+        <>
+          <Card variant="outlined">
+            <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+              {rows.map((skill, idx) => {
+                const kind = normalizeKind(skill.kind);
+                return (
+                  <Box key={skill.name}>
+                    {idx > 0 && <Divider />}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                        px: 2,
+                        py: 1.5,
+                        "&:hover": { bgcolor: "action.hover" },
+                      }}
+                    >
+                      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
                         <Box
                           sx={{
                             display: "flex",
                             alignItems: "center",
-                            gap: 1.5,
-                            px: 2,
-                            py: 1.5,
-                            "&:hover": { bgcolor: "action.hover" },
+                            gap: 1,
+                            flexWrap: "wrap",
                           }}
                         >
-                          <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                            <Box
-                              sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: 1,
-                                flexWrap: "wrap",
-                              }}
-                            >
-                              <Typography variant="body1" fontWeight={600}>
-                                {skill.name}
-                              </Typography>
-                              {/* No kind chip: the group heading above already
-                                  names the kind. Only state that the grouping
-                                  can't convey gets a chip. */}
-                              {updatable.has(skill.name) && (
-                                <Chip
-                                  size="small"
-                                  color="warning"
-                                  label="update available"
-                                />
-                              )}
-                              {/* Org and platform groups are read-only by
-                                  definition (the blurb says so), so only flag
-                                  it where the grouping doesn't imply it. */}
-                              {!skill.editable &&
-                                kind !== "org" &&
-                                kind !== "platform" && (
-                                  <Chip
-                                    size="small"
-                                    variant="outlined"
-                                    label="read-only"
-                                  />
-                                )}
-                            </Box>
-                            <Typography
-                              variant="body2"
-                              color="text.secondary"
-                              sx={{ mt: 0.5 }}
-                            >
-                              {skill.description}
-                            </Typography>
-                          </Box>
-                          <Box
-                            sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}
-                          >
-                            {/* View is available for every kind — inspecting a
-                                read-only org/platform skill's body is the whole
-                                point of the viewer. */}
+                          <Typography variant="body1" fontWeight={600}>
+                            {skill.name}
+                          </Typography>
+                          {/* The kind chip is the flat list's only kind
+                              signal; its tooltip carries the kind's blurb,
+                              including read-only-ness — there is no separate
+                              read-only chip. */}
+                          <Tooltip title={kindBlurb(kind)}>
+                            <Chip
+                              size="small"
+                              color={kindChipColor(kind)}
+                              label={kindLabel(kind)}
+                            />
+                          </Tooltip>
+                          {updatable.has(skill.name) && (
+                            <Chip
+                              size="small"
+                              color="warning"
+                              label="update available"
+                            />
+                          )}
+                        </Box>
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ mt: 0.5 }}
+                        >
+                          {skill.description}
+                        </Typography>
+                      </Box>
+                      <Box sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}>
+                        {/* View is available for every kind — inspecting a
+                            read-only org/platform skill's body is the whole
+                            point of the viewer. */}
+                        <Button
+                          size="small"
+                          startIcon={<Eye size={16} />}
+                          onClick={() => setViewTarget(skill.name)}
+                        >
+                          View
+                        </Button>
+                        {skill.editable && (
+                          <>
                             <Button
                               size="small"
-                              startIcon={<Eye size={16} />}
-                              onClick={() => setViewTarget(skill.name)}
+                              startIcon={<Pencil size={16} />}
+                              onClick={() => setEditTarget(skill.name)}
                             >
-                              View
+                              Edit
                             </Button>
-                            {skill.editable && (
-                              <>
-                                <Button
-                                  size="small"
-                                  startIcon={<Pencil size={16} />}
-                                  onClick={() => setEditTarget(skill.name)}
-                                >
-                                  Edit
-                                </Button>
-                                <Button
-                                  size="small"
-                                  color="error"
-                                  startIcon={<Trash2 size={16} />}
-                                  onClick={() => setDeleteTarget(skill.name)}
-                                >
-                                  Delete
-                                </Button>
-                              </>
-                            )}
-                          </Box>
-                        </Box>
+                            <Button
+                              size="small"
+                              color="error"
+                              startIcon={<Trash2 size={16} />}
+                              onClick={() => setDeleteTarget(skill.name)}
+                            >
+                              Delete
+                            </Button>
+                          </>
+                        )}
                       </Box>
-                    );
-                  })}
-                </CardContent>
-              </Card>
-            )}
-          </Box>
-        ))}
-      </Box>
+                    </Box>
+                  </Box>
+                );
+              })}
+            </CardContent>
+          </Card>
+          {/* Hidden on a single page — it would be dead UI. */}
+          {pageCount > 1 && (
+            <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+              <Pagination
+                count={pageCount}
+                page={page}
+                onChange={(_, next) => setRequestedPage(next)}
+              />
+            </Box>
+          )}
+        </>
+      )}
 
       <ImportSkillDialog
         open={importOpen}

--- a/apps/console/src/features/settings/skillKind.ts
+++ b/apps/console/src/features/settings/skillKind.ts
@@ -64,31 +64,19 @@ export function kindChipColor(
   }
 }
 
-/** Display order of the catalogue's groups, with each group's one-line blurb. */
-export const SKILL_GROUPS: {
-  kind: SkillKind;
-  heading: string;
-  blurb: string;
-}[] = [
-  {
-    kind: "org",
-    heading: "Organization",
-    blurb: "Shipped with the platform. Read-only — view to inspect the body.",
-  },
-  {
-    kind: "platform",
-    heading: "Platform",
-    blurb:
-      "Generation-flow guidance the platform agents follow (design, tasks, wireframes). Read-only.",
-  },
-  {
-    kind: "custom",
-    heading: "Custom",
-    blurb: "Authored by your organization.",
-  },
-  {
-    kind: "imported",
-    heading: "Imported",
-    blurb: "AgentSkills brought in from the ecosystem.",
-  },
-];
+// One-line explanation per kind, shown as a tooltip on the row's kind chip
+// (issue #172): the flat list has no group headings to carry it, and the
+// org/platform blurbs are also where read-only-ness is stated — the list
+// shows no separate read-only chip.
+export function kindBlurb(kind: SkillKind): string {
+  switch (kind) {
+    case "org":
+      return "Shipped with the platform. Read-only — view to inspect the body.";
+    case "platform":
+      return "Generation-flow guidance the platform agents follow (design, tasks, wireframes). Read-only.";
+    case "custom":
+      return "Authored by your organization.";
+    case "imported":
+      return "AgentSkills brought in from the ecosystem.";
+  }
+}

--- a/apps/console/src/features/settings/skillsList.test.ts
+++ b/apps/console/src/features/settings/skillsList.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { paginateSkills } from "./skillsList";
+
+const skill = (name: string, kind = "org", description = "") => ({
+  name,
+  kind,
+  description,
+});
+
+const catalogue = [
+  skill("react-webapp", "org", "How to build a React SPA on the platform."),
+  skill("go", "org", "How to build a Go service on the platform."),
+  skill("task-breakdown", "platform", "Breaks a design into buildable tasks."),
+  skill("acme-deploy-checklist", "custom", "Acme's internal checklist."),
+  skill("find-skills", "imported", "Discover community AgentSkills."),
+];
+
+describe("paginateSkills", () => {
+  it("sorts alphabetically by name across kinds", () => {
+    const { rows } = paginateSkills(catalogue, "", 1, 10);
+    expect(rows.map((s) => s.name)).toEqual([
+      "acme-deploy-checklist",
+      "find-skills",
+      "go",
+      "react-webapp",
+      "task-breakdown",
+    ]);
+  });
+
+  it("slices the requested page and reports the page count", () => {
+    const many = Array.from({ length: 23 }, (_, i) =>
+      skill(`skill-${String(i).padStart(2, "0")}`),
+    );
+    const page1 = paginateSkills(many, "", 1, 10);
+    expect(page1.rows).toHaveLength(10);
+    expect(page1.pageCount).toBe(3);
+    expect(page1.total).toBe(23);
+
+    const page3 = paginateSkills(many, "", 3, 10);
+    expect(page3.rows).toHaveLength(3);
+    expect(page3.rows[0]?.name).toBe("skill-20");
+  });
+
+  it("filters by name, description, raw kind, and displayed kind label", () => {
+    expect(
+      paginateSkills(catalogue, "go", 1, 10).rows.map((s) => s.name),
+    ).toEqual(["go"]);
+    expect(
+      paginateSkills(catalogue, "community", 1, 10).rows.map((s) => s.name),
+    ).toEqual(["find-skills"]);
+    expect(
+      paginateSkills(catalogue, "imported", 1, 10).rows.map((s) => s.name),
+    ).toEqual(["find-skills"]);
+    // The chip reads "Organization" — that is what people will type.
+    expect(
+      paginateSkills(catalogue, "organization", 1, 10).rows.map((s) => s.name),
+    ).toEqual(["go", "react-webapp"]);
+  });
+
+  it("treats a blank or whitespace query as no filter", () => {
+    expect(paginateSkills(catalogue, "   ", 1, 10).total).toBe(5);
+  });
+
+  it("clamps an out-of-range page to the nearest valid page", () => {
+    const many = Array.from({ length: 23 }, (_, i) => skill(`skill-${i}`));
+    // Page 4 no longer exists after the list shrank to 3 pages.
+    const clamped = paginateSkills(many, "", 4, 10);
+    expect(clamped.page).toBe(3);
+    expect(clamped.rows).toHaveLength(3);
+    // Below 1 clamps up.
+    expect(paginateSkills(many, "", 0, 10).page).toBe(1);
+  });
+
+  it("returns one empty page for an empty or fully-filtered list", () => {
+    const empty = paginateSkills([], "", 1, 10);
+    expect(empty.rows).toEqual([]);
+    expect(empty.pageCount).toBe(1);
+    expect(empty.page).toBe(1);
+
+    const noMatch = paginateSkills(catalogue, "zzz-no-such", 5, 10);
+    expect(noMatch.rows).toEqual([]);
+    expect(noMatch.pageCount).toBe(1);
+    expect(noMatch.page).toBe(1);
+    expect(noMatch.total).toBe(0);
+  });
+});

--- a/apps/console/src/features/settings/skillsList.ts
+++ b/apps/console/src/features/settings/skillsList.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { kindLabel, normalizeKind } from "./skillKind";
+
+// Structural subset of the generated SkillSummary — keeps this module a pure
+// list pipeline, testable without the generated client types.
+interface SkillLike {
+  name: string;
+  kind: string;
+  description?: string;
+}
+
+export interface SkillsPage<T extends SkillLike> {
+  rows: T[];
+  /** The page actually shown — the requested page clamped to [1, pageCount]. */
+  page: number;
+  pageCount: number;
+  /** Matching skills across all pages. */
+  total: number;
+}
+
+// Filter → sort → clamp → slice, in one pure derivation (issue #172): the
+// catalogue is fully loaded (tens of skills), so paging is client-side like
+// the #96 filter. Clamping here — rather than resetting page state in an
+// effect — is what keeps a shrinking list (delete, sync) on the nearest
+// still-valid page.
+export function paginateSkills<T extends SkillLike>(
+  skills: T[],
+  query: string,
+  requestedPage: number,
+  pageSize: number,
+): SkillsPage<T> {
+  const q = query.trim().toLowerCase();
+  // Match the displayed kind label as well as the raw value — the chip reads
+  // "Organization", so that is what people will type.
+  const matches = (skill: T) =>
+    !q ||
+    [
+      skill.name,
+      skill.description,
+      skill.kind,
+      kindLabel(normalizeKind(skill.kind)),
+    ].some((field) => (field ?? "").toLowerCase().includes(q));
+
+  const filtered = skills
+    .filter(matches)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const page = Math.min(Math.max(requestedPage, 1), pageCount);
+
+  return {
+    rows: filtered.slice((page - 1) * pageSize, page * pageSize),
+    page,
+    pageCount,
+    total: filtered.length,
+  };
+}

--- a/apps/console/src/mocks/fixtures/settings.ts
+++ b/apps/console/src/mocks/fixtures/settings.ts
@@ -118,8 +118,10 @@ export const skillsLoadError: ErrorModel = {
 };
 
 // Covers all four kinds (org | platform | custom | imported — the BE's real
-// vocabulary; builtin/flow are retired) so the catalogue's grouped rendering,
+// vocabulary; builtin/flow are retired) so the catalogue's kind chips,
 // read-only vs editable actions, and the updates-available list all exercise.
+// More than one page of skills (10/page, issue #172) so the flat list's
+// pagination is exercisable in mock mode.
 export const seedSkills: SkillDetailBody[] = [
   {
     orgId: "org-1",
@@ -237,6 +239,118 @@ Search the registry, read the SKILL.md, and check the declared license.`,
     references: {},
     contentSha: "sha-fs-1",
     updatedAt: "2026-07-01T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "node-service",
+    kind: "org",
+    editable: false,
+    description: "How to build a Node.js service on the platform.",
+    skillMd: `---
+name: node-service
+description: How to build a Node.js service on the platform.
+---
+
+Pin the LTS base image; expose \`GET /health\` on port **9090**.`,
+    references: {},
+    contentSha: "sha-ns-1",
+    updatedAt: "2026-05-03T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "python-service",
+    kind: "org",
+    editable: false,
+    description: "How to build a Python service on the platform.",
+    skillMd: `---
+name: python-service
+description: How to build a Python service on the platform.
+---
+
+Use \`uv\` for dependency management; expose \`GET /health\` on port **9090**.`,
+    references: {},
+    contentSha: "sha-ps-1",
+    updatedAt: "2026-05-03T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "postgres-schema",
+    kind: "org",
+    editable: false,
+    description: "Schema and migration conventions for platform databases.",
+    skillMd: `---
+name: postgres-schema
+description: Schema and migration conventions for platform databases.
+---
+
+One migration per change; never edit an applied migration.`,
+    references: {},
+    contentSha: "sha-pg-1",
+    updatedAt: "2026-05-04T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "wireframes",
+    kind: "platform",
+    editable: false,
+    description: "Derives per-component wireframes from the design file.",
+    skillMd: `---
+name: wireframes
+description: Derives per-component wireframes from the design file.
+---
+
+Derive one wireframe per user-facing component in the approved design.`,
+    references: {},
+    contentSha: "sha-wf-1",
+    updatedAt: "2026-05-01T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "validation-files",
+    kind: "platform",
+    editable: false,
+    description: "Derives validation files from approved requirements.",
+    skillMd: `---
+name: validation-files
+description: Derives validation files from approved requirements.
+---
+
+Every requirement gets at least one validation criterion.`,
+    references: {},
+    contentSha: "sha-vf-1",
+    updatedAt: "2026-05-01T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "acme-api-style",
+    kind: "custom",
+    editable: true,
+    description: "Acme's REST API naming and versioning conventions.",
+    skillMd: `---
+name: acme-api-style
+description: Acme's REST API naming and versioning conventions.
+---
+
+Plural nouns, kebab-case paths, \`/v1\` prefix, RFC 9457 errors.`,
+    references: {},
+    contentSha: "sha-aas-1",
+    updatedAt: "2026-06-22T00:00:00Z",
+  },
+  {
+    orgId: "org-1",
+    name: "commit-conventions",
+    kind: "imported",
+    editable: true,
+    description: "Conventional-commit message rules for agent-authored PRs.",
+    skillMd: `---
+name: commit-conventions
+description: Conventional-commit message rules for agent-authored PRs.
+---
+
+\`type(scope): summary\` — imperative, no trailing period.`,
+    references: {},
+    contentSha: "sha-cc-1",
+    updatedAt: "2026-07-02T00:00:00Z",
   },
 ];
 


### PR DESCRIPTION
Closes #172. Follow-up to #143 (PR #145 is merged and frozen).

## What changed
- **Flat list replaces the four kind-group sections** on Settings → Skills — one card, alphabetical by name.
- **Kind chip on every row** (`Organization` / `Platform` / `Custom` / `Imported`, existing `kindLabel` + `kindChipColor` mapping). Its **tooltip carries the kind's one-line blurb**, which is also where read-only-ness is stated — the standalone `read-only` chip is removed (non-editable rows also only offer View).
- **Numbered client-side pagination**, fixed 10/page, hidden on a single page. No contract change — `GET /skills` already returns the full catalogue (same rationale as #96's client-side filter).
- **Search retained** (name / description / kind label). A query change resets to page 1; a list shrinking underneath the current page (delete, sync) clamps to the nearest valid page.
- The filter → sort → clamp → slice pipeline is a pure function in `skillsList.ts` with unit tests.
- Mock fixtures grew from 6 to 13 skills so pagination is exercisable in mock mode.

Unchanged: row layout, `update available` chip, toolbar (search / Sync / Import), viewer, editor, import and delete dialogs.

## Decisions
All five delivery decisions (pagination control, sort order, blurb placement, read-only signalling, page-state behavior) are recorded on the issue: https://github.com/wso2/labs-agentic-engineer/issues/172#issuecomment-4933336554

## Verification
- `pnpm --filter @aep/console typecheck` / `test` (51 passed, incl. 6 new for `paginateSkills`) / `lint` — all green.
- Exercised in mock mode (`VITE_API_MODE=mock`, `connected` scenario): page 1 → page 2, search resetting to page 1, kind-label search matches, chip tooltip, "No matches.", pagination hidden on a single page. Pre-existing console warnings (`showName`, Fragment `aria-label`) also occur on the untouched Credentials tab — app-shell noise, not from this change.

Screenshots incoming below (drag-and-drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
