### PR TITLE
fix(aep-api): serve repoUrl in GET /skills — Import dialog's PR tab always showed "connect GitHub"

### DIFF
--- a/services/aep-api/internal/feature/skills/repo_store.go
+++ b/services/aep-api/internal/feature/skills/repo_store.go
@@ -171,6 +171,24 @@ func (s *SkillService) ListSummaries(ctx context.Context, orgID string) ([]Skill
 	return out, nil
 }
 
+// RepoWebURL returns the HTML URL of the org's skills repo — the stored clone
+// URL with any ".git" suffix trimmed (the contract SkillSummaryList.repoUrl;
+// it powers the console Import dialog's via-pull-request link). Provisions the
+// repo on first touch like every read, and degrades to "" on any failure —
+// same posture as the catalog (§12); the console shows its connect-GitHub
+// guidance for an empty URL.
+func (s *SkillService) RepoWebURL(ctx context.Context, orgID string) string {
+	if s == nil || s.git == nil || s.repos == nil || orgID == "" {
+		return ""
+	}
+	repo, err := s.ensureSkillsRepo(ctx, orgID)
+	if err != nil {
+		slog.WarnContext(ctx, "skills: resolve repo url failed — serving empty", "org", orgID, "error", err)
+		return ""
+	}
+	return strings.TrimSuffix(repo.RepoURL, ".git")
+}
+
 // ---- catalog loading ---------------------------------------------------------
 
 // catalog returns the org's skills at the branch tip, degrading to empty on

--- a/services/aep-api/internal/feature/skills/repo_store_test.go
+++ b/services/aep-api/internal/feature/skills/repo_store_test.go
@@ -188,6 +188,41 @@ func TestList_SeedsBuiltinsOnFirstRead(t *testing.T) {
 	}
 }
 
+// RepoWebURL powers the console Import dialog's "open the org skills repo"
+// link (the GET /skills envelope's repoUrl — contract SkillSummaryList). It is
+// the stored clone URL projected to the HTML URL (".git" trimmed), provisioning
+// the repo on first touch like every other read.
+func TestRepoWebURL_ProjectsCloneURLToHTMLURL(t *testing.T) {
+	t.Parallel()
+	svc, host := newTestStore(t)
+	ctx := context.Background()
+
+	got := svc.RepoWebURL(ctx, "org1")
+	if got == "" {
+		t.Fatalf("RepoWebURL: want the provisioned repo's HTML URL, got empty")
+	}
+	row, err := host.GetRepo(ctx, "org1", SkillsRepoProject)
+	if err != nil {
+		t.Fatalf("repo row must be provisioned by RepoWebURL: %v", err)
+	}
+	if want := strings.TrimSuffix(row.RepoURL, ".git"); got != want {
+		t.Fatalf("RepoWebURL = %q, want %q", got, want)
+	}
+	if strings.HasSuffix(got, ".git") {
+		t.Fatalf("RepoWebURL must be the HTML URL, not the clone URL: %q", got)
+	}
+}
+
+// A degraded boot (no git plumbing wired) serves "" — same posture as the
+// catalog's degrade-to-empty; the console shows its connect-GitHub guidance.
+func TestRepoWebURL_DegradesToEmpty(t *testing.T) {
+	t.Parallel()
+	svc := NewSkillService(nil, nil)
+	if got := svc.RepoWebURL(context.Background(), "org1"); got != "" {
+		t.Fatalf("RepoWebURL on degraded service = %q, want empty", got)
+	}
+}
+
 func TestFreshOrgProvisioning_SeedsEmbeddedLibrary(t *testing.T) {
 	t.Parallel()
 	svc, host := newTestStore(t)

--- a/services/aep-api/internal/feature/skills/skill_component_test.go
+++ b/services/aep-api/internal/feature/skills/skill_component_test.go
@@ -154,12 +154,18 @@ func TestSkillsComponent_List_MatchesGolden(t *testing.T) {
 		t.Fatalf("skills[] element field set drifted:\n got %v\nwant %v", gotElem, wantElem)
 	}
 
-	// Semantics: the seeded built-ins are present, read-only.
+	// Semantics: the seeded built-ins are present, read-only — and the envelope
+	// carries the org skills repo's HTML URL (contract SkillSummaryList.repoUrl;
+	// the console Import dialog's via-pull-request link depends on it).
 	var obj struct {
-		Skills []map[string]any `json:"skills"`
+		Skills  []map[string]any `json:"skills"`
+		RepoURL string           `json:"repoUrl"`
 	}
 	if err := json.Unmarshal(resp.Body.Bytes(), &obj); err != nil {
 		t.Fatalf("decode: %v", err)
+	}
+	if obj.RepoURL == "" {
+		t.Fatalf("list envelope must carry repoUrl (org skills repo HTML URL): %s", resp.Body.String())
 	}
 	var sawGo bool
 	for _, s := range obj.Skills {

--- a/services/aep-api/internal/feature/skills/skill_huma.go
+++ b/services/aep-api/internal/feature/skills/skill_huma.go
@@ -122,7 +122,14 @@ func RegisterSkill(
 		if err != nil {
 			return nil, mapSkillError(err)
 		}
-		return &skillListOutput{Body: map[string]any{"skills": summaries}}, nil
+		// repoUrl is the org skills repo's HTML URL (contract
+		// SkillSummaryList.repoUrl) — "" while the repo can't be provisioned
+		// (e.g. GitHub not connected yet); the console keys its Import
+		// dialog's via-pull-request guidance off it.
+		return &skillListOutput{Body: map[string]any{
+			"skills":  summaries,
+			"repoUrl": skillSvc.RepoWebURL(ctx, in.OrgHandle),
+		}}, nil
 	})
 
 	huma.Register(api, huma.Operation{

--- a/services/aep-api/testdata/harvest/golden/get_org_skills.json
+++ b/services/aep-api/testdata/harvest/golden/get_org_skills.json
@@ -28,5 +28,6 @@
       "contentSha": "d8f8ccc491f493f02e396a2d39fc8c1924913884aa86476474e1a51968bd946b",
       "editable": false
     }
-  ]
+  ],
+  "repoUrl": "https://github.com/asdlc-repos/org-skills"
 }


