### PR TITLE
fix(skills/go): a plain service a web-app calls needs CORS (gateway only covers managed APIs)

### DIFF
--- a/services/aep-api/skills/embedded/go/SKILL.md
+++ b/services/aep-api/skills/embedded/go/SKILL.md
@@ -80,6 +80,17 @@ per-user data, include this Scope bullet:
   `mattn/go-sqlite3` — its CGO compilation step times out under the
   build pod's CPU throttle."
 
+For a Go service a `web-application` calls directly — the web-app declares a
+`component`-kind dependency on it — that is NOT a managed API (`exposesAPI`
+unset), include this Scope bullet:
+
+- "CORS: a browser calls this service cross-origin (the web-app is served from
+  a different gateway host), so wrap the router in a permissive CORS middleware
+  that sets `Access-Control-Allow-Origin`/`-Methods`/`-Headers` and answers the
+  `OPTIONS` preflight with 204 — the browser blocks every call otherwise. A
+  managed API (`exposesAPI` set) instead relies on the gateway for CORS and
+  must NOT add its own; see the api-management skill."
+
 For every Go task, include this Acceptance criteria bullet:
 
 - "Local `go build -o /dev/null ./...` exits 0 and, if the service has
@@ -128,6 +139,27 @@ mux.HandleFunc("PATCH /todos/{id}", updateTodo)
 
 log.Printf("listening on :9090")
 log.Fatal(http.ListenAndServe(":9090", mux))
+```
+
+When a `web-application` calls this service directly and it is not a managed
+API (`exposesAPI` unset), wrap the router so the cross-origin browser fetch is
+allowed — set the headers on every response and answer `OPTIONS` with 204:
+
+```go
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// serve it: http.ListenAndServe(":9090", withCORS(mux))
 ```
 
 SQLite — pure-Go driver, use literal `"sqlite"` (not `"sqlite3"`):

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -80,6 +80,17 @@ per-user data, include this Scope bullet:
   `mattn/go-sqlite3` — its CGO compilation step times out under the
   build pod's CPU throttle."
 
+For a Go service a `web-application` calls directly — the web-app declares a
+`component`-kind dependency on it — that is NOT a managed API (`exposesAPI`
+unset), include this Scope bullet:
+
+- "CORS: a browser calls this service cross-origin (the web-app is served from
+  a different gateway host), so wrap the router in a permissive CORS middleware
+  that sets `Access-Control-Allow-Origin`/`-Methods`/`-Headers` and answers the
+  `OPTIONS` preflight with 204 — the browser blocks every call otherwise. A
+  managed API (`exposesAPI` set) instead relies on the gateway for CORS and
+  must NOT add its own; see the api-management skill."
+
 For every Go task, include this Acceptance criteria bullet:
 
 - "Local `go build -o /dev/null ./...` exits 0 and, if the service has
@@ -128,6 +139,27 @@ mux.HandleFunc("PATCH /todos/{id}", updateTodo)
 
 log.Printf("listening on :9090")
 log.Fatal(http.ListenAndServe(":9090", mux))
+```
+
+When a `web-application` calls this service directly and it is not a managed
+API (`exposesAPI` unset), wrap the router so the cross-origin browser fetch is
+allowed — set the headers on every response and answer `OPTIONS` with 204:
+
+```go
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// serve it: http.ListenAndServe(":9090", withCORS(mux))
 ```
 
 SQLite — pure-Go driver, use literal `"sqlite"` (not `"sqlite3"`):


### PR DESCRIPTION
## What this fixes

AEP's coding agents generate user apps: typically a `web-application` (React
SPA) plus one or more Go services. The SPA is served from a **different gateway
host** than its backend service, so the browser's call to the API is
**cross-origin** — which requires the service to return CORS headers.

The platform's gateway *does* attach an Envoy CORS filter, but **only to a
managed API** (a service with `exposesAPI` set → the `api-configuration`
ClusterTrait). A **plain service** (`exposesAPI` unset) gets a raw HTTPRoute
with **no CORS**, and the `go` skill said nothing about it — so the coding
agent shipped a service with no CORS, and the browser silently blocked every
request from the SPA (the UI shows a generic "something went wrong").

```mermaid
flowchart TD
    A["Browser SPA (web-app host)"] -->|"cross-origin fetch"| B{"Service exposes a managed API?"}
    B -->|"yes — exposesAPI set"| C["Gateway attaches Envoy CORS<br/>(api-configuration trait)"]
    C --> G["✅ browser accepts response"]
    B -->|"no — plain service"| D["No gateway CORS"]
    D --> E{"Service adds CORS itself?"}
    E -->|"no (the bug)"| F["❌ browser blocks the response"]
    E -->|"yes — withCORS middleware"| G
    style F fill:#f8d7da,stroke:#c00
    style G fill:#d4edda,stroke:#0a0
```

## The change

Adds CORS guidance to the `go` skill (`skills/go/SKILL.md` + the vendored
`skills/embedded/` copy compiled into aep-api), in two places matching the
skill's existing pattern:

1. A conditional **tech-lead Scope bullet** — added to the task only for a
   service a `web-application` calls directly that is **not** a managed API.
2. A **`withCORS` middleware** at the router setup (the point of authoring):
   sets `Access-Control-Allow-Origin`/`-Methods`/`-Headers` and answers the
   `OPTIONS` preflight with 204.

Both are **gated on "web-app calls it directly AND `exposesAPI` unset"**, so
this never contradicts the `api-management` skill — which correctly says a
managed API must **not** add its own CORS (the gateway does it; doubled headers
break browsers).

## How it was found & verified

Surfaced in an end-to-end validation: the deployed weather dashboard rendered
but every lookup failed. The backend worked when called directly (returned live
weather), and the preflight `OPTIONS` returned `405` with no
`Access-Control-Allow-Origin` — confirming missing CORS. Adding this exact
`withCORS` middleware to the service unblocked the browser lookup end-to-end
(live data rendered in the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte
