### PR TITLE
fix(console): task log renders event payloads and stops swallowing seq-0 lines

### DIFF
--- a/apps/console/src/features/tasks/components/TaskLogView.tsx
+++ b/apps/console/src/features/tasks/components/TaskLogView.tsx
@@ -19,52 +19,9 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Box, Typography } from "@wso2/oxygen-ui";
 import type { components } from "../../../generated/aep-api";
+import { formatLine, timelineEventKey } from "../lib/timeline";
 
 type TimelineEvent = components["schemas"]["TimelineEvent"];
-
-// One console line per TimelineEvent, formatted by kind (#173 decisions:
-// flat log; execution attempts are divider lines, not UI sections).
-function formatLine(e: TimelineEvent): { text: string; tone: string } {
-  switch (e.kind) {
-    case "phase":
-      return { text: `▸ ${e.phase ?? e.message ?? "phase"}`, tone: "info.light" };
-    case "tool_use":
-      return {
-        text: `$ ${e.tool ?? "tool"}${e.command ? ` ${e.command}` : ""}`,
-        tone: "grey.400",
-      };
-    case "git_commit":
-      return {
-        text: `✓ commit ${e.sha?.slice(0, 7) ?? ""}${e.files ? ` · ${e.files} files` : ""}`,
-        tone: "success.light",
-      };
-    case "git_push":
-      return {
-        text: `↑ push${e.branch ? ` ${e.branch}` : ""}`,
-        tone: "success.light",
-      };
-    case "gh_action":
-    case "build_step":
-      return {
-        text: `⚙ ${e.step ?? e.summary ?? e.kind}${e.status ? ` — ${e.status}` : ""}`,
-        tone: e.status === "failed" ? "error.light" : "info.light",
-      };
-    case "result":
-      return {
-        text: `■ ${e.summary ?? e.status ?? "finished"}${e.error ? ` — ${e.error}` : ""}`,
-        tone: e.error || e.status === "failed" ? "error.light" : "success.light",
-      };
-    default: {
-      const tone =
-        e.level === "error"
-          ? "error.light"
-          : e.level === "warn"
-            ? "warning.light"
-            : "grey.300";
-      return { text: e.message ?? e.summary ?? "", tone };
-    }
-  }
-}
 
 type Row =
   | { type: "divider"; key: string; label: string }
@@ -84,14 +41,14 @@ function toRows(lines: TimelineEvent[]): Row[] {
       }
       rows.push({
         type: "divider",
-        key: `div:${line.executionId}:${line.seq}`,
+        key: `div:${timelineEventKey(line)}`,
         label: `attempt ${attemptNo.get(line.executionId)} · ${line.executionKind}`,
       });
     }
     const { text, tone } = formatLine(line);
     rows.push({
       type: "line",
-      key: `${line.executionId}:${line.seq}`,
+      key: timelineEventKey(line),
       text,
       tone,
     });

--- a/apps/console/src/features/tasks/hooks/useTaskLog.ts
+++ b/apps/console/src/features/tasks/hooks/useTaskLog.ts
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { parseSseStream } from "@aep/agent-stream";
 import type { components } from "../../../generated/aep-api";
 import { client } from "../../../api/client";
+import { timelineEventKey } from "../lib/timeline";
 
 type TaskStreamEvent = components["schemas"]["TaskStreamEvent"];
 type TaskView = components["schemas"]["TaskView"];
