### PR TITLE
feat: stream addFile content live into the collab doc + chat "Creating…" card

### DIFF
--- a/apps/console/src/features/agent-chat/chatStore.test.ts
+++ b/apps/console/src/features/agent-chat/chatStore.test.ts
@@ -40,6 +40,7 @@ import {
   getMessages,
   setTurnStatus,
   subscribe,
+  upsertToolMessage,
 } from "./chatStore";
 
 let n = 0;
@@ -82,11 +83,50 @@ describe("chatStore", () => {
     const key = freshKey();
     addMessage(key, { role: "user", content: "go", turnId: "t1", status: "in_flight" });
     appendAssistantText(key, "t1", "partial");
-    addMessage(key, { role: "tool", turnId: "t1", op: "edit", path: "requirements/prd.md", ok: true });
+    addMessage(key, {
+      role: "tool",
+      turnId: "t1",
+      toolCallId: "c1",
+      status: "done",
+      op: "edit",
+      path: "requirements/prd.md",
+      ok: true,
+    });
     dropTurnOutput(key, "t1");
     const msgs = getMessages(key);
     expect(msgs).toHaveLength(1);
     expect(msgs[0]?.role).toBe("user");
+  });
+
+  it("upsertToolMessage inserts a streaming card then flips it to done in place", () => {
+    const key = freshKey();
+    const base = {
+      role: "tool" as const,
+      turnId: "t1",
+      toolCallId: "c1",
+      op: "add",
+      path: "specs/requirements/requirements.md",
+      ok: true,
+    };
+    upsertToolMessage(key, { ...base, status: "streaming" });
+    expect(getMessages(key)).toHaveLength(1);
+    expect(getMessages(key)[0]).toMatchObject({ status: "streaming", op: "add" });
+    upsertToolMessage(key, { ...base, status: "done" });
+    const msgs = getMessages(key);
+    expect(msgs).toHaveLength(1); // same card, updated in place — no duplicate row
+    expect(msgs[0]).toMatchObject({ status: "done", op: "add" });
+  });
+
+  it("upsertToolMessage keeps distinct toolCallIds apart and never matches a blank id", () => {
+    const key = freshKey();
+    const mk = (toolCallId: string, path: string) => ({
+      role: "tool" as const, turnId: "t1", toolCallId, status: "done" as const, op: "add", path, ok: true,
+    });
+    upsertToolMessage(key, mk("c1", "a.md"));
+    upsertToolMessage(key, mk("c2", "b.md"));
+    upsertToolMessage(key, mk("", "c.md"));
+    upsertToolMessage(key, mk("", "d.md"));
+    expect(getMessages(key)).toHaveLength(4);
   });
 
   it("mints one conversation id per project and persists it", () => {

--- a/apps/console/src/features/agent-chat/chatStore.ts
+++ b/apps/console/src/features/agent-chat/chatStore.ts
@@ -35,6 +35,10 @@ export type ChatMessage =
       id: string;
       role: "tool";
       turnId: string;
+      /** Correlates the streaming card with its tool-result (== toolCallId). */
+      toolCallId: string;
+      /** `streaming` while the tool input is still arriving; `done` on result. */
+      status: "streaming" | "done";
       op: string;
       path: string;
       ok: boolean;
@@ -106,6 +110,30 @@ type WithoutId<T> = T extends unknown ? Omit<T, "id"> : never;
 
 export function addMessage(key: string, msg: WithoutId<ChatMessage>): void {
   persist(key, [...load(key), { ...msg, id: nextId() } as ChatMessage]);
+}
+
+/**
+ * Add or update a tool card in place, keyed by `toolCallId`. A "streaming" card
+ * ("Creating <file>") is written the moment the path resolves mid tool-input,
+ * then flipped to "done" ("Created <file>") on the tool-result — same card, no
+ * duplicate row. A blank toolCallId always appends (never a false in-place hit).
+ */
+export function upsertToolMessage(
+  key: string,
+  msg: WithoutId<Extract<ChatMessage, { role: "tool" }>>,
+): void {
+  const messages = [...load(key)];
+  const idx = msg.toolCallId
+    ? messages.findIndex(
+        (m) => m.role === "tool" && m.toolCallId === msg.toolCallId,
+      )
+    : -1;
+  if (idx >= 0) {
+    messages[idx] = { ...messages[idx], ...msg, id: messages[idx]!.id } as ChatMessage;
+  } else {
+    messages.push({ ...msg, id: nextId() } as ChatMessage);
+  }
+  persist(key, messages);
 }
 
 /** Streamed text accumulates into the turn's last assistant message. */

--- a/apps/console/src/features/agent-chat/components/AgentChatPanel.tsx
+++ b/apps/console/src/features/agent-chat/components/AgentChatPanel.tsx
@@ -67,19 +67,38 @@ function instructionFor(
 // new stack — narration + tool cards; the agent's FILE edits arrive through
 // the live spec room (collab turns), not through this panel.
 
-function opLabel(op: string): string {
+function opLabel(op: string, status: "streaming" | "done"): string {
+  const active = status === "streaming";
   switch (op) {
     case "add":
-      return "Created";
+      return active ? "Creating" : "Created";
     case "remove":
-      return "Deleted";
+      return active ? "Deleting" : "Deleted";
     default:
-      return "Modified";
+      return active ? "Modifying" : "Modified";
   }
 }
 
 function leafName(path: string): string {
   return path.split("/").at(-1) ?? path;
+}
+
+// A small spinning ring shown while a tool's input is still streaming in.
+function Spinner() {
+  return (
+    <Box
+      sx={{
+        width: 12,
+        height: 12,
+        borderRadius: "50%",
+        border: "2px solid",
+        borderColor: "divider",
+        borderTopColor: "primary.main",
+        animation: "agentChatSpin 0.7s linear infinite",
+        "@keyframes agentChatSpin": { to: { transform: "rotate(360deg)" } },
+      }}
+    />
+  );
 }
 
 function MessageRow({ msg }: { msg: ChatMessage }) {
@@ -170,18 +189,20 @@ function ToolCardRow({
         py: 0.75,
         borderRadius: 1.5,
         border: 1,
-        borderColor: msg.ok ? "divider" : "error.main",
+        borderColor: !msg.ok && msg.status === "done" ? "error.main" : "divider",
         bgcolor: "background.paper",
       }}
     >
-      {msg.ok ? (
+      {msg.status === "streaming" ? (
+        <Spinner />
+      ) : msg.ok ? (
         <Check size={14} color="var(--oxygen-palette-success-main, green)" />
       ) : (
         <XIcon size={14} color="var(--oxygen-palette-error-main, red)" />
       )}
       <Wrench size={14} />
       <Typography variant="caption" color="text.secondary">
-        {opLabel(msg.op)}
+        {opLabel(msg.op, msg.status)}
       </Typography>
       {showFile && (
         <Tooltip title={msg.path}>
@@ -220,7 +241,8 @@ function ToolGroup({
       </Box>
     ) : null;
   }
-  const anyFailed = tools.some((t) => !t.ok);
+  const anyStreaming = tools.some((t) => t.status === "streaming");
+  const anyFailed = tools.some((t) => t.status === "done" && !t.ok);
   return (
     <Box sx={{ ml: 4 }}>
       <Stack
@@ -242,7 +264,9 @@ function ToolGroup({
           "&:hover": { bgcolor: "action.hover" },
         }}
       >
-        {anyFailed ? (
+        {anyStreaming ? (
+          <Spinner />
+        ) : anyFailed ? (
           <XIcon size={14} color="var(--oxygen-palette-error-main, red)" />
         ) : (
           <Check size={14} color="var(--oxygen-palette-success-main, green)" />

--- a/apps/console/src/features/agent-chat/runTurn.ts
+++ b/apps/console/src/features/agent-chat/runTurn.ts
@@ -20,10 +20,17 @@
 // the FILE changes in the live room doc, so the panel folds only narration
 // (text deltas), tool results (cards), errors, and the one aep-api terminal.
 
-import { parseSseStream, toChange, type StreamPart } from "@aep/agent-stream";
+import {
+  parseSseStream,
+  toChange,
+  opForTool,
+  readToolInputPath,
+  type StreamPart,
+} from "@aep/agent-stream";
 import {
   appendAssistantText,
   addMessage,
+  upsertToolMessage,
   setTurnStatus,
 } from "./chatStore.js";
 import { getTurn, openTurnStream } from "./api/turns.js";
@@ -43,18 +50,49 @@ export async function attachAndFoldTurn(
   signal: AbortSignal,
 ): Promise<void> {
   let sawTerminal = false;
+  // Per tool call: accumulate its streamed input args so the path can be read as
+  // soon as it closes (path is the first schema property), then show a "Creating
+  // <file>" card BEFORE the tool finishes. Keyed by the input-stream id (== the
+  // eventual toolCallId). `carded` guards against re-emitting once shown.
+  const inputs = new Map<string, { toolName: string; buf: string; carded: boolean }>();
 
   const fold = (part: StreamPart): void => {
     switch (part.type) {
       case "text-delta":
         appendAssistantText(chatKey, turnId, part.delta ?? part.text ?? "");
         break;
+      case "tool-input-start":
+        if (part.toolName && FILE_TOOLS.has(part.toolName) && part.id) {
+          inputs.set(part.id, { toolName: part.toolName, buf: "", carded: false });
+        }
+        break;
+      case "tool-input-delta": {
+        const st = part.id ? inputs.get(part.id) : undefined;
+        if (!st || st.carded) break;
+        st.buf += part.delta ?? "";
+        const path = readToolInputPath(st.buf);
+        if (path) {
+          st.carded = true;
+          upsertToolMessage(chatKey, {
+            role: "tool",
+            turnId,
+            toolCallId: part.id!,
+            status: "streaming",
+            op: opForTool(st.toolName),
+            path,
+            ok: true,
+          });
+        }
+        break;
+      }
       case "tool-result": {
         if (!part.toolName || !FILE_TOOLS.has(part.toolName)) break;
         const change = toChange(part);
-        addMessage(chatKey, {
+        upsertToolMessage(chatKey, {
           role: "tool",
           turnId,
+          toolCallId: part.toolCallId ?? "",
+          status: "done",
           op: change.op,
           path: change.path,
           ok: change.result?.ok !== false,
@@ -84,7 +122,7 @@ export async function attachAndFoldTurn(
         });
         break;
       default:
-        break; // start/finish/tool-input plumbing — nothing to render
+        break; // start/finish/tool-input-end/tool-call plumbing — nothing to render
     }
   };
 

--- a/apps/console/src/features/agent-chat/toolGrouping.test.ts
+++ b/apps/console/src/features/agent-chat/toolGrouping.test.ts
@@ -24,6 +24,8 @@ const tool = (id: string, path: string, ok = true): ChatMessage => ({
   id,
   role: "tool",
   turnId: "t1",
+  toolCallId: id,
+  status: "done",
   op: "edit",
   path,
   ok,

--- a/apps/console/src/mocks/handlers/agent-chat.ts
+++ b/apps/console/src/mocks/handlers/agent-chat.ts
@@ -75,13 +75,23 @@ export const agentChatHandlers = [
     }
     return sse([
       { type: "text-delta", delta: "Joining the spec workspace… " },
-      { type: "text-delta", delta: "I'll update the requirements now." },
+      { type: "text-delta", delta: "I'll create the requirements now." },
+      // Streamed tool input: the panel shows "Creating requirements.md" as soon
+      // as the path resolves, then flips to "Created" on the tool-result.
+      { type: "tool-input-start", id: "tc-1", toolName: "addFile" },
+      {
+        type: "tool-input-delta",
+        id: "tc-1",
+        delta: '{"path":"specs/requirements/requirements.md","content":"# Requirements',
+      },
+      { type: "tool-input-delta", id: "tc-1", delta: '\\n\\n## Overview\\nA simple todo app.' },
+      { type: "tool-input-end", id: "tc-1" },
       {
         type: "tool-result",
-        toolName: "editFile",
+        toolName: "addFile",
         toolCallId: "tc-1",
         input: { path: "specs/requirements/requirements.md" },
-        output: { ok: true, op: "edit", path: "specs/requirements/requirements.md", status: "applied" },
+        output: { ok: true, op: "add", path: "specs/requirements/requirements.md", status: "applied" },
       },
       { type: "text-delta", delta: "\n\nDone — the change is live in the shared doc." },
       { type: "turn-committed", noChanges: true },

--- a/packages/agent-stream/src/change.ts
+++ b/packages/agent-stream/src/change.ts
@@ -48,6 +48,29 @@ export function isFileMutationTool(toolName: string): boolean {
   return Object.hasOwn(OP_BY_TOOL, toolName);
 }
 
+/** Wire tool name → op, for labelling a tool card BEFORE its result arrives. */
+export function opForTool(toolName: string): Op {
+  return OP_BY_TOOL[toolName] ?? "edit";
+}
+
+/**
+ * Best-effort read of the `path` field from a PARTIAL tool-input args buffer
+ * (the concatenated `tool-input-delta`s). `path` is the first schema property in
+ * every file tool, so it resolves the instant its JSON string closes — letting a
+ * consumer label a card ("Creating <path>") mid-stream, before the tool finishes.
+ * Returns undefined until the path string is complete. Intentionally regex-based
+ * and dependency-light (the console can't pull the AI SDK's parsePartialJson).
+ */
+export function readToolInputPath(buf: string): string | undefined {
+  const m = /"path"\s*:\s*"((?:[^"\\]|\\.)*)"/.exec(buf);
+  if (!m) return undefined;
+  try {
+    return JSON.parse(`"${m[1]}"`) as string;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Pure field projection of ONE `tool-result` part → a reviewable `Change`. The
  * part carries everything in one frame (`input` + `output`), so any consumer

--- a/packages/agent-stream/src/index.ts
+++ b/packages/agent-stream/src/index.ts
@@ -94,7 +94,7 @@ export type { Equal } from "./type-equal.js";
 
 // --- The fold surface --------------------------------------------------------
 export { FileBundle, lf, FRONTMATTER_RE } from "./bundle.js";
-export { toChange, applyToolCall, isFileMutationTool } from "./change.js";
+export { toChange, applyToolCall, isFileMutationTool, opForTool, readToolInputPath } from "./change.js";
 
 // --- The component design.json write-gate (travels with FileBundle) ----------
 export {

--- a/packages/agent-stream/test/change.test.ts
+++ b/packages/agent-stream/test/change.test.ts
@@ -20,7 +20,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { FileBundle } from "../src/bundle.js";
 import { SEED_FILES } from "./seed.js";
-import { toChange, applyToolCall, isFileMutationTool } from "../src/change.js";
+import {
+  toChange,
+  applyToolCall,
+  isFileMutationTool,
+  opForTool,
+  readToolInputPath,
+} from "../src/change.js";
 import type { StreamPart } from "../src/stream-types.js";
 
 const OPENAPI = "specs/design/components/hello-api/openapi.yaml";
@@ -41,6 +47,28 @@ test("applyToolCall reconstructs file state by folding an editFile call (matches
   // with no second matcher — the eval relies on this (newContent is gone, §5).
   assert.deepEqual(folded.snapshot(), direct.snapshot());
   assert.ok(folded.read(OPENAPI)!.includes('"Hi there!"'));
+});
+
+test("readToolInputPath resolves the path once its string closes, decoding escapes", () => {
+  // Path string still open → not resolvable yet.
+  assert.equal(readToolInputPath('{"path":"specs/req'), undefined);
+  // Path closed (content just starting) → resolved even though the object isn't.
+  assert.equal(
+    readToolInputPath('{"path":"specs/requirements/requirements.md","content":"# R'),
+    "specs/requirements/requirements.md",
+  );
+  // JSON escapes in the path are decoded.
+  assert.equal(readToolInputPath('{"path":"a\\"b.md"'), 'a"b.md');
+  // No path key present yet.
+  assert.equal(readToolInputPath("{"), undefined);
+  assert.equal(readToolInputPath(""), undefined);
+});
+
+test("opForTool maps file tools to ops (unknown → edit)", () => {
+  assert.equal(opForTool("addFile"), "add");
+  assert.equal(opForTool("editFile"), "edit");
+  assert.equal(opForTool("removeFile"), "remove");
+  assert.equal(opForTool("loadSkill"), "edit");
 });
 
 test("applyToolCall folds add then remove in stream order", () => {

--- a/services/agents/src/collab/streaming-add.test.ts
+++ b/services/agents/src/collab/streaming-add.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * StreamingDocWriter unit tests — deterministic, no model. We hand-craft the
+ * `tool-input-*` / `tool-result` parts (chunking the JSON args exactly like a
+ * provider would) and assert what lands on a fake RoomPeer.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FileBundle, type StreamPart } from "@aep/agent-stream";
+import type { RoomPeer } from "./room-peer.js";
+import { StreamingDocWriter } from "./streaming-add.js";
+
+class FakePeer implements RoomPeer {
+  sets: { path: string; content: string }[] = [];
+  deletes: string[] = [];
+  files(): Record<string, string> {
+    return {};
+  }
+  set(path: string, content: string): void {
+    this.sets.push({ path, content });
+  }
+  delete(path: string): void {
+    this.deletes.push(path);
+  }
+  leave(): void {}
+}
+
+/** Chunk an addFile's JSON args into `tool-input-delta`s (start..deltas..end). */
+function addFileParts(id: string, path: string, content: string, chunk = 7): StreamPart[] {
+  const wire = JSON.stringify({ path, content });
+  const parts: StreamPart[] = [{ type: "tool-input-start", id, toolName: "addFile" }];
+  for (let i = 0; i < wire.length; i += chunk) {
+    parts.push({ type: "tool-input-delta", id, delta: wire.slice(i, i + chunk) });
+  }
+  parts.push({ type: "tool-input-end", id });
+  return parts;
+}
+
+function toolResult(id: string, ok: boolean, path: string): StreamPart {
+  return {
+    type: "tool-result",
+    toolCallId: id,
+    toolName: "addFile",
+    input: { path },
+    output: { ok, path, op: "add", status: ok ? "applied" : undefined },
+  };
+}
+
+async function feed(writer: StreamingDocWriter, parts: StreamPart[]): Promise<void> {
+  for (const p of parts) writer.observe(p);
+  await writer.drain();
+}
+
+const MD_PATH = "specs/requirements/requirements.md";
+const MD = "# Todo App\n\n## Overview\nManage todo items.\n\n## Rules\n- title\n- done flag\n";
+
+test("streams markdown addFile incrementally, line-by-line, converging to full content", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+
+  await feed(writer, addFileParts("c1", MD_PATH, MD));
+  writer.observe(toolResult("c1", true, MD_PATH));
+  await writer.drain();
+
+  assert.ok(peer.sets.length >= 2, `expected incremental writes, got ${peer.sets.length}`);
+  assert.ok(peer.sets.every((s) => s.path === MD_PATH), "all writes target the same path");
+
+  // Monotonic prefix growth: each write extends the previous.
+  for (let i = 1; i < peer.sets.length; i++) {
+    assert.ok(
+      peer.sets[i]!.content.startsWith(peer.sets[i - 1]!.content),
+      `write ${i} must extend write ${i - 1}`,
+    );
+  }
+  // At least one intermediate write ends on a line boundary (proves line flushing).
+  assert.ok(
+    peer.sets.slice(0, -1).some((s) => s.content.endsWith("\n")),
+    "expected a line-boundary intermediate write",
+  );
+  // Final write is the whole body; nothing rolled back.
+  assert.equal(peer.sets.at(-1)!.content, MD);
+  assert.deepEqual(peer.deletes, []);
+  assert.deepEqual(writer.rollbackDangling(), []);
+});
+
+test("path resolves before any content is written", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+  await feed(writer, addFileParts("c1", MD_PATH, MD));
+  // The very first write already knows the correct path (path streamed first).
+  assert.ok(peer.sets.length > 0);
+  assert.equal(peer.sets[0]!.path, MD_PATH);
+});
+
+test("skips non-markdown addFile (execute owns yaml/json — no preview)", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+  await feed(writer, addFileParts("c1", "specs/design/components/x/openapi.yaml", "openapi: 3.0.0\ninfo: {}\n"));
+  writer.observe(toolResult("c1", true, "specs/design/components/x/openapi.yaml"));
+  await writer.drain();
+  assert.deepEqual(peer.sets, []);
+  assert.deepEqual(peer.deletes, []);
+});
+
+test("skips addFile onto an already-existing path", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({ [MD_PATH]: "old" }));
+  await feed(writer, addFileParts("c1", MD_PATH, MD));
+  assert.deepEqual(peer.sets, []);
+});
+
+test("rolls back a truncated stream (no tool-input-end, no tool-result)", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+
+  const parts = addFileParts("c1", MD_PATH, MD);
+  // Drop the tool-input-end and everything is left dangling mid-body.
+  const truncated = parts.slice(0, Math.floor(parts.length * 0.6));
+  await feed(writer, truncated);
+
+  assert.ok(peer.sets.length >= 1, "should have optimistically written a partial preview");
+  const dropped = writer.rollbackDangling();
+  assert.deepEqual(dropped, [MD_PATH]);
+  assert.deepEqual(peer.deletes, [MD_PATH]);
+});
+
+test("rolls back when execute rejects the op (tool-result ok:false)", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+  await feed(writer, addFileParts("c1", MD_PATH, MD));
+  writer.observe(toolResult("c1", false, MD_PATH));
+  await writer.drain();
+
+  assert.deepEqual(peer.deletes, [MD_PATH], "rejected op must undo the optimistic preview");
+  assert.deepEqual(writer.rollbackDangling(), [], "already finalized — no double drop");
+});
+
+test("handles two concurrent addFile calls independently (keyed by id)", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+  const p1 = addFileParts("c1", "specs/requirements/a.md", "# A\nalpha\n");
+  const p2 = addFileParts("c2", "specs/requirements/b.md", "# B\nbeta\n");
+  // Interleave the two streams.
+  const merged: StreamPart[] = [];
+  for (let i = 0; i < Math.max(p1.length, p2.length); i++) {
+    if (p1[i]) merged.push(p1[i]!);
+    if (p2[i]) merged.push(p2[i]!);
+  }
+  await feed(writer, merged);
+  writer.observe(toolResult("c1", true, "specs/requirements/a.md"));
+  writer.observe(toolResult("c2", true, "specs/requirements/b.md"));
+  await writer.drain();
+
+  assert.equal(peer.sets.filter((s) => s.path === "specs/requirements/a.md").at(-1)!.content, "# A\nalpha\n");
+  assert.equal(peer.sets.filter((s) => s.path === "specs/requirements/b.md").at(-1)!.content, "# B\nbeta\n");
+  assert.deepEqual(peer.deletes, []);
+});

--- a/services/agents/src/collab/streaming-add.ts
+++ b/services/agents/src/collab/streaming-add.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * StreamingDocWriter (#86 follow-up) — live-stream an `addFile` body into the
+ * collab doc AS THE MODEL TYPES IT, instead of one write when the tool call
+ * closes. It is a pure OPTIMISTIC PREVIEW layered over the parts the turn loop
+ * already forwards; the tool's `execute()` (DocFileBundle → FileBundle) stays the
+ * authority for validation and the D14 manifest, so this writes nothing the
+ * bundle wouldn't, and the final flush reconciles to the same content (an
+ * idempotent no-op once `execute` runs).
+ *
+ * Mechanism:
+ *  - AI SDK v7 streams tool input as `tool-input-start` → `tool-input-delta` (a
+ *    growing, JSON-escaped args buffer) → `tool-input-end`, correlated by `id`
+ *    (== the later `toolCallId`).
+ *  - `parsePartialJson` (from `ai`) decodes the partial buffer; `path` resolves
+ *    strictly before `content` starts (schema property order is load-bearing,
+ *    files.ts), so the moment `content` appears the path is final and gate-able.
+ *  - Writes flush on LINE BOUNDARIES: char-by-char markdown churns the
+ *    ProseMirror fragment (~30× the Yjs traffic + rewrites earlier text); line
+ *    boundaries are clean.
+ *
+ * Scope (v1): room-mode, MARKDOWN addFile only (no content-gate ⇒ no deferred
+ * -validation risk). Non-md / already-existing paths are skipped (execute owns
+ * them). Non-finalized streams (truncation / reject) are rolled back.
+ */
+
+import { parsePartialJson } from "ai";
+import { isMarkdownPath } from "@aep/collab-doc";
+import type { FileBundle, StreamPart } from "@aep/agent-stream";
+import type { RoomPeer } from "./room-peer.js";
+import { ADD_FILE } from "../agents/main/tools/files.js";
+
+interface CallState {
+  /** Accumulated tool-input args text (JSON) for this tool call. */
+  buf: string;
+  /** Resolved + gated path; set once we commit to streaming this call. */
+  path?: string;
+  /** True once the path passed the gate and we are mirroring content. */
+  streaming: boolean;
+  /** True once the path failed the gate — ignore this call's deltas. */
+  skipped: boolean;
+  /** Chars of `content` already written to the doc (line-boundary watermark). */
+  flushedLen: number;
+  /** True once `execute` confirmed the write (ok) — excludes it from rollback. */
+  finalized: boolean;
+}
+
+export class StreamingDocWriter {
+  private readonly calls = new Map<string, CallState>();
+  /** Serializes async handling so `observe` stays sync and writes stay ordered. */
+  private tail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly peer: RoomPeer,
+    private readonly bundle: FileBundle,
+  ) {}
+
+  /** Feed one stream part (call for EVERY part the turn forwards). Never throws. */
+  observe(part: StreamPart): void {
+    this.tail = this.tail.then(() => this.handle(part)).catch(() => {});
+  }
+
+  /** Await all queued work. Call once the stream ends, before rollbackDangling. */
+  async drain(): Promise<void> {
+    await this.tail;
+  }
+
+  /**
+   * Delete any path we optimistically streamed but that `execute` never
+   * confirmed (a severed/truncated stream, or a rejected op). Idempotent; call
+   * on every turn exit path after `drain()`. Returns the paths dropped.
+   */
+  rollbackDangling(): string[] {
+    const dropped: string[] = [];
+    for (const s of this.calls.values()) {
+      if (s.streaming && s.path && !s.finalized) {
+        this.peer.delete(s.path);
+        s.finalized = true; // don't double-drop
+        dropped.push(s.path);
+      }
+    }
+    return dropped;
+  }
+
+  private async handle(part: StreamPart): Promise<void> {
+    switch (part.type) {
+      case "tool-input-start":
+        if (part.toolName === ADD_FILE && part.id) {
+          this.calls.set(part.id, {
+            buf: "",
+            streaming: false,
+            skipped: false,
+            flushedLen: 0,
+            finalized: false,
+          });
+        }
+        return;
+
+      case "tool-input-delta": {
+        const s = part.id ? this.calls.get(part.id) : undefined;
+        if (!s || s.skipped) return;
+        s.buf += part.delta ?? "";
+        const content = await this.decodeContent(s.buf);
+        if (content === undefined) return; // content not started (or unparseable yet)
+
+        // Gate exactly once: content having started means `path` is final.
+        if (!s.streaming) {
+          const path = await this.decodePath(s.buf);
+          if (path && isMarkdownPath(path) && !this.bundle.has(path)) {
+            s.streaming = true;
+            s.path = path;
+          } else {
+            s.skipped = true; // non-md / already-exists → execute owns it, no preview
+            return;
+          }
+        }
+        this.flushLines(s, content);
+        return;
+      }
+
+      case "tool-input-end": {
+        const s = part.id ? this.calls.get(part.id) : undefined;
+        if (!s || !s.streaming || !s.path) return;
+        const content = await this.decodeContent(s.buf);
+        // Final flush: the whole body (incl. the trailing partial line).
+        if (content !== undefined && content.length > s.flushedLen) {
+          this.peer.set(s.path, content);
+          s.flushedLen = content.length;
+        }
+        return;
+      }
+
+      case "tool-result": {
+        const s = part.toolCallId ? this.calls.get(part.toolCallId) : undefined;
+        if (!s || !s.streaming || !s.path) return;
+        const out = part.output as { ok?: boolean } | undefined;
+        if (out?.ok) {
+          s.finalized = true; // execute wrote authoritatively — keep the doc content
+        } else {
+          this.peer.delete(s.path); // execute rejected — undo the optimistic preview
+          s.finalized = true;
+        }
+        return;
+      }
+    }
+  }
+
+  /** Write all COMPLETE lines of `content` past the watermark (diff ⇒ tail insert). */
+  private flushLines(s: CallState, content: string): void {
+    const lastNl = content.lastIndexOf("\n");
+    const boundary = lastNl + 1; // include the newline; 0 when there is none yet
+    if (boundary > s.flushedLen) {
+      this.peer.set(s.path!, content.slice(0, boundary));
+      s.flushedLen = boundary;
+    }
+  }
+
+  private async decodeContent(buf: string): Promise<string | undefined> {
+    const { value } = await parsePartialJson(buf);
+    const c = (value as { content?: unknown } | undefined)?.content;
+    return typeof c === "string" ? c : undefined;
+  }
+
+  private async decodePath(buf: string): Promise<string> {
+    const { value } = await parsePartialJson(buf);
+    const p = (value as { path?: unknown } | undefined)?.path;
+    return typeof p === "string" ? p.trim() : "";
+  }
+}

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -32,6 +32,7 @@
 import { isStepCount, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { FileBundle, type McpConfig, type StreamPart, type Toolset } from "@aep/agent-stream";
 import { DocFileBundle } from "../collab/doc-bundle.js";
+import { StreamingDocWriter } from "../collab/streaming-add.js";
 import type { RoomPeer } from "../collab/room-peer.js";
 import { runTurn } from "../agents/main/run-turn.js";
 import { buildFileTools, ASK_QUESTION } from "../agents/main/tools/files.js";
@@ -139,6 +140,10 @@ export interface RunConversationTurnInput {
 
 export async function runConversationTurn(input: RunConversationTurnInput): Promise<Conversation> {
   input.guard.acquire(input.id); // throws ConcurrentTurnError on a concurrent turn → 409
+  // Live-preview writer (flag-gated, room-scoped files turns only): mirrors each
+  // addFile body into the doc AS IT STREAMS. Hoisted so the finally can drain +
+  // roll back a severed/rejected preview on EVERY exit path (before peer.leave).
+  let docWriter: StreamingDocWriter | undefined;
   try {
     // 1. load or lazily create
     const conv = (await input.store.get(input.id)) ?? freshConversation(input.id);
@@ -186,6 +191,22 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       }
     }
 
+    // 3c. Live doc streaming: a room-scoped `files` turn has a bundle + peer to
+    //     preview into, so mirror each applied addFile body onto the doc as it
+    //     streams. Wrap onEvent so the writer observes every part; SSE forwarding
+    //     is unaffected (observe only enqueues). The bundle's execute() stays the
+    //     authority (validation + D14 manifest); the writer is an optimistic
+    //     preview that reconciles to the same content.
+    if (input.collabPeer && bundle) {
+      docWriter = new StreamingDocWriter(input.collabPeer, bundle);
+    }
+    const onEvent = docWriter
+      ? (p: StreamPart) => {
+          docWriter!.observe(p);
+          input.onEvent(p);
+        }
+      : input.onEvent;
+
     // 4. one generic turn. The instructions append the skill catalog at the END
     //    of the system prompt; buildPrompt inlines CURRENT STATE; prepend a one-line
     //    divergence note ONLY when the FE flagged an external edit (append-only).
@@ -200,7 +221,7 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       stopWhen: [isStepCount(config.maxSteps) /*, hasToolCall("ask_question") */],
       maxOutputTokens: config.maxOutputTokens,
       providerOptions: modelProviderOptions(),
-      onEvent: input.onEvent,
+      onEvent,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });
 
@@ -225,6 +246,14 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
     input.onEvent(buildManifestPart(bundle));
     return conv;
   } finally {
+    // Drain the live-preview writer and undo any addFile body we streamed but that
+    // never finalized (a severed or rejected op). Runs before the server detaches
+    // the peer (server.ts finally); on a clean turn every preview is already
+    // finalized by its tool-result, so this drops nothing.
+    if (docWriter) {
+      await docWriter.drain();
+      docWriter.rollbackDangling();
+    }
     input.guard.release(input.id);
   }
 }


### PR DESCRIPTION
## What

Live-stream an `addFile` markdown body into the collab Y.Doc **as the model types it** (line-boundary flushed), so a generated `requirements.md` / `design.md` types itself in the spec editor — and reflect it in the agent chat: the tool card shows **"Creating <file>"** the moment the path resolves, then flips to **"Created"** on completion (spinner → check). **Default behavior** for room-scoped generation turns.

## How

**Agents** — `StreamingDocWriter` (`services/agents/src/collab/streaming-add.ts`) observes the `tool-input-start/delta/end` parts the turn already forwards, decodes the growing args via `parsePartialJson`, gates on the path (markdown + new file), and mirrors **line-flushed** writes onto the `RoomPeer`; rolls back (`peer.delete`) any body left un-finalized by a severed/rejected op. Wired into `run-conversation-turn.ts` (wrapped `onEvent` + drain/rollback in the `finally`). `execute()` / `DocFileBundle` remain the authority for validation + the D14 manifest — the writer is an idempotent optimistic preview.

**Console** — `runTurn` now consumes the `tool-input-*` SSE parts (previously dropped at the fold's default case): a "streaming" card appears once the path resolves and flips to "done" on the tool-result. Also covers `editFile` ("Modifying"). New dependency-light helpers `opForTool` + `readToolInputPath` in `@aep/agent-stream`; the `chatStore` tool message gains `status` + `toolCallId` with an `upsertToolMessage` (update-in-place).

## Notes

- **Line-boundary flushing is required**: char-by-char markdown churns the ProseMirror fragment ~30× and rewrites earlier text; line boundaries are clean.
- Anthropic streams tool input granularly (~37 `tool-input-delta`s for a 3.6 KB body), so there is real content to stream. The FE card path is independent of the write path (same tool-input stream), so it also works for `editFile`.

## Verification

- `agent-stream` 62/62, `agents` 140/140, console `agent-chat` 14/14; typecheck + lint clean.
- **e2e on a local cluster**: the body streams into the editor and the chat card goes Creating → Created; agent-marked md files are held by the committer for review; zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