### PR DESCRIPTION
## Problem

Settings → Skills → Import → **Via pull request** always shows

> The org skills repo isn't available yet — connect GitHub and the platform will provision it.

even when GitHub is connected and the `org-skills` repo exists.

## Root cause

The committed contract (`packages/contracts/api/v1/openapi.yaml`, `SkillSummaryList`) requires `repoUrl` — the HTML URL of the org skills repo — in the `GET /skills` envelope, and the console keys the dialog's via-PR guidance off it (`ImportSkillDialog` renders the connect-GitHub alert whenever `repoUrl` is falsy). But the `list-skills` handler only ever returned `{"skills": ...}`, so the field was always absent and the alert always showed. (The MSW mock layer does return `repoUrl`, which is why dev-with-mocks looked fine.)

## Fix

Contract-first, code → spec:

- `SkillService.RepoWebURL(ctx, orgID)` — the stored clone URL projected to the HTML URL (`.git` trimmed), provisioning the repo on first touch like every other read and degrading to `""` on failure (same posture as the catalog's degrade-to-empty §12; an empty URL is exactly the state where the console's connect-GitHub guidance is correct).
- The `list-skills` handler now includes `repoUrl` in the envelope.
- Golden `get_org_skills.json` updated; component test asserts the envelope carries a non-empty `repoUrl`; unit tests pin the HTML-URL projection and the degraded-boot empty.

No console change needed — the generated client types already carry `repoUrl` and the dialog logic is correct once the field arrives.

## Testing

- New failing-first tests: `TestRepoWebURL_ProjectsCloneURLToHTMLURL`, `TestRepoWebURL_DegradesToEmpty`, and the extended `TestSkillsComponent_List_MatchesGolden` (real handler chain over real bare git origins).
- Full `services/aep-api` short suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)