### PR TITLE
fix(skills/go): build the main package, not `./...`, in the component Dockerfile

### DIFF
--- a/services/aep-api/skills/embedded/go/SKILL.md
+++ b/services/aep-api/skills/embedded/go/SKILL.md
@@ -200,6 +200,10 @@ WORKDIR /src
 COPY go.mod ./
 RUN go mod download
 COPY . .
+# Build the main package: `./` (the module root, where main.go lives) or
+# `./cmd/<name>`. A real `-o` target takes exactly ONE package — with main +
+# internal/* present, `go build -o /out/app ./...` fails "cannot write multiple
+# packages to non-directory". (`./...` is for the `-o /dev/null` verify only.)
 RUN CGO_ENABLED=0 go build -ldflags='-s -w' -o /out/app ./
 
 FROM alpine:3.20
@@ -264,6 +268,7 @@ absence. Only when you DO have external dependencies must the committed
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| Build fails `go: cannot write multiple packages to non-directory /out/app` | Dockerfile used `go build -o /out/app ./...` on a multi-package module | Build the main package only: `go build -o /out/app ./` (or `./cmd/<name>`). `./...` is valid only with `-o /dev/null` for verification. |
 | Build fails with `go.mod requires go >= 1.25` | Dockerfile pinned older Go | Use `FROM golang:1.25-alpine AS builder`. |
 | Build times out at the `mattn/go-sqlite3` step | CGO compilation under throttle | Switch to `modernc.org/sqlite`. |
 | `sql.Open` returns `unknown driver "sqlite3"` | Used `mattn` driver name with `modernc` import | Use `sql.Open("sqlite", ...)`. |

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -200,6 +200,10 @@ WORKDIR /src
 COPY go.mod ./
 RUN go mod download
 COPY . .
+# Build the main package: `./` (the module root, where main.go lives) or
+# `./cmd/<name>`. A real `-o` target takes exactly ONE package — with main +
+# internal/* present, `go build -o /out/app ./...` fails "cannot write multiple
+# packages to non-directory". (`./...` is for the `-o /dev/null` verify only.)
 RUN CGO_ENABLED=0 go build -ldflags='-s -w' -o /out/app ./
 
 FROM alpine:3.20
@@ -264,6 +268,7 @@ absence. Only when you DO have external dependencies must the committed
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| Build fails `go: cannot write multiple packages to non-directory /out/app` | Dockerfile used `go build -o /out/app ./...` on a multi-package module | Build the main package only: `go build -o /out/app ./` (or `./cmd/<name>`). `./...` is valid only with `-o /dev/null` for verification. |
 | Build fails with `go.mod requires go >= 1.25` | Dockerfile pinned older Go | Use `FROM golang:1.25-alpine AS builder`. |
 | Build times out at the `mattn/go-sqlite3` step | CGO compilation under throttle | Switch to `modernc.org/sqlite`. |
 | `sql.Open` returns `unknown driver "sqlite3"` | Used `mattn` driver name with `modernc` import | Use `sql.Open("sqlite", ...)`. |


### PR DESCRIPTION
## What this fixes

AEP generates each user's application with **coding agents**. For a Go
service, the agent follows the `go` **skill**, which tells it how to write the
component's `Dockerfile`. That Dockerfile is later run by the platform's image
build (Argo) to produce the container that gets deployed.

The skill's canonical Dockerfile builds the service correctly:

```dockerfile
RUN CGO_ENABLED=0 go build -ldflags='-s -w' -o /out/app ./
```

but the same skill also shows a **verify** command that compiles *every*
package and throws the binaries away:

```bash
go build -o /dev/null ./...   # compile-check only
```

The agent conflated the two and emitted the build line as
`go build -o /out/app ./...`. That is invalid: `go build` cannot write
**multiple packages** to a single `-o` file. Any real service has more than
one package (`main` + `internal/handlers` + `internal/models` …), so the image
build fails and the component never deploys:

```
go: cannot write multiple packages to non-directory /out/app
Error: building at STEP "RUN ... go build -o /out/app ./...": exit status 1
→ Argo build workflow: Failed
```

## Where it breaks

```mermaid
flowchart TD
    A["Coding agent writes<br/>weather-api/Dockerfile"] --> B{"go build -o /out/app  ???"}
    B -->|"./...  (selects ALL packages)"| C["go: cannot write multiple<br/>packages to non-directory"]
    C --> D["Argo build workflow: Failed"]
    D --> E["No image → component never deploys"]
    B -->|".  (the single main package)"| F["one binary /out/app"]
    F --> G["Image pushed → component deploys ✅"]
    style C fill:#f8d7da,stroke:#c00
    style D fill:#f8d7da,stroke:#c00
    style E fill:#f8d7da,stroke:#c00
    style F fill:#d4edda,stroke:#0a0
    style G fill:#d4edda,stroke:#0a0
```

## The change

Two edits to the `go` skill (repo-root `skills/go/SKILL.md`, plus its vendored
`skills/embedded/` copy that is compiled into the aep-api binary):

1. **A positive inline comment at the build line** — the point of action, so
   the distinction is unmissable exactly where the agent writes it:

   > Build the main package: `./` (the module root, where `main.go` lives) or
   > `./cmd/<name>`. A real `-o` target takes exactly ONE package — with
   > `main` + `internal/*` present, `go build -o /out/app ./...` fails "cannot
   > write multiple packages to non-directory". (`./...` is for the
   > `-o /dev/null` verify only.)

2. **A troubleshooting-table row** mapping the exact error string → the fix,
   for the separate "I'm debugging a failed build" access path.

No new prohibition was added: stating the rule positively at the point of
action avoids duplicating it or phrasing it as a "don't" (which reads as a
negation and tends to backfire).

## How it was found

Surfaced while driving an end-to-end validation build: the `weather-api`
component's Argo build failed on exactly this line. Patching the Dockerfile to
`-o /out/app .` made the build succeed, confirming the root cause.

## Verification

- `make vendor-skills` re-run; `skills/embedded/go/SKILL.md` byte-matches the
  source (so `vendor-skills-check` stays green).
- Confirmed a real build with `-o /out/app .` succeeds on the multi-package
  `weather-api` service that previously failed with `./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte
