### PR TITLE
feat(aep-api): filter Tasks by build/spec version via an aep:spec/<tag> label

### DIFF
--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -3239,6 +3239,13 @@ paths:
               - closed
               - all
             type: string
+        - description: Filter to Tasks planned from this spec/build version tag (e.g. v3); empty returns all versions.
+          explode: false
+          in: query
+          name: tag
+          schema:
+            description: Filter to Tasks planned from this spec/build version tag (e.g. v3); empty returns all versions.
+            type: string
       responses:
         "200":
           content:
@@ -3258,7 +3265,7 @@ paths:
           description: Error
       security:
         - userJWT: []
-      summary: List a project's Tasks (live GitHub ⋈ executions → derived status)
+      summary: List a project's Tasks (live GitHub ⋈ executions → derived status), optionally scoped to one spec/build version tag
       tags:
         - Tasks
   /projects/{projectName}/tasks/{issueNumber}:

--- a/services/aep-api/internal/contracts/taskmeta/labels.go
+++ b/services/aep-api/internal/contracts/taskmeta/labels.go
@@ -65,6 +65,15 @@ const (
 	// Classify vocabulary (it classifies as KindOther) so the status-projection
 	// reconciler never strips it.
 	LabelProvisionNoted = "aep:provision-noted"
+
+	// LabelSpecPrefix is prepended to a spec version tag (v<N>) to form its
+	// label ("aep:spec/v3"), so Tasks are filterable server-side (GitHub
+	// labels=) by the spec/build version they were planned from. Like the other
+	// prefixes it carries a flat, filterable fact; the structured value also
+	// lives in the machine block (block.SpecTag). It is deliberately absent from
+	// Classify (it classifies as KindOther) so the status-projection reconciler
+	// never strips it — the same guarantee LabelProvisionNoted relies on.
+	LabelSpecPrefix = "aep:spec/"
 )
 
 // ExecutorClass is the single routing dimension (§3): coding tasks are
@@ -97,6 +106,16 @@ func OriginLabel(o Origin) string { return LabelOriginPrefix + string(o) }
 // StatusLabel returns the projection label for a derived status
 // ("aep:status/ready_for_review"). Platform-written only.
 func StatusLabel(s DerivedStatus) string { return LabelStatusPrefix + string(s) }
+
+// SpecTagLabel returns the spec-version label for a spec/build tag
+// ("aep:spec/v3"). An empty tag yields "" (no label) so callers can append it
+// unconditionally.
+func SpecTagLabel(tag string) string {
+	if tag == "" {
+		return ""
+	}
+	return LabelSpecPrefix + tag
+}
 
 // NewTaskLabels is the label set stamped on a freshly created Task: marker,
 // class, origin. Command and projection labels are added later by humans and

