### PR TITLE
fix(skills): a component dependency is a directed caller→callee edge (no reverse edges)

### DIFF
--- a/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
+++ b/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
@@ -142,8 +142,13 @@ every arrow there appears here and vice versa — a mismatch is a defect. Each
 entry has a `kind` (which selects the meaningful fields) and a `name`; pick the
 kind by WHAT the target is:
 
-- **`component`** — a SIBLING component in this same design (a `<name>/` under
-  `components/`). Just `{ "kind": "component", "name": "expense-webapp" }`.
+- **`component`** — a SIBLING component in this same design that THIS component
+  CALLS: a directed caller→callee edge (one Interactions arrow). Declare it ONLY
+  on the caller, naming the callee it invokes:
+  `{ "kind": "component", "name": "expense-api" }`. Never add the reverse edge —
+  a web-app depends on the API it calls; the API does NOT depend on the web-app
+  that calls it. If a component isn't actually called by this one, it is not a
+  dependency of it (do not list it "for reference").
 - **`org-service`** — a service owned by ANOTHER project in the org that
   publishes its endpoint for cross-project use. `name` is the provider's
   component name. `{ "kind": "org-service", "name": "identity-api" }`.
@@ -170,7 +175,7 @@ kind by WHAT the target is:
 
 ```json
 "dependencies": [
-  { "kind": "component", "name": "expense-webapp" },
+  { "kind": "component", "name": "expense-api" },
   { "kind": "platform-resource", "name": "orders-db", "resourceType": "postgres" },
   { "kind": "external", "name": "stripe",
     "config": [ { "key": "STRIPE_API_KEY", "secret": true, "description": "Your Stripe secret API key" } ] },

--- a/skills/high-level-architecture/SKILL.md
+++ b/skills/high-level-architecture/SKILL.md
@@ -142,8 +142,13 @@ every arrow there appears here and vice versa — a mismatch is a defect. Each
 entry has a `kind` (which selects the meaningful fields) and a `name`; pick the
 kind by WHAT the target is:
 
-- **`component`** — a SIBLING component in this same design (a `<name>/` under
-  `components/`). Just `{ "kind": "component", "name": "expense-webapp" }`.
+- **`component`** — a SIBLING component in this same design that THIS component
+  CALLS: a directed caller→callee edge (one Interactions arrow). Declare it ONLY
+  on the caller, naming the callee it invokes:
+  `{ "kind": "component", "name": "expense-api" }`. Never add the reverse edge —
+  a web-app depends on the API it calls; the API does NOT depend on the web-app
+  that calls it. If a component isn't actually called by this one, it is not a
+  dependency of it (do not list it "for reference").
 - **`org-service`** — a service owned by ANOTHER project in the org that
   publishes its endpoint for cross-project use. `name` is the provider's
   component name. `{ "kind": "org-service", "name": "identity-api" }`.
@@ -170,7 +175,7 @@ kind by WHAT the target is:
 
 ```json
 "dependencies": [
-  { "kind": "component", "name": "expense-webapp" },
+  { "kind": "component", "name": "expense-api" },
   { "kind": "platform-resource", "name": "orders-db", "resourceType": "postgres" },
   { "kind": "external", "name": "stripe",
     "config": [ { "key": "STRIPE_API_KEY", "secret": true, "description": "Your Stripe secret API key" } ] },


### PR DESCRIPTION
## What this fixes

A generated design declared a **backwards `component` dependency**: the service `audit-hub-api` listed the web-app it serves (`audit-hub-webapp`) as a `component` dependency — with the agent's own description admitting *"not called by this service, listed for reference."*

A `component` dependency is a **directed caller→callee edge** ("this component *calls* that one"). The correct edge already existed on the web-app side (`audit-hub-webapp → audit-hub-api`); the reverse edge on the api is spurious.

**Why it matters:** a reverse edge draws a wrong arrow in the cell diagram, and — worse — the #164 build funnel treats a `component` dependency as something to wait on, so a bogus edge can gate a component's coding on the wrong sibling.

**Root cause:** the skill defined `component` as *"a SIBLING component in this same design"* with **no direction rule**, and its example even named a **web-app** as the dependency target — modelling the wrong direction.

## The change

- States the rule **positively**: declare a `component` dependency **only on the caller**, naming the callee it invokes; never the reverse; and don't list a component "for reference" if it isn't actually called.
- Fixes the example to name a **service** callee (`expense-api`) instead of a web-app.

```
web-app  ──calls──▶  api        ✅  api is a `component` dep OF the web-app
api      ──▶ web-app            ❌  never — the api doesn't call the web-app
```

Re-vendors `skills/embedded/` so the aep-api-compiled copy matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte
