### PR TITLE
polish(console): PAT scope guide on onboarding + Settings GitHub card (#102)

### DIFF
--- a/apps/console/src/features/onboarding/components/GitHubStep.tsx
+++ b/apps/console/src/features/onboarding/components/GitHubStep.tsx
@@ -26,20 +26,9 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import {
-  ExternalLink,
-  Eye,
-  EyeOff,
-  GitHub,
-  Lightbulb,
-} from "@wso2/oxygen-ui-icons-react";
+import { Eye, EyeOff, GitHub, Lightbulb } from "@wso2/oxygen-ui-icons-react";
 import { useConnectGitHubPat } from "../../settings/api/queries";
-
-// Classic-PAT URL preselecting the scopes the platform needs (#102 decision:
-// classic PAT, repo + read:org; exact set confirmed via the BE handshake
-// issue #171 — a correction here is copy-only).
-const TOKEN_URL =
-  "https://github.com/settings/tokens/new?scopes=repo,read:org&description=Agentic%20Engineer%20Platform";
+import { GitHubPatScopeGuide } from "../../settings/components/GitHubPatScopeGuide";
 
 // Validation is the PATCH itself: the BFF probes the PAT against GitHub
 // before persisting (#96 pattern), so errors surface from the mutation.
@@ -63,9 +52,8 @@ export function GitHubStep() {
       </Box>
       <Typography variant="body2" color="text.secondary">
         The platform hosts your organization's skills catalogue and project
-        repos on GitHub. Create a <strong>classic personal access token</strong>{" "}
-        with the <code>repo</code> and <code>read:org</code> scopes, owned by a
-        member of the GitHub organization the platform should use.
+        repos on GitHub. The token must be owned by a member of the GitHub
+        organization the platform should use.
       </Typography>
       <Alert severity="info" icon={<Lightbulb size={18} />}>
         Pro tip: create a dedicated GitHub organization for this platform so
@@ -73,17 +61,7 @@ export function GitHubStep() {
         your team's main org.
       </Alert>
 
-      <Button
-        variant="text"
-        size="small"
-        href={TOKEN_URL}
-        target="_blank"
-        rel="noreferrer"
-        endIcon={<ExternalLink size={14} />}
-        sx={{ alignSelf: "flex-start" }}
-      >
-        Create a token on GitHub (scopes preselected)
-      </Button>
+      <GitHubPatScopeGuide />
 
       <TextField
         required

--- a/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
+++ b/apps/console/src/features/settings/components/GitHubCredentialCard.tsx
@@ -37,9 +37,10 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { ExternalLink, Eye, EyeOff, GitHub, Lightbulb } from "@wso2/oxygen-ui-icons-react";
+import { Eye, EyeOff, GitHub, Lightbulb } from "@wso2/oxygen-ui-icons-react";
 import type { components } from "../../../generated/aep-api";
 import { useConnectGitHubPat, useDisconnectGitProvider } from "../api/queries";
+import { GitHubPatScopeGuide } from "./GitHubPatScopeGuide";
 
 type GitProviderProjection = components["schemas"]["GitProviderProjection"];
 
@@ -123,9 +124,7 @@ export function GitHubCredentialCard({
               Connect a GitHub personal access token with{" "}
               <strong>organization-level access</strong> so the platform can
               read and write this org's spec and code repos and host its skills
-              catalogue. Use a fine-grained token with the organization set as
-              the resource owner, or a classic token with the{" "}
-              <code>repo</code> scope owned by a member of the org.
+              catalogue. The token must be owned by a member of the org.
             </Typography>
             <Alert severity="info" icon={<Lightbulb size={18} />}>
               Pro tip: create a dedicated GitHub organization for this platform
@@ -136,6 +135,7 @@ export function GitHubCredentialCard({
         )}
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <GitHubPatScopeGuide />
           <TextField
             label={
               connected
@@ -172,17 +172,6 @@ export function GitHubCredentialCard({
             helperText="The GitHub organization the platform reads and writes repos in."
             fullWidth
           />
-          <Button
-            variant="text"
-            size="small"
-            href="https://github.com/settings/personal-access-tokens/new"
-            target="_blank"
-            rel="noreferrer"
-            endIcon={<ExternalLink size={14} />}
-            sx={{ alignSelf: "flex-start" }}
-          >
-            Create a token on GitHub
-          </Button>
           {connect.isError && (
             <Alert severity="error">{connect.error.message}</Alert>
           )}

--- a/apps/console/src/features/settings/components/GitHubPatScopeGuide.tsx
+++ b/apps/console/src/features/settings/components/GitHubPatScopeGuide.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Box, Button, Chip, Typography } from "@wso2/oxygen-ui";
+import { ExternalLink } from "@wso2/oxygen-ui-icons-react";
+
+// The platform's documented classic-PAT scope set (carried over from the
+// legacy console's ConnectPATForm; final confirmation tracked on the BE
+// handshake issue #171). Rendered identically by the onboarding wizard and
+// the Settings GitHub card so the two surfaces can't drift.
+const REQUIRED_PAT_SCOPES = [
+  {
+    scope: "repo",
+    why: "read and write the org's spec, code, and skills repositories",
+  },
+  {
+    scope: "admin:org",
+    why: "create and manage repositories under the GitHub organization",
+  },
+  {
+    scope: "admin:repo_hook",
+    why: "register the per-repo webhook when a project repo is provisioned",
+  },
+] as const;
+
+// Classic-token creation URL with the required scopes preselected.
+const TOKEN_URL = `https://github.com/settings/tokens/new?scopes=${REQUIRED_PAT_SCOPES.map(
+  (s) => s.scope,
+).join(",")}&description=Agentic%20Engineer%20Platform`;
+
+// Scope checklist + preselected-scopes creation link for a classic GitHub
+// PAT. The surrounding surface owns any intro copy; this renders only the
+// guidance that must stay identical everywhere.
+export function GitHubPatScopeGuide() {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Typography variant="body2">
+        The token must be a <strong>classic personal access token</strong> with
+        these scopes:
+      </Typography>
+      <Box
+        component="ul"
+        sx={{
+          m: 0,
+          pl: 3,
+          display: "flex",
+          flexDirection: "column",
+          gap: 0.75,
+        }}
+      >
+        {REQUIRED_PAT_SCOPES.map(({ scope, why }) => (
+          <Typography key={scope} component="li" variant="body2">
+            <Chip
+              label={scope}
+              size="small"
+              sx={{ fontFamily: "monospace", mr: 1 }}
+            />
+            {why}
+          </Typography>
+        ))}
+      </Box>
+      <Button
+        variant="text"
+        size="small"
+        href={TOKEN_URL}
+        target="_blank"
+        rel="noreferrer"
+        endIcon={<ExternalLink size={14} />}
+        sx={{ alignSelf: "flex-start" }}
+      >
+        Create a token on GitHub (scopes preselected)
+      </Button>
+    </Box>
+  );
+}

--- a/services/aep-api/internal/feature/orgconfig/config_actions_component_test.go
+++ b/services/aep-api/internal/feature/orgconfig/config_actions_component_test.go
@@ -104,6 +104,13 @@ func TestConfigComponent_Disconnect_ConnectedThenGone(t *testing.T) {
 	if m := decodeCfg(t, resp.Body.Bytes()); m["status"] != "disconnected" {
 		t.Fatalf("disconnect body drifted: %v", m)
 	}
+	// The credential row is retained (status flip, not delete — audit trail and
+	// app re-adoption need it), but the config contract says null = not
+	// connected (types.go, ADR-0009): a disconnected org must project
+	// gitProvider as null so the console re-gates onboarding at the GitHub step.
+	if m := decodeCfg(t, c.h.AsOrg("acme").Get(configPath).Body.Bytes()); m["gitProvider"] != nil {
+		t.Fatalf("disconnected gitProvider must project as null: %v", m["gitProvider"])
+	}
 }
 
 func TestConfigComponent_Disconnect_NeverConnected(t *testing.T) {

--- a/services/aep-api/internal/feature/orgconfig/service.go
+++ b/services/aep-api/internal/feature/orgconfig/service.go
@@ -140,9 +140,13 @@ func (s *Service) Get(ctx context.Context, org string) (*ConfigProjection, error
 	if s.credentialSvc != nil {
 		proj, err := s.credentialSvc.Status(ctx, org)
 		switch {
-		case err == nil:
+		// A disconnected row is retained by the disconnect cascade (audit trail,
+		// app re-adoption) but the config contract says null = not connected —
+		// projecting it would keep the console's onboarding gate (ADR-0009) and
+		// settings card treating the org as connected.
+		case err == nil && proj.Status != "disconnected":
 			out.GitProvider = gitProviderProjectionFrom(proj)
-		case isNotFound(err):
+		case err == nil || isNotFound(err):
 			out.GitProvider = nil
 		default:
 			return nil, fmt.Errorf("orgconfig get gitProvider: %w", err)


### PR DESCRIPTION
Follow-up to #174 (merged while this was in flight — frozen, so this rides its own PR). Refs #102, #96; scope confirmation tracked on #171.

## What

- New `GitHubPatScopeGuide` (in `features/settings/components/`, reused by the onboarding wizard): the platform's **documented** classic-PAT scope set with per-scope rationale —
  - `repo` — read and write the org's spec, code, and skills repositories
  - `admin:org` — create and manage repositories under the GitHub organization
  - `admin:repo_hook` — register the per-repo webhook when a project repo is provisioned
- Set carried over from the legacy console's `ConnectPATForm` ("Required scopes: repo, admin:org, admin:repo_hook"), replacing the `repo` + `read:org` guess that shipped in #174; grounded against current aep-api (`webhook_service.go` registers per-repo hooks for PAT credentials).
- Token-creation link now preselects these scopes; the Settings card's stale fine-grained-token copy is gone. One component on both surfaces so the guidance can't drift.

## Verified (mock mode)

Wizard step 1 and Settings → Credentials (not-connected and connected/replace) render the identical guide; `pnpm test` 45/45, `tsc` + `eslint` clean. Screenshots attached below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR: disconnected git provider projects as null (aep-api)

`51e9648` fixes the disconnect flow this same surface exposed: the disconnect cascade retains the credential row with `status='disconnected'` (audit trail, app re-adoption), but `GET /config` projected that retained row as a live `gitProvider` section. The contract says null = not connected (ADR-0009), so the Settings card kept showing a green "disconnected" chip and the onboarding wizard skipped the GitHub step after a disconnect. `orgconfig.Service.Get` now maps a disconnected row to `gitProvider: null`; regression assertion added to `TestConfigComponent_Disconnect_ConnectedThenGone` (failed before the fix). `orgconfig` + `orgcreds` component suites green against a real Postgres testcontainer.