@@ -30,7 +31,7 @@ export type TaskLogPhase = "connecting" | "live" | "reconnecting" | "ended";
 export interface TaskLogState {
   /** Live task upserted from `task` frames (fresher than get-task). */
   task: TaskView | undefined;
-  /** Unified timeline, deduped by executionId+seq (reconnects re-emit). */
+  /** Unified timeline, deduped by timelineEventKey (reconnects re-emit). */
   lines: TimelineEvent[];
   /** Settled derivedStatus from the `done` frame — the stream is over. */
   settledStatus: string | undefined;
@@ -107,7 +108,7 @@ export function useTaskLog(
           case "line": {
             const line = event.line;
             if (!line) break;
-            const key = `${line.executionId}:${line.seq}`;
+            const key = timelineEventKey(line);
             if (seen.current.has(key)) break;
             seen.current.add(key);
             setLines((prev) => [...prev, line]);

--- a/apps/console/src/features/tasks/lib/timeline.test.ts
+++ b/apps/console/src/features/tasks/lib/timeline.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { components } from "../../../generated/aep-api";
+import { formatLine, timelineEventKey } from "./timeline";
+
+type TimelineEvent = components["schemas"]["TimelineEvent"];
+
+function line(over: Partial<TimelineEvent>): TimelineEvent {
+  return {
+    schemaVersion: 1,
+    ts: "2026-07-11T07:11:34.763983714Z",
+    seq: 0,
+    kind: "log",
+    executionId: "exec-1",
+    executionKind: "coding",
+    ...over,
+  };
+}
+
+describe("timelineEventKey", () => {
+  it("uses executionId+seq for structured runner events", () => {
+    expect(timelineEventKey(line({ seq: 7, kind: "phase" }))).toBe("exec-1:7");
+  });
+
+  it("seq-0 wrapped stdout lines get distinct keys (ts+text fallback)", () => {
+    // The BFF wraps plain runner stdout as log events without stamping seq
+    // (agent_progress.go), so every wrapped line arrives with seq 0 — a
+    // shared executionId:0 key would swallow all but the first.
+    const a = line({ summary: "[skills-resolve] nothing to materialise" });
+    const b = line({
+      summary: "[oneshot] no per-task skills",
+      ts: "2026-07-11T07:11:34.764081694Z",
+    });
+    expect(timelineEventKey(a)).not.toBe(timelineEventKey(b));
+    // …and the key is stable across reconnect replays of the same line.
+    expect(timelineEventKey(a)).toBe(timelineEventKey(line({ ...a })));
+  });
+});
+
+describe("formatLine", () => {
+  it("Bash tool_use renders the bare command — `$` already says shell", () => {
+    const { text } = formatLine(
+      line({ kind: "tool_use", tool: "Bash", summary: "npm run build", seq: 3 }),
+    );
+    expect(text).toBe("$ npm run build");
+  });
+
+  it("file-tool tool_use keeps the tool as the verb", () => {
+    const { text } = formatLine(
+      line({ kind: "tool_use", tool: "Write", summary: "src/App.tsx", seq: 5 }),
+    );
+    expect(text).toBe("$ Write src/App.tsx");
+  });
+
+  it("tool_use without a summary still names the tool", () => {
+    const { text } = formatLine(line({ kind: "tool_use", tool: "Read", seq: 4 }));
+    expect(text).toBe("$ Read");
+  });
+
+  it("log lines render message or summary", () => {
+    expect(formatLine(line({ summary: "[oneshot] hello" })).text).toBe(
+      "[oneshot] hello",
+    );
+  });
+
+  it("gh_action renders its command payload", () => {
+    const { text } = formatLine(
+      line({ kind: "gh_action", command: "gh pr create --fill", seq: 9 }),
+    );
+    expect(text).toBe("⚙ gh pr create --fill");
+  });
+});

--- a/apps/console/src/features/tasks/lib/timeline.ts
+++ b/apps/console/src/features/tasks/lib/timeline.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+
+type TimelineEvent = components["schemas"]["TimelineEvent"];
+
+/**
+ * Identity of one timeline line — the replay-dedup key and the list key.
+ * Structured runner events carry a per-execution monotonic seq. Plain runner
+ * stdout wrapped by the BFF (agent_progress.go) arrives with seq 0 on every
+ * line, so a bare executionId:seq key would collide and swallow all but the
+ * first; those fall back to the line's K8s timestamp + text, which is
+ * per-line unique and identical across reconnect replays of the same line.
+ */
+export function timelineEventKey(e: TimelineEvent): string {
+  if (e.seq) return `${e.executionId}:${e.seq}`;
+  return `${e.executionId}:0:${e.ts}:${e.summary ?? e.message ?? ""}`;
+}
+
+/**
+ * One console line per TimelineEvent, formatted by kind (#173 decisions:
+ * flat log; execution attempts are divider lines, not UI sections).
+ */
+export function formatLine(e: TimelineEvent): { text: string; tone: string } {
+  switch (e.kind) {
+    case "phase":
+      return { text: `▸ ${e.phase ?? e.message ?? "phase"}`, tone: "info.light" };
+    case "tool_use":
+      // The payload rides in summary (Bash: the command; file tools: the
+      // path) — tool_use has no command field, that's gh_action's. For Bash
+      // the `$` prompt already says "shell", so the tool name is noise; for
+      // every other tool it is the verb (Write/Read/Edit <path>).
+      if (e.tool === "Bash" && e.summary) {
+        return { text: `$ ${e.summary}`, tone: "grey.400" };
+      }
+      return {
+        text: `$ ${e.tool ?? "tool"}${e.summary ? ` ${e.summary}` : ""}`,
+        tone: "grey.400",
+      };
+    case "git_commit":
+      return {
+        text: `✓ commit ${e.sha?.slice(0, 7) ?? ""}${e.files ? ` · ${e.files} files` : ""}`,
+        tone: "success.light",
+      };
+    case "git_push":
+      return {
+        text: `↑ push${e.branch ? ` ${e.branch}` : ""}`,
+        tone: "success.light",
+      };
+    case "gh_action":
+    case "build_step":
+      // gh_action's payload is its command; build_step's is step/summary.
+      return {
+        text: `⚙ ${e.step ?? e.summary ?? e.command ?? e.kind}${e.status ? ` — ${e.status}` : ""}`,
+        tone: e.status === "failed" ? "error.light" : "info.light",
+      };
+    case "result":
+      return {
+        text: `■ ${e.summary ?? e.status ?? "finished"}${e.error ? ` — ${e.error}` : ""}`,
+        tone: e.error || e.status === "failed" ? "error.light" : "success.light",
+      };
+    default: {
+      const tone =
+        e.level === "error"
+          ? "error.light"
+          : e.level === "warn"
+            ? "warning.light"
+            : "grey.300";
+      return { text: e.message ?? e.summary ?? "", tone };
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #192's task-log page — three field-mismatch bugs hid most of the log's content (user report: "in the task log I can't see the log line").

## Bugs → fixes

1. **`tool_use` printed the tool, dropped the payload.** The runner puts the content in `summary` (`remote-worker/src/lib/progress/schema.ts:47-51` — Bash: the command, file tools: the path); the view rendered the nonexistent `command` field (that's `gh_action`'s). Now: Bash renders `$ npm run build` (the `$` prompt already says shell), other tools keep the verb — `$ Write src/App.tsx`.
2. **`gh_action` printed bare `⚙ gh_action`.** Its payload is `command`; the view read only `step`/`summary`. Now in the fallback chain.
3. **Every plain stdout line after the first vanished.** The BFF wraps non-NDJSON runner output as log events without stamping `seq` (`agent_progress.go:236-249`), so all wrapped lines share `seq: 0`; the console's `executionId:seq` dedup key (and React list key) collided and silently dropped them. New `timelineEventKey` falls back to `executionId:0:ts:text` for seq-0 lines — unique per line, stable across reconnect replays, so replay dedup still works.

`formatLine` moves to `features/tasks/lib/timeline.ts` beside the key helper; `useTaskLog` (dedup) and `TaskLogView` (keys) share them. 

## Testing

- New `timeline.test.ts` (6 cases: key identity/stability, Bash/file-tool/gh_action/log rendering); full console suite green on current `aep-rewrite` (102 tests), typecheck + lint clean.
- Verified live against a real coding-agent run (`hello2-testing-print` task #1): captured the SSE stream via curl, confirmed seq-0 lines and payload fields, and confirmed the rendered log shows commands, gh commands, and both `[skills-resolve]`/`[oneshot]` bootstrap lines after the fix.

Deliberately untouched (producer-side, noted for later): the BFF could stamp a real seq on wrapped lines; runner redaction masks some ordinary paths as `[REDACTED]`; one push event carries `2>&1` as its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
