### PR TITLE
fix(console): open API contract in an authenticated in-app dialog

### DIFF
--- a/apps/console/src/features/projects/api/keys.ts
+++ b/apps/console/src/features/projects/api/keys.ts
@@ -26,6 +26,8 @@ export const projectKeys = {
   status: (name: string) => [...projectKeys.detail(name), "status"] as const,
   components: (name: string) =>
     [...projectKeys.detail(name), "components"] as const,
+  componentOpenapi: (name: string, component: string) =>
+    [...projectKeys.components(name), component, "openapi"] as const,
   tasks: (name: string) => [...projectKeys.detail(name), "tasks"] as const,
   tags: (name: string) => [...projectKeys.detail(name), "tags"] as const,
 };

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -149,6 +149,36 @@ export function useProjectComponents(projectName: string) {
   );
 }
 
+// A service component's OpenAPI contract, for the in-app viewer dialog. Lazy
+// (`enabled`) — only fetched when the user opens the contract, not on every
+// overview render. Goes through the authenticated client so the Bearer token
+// rides along; the old plain <a href> to this JWT-guarded endpoint 401'd
+// because a browser navigation carries no Authorization header.
+export function useComponentOpenApi(
+  projectName: string,
+  componentName: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: projectKeys.componentOpenapi(projectName, componentName),
+    enabled,
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/projects/{projectName}/components/{componentName}/openapi",
+        { params: { path: { projectName, componentName } } },
+      );
+      if (error || data === undefined) {
+        const e = error as { detail?: string; title?: string } | undefined;
+        throw new Error(
+          e?.detail ?? e?.title ?? "Failed to load the API contract",
+        );
+      }
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}
+
 // Spec version tags (#117). The BE hasn't implemented /tags yet, so a failed
 // read degrades to "no tags" instead of an error card — the version chips
 // simply don't render until the endpoint lands.

--- a/apps/console/src/features/projects/components/ComponentOpenApiDialog.tsx
+++ b/apps/console/src/features/projects/components/ComponentOpenApiDialog.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { OpenApiView } from "@aep/ui-openapi-view";
+import { useComponentOpenApi } from "../api/queries";
+
+// Renders a service component's OpenAPI contract in-app via the shared
+// OpenApiView. Replaces the old "API contract" link, which navigated the
+// browser straight to the JWT-guarded /openapi endpoint and 401'd (a raw
+// navigation carries no Bearer token). Fetching through the authenticated
+// client fixes that; the viewer also renders the spec instead of dumping the
+// endpoint's `{ spec }` JSON envelope into a new tab.
+export function ComponentOpenApiDialog({
+  projectName,
+  componentName,
+  onClose,
+}: {
+  projectName: string;
+  componentName: string | null;
+  onClose: () => void;
+}) {
+  const open = componentName !== null;
+  const { data, isLoading, isError, error } = useComponentOpenApi(
+    projectName,
+    componentName ?? "",
+    open,
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        <Typography variant="h6" fontWeight={700}>
+          {componentName} · API contract
+        </Typography>
+      </DialogTitle>
+
+      {/* OpenApiView owns its own padding + scroll (height: 100%), so the
+          content area is zero-padding and height-bounded. */}
+      <DialogContent dividers sx={{ p: 0, height: "80vh" }}>
+        {isLoading && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {isError && (
+          <Box sx={{ p: 3 }}>
+            <Alert severity="error">
+              {error?.message ?? "Failed to load the API contract"}
+            </Alert>
+          </Box>
+        )}
+
+        {data && <OpenApiView spec={data.spec} />}
+      </DialogContent>
+
+      <DialogActions>
+        <Button variant="contained" onClick={onClose}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/console/src/features/projects/components/ComponentsList.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { useState } from "react";
 import {
   Avatar,
   Chip,
@@ -25,14 +26,14 @@ import {
 } from "@wso2/oxygen-ui";
 import { ExternalLink, FileCode } from "@wso2/oxygen-ui-icons-react";
 import type { components } from "../../../generated/aep-api";
-import { env } from "../../../config/env";
+import { ComponentOpenApiDialog } from "./ComponentOpenApiDialog";
 
 type Component = components["schemas"]["Component"];
 
 // The component type is OpenChoreo's own ComponentType name, end-to-end.
 const isWebApp = (c: Component) => c.type === "web-application";
 
-function componentLink(projectName: string, c: Component) {
+function componentLink(c: Component, onOpenContract: (name: string) => void) {
   if (isWebApp(c)) {
     return c.endpointUrl ? (
       <MuiLink
@@ -50,14 +51,22 @@ function componentLink(projectName: string, c: Component) {
       </Typography>
     );
   }
-  // API/service rows link to the component's OpenAPI contract.
+  // API/service rows open the component's OpenAPI contract in-app. It's a
+  // button, not an <a href>: the /openapi endpoint is JWT-guarded and a raw
+  // browser navigation carries no Bearer token (401). The dialog fetches
+  // through the authenticated client instead.
   return (
     <MuiLink
-      href={`${env.apiBaseUrl}/api/v1/projects/${projectName}/components/${c.name}/openapi`}
-      target="_blank"
-      rel="noreferrer"
+      component="button"
+      type="button"
+      onClick={() => onOpenContract(c.name)}
       variant="body2"
-      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.5,
+        verticalAlign: "baseline",
+      }}
     >
       API contract <FileCode size={14} />
     </MuiLink>
@@ -73,6 +82,10 @@ export function ComponentsList({
   projectName: string;
   items: Component[];
 }) {
+  const [contractComponent, setContractComponent] = useState<string | null>(
+    null,
+  );
+
   if (items.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 3 }}>
@@ -134,12 +147,17 @@ export function ComponentsList({
                 />
               </ListingTable.Cell>
               <ListingTable.Cell sx={{ maxWidth: 200 }}>
-                {componentLink(projectName, c)}
+                {componentLink(c, setContractComponent)}
               </ListingTable.Cell>
             </ListingTable.Row>
           ))}
         </ListingTable.Body>
       </ListingTable>
+      <ComponentOpenApiDialog
+        projectName={projectName}
+        componentName={contractComponent}
+        onClose={() => setContractComponent(null)}
+      />
     </ListingTable.Container>
   );
 }

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -2,6 +2,7 @@ import type { components } from "../../generated/aep-api";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 type ComponentList = components["schemas"]["ComponentList"];
+type ComponentOpenAPI = components["schemas"]["ComponentOpenAPI"];
 type TaskView = components["schemas"]["TaskView"];
 type TagList = components["schemas"]["TagList"];
 type FileMeta = components["schemas"]["FileMeta"];
@@ -228,6 +229,39 @@ const deployedComponents: ComponentList = {
       : c,
   ),
 };
+
+// The OpenAPI contract served by GET .../components/:name/openapi — a
+// `{ spec }` envelope carrying a raw document, exactly as aep-api returns it
+// (read off specs/design). The ComponentOpenApiDialog renders `spec` via the
+// shared OpenApiView. Title is keyed off the component so the viewer's hero
+// reflects which row was opened.
+export function componentOpenApi(componentName: string): ComponentOpenAPI {
+  const spec = `openapi: 3.0.0
+info:
+  title: ${componentName}
+  version: 1.0.0
+  description: Mock API contract for ${componentName}.
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: A list of items
+    post:
+      summary: Create an item
+      responses:
+        "201":
+          description: Created
+`;
+  return { componentName, componentType: "service", spec };
+}
 
 export const projectComponents: Record<
   Exclude<ProjectScenario, "error">,

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse, type JsonBodyType } from "msw";
 import {
+  componentOpenApi,
   projectComponents,
   projectSectionError,
   projectSpecFiles,
@@ -46,6 +47,12 @@ export const projectHandlers = [
   ),
   http.get("*/api/v1/projects/:projectName/components", () =>
     respond((s) => projectComponents[s]),
+  ),
+  // The component's OpenAPI contract for the in-app viewer dialog. Errors
+  // follow the section scenario; otherwise a spec keyed to the component name.
+  http.get(
+    "*/api/v1/projects/:projectName/components/:componentName/openapi",
+    ({ params }) => respond(() => componentOpenApi(String(params.componentName))),
   ),
   http.get("*/api/v1/projects/:projectName/tasks", () =>
     respond((s) => projectTasks[s]),


### PR DESCRIPTION
## Problem
Clicking **API contract** in the Components table returned **401 Unauthorized**.

The link was a raw `<a href target="_blank">` navigation to the JWT-guarded
`/projects/{p}/components/{c}/openapi` endpoint. The console holds its OIDC token
in JS and attaches `Authorization: Bearer` only via the fetch wrapper — there is
**no cookie session** — so a browser navigation carried no auth header and the
BFF rejected it. (That endpoint also returns a `{spec}` JSON envelope, not a raw
document, so opening it in a tab was doubly wrong.)

## Fix
Route it through the authenticated client and render the spec in-app:

- **`ComponentOpenApiDialog`** (new) — fetches the spec via the openapi-fetch
  client and renders it with the existing `@aep/ui-openapi-view` `OpenApiView`
  (the same viewer `SpecView` already uses).
- **`useComponentOpenApi`** — lazy hook (fires only when the dialog opens) +
  `componentOpenapi` query key.
- **`ComponentsList`** — "API contract" is now a button that opens the dialog;
  identical look (FileCode icon), no navigation.
- **MSW** — mock handler + fixture so it also works in mock/dev mode.

No contract change (`ComponentOpenAPI` was already typed) and no new deps.

## Verification
- typecheck, lint, and production build pass.
- Rebuilt the `aep-console` image and drove the live env with Playwright
  (logged into Thunder as `admin`): the API contract control is a `<button>`,
  the dialog renders the deployed `hello-api` component's OpenAPI spec
  (`GET /hello`, `GET /health`, Greeting/Error schemas), and the
  `.../components/hello-api/openapi` request returns **200 with an
  `Authorization: Bearer` header** (previously 401). No 401/error state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)