### PR TITLE
fix(thunder-app-operator): unstick builds on org-auth — nudge the owning binding when the app is ready

### DIFF
--- a/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/rbac.yaml
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/rbac.yaml
@@ -28,6 +28,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  # OpenChoreo ResourceReleaseBindings — the operator nudges the owning binding
+  # (annotation patch) when an app becomes ready, so OC re-reconciles it and
+  # resolves the client_id output instead of staying stuck Ready=False.
+  - apiGroups: ["openchoreo.dev"]
+    resources: ["resourcereleasebindings"]
+    verbs: ["get", "list", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployments/single-cluster/resource-types/thunder-app/operator/internal/controller/thunderapplication_controller.go
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/internal/controller/thunderapplication_controller.go
@@ -28,7 +28,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +55,14 @@ const (
 	// cheap to re-reconcile; exponential backoff is not worth the complexity
 	// at v1 scope.
 	errBackoff = 30 * time.Second
+
+	// Labels OpenChoreo's renderedrelease-controller stamps on every rendered
+	// object — they let us trace this app back to the owning ResourceReleaseBinding.
+	labelResource     = "openchoreo.dev/resource"
+	labelCPNamespace  = "openchoreo.dev/namespace"
+	// annReadyNudge, set on the owning binding, forces one binding re-reconcile
+	// when this app becomes ready (see nudgeOwningBindings).
+	annReadyNudge = "aep.wso2.com/thunder-ready-nudge"
 )
 
 // Reconciler reconciles ThunderApplication objects.
@@ -66,6 +76,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=aep.wso2.com,resources=thunderapplications/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=aep.wso2.com,resources=thunderapplications/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=openchoreo.dev,resources=resourcereleasebindings,verbs=get;list;patch
 
 // Reconcile drives a ThunderApplication toward its desired Thunder OAuth
 // application and publishes the resulting client_id.
@@ -108,7 +119,58 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.Status().Update(ctx, &app); err != nil {
 		return ctrl.Result{}, err
 	}
+	r.nudgeOwningBindings(ctx, &app)
 	return ctrl.Result{}, nil
+}
+
+// nudgeOwningBindings forces OpenChoreo's ResourceReleaseBinding controller to
+// re-reconcile the binding(s) that rendered this app. That controller evaluates
+// its readyWhen/outputs CEL against the app's status ONCE — before Thunder has
+// minted the client_id — and does not requeue when the app later becomes ready,
+// so the binding stays Ready=False forever and any build depending on the
+// resource hangs. Patching an annotation triggers exactly one binding
+// reconcile, which now sees status.ready + status.clientId and resolves its
+// outputs. The nudge value is the client_id (stable), so repeat passes with the
+// same id are skipped — no reconcile storm. Best-effort: a failure only leaves
+// the pre-existing stuck state, which the next reconcile retries.
+func (r *Reconciler) nudgeOwningBindings(ctx context.Context, app *v1alpha1.ThunderApplication) {
+	logger := log.FromContext(ctx)
+	resource := app.Labels[labelResource]
+	cpNamespace := app.Labels[labelCPNamespace]
+	if resource == "" || cpNamespace == "" {
+		return // not a rendered-release-managed app — nothing owns it
+	}
+
+	bindings := &unstructured.UnstructuredList{}
+	bindings.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "openchoreo.dev",
+		Version: "v1alpha1",
+		Kind:    "ResourceReleaseBindingList",
+	})
+	if err := r.List(ctx, bindings,
+		client.InNamespace(cpNamespace),
+		client.MatchingLabels{labelResource: resource},
+	); err != nil {
+		logger.Error(err, "nudge: list owning bindings failed", "resource", resource)
+		return
+	}
+
+	for i := range bindings.Items {
+		b := &bindings.Items[i]
+		anns := b.GetAnnotations()
+		if anns[annReadyNudge] == app.Status.ClientID {
+			continue // already nudged for this client_id
+		}
+		before := b.DeepCopy()
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		anns[annReadyNudge] = app.Status.ClientID
+		b.SetAnnotations(anns)
+		if err := r.Patch(ctx, b, client.MergeFrom(before)); err != nil {
+			logger.Error(err, "nudge: patch binding failed", "binding", b.GetName())
+		}
+	}
 }
 
 // reconcileDelete removes the backing Thunder app and drops the finalizer.


### PR DESCRIPTION
## What this fixes

A build that depends on a **thunder-app** (`org-auth`) platform-resource **hangs indefinitely**.

### Root cause (an OpenChoreo binding race)
When aep-api provisions the resource, OpenChoreo renders a `ThunderApplication` and a `ResourceReleaseBinding`. The binding controller evaluates its `readyWhen`/outputs CEL against the app's status **once** — but at that moment Thunder hasn't minted the `client_id` yet:

```
OutputsResolved = False: output "client_id": CEL 'applied.app.status.clientId': no such key
ResourcesReady  = False: Resource "app" readyWhen returned false
```

The ThunderApplication then becomes `ready: true` with a `clientId`, but **the binding controller never requeues on that change** — its conditions stay pinned at `observedGeneration 1`. So the binding is stuck `Ready=False` forever → aep-api's `ResourceWatcher` (correctly waiting on the binding's Ready condition) waits forever → the `aep:provision` gate never closes → coding tasks never dispatch → build hangs.

```mermaid
sequenceDiagram
    participant AEP as aep-api
    participant OC as OC binding controller
    participant TA as ThunderApplication
    participant OP as thunder-app operator
    AEP->>OC: create ResourceReleaseBinding
    OC->>TA: render app
    OC->>OC: eval readyWhen/outputs (gen 1) → clientId missing → Ready=False
    OP->>TA: mint OAuth client → status.ready=true, clientId set
    Note over OC: never requeues on app status change → stuck Ready=False
    OP-->>OC: (THIS PR) patch binding annotation → 1 re-reconcile
    OC->>OC: eval outputs → clientId resolves → Ready=True ✅
    AEP->>AEP: provision gate closes → build proceeds
```

### The fix
The operator is the one component that *knows* when the app is actually ready. After it sets `status.Ready` + `clientId`, it now:
1. Traces the owning `ResourceReleaseBinding` via the `openchoreo.dev/resource` + `openchoreo.dev/namespace` labels OC stamps on the rendered app.
2. Patches a `aep.wso2.com/thunder-ready-nudge` annotation (value = the `clientId`) to force **exactly one** binding re-reconcile — which now resolves the output → `Ready=True`.

The nudge value is the stable `clientId`, so repeat reconciles are skipped (no reconcile storm). Adds `resourcereleasebindings` `get;list;patch` RBAC.

### Verification (on-cluster)
- Deployed the built operator; on reconcile it **patched the owning binding** with the nudge annotation — RBAC OK, and a forced re-reconcile did **not** re-nudge (idempotent, value already == clientId).
- The equivalent manual nudge was confirmed to flip a stuck binding to `Ready=True` and unblock the hung build.

> Note: the *cleanest* long-term fix is upstream in OpenChoreo (the binding controller should watch/requeue on the referenced resource's status). This operator-side nudge is the practical in-repo fix that self-heals every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte
