### PR TITLE
feat(console): overview Components table shows the web app's public URL (#196)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -83,6 +83,13 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
+- Overview Components table — web apps get their "Open app" URL, console-side:
+  each web-application row reads its dev deployment's `endpointUrl` from the
+  existing `list-deployments` endpoint (no BE change; `Component.endpointUrl`
+  stays as noted contract drift) —
+  [#196](https://github.com/wso2/labs-agentic-engineer/issues/196)
+  ([#197](https://github.com/wso2/labs-agentic-engineer/issues/197) closed unimplemented)
+
 - Project overview — versioned pipeline (Spec → Build → Deploy) on a single
   adaptive status poll: per-stage version chips (v1, v1+), task/component
   counts from nested ProjectStatus stage aggregates; list-tasks + /tags leave

--- a/apps/console/src/features/projects/api/keys.ts
+++ b/apps/console/src/features/projects/api/keys.ts
@@ -28,6 +28,8 @@ export const projectKeys = {
     [...projectKeys.detail(name), "components"] as const,
   componentOpenapi: (name: string, component: string) =>
     [...projectKeys.components(name), component, "openapi"] as const,
+  componentDeployments: (name: string, component: string) =>
+    [...projectKeys.components(name), component, "deployments"] as const,
   tasks: (name: string) => [...projectKeys.detail(name), "tasks"] as const,
   tags: (name: string) => [...projectKeys.detail(name), "tags"] as const,
   buildPreflight: (name: string) =>

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -26,6 +26,7 @@ import {
 import type { components } from "../../../generated/aep-api";
 import { client } from "../../../api/client";
 import { useConfig } from "../../settings/api/queries";
+import { firstEndpointUrl } from "../lib/deploymentUrl";
 import { projectKeys } from "./keys";
 
 type CreateProjectRequest = components["schemas"]["CreateProjectRequest"];
@@ -148,6 +149,32 @@ export function useProjectComponents(projectName: string) {
       }),
     "components",
   );
+}
+
+// A web app's public URL (#196): read from its deployments — the dev
+// binding's resolved endpointUrl rides on list-deployments, while
+// list-components never fills Component.endpointUrl (noted contract drift).
+// Fetched only for web-application rows; refreshes with the components list
+// (same no-standing-interval regime — a deploy transition invalidates both).
+export function useComponentEndpointUrl(
+  projectName: string,
+  componentName: string,
+) {
+  return useQuery({
+    queryKey: projectKeys.componentDeployments(projectName, componentName),
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/projects/{projectName}/components/{componentName}/deployments",
+        { params: { path: { projectName, componentName } } },
+      );
+      if (error || data === undefined) {
+        const e = error as { detail?: string; title?: string } | undefined;
+        throw new Error(e?.detail ?? e?.title ?? "Failed to load deployments");
+      }
+      return data;
+    },
+    select: (data) => firstEndpointUrl(data.items),
+  });
 }
 
 // A service component's OpenAPI contract, for the in-app viewer dialog. Lazy

--- a/apps/console/src/features/projects/components/ComponentsList.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.tsx
@@ -26,6 +26,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ExternalLink, FileCode } from "@wso2/oxygen-ui-icons-react";
 import type { components } from "../../../generated/aep-api";
+import { useComponentEndpointUrl } from "../api/queries";
 import { ComponentOpenApiDialog } from "./ComponentOpenApiDialog";
 
 type Component = components["schemas"]["Component"];
@@ -33,33 +34,56 @@ type Component = components["schemas"]["Component"];
 // The component type is OpenChoreo's own ComponentType name, end-to-end.
 const isWebApp = (c: Component) => c.type === "web-application";
 
-function componentLink(c: Component, onOpenContract: (name: string) => void) {
-  if (isWebApp(c)) {
-    return c.endpointUrl ? (
-      <MuiLink
-        href={c.endpointUrl}
-        target="_blank"
-        rel="noreferrer"
-        variant="body2"
-        sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
-      >
-        Open app <ExternalLink size={14} />
-      </MuiLink>
-    ) : (
+// A web app's "Open app" link (#196). The URL comes from the component's
+// deployments read (dev binding's resolved endpointUrl) — list-components
+// never fills Component.endpointUrl, though the field stays preferred here
+// in case the backend ever closes that drift. Until a URL exists (not yet
+// deployed, or fetch in flight/failed) the placeholder keeps its promise.
+function WebAppLink({
+  projectName,
+  component,
+}: {
+  projectName: string;
+  component: Component;
+}) {
+  const deployed = useComponentEndpointUrl(projectName, component.name);
+  const href = component.endpointUrl ?? deployed.data;
+  if (!href) {
+    return (
       <Typography variant="caption" color="text.secondary">
         URL appears once deployed
       </Typography>
     );
   }
-  // API/service rows open the component's OpenAPI contract in-app. It's a
-  // button, not an <a href>: the /openapi endpoint is JWT-guarded and a raw
-  // browser navigation carries no Bearer token (401). The dialog fetches
-  // through the authenticated client instead.
+  return (
+    <MuiLink
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      variant="body2"
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+    >
+      Open app <ExternalLink size={14} />
+    </MuiLink>
+  );
+}
+
+// API/service rows open the component's OpenAPI contract in-app. It's a
+// button, not an <a href>: the /openapi endpoint is JWT-guarded and a raw
+// browser navigation carries no Bearer token (401). The dialog fetches
+// through the authenticated client instead.
+function ContractLink({
+  name,
+  onOpenContract,
+}: {
+  name: string;
+  onOpenContract: (name: string) => void;
+}) {
   return (
     <MuiLink
       component="button"
       type="button"
-      onClick={() => onOpenContract(c.name)}
+      onClick={() => onOpenContract(name)}
       variant="body2"
       sx={{
         display: "inline-flex",
@@ -147,7 +171,14 @@ export function ComponentsList({
                 />
               </ListingTable.Cell>
               <ListingTable.Cell sx={{ maxWidth: 200 }}>
-                {componentLink(c, setContractComponent)}
+                {isWebApp(c) ? (
+                  <WebAppLink projectName={projectName} component={c} />
+                ) : (
+                  <ContractLink
+                    name={c.name}
+                    onOpenContract={setContractComponent}
+                  />
+                )}
               </ListingTable.Cell>
             </ListingTable.Row>
           ))}

--- a/apps/console/src/features/projects/lib/deploymentUrl.test.ts
+++ b/apps/console/src/features/projects/lib/deploymentUrl.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { firstEndpointUrl } from "./deploymentUrl";
+
+describe("firstEndpointUrl", () => {
+  it("picks the first deployment with a resolved URL", () => {
+    expect(
+      firstEndpointUrl([
+        { componentName: "web", environment: "development" }, // binding not ready yet
+        {
+          componentName: "web",
+          environment: "development",
+          endpointUrl: "https://web.dev.example.io",
+        },
+      ]),
+    ).toBe("https://web.dev.example.io");
+  });
+
+  it("returns undefined when nothing is deployed or the list is null", () => {
+    expect(firstEndpointUrl([])).toBeUndefined();
+    expect(firstEndpointUrl(null)).toBeUndefined();
+    expect(firstEndpointUrl(undefined)).toBeUndefined();
+    expect(
+      firstEndpointUrl([{ componentName: "web", endpointUrl: "" }]),
+    ).toBeUndefined();
+  });
+});

--- a/apps/console/src/features/projects/lib/deploymentUrl.ts
+++ b/apps/console/src/features/projects/lib/deploymentUrl.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+
+type Deployment = components["schemas"]["Deployment"];
+
+// A web app's public URL from its deployments (#196): the first deployment
+// carrying a resolved endpointUrl — the same "first non-empty" rule aep-api's
+// runtime-config uses. Today only the dev environment deploys, so first
+// non-empty and "the dev URL" coincide.
+export function firstEndpointUrl(
+  items: Deployment[] | null | undefined,
+): string | undefined {
+  for (const d of items ?? []) {
+    if (d.endpointUrl) return d.endpointUrl;
+  }
+  return undefined;
+}

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -6,6 +6,7 @@ type ComponentOpenAPI = components["schemas"]["ComponentOpenAPI"];
 type TaskView = components["schemas"]["TaskView"];
 type TagList = components["schemas"]["TagList"];
 type BuildList = components["schemas"]["BuildList"];
+type DeploymentList = components["schemas"]["DeploymentList"];
 type FileMeta = components["schemas"]["FileMeta"];
 type FileContent = components["schemas"]["FileContent"];
 type ErrorModel = components["schemas"]["ErrorModel"];
@@ -223,13 +224,32 @@ const builtComponents: ComponentList = {
   ],
 };
 
-const deployedComponents: ComponentList = {
-  items: (builtComponents.items ?? []).map((c) =>
-    c.type === "web-application"
-      ? { ...c, endpointUrl: "https://storefront.dev.acme-aep.io" }
-      : c,
-  ),
-};
+// Note: no endpointUrl on the components themselves — the real backend never
+// fills Component.endpointUrl (noted drift, #196); the console reads a web
+// app's URL from list-deployments (componentDeployments below).
+const deployedComponents: ComponentList = builtComponents;
+
+// Deployments backing list-deployments (#196): the deployed scenario gives
+// the web app its dev binding URL (matching the pre-#196 fixture semantics);
+// earlier scenarios have no resolved URL yet.
+export function componentDeployments(
+  s: Exclude<ProjectScenario, "error">,
+  componentName: string,
+): DeploymentList {
+  if (s === "deployed" && componentName === "storefront") {
+    return {
+      items: [
+        {
+          componentName,
+          environment: "development",
+          status: "Ready",
+          endpointUrl: "https://storefront.dev.acme-aep.io",
+        },
+      ],
+    };
+  }
+  return { items: [] };
+}
 
 // The OpenAPI contract served by GET .../components/:name/openapi — a
 // `{ spec }` envelope carrying a raw document, exactly as aep-api returns it

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse, type JsonBodyType } from "msw";
 import {
+  componentDeployments,
   componentOpenApi,
   projectBuilds,
   projectComponents,
@@ -54,6 +55,12 @@ export const projectHandlers = [
   http.get(
     "*/api/v1/projects/:projectName/components/:componentName/openapi",
     ({ params }) => respond(() => componentOpenApi(String(params.componentName))),
+  ),
+  // A web app's dev deployment URL for the overview's "Open app" link (#196).
+  http.get(
+    "*/api/v1/projects/:projectName/components/:componentName/deployments",
+    ({ params }) =>
+      respond((s) => componentDeployments(s, String(params.componentName))),
   ),
   http.get("*/api/v1/projects/:projectName/tasks", ({ request }) => {
     // ?tag=vN scopes to one build's lineage, mirroring the aep:spec/<tag>


### PR DESCRIPTION
Implements wso2/labs-agentic-engineer#196 (decisions in the issue comments; fetch strategy revised to console-side, #197 closed unimplemented).

## What

Web-application rows in the overview's Components table now resolve their **"Open app"** link from the existing `list-deployments` endpoint — the dev binding's resolved `endpointUrl` (OpenChoreo `ReleaseBinding.status.endpoints[].externalURLs.http`). No backend change.

- New `useComponentEndpointUrl(project, component)` query + `firstEndpointUrl` picker (first non-empty deployment URL — the same rule aep-api's runtime-config applies).
- `ComponentsList`: the web-app cell becomes a `WebAppLink` component owning the query; `Component.endpointUrl` stays the preferred source if the backend ever closes that drift. Placeholder ("URL appears once deployed") until a URL exists — no distinct deployed-but-no-URL state (issue decision 1).
- Freshness: fetched alongside the components list, no standing poll — the status poll's deploy transition invalidates both (decision 3).
- Mocks mirror the real backend now: the URL moved off the components fixture onto a `list-deployments` handler (`deployed` scenario → storefront URL).

## Testing

- `deploymentUrl.test.ts` (picker: first non-empty, empty/null cases); console suite green (97 tests), typecheck + lint clean.
- Mock-mode UI verified on the dev server: `deployed` scenario renders `Open app → https://storefront.dev.acme-aep.io` (from the deployments handler), `building` scenario keeps the placeholder. Screenshots below (drag-and-drop pending).

Screenshots to attach: `196-components-deployed-open-app.png`, `196-components-building-placeholder.png` (repo root).

Live validation against a real deployed project is the Ship-stage step (fresh cluster currently has no deployed web app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