--- a/services/aep-api/internal/contracts/taskmeta/labels_test.go
+++ b/services/aep-api/internal/contracts/taskmeta/labels_test.go
@@ -34,6 +34,12 @@ func TestLabelBuilders(t *testing.T) {
 	if got := StatusLabel(StatusReadyForReview); got != "aep:status/ready_for_review" {
 		t.Errorf("StatusLabel = %q", got)
 	}
+	if got := SpecTagLabel("v3"); got != "aep:spec/v3" {
+		t.Errorf("SpecTagLabel(v3) = %q", got)
+	}
+	if got := SpecTagLabel(""); got != "" {
+		t.Errorf("SpecTagLabel(\"\") = %q; want empty (no label)", got)
+	}
 	got := NewTaskLabels(ClassCoding, OriginSpecPlan)
 	want := []string{"aep:task", "aep:coding", "aep:origin/spec-plan"}
 	if !reflect.DeepEqual(got, want) {
@@ -51,8 +57,11 @@ func TestClassify(t *testing.T) {
 		"aep:hold":               KindHold,
 		"aep:status/in_progress": KindStatus,
 		"aep:attention":          KindAttention,
-		"bug":                    KindOther,
-		"aep:unknown":            KindOther,
+		// aep:spec/<tag> is deliberately KindOther so the projection reconciler
+		// never strips the build-lineage label.
+		"aep:spec/v3": KindOther,
+		"bug":         KindOther,
+		"aep:unknown": KindOther,
 	}
 	for label, want := range tests {
 		if got := Classify(label); got != want {

--- a/services/aep-api/internal/feature/build/build_huma.go
+++ b/services/aep-api/internal/feature/build/build_huma.go
@@ -240,17 +240,16 @@ func (s *Service) taskStatuses(ctx context.Context, orgID, projectID, tag string
 	byIssue := map[int]*BuildStatusTask{}
 	order := make([]int, 0)
 
-	// 1. Durable base: the tasks stamped with this build's lineage tag.
+	// 1. Durable base: the tasks stamped with this build's lineage tag. The
+	// aep:spec/<tag> label scopes the read server-side, so every returned row
+	// already belongs to this version.
 	if s.tasks != nil {
-		views, err := s.tasks.List(ctx, orgID, projectID, "all")
+		views, err := s.tasks.ListByTag(ctx, orgID, projectID, "all", tag)
 		if err != nil {
 			slog.WarnContext(ctx, "build status: durable task read failed",
 				"org", orgID, "project", projectID, "error", err)
 		}
 		for _, v := range views {
-			if v.Lineage.SpecTag != tag {
-				continue // a different version's task
-			}
 			bt := BuildStatusTask{
 				IssueNumber: int64(v.IssueNumber),
 				Title:       v.Title,

--- a/services/aep-api/internal/feature/build/build_test.go
+++ b/services/aep-api/internal/feature/build/build_test.go
@@ -97,8 +97,22 @@ type fakeTasks struct {
 	err   error
 }
 
-func (f fakeTasks) List(context.Context, string, string, string) ([]task.TaskView, error) {
-	return f.views, f.err
+func (f fakeTasks) ListByTag(_ context.Context, _, _, _, tag string) ([]task.TaskView, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if tag == "" {
+		return f.views, nil
+	}
+	// Mirror the real read: the aep:spec/<tag> label scopes to one version, so
+	// every returned row carries that specTag.
+	out := make([]task.TaskView, 0, len(f.views))
+	for _, v := range f.views {
+		if v.Lineage.SpecTag == tag {
+			out = append(out, v)
+		}
+	}
+	return out, nil
 }
 
 func newSvc(runner *fakeRunner, store *fakeStore, repos fakeRepos, tagger *fakeTagger, tasks TaskReader) *Service {

--- a/services/aep-api/internal/feature/build/ports.go
+++ b/services/aep-api/internal/feature/build/ports.go
@@ -69,10 +69,10 @@ type WorkflowRunner interface {
 }
 
 // TaskReader is the DURABLE task source behind a build's task list: the live
-// GitHub ⋈ executions read (the same one behind GET /tasks), which the build
-// scopes to its own lineage tag. It survives an archived Temporal run — the
-// workflow query only refines in-flight status on top of it. Satisfied by
-// *task.Reads.
+// GitHub ⋈ executions read (the same one behind GET /tasks), scoped by the build
+// to its own lineage tag via the aep:spec/<tag> label. It survives an archived
+// Temporal run — the workflow query only refines in-flight status on top of it.
+// Satisfied by *task.Reads.
 type TaskReader interface {
-	List(ctx context.Context, orgID, projectID, state string) ([]task.TaskView, error)
+	ListByTag(ctx context.Context, orgID, projectID, state, tag string) ([]task.TaskView, error)
 }

--- a/services/aep-api/internal/feature/task/plan_tap.go
+++ b/services/aep-api/internal/feature/task/plan_tap.go
@@ -236,6 +236,12 @@ func (t *planTap) handlePlan(out *taskplan.PlanTaskOk) {
 		return
 	}
 	labels := taskmeta.NewTaskLabels(taskmeta.ClassCoding, origin)
+	// Stamp the build/spec version as a filterable label so Tasks can be listed
+	// server-side by the version they were planned from (aep:spec/<tag>). The
+	// same value is the block's structured specTag; the label is its flat mirror.
+	if l := taskmeta.SpecTagLabel(t.specTag); l != "" {
+		labels = append(labels, l)
+	}
 	issue, err := t.issues.CreateIssue(t.ctx, t.orgID, t.projectID, gitrepo.CreateIssueRequest{
 		Title:  out.Title,
 		Body:   body,

--- a/services/aep-api/internal/feature/task/plan_tap_test.go
+++ b/services/aep-api/internal/feature/task/plan_tap_test.go
@@ -84,8 +84,8 @@ func TestPlanTap_PlanCreatesIssueWithLabelsAndBlock(t *testing.T) {
 		t.Fatalf("expected 1 issue created, got %d", len(issues.created))
 	}
 	got := issues.created[0]
-	// Labels: marker + class + origin.
-	for _, want := range []string{taskmeta.LabelMarker, taskmeta.LabelCoding, taskmeta.OriginLabel(taskmeta.OriginSpecPlan)} {
+	// Labels: marker + class + origin + the spec-version lineage label.
+	for _, want := range []string{taskmeta.LabelMarker, taskmeta.LabelCoding, taskmeta.OriginLabel(taskmeta.OriginSpecPlan), taskmeta.SpecTagLabel("req-v1")} {
 		if !issueHasAll(got.Labels, []string{want}) {
 			t.Errorf("expected label %q, got %v", want, got.Labels)
 		}
@@ -374,5 +374,22 @@ func gitrepoIssue(number int, component, designTag string) gitrepo.IssueInfo {
 		State:  "open",
 		URL:    fmt.Sprintf("https://github.com/o/r/issues/%d", number),
 		Labels: taskmeta.NewTaskLabels(taskmeta.ClassCoding, taskmeta.OriginSpecPlan),
+	}
+}
+
+// taggedIssue builds a seeded Task issue stamped with a spec version, exactly as
+// plan_tap writes it: the aep:spec/<tag> label plus the specTag in its machine
+// block.
+func taggedIssue(number int, component, specTag string) gitrepo.IssueInfo {
+	block := taskmeta.Block{Component: component, Origin: taskmeta.OriginSpecPlan, SpecTag: specTag, DesignTag: "design-v1"}
+	body := taskmeta.ComposeBody(block, taskmeta.Human{Rationale: "orig"})
+	labels := append(taskmeta.NewTaskLabels(taskmeta.ClassCoding, taskmeta.OriginSpecPlan), taskmeta.SpecTagLabel(specTag))
+	return gitrepo.IssueInfo{
+		Number: number,
+		Title:  "Implement " + component,
+		Body:   body,
+		State:  "open",
+		URL:    fmt.Sprintf("https://github.com/o/r/issues/%d", number),
+		Labels: labels,
 	}
 }

--- a/services/aep-api/internal/feature/task/reads.go
+++ b/services/aep-api/internal/feature/task/reads.go
@@ -90,11 +90,24 @@ func NewReads(issues IssueClient, repos RepoResolver, execs ExecutionReader, ver
 // List returns the project's Tasks filtered by state ("open" | "closed" |
 // "all"; default "open"). FE groups by derivedStatus client-side (§8).
 func (r *Reads) List(ctx context.Context, orgID, projectID, state string) ([]TaskView, error) {
+	return r.ListByTag(ctx, orgID, projectID, state, "")
+}
+
+// ListByTag is List additionally scoped to a single spec/build version tag: it
+// returns only Tasks carrying the aep:spec/<tag> label (ANDed with the Task
+// marker, server-side via the GitHub labels= query). An empty tag returns every
+// Task (== List). This is the read behind GET /tasks?tag=v3 and the build's
+// per-version task list.
+func (r *Reads) ListByTag(ctx context.Context, orgID, projectID, state, tag string) ([]TaskView, error) {
 	repoFullName, err := resolveRepoFullName(ctx, r.repos, orgID, projectID)
 	if err != nil {
 		return nil, err
 	}
-	issues, err := r.issues.ListIssues(ctx, orgID, projectID, []string{taskmeta.LabelMarker})
+	labels := []string{taskmeta.LabelMarker}
+	if l := taskmeta.SpecTagLabel(tag); l != "" {
+		labels = append(labels, l)
+	}
+	issues, err := r.issues.ListIssues(ctx, orgID, projectID, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/services/aep-api/internal/feature/task/task_huma.go
+++ b/services/aep-api/internal/feature/task/task_huma.go
@@ -48,6 +48,7 @@ type listInput struct {
 	humakit.OrgScopedInput
 	ProjectName string `path:"projectName" doc:"Project name (DNS-label slug)"`
 	State       string `query:"state" enum:"open,closed,all" doc:"Which Tasks to return (default open)"`
+	Tag         string `query:"tag" doc:"Filter to Tasks planned from this spec/build version tag (e.g. v3); empty returns all versions."`
 }
 
 type listOutput struct {
@@ -98,14 +99,14 @@ func RegisterTask(api huma.API, reads *Reads, commands *Commands, plan *PlanServ
 		OperationID: "list-tasks",
 		Method:      http.MethodGet,
 		Path:        "/projects/{projectName}/tasks",
-		Summary:     "List a project's Tasks (live GitHub ⋈ executions → derived status)",
+		Summary:     "List a project's Tasks (live GitHub ⋈ executions → derived status), optionally scoped to one spec/build version tag",
 		Tags:        []string{"Tasks"},
 		Security:    humakit.SecurityUserJWT,
 	}, func(ctx context.Context, in *listInput) (*listOutput, error) {
 		if reads == nil {
 			return nil, huma.Error503ServiceUnavailable("tasks not configured")
 		}
-		views, err := reads.List(ctx, in.OrgHandle, in.ProjectName, in.State)
+		views, err := reads.ListByTag(ctx, in.OrgHandle, in.ProjectName, in.State, in.Tag)
 		if err != nil {
 			return nil, mapReadError(err)
 		}

--- a/services/aep-api/internal/feature/task/task_test.go
+++ b/services/aep-api/internal/feature/task/task_test.go
@@ -97,6 +97,36 @@ func TestReads_List_DerivesStatusFromExecutions(t *testing.T) {
 	}
 }
 
+func TestReads_ListByTag_FiltersBySpecLabel(t *testing.T) {
+	issues := newFakeIssues()
+	issues.seed(taggedIssue(1, "user-service", "v3"))
+	issues.seed(taggedIssue(2, "order-service", "v3"))
+	issues.seed(taggedIssue(3, "cart-service", "v2")) // an earlier build's task
+
+	// Scoped to v3: only the two v3 Tasks (the label query excludes v2).
+	views, err := newReads(issues, newFakeExecReader()).ListByTag(context.Background(), "org1", "proj1", "all", "v3")
+	if err != nil {
+		t.Fatalf("ListByTag(v3): %v", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("want 2 tasks for v3, got %d: %+v", len(views), views)
+	}
+	for _, v := range views {
+		if v.Lineage.SpecTag != "v3" {
+			t.Errorf("view %d specTag = %q, want v3", v.IssueNumber, v.Lineage.SpecTag)
+		}
+	}
+
+	// Empty tag is identical to List: every Task, regardless of version.
+	all, err := newReads(issues, newFakeExecReader()).ListByTag(context.Background(), "org1", "proj1", "all", "")
+	if err != nil {
+		t.Fatalf("ListByTag(all): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("empty tag must return all tasks, got %d", len(all))
+	}
+}
+
 func TestReads_List_CarriesHumanBodyWithoutMachineBlock(t *testing.T) {
 	issues := newFakeIssues()
 	block := taskmeta.Block{Component: "user-service", Origin: taskmeta.OriginSpecPlan, DesignTag: "design-v1"}


### PR DESCRIPTION
## What

Adds a way to list a project's Tasks scoped to one build/spec version.

- **Label the lineage.** Every planned Task issue is stamped with an `aep:spec/<tag>` label (the build's `v<N>` version) at creation, alongside the existing `specTag` machine-block field. The label is the flat, GitHub-filterable mirror of the structured block value.
- **New filter.** `GET /projects/{projectName}/tasks` gains an optional `?tag=v3` query param that scopes the result to that version via a **server-side GitHub `labels=` AND-filter** (`aep:task` + `aep:spec/v3`). Omitted → all versions (unchanged behavior). Returns the full `TaskView[]` — same shape as `list-tasks`.
- **One filter path.** `GET /projects/{projectName}/build/{tag}` moves off its in-Go `Lineage.SpecTag` compare onto the same label-scoped read (`ListByTag`), so both surfaces share one mechanism.

## Why

`/build/{tag}` already listed a version's tasks by filtering in Go; this promotes the build tag to a first-class, GitHub-queryable label so the same scoping is available on the general `list-tasks` surface (and in the GitHub UI) and both endpoints filter the same way.

## Design notes

- Chose a **query param on `list-tasks`** over a `tasks/{tag}` path — the latter collides with `tasks/{issueNumber}` under Go's `ServeMux` (panics at boot).
- `aep:spec/<tag>` is deliberately kept **out of `taskmeta.Classify` (→ `KindOther`)** so the status-projection reconciler never strips it — the same guarantee `aep:provision-noted` relies on. All label mutations in the codebase are incremental `AddLabels`/`RemoveLabel`; nothing does a wholesale `SetLabels`.
- `Reads.List(state)` is kept as a thin wrapper over `ListByTag(state, "")`, so the `build` `TaskReader` port and the devflow planner adapter are unchanged.

## Files

| Area | Change |
|---|---|
| `contracts/taskmeta/labels.go` | `LabelSpecPrefix` + `SpecTagLabel()` |
| `feature/task/plan_tap.go` | stamp the spec label on issue creation |
| `feature/task/reads.go` | `ListByTag`; `List` delegates |
| `feature/task/task_huma.go` | optional `?tag=` on `list-tasks` |
| `feature/build/{ports,build_huma}.go` | `TaskReader.ListByTag`; drop manual `specTag` filter |
| `packages/contracts/api/v1/openapi.yaml` | `tag` query param on `list-tasks` |

## Test plan

- **Unit/component (Go):** `SpecTagLabel` + `Classify(aep:spec/*)→KindOther`; `plan_tap` stamps the label; `ListByTag` filters by the label (empty tag → all); build's per-tag lineage tests pass through the migrated `ListByTag`. `go build` / `vet` / `gofmt` / `golangci-lint` clean.
- **Live e2e against real GitHub** (local cluster, real build + real agent planning on `asdlc-repos/hello-world-apii32r41`):
  - Direct GitHub read: created issue carries `["aep:task","aep:coding","aep:origin/spec-plan","aep:spec/v1"]` ✅
  - `GET /tasks?tag=v1` → the task (real `labels=` match) ✅
  - `GET /tasks?tag=v2` (bogus) → empty ✅
  - `GET /tasks` (no tag) → all ✅
  - `GET /build/v1` (migrated path) → lists the task ✅

## Notes

- The `tag` filter is label-based; Tasks created **before** this change won't carry the label. Fine for a forward-looking feature; `/build/{tag}`'s prior `specTag` compare covered historical rows, so this is a conscious trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)