### PR TITLE
Streamed cell architecture diagram from a design DSL

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -38,12 +38,16 @@ RUN pnpm install --frozen-lockfile --filter @aep/console...
 # (@aep/agent-stream — the agent-chat panel's SSE contracts, #130;
 # @aep/collab-doc — the AgentInsertion mark shared with the editor, #86 ph6;
 # @aep/design-projection + @aep/excalidraw-dsl — the rich design view's
-# projection + wireframe DSL, #149). The @aep/ui-* view packages resolve to
-# their src/ (types: src/index.ts) so tsc reads them directly — no pre-build.
+# projection + wireframe DSL, #149; @aep/ui-cell-diagram-react — the vendored
+# xyflow renderer, which ships types: dist/index.d.ts so consumers read its
+# pre-built declarations instead of re-typechecking its source). The
+# @aep/ui-cell-diagram-view package resolves to its src/ (types: src/index.ts)
+# so tsc reads it directly — no pre-build.
 RUN pnpm --filter @aep/agent-stream build
 RUN pnpm --filter @aep/collab-doc build
 RUN pnpm --filter @aep/design-projection build
 RUN pnpm --filter @aep/excalidraw-dsl build
+RUN pnpm --filter @aep/ui-cell-diagram-react build
 RUN pnpm --filter @aep/console gen
 RUN pnpm --filter @aep/console build
 

--- a/apps/console/src/features/projects/lib/promptStore.ts
+++ b/apps/console/src/features/projects/lib/promptStore.ts
@@ -78,17 +78,8 @@ export function buildSpecGenerationInstruction(prompt: string | null): string {
 export function buildDesignGenerationInstruction(): string {
   return (
     "Generate the complete component design for this project based on the " +
-    "current requirements. Emit the artifacts in EXACTLY this order: " +
-    "(1) FIRST specs/design/design.cell — the architecture diagram (use the " +
-    "cell-architecture-dsl skill for the grammar and boundary rules), written " +
-    "in a single addFile; the platform streams it into the live diagram as you " +
-    "write, so it renders line by line; " +
-    "(2) the overall architecture in specs/design/design.md; " +
-    "(3) for each component specs/design/components/<name>/design.json — the " +
-    "component ids MUST match those in design.cell, and every design.cell edge " +
-    "touching a component must appear as a dependency in that component's " +
-    "design.json; " +
-    "(4) openapi.yaml for services. If a design already exists, regenerate it to " +
-    "match the current requirements."
+    "current requirements, following the high-level-architecture skill (which " +
+    "begins with the specs/design/design.cell architecture diagram). If a " +
+    "design already exists, regenerate it to match the current requirements."
   );
 }

--- a/apps/console/src/features/projects/lib/promptStore.ts
+++ b/apps/console/src/features/projects/lib/promptStore.ts
@@ -78,8 +78,7 @@ export function buildSpecGenerationInstruction(prompt: string | null): string {
 export function buildDesignGenerationInstruction(): string {
   return (
     "Generate the complete component design for this project based on the " +
-    "current requirements, following the high-level-architecture skill (which " +
-    "begins with the specs/design/design.cell architecture diagram). If a " +
-    "design already exists, regenerate it to match the current requirements."
+    "current requirements. If a design already exists, regenerate it to match " +
+    "the current requirements."
   );
 }

--- a/apps/console/src/features/projects/lib/promptStore.ts
+++ b/apps/console/src/features/projects/lib/promptStore.ts
@@ -78,9 +78,17 @@ export function buildSpecGenerationInstruction(prompt: string | null): string {
 export function buildDesignGenerationInstruction(): string {
   return (
     "Generate the complete component design for this project based on the " +
-    "current requirements: the overall architecture in specs/design/design.md, " +
-    "and for each component specs/design/components/<name>/design.json (plus " +
-    "openapi.yaml for services). If a design already exists, regenerate it to " +
+    "current requirements. Emit the artifacts in EXACTLY this order: " +
+    "(1) FIRST specs/design/design.cell — the architecture diagram (use the " +
+    "cell-architecture-dsl skill for the grammar and boundary rules), written " +
+    "in a single addFile; the platform streams it into the live diagram as you " +
+    "write, so it renders line by line; " +
+    "(2) the overall architecture in specs/design/design.md; " +
+    "(3) for each component specs/design/components/<name>/design.json — the " +
+    "component ids MUST match those in design.cell, and every design.cell edge " +
+    "touching a component must appear as a dependency in that component's " +
+    "design.json; " +
+    "(4) openapi.yaml for services. If a design already exists, regenerate it to " +
     "match the current requirements."
   );
 }

--- a/apps/console/src/features/spec/api/designTree.test.ts
+++ b/apps/console/src/features/spec/api/designTree.test.ts
@@ -78,7 +78,25 @@ describe("buildDesignSection", () => {
   it("returns empty section when there are no design files", () => {
     const section = buildDesignSection([e("specs/requirements/prd.md")]);
     expect(section.hasComponents).toBe(false);
+    expect(section.hasCellDsl).toBe(false);
     expect(section.components).toEqual([]);
+    expect(section.overview).toEqual([]);
+  });
+
+  it("keeps design.cell out of the overview and flags hasCellDsl", () => {
+    const section = buildDesignSection([
+      e("specs/design/design.cell"),
+      e("specs/design/design.md"),
+    ]);
+    // design.cell is rendered via the Architecture tab, never as a file row.
+    expect(section.overview.map((f) => f.path)).toEqual(["specs/design/design.md"]);
+    expect(section.hasCellDsl).toBe(true);
+  });
+
+  it("flags hasCellDsl even before any component folders exist", () => {
+    const section = buildDesignSection([e("specs/design/design.cell")]);
+    expect(section.hasCellDsl).toBe(true);
+    expect(section.hasComponents).toBe(false);
     expect(section.overview).toEqual([]);
   });
 });

--- a/apps/console/src/features/spec/api/designTree.ts
+++ b/apps/console/src/features/spec/api/designTree.ts
@@ -36,8 +36,13 @@ export interface DesignSection {
   /** Design files directly under design/ (e.g. design.md). */
   overview: SpecFileEntry[];
   hasComponents: boolean;
+  /** Whether a project-level design.cell exists (drives the Architecture tab). */
+  hasCellDsl: boolean;
   components: DesignComponentNode[];
 }
+
+/** The project-level cell-diagram DSL path (rendered via the Architecture tab, never as a file). */
+export const DESIGN_CELL_PATH = "specs/design/design.cell";
 
 // SpecFileEntry.path is the full repo-relative path (mapping.ts's current
 // scheme — the unprefixed room-key scheme it retired), so this must match
@@ -61,8 +66,11 @@ function isDsl(path: string): boolean {
  */
 export function buildDesignSection(files: SpecFileEntry[]): DesignSection {
   const design = files.filter((f) => f.group === "designs");
+  const hasCellDsl = design.some((f) => f.path === DESIGN_CELL_PATH);
+  // design.cell is surfaced through the Architecture tab (streaming cell
+  // diagram), never as a raw text file — keep it out of the overview list.
   const overview = design
-    .filter((f) => componentOf(f.path) === null)
+    .filter((f) => componentOf(f.path) === null && f.path !== DESIGN_CELL_PATH)
     .sort((a, b) => a.path.localeCompare(b.path));
 
   const byComponent = new Map<string, DesignComponentNode>();
@@ -83,7 +91,7 @@ export function buildDesignSection(files: SpecFileEntry[]): DesignSection {
   );
   for (const c of components) c.files.sort((a, b) => a.path.localeCompare(b.path));
 
-  return { overview, hasComponents: components.length > 0, components };
+  return { overview, hasComponents: components.length > 0, hasCellDsl, components };
 }
 
 /** Stable string identity for a selection (React keys + selected-state compare). */

--- a/apps/console/src/features/spec/api/useDerivedDesign.ts
+++ b/apps/console/src/features/spec/api/useDerivedDesign.ts
@@ -18,24 +18,30 @@
 
 import { useMemo } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import type { CellDiagramProject } from "@aep/design-projection";
-import { deriveCellDiagramProject } from "../derive/deriveCellDiagram";
+import { deriveCellDsl } from "../derive/deriveCellDiagram";
 import { deriveWireframeScene } from "../derive/deriveWireframe";
 import { fetchSpecFileContent } from "./queries";
 import { specKeys } from "./keys";
 import type { SpecFileEntry } from "./mapping";
 
-/** The component design.json entries (drives both the fetch set and the memo key). */
+/**
+ * The COMMITTED component design.json entries (drives both the fetch set and
+ * the memo key). Only files with a real git blob sha are included: a collab-only
+ * file the agent is still writing carries `sha === ""` (SpecView seeds live doc
+ * paths that way) and does NOT exist in git yet, so REST-fetching it would 404
+ * on a loop. During live design those are shown via the streaming `design.cell`
+ * instead; the derived model kicks in once the design.json files commit.
+ */
 function designJsonEntries(files: SpecFileEntry[]): SpecFileEntry[] {
   return files
-    .filter((f) => f.group === "designs" && f.path.endsWith("/design.json"))
+    .filter((f) => f.group === "designs" && f.path.endsWith("/design.json") && f.sha !== "")
     .sort((a, b) => a.path.localeCompare(b.path));
 }
 
 export function useDerivedCellDiagram(
   projectName: string,
   files: SpecFileEntry[],
-): { project: CellDiagramProject | null; isPending: boolean; isError: boolean } {
+): { dsl: string | null; isPending: boolean; isError: boolean } {
   const entries = useMemo(() => designJsonEntries(files), [files]);
 
   const results = useQueries({
@@ -50,21 +56,21 @@ export function useDerivedCellDiagram(
   const isError = results.some((r) => r.isError);
   const dataKey = results.map((r) => r.data?.sha).join(",");
 
-  const project = useMemo(() => {
+  const dsl = useMemo(() => {
     if (isPending || isError) return null;
     // f.path is already the full repo path (specs/design/components/<c>/design.json)
-    // deriveCellDiagramProject expects — mapping.ts's SpecFileEntry.path scheme,
-    // no conversion needed (the old unprefixed room-key scheme is retired).
+    // deriveCellDsl expects — mapping.ts's SpecFileEntry.path scheme, no
+    // conversion needed (the old unprefixed room-key scheme is retired).
     const byRepoPath: Record<string, string> = {};
     entries.forEach((f, i) => {
       const content = results[i]?.data?.content;
       if (typeof content === "string") byRepoPath[f.path] = content;
     });
-    return deriveCellDiagramProject(byRepoPath);
+    return deriveCellDsl(projectName, byRepoPath);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entries, isPending, isError, dataKey]);
+  }, [entries, isPending, isError, dataKey, projectName]);
 
-  return { project, isPending, isError };
+  return { dsl, isPending, isError };
 }
 
 export function useDerivedWireframe(

--- a/apps/console/src/features/spec/collab/useYTextString.ts
+++ b/apps/console/src/features/spec/collab/useYTextString.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import type * as Y from "yjs";
+
+/**
+ * Subscribe to a live `Y.Text` and re-render on every content delta, returning
+ * its current string (or `null` when no text is bound). `useCollabSpec`'s own
+ * `version` counter only bumps when the set of doc paths changes, not on
+ * per-keystroke content edits — so a consumer that needs the growing content of
+ * one file (e.g. a streaming `design.cell` feeding the cell diagram) must
+ * observe the `Y.Text` itself. Mirrors `observeRemote` in `textareaBinding.ts`,
+ * but surfaces the value as React state instead of writing into a DOM node.
+ *
+ * String snapshots are primitives, so React compares them by value (Object.is)
+ * — returning `ytext.toString()` from `getSnapshot` cannot loop.
+ */
+export function useYTextString(ytext: Y.Text | null): string | null {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!ytext) return () => {};
+      ytext.observe(onStoreChange);
+      return () => ytext.unobserve(onStoreChange);
+    },
+    [ytext],
+  );
+
+  const getSnapshot = useCallback(() => (ytext ? ytext.toString() : null), [ytext]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/apps/console/src/features/spec/components/CellDiagramPanel.tsx
+++ b/apps/console/src/features/spec/components/CellDiagramPanel.tsx
@@ -16,33 +16,84 @@
  * under the License.
  */
 
-import { Alert, Box, CircularProgress } from "@wso2/oxygen-ui";
+import { Alert, Box, Chip, CircularProgress, Typography } from "@wso2/oxygen-ui";
 import { CellDiagramView } from "@aep/ui-cell-diagram-view";
 import { useDerivedCellDiagram } from "../api/useDerivedDesign";
 import type { SpecFileEntry } from "../api/mapping";
+import type { CollabSpec } from "../collab/useCollabSpec";
+import { useYTextString } from "../collab/useYTextString";
+
+/** Project-level cell-diagram DSL the agent streams first, ahead of design.json. */
+const DESIGN_CELL_PATH = "specs/design/design.cell";
 
 export function CellDiagramPanel({
   projectName,
   files,
+  collab,
 }: {
   projectName: string;
   files: SpecFileEntry[];
+  collab: CollabSpec;
 }) {
-  const { project, isPending, isError } = useDerivedCellDiagram(projectName, files);
+  const { dsl, isPending, isError } = useDerivedCellDiagram(projectName, files);
 
-  if (isPending) {
+  // The committed design.json bundle is authoritative — `dsl` is derived from
+  // it (design.json → cell DSL, same boundary rules as design.cell). While it
+  // is not yet resolved (no committed design.json, or its fetches still
+  // pending/failing mid-turn), fall back to the live `design.cell` DSL
+  // streaming into the collab doc so the diagram renders piece-by-piece as the
+  // agent writes it. Both paths feed the SAME renderer via a DSL string, so the
+  // streamed and reloaded diagrams match.
+  const liveSource = useYTextString(collab.getFileText(DESIGN_CELL_PATH));
+  const derivedReady = !isPending && !isError && dsl != null;
+  const streaming =
+    !derivedReady && typeof liveSource === "string" && liveSource.trim().length > 0;
+  // An agent peer in the room means a design is actively being generated; show a
+  // "waiting" cell rather than the generic "generate a design" empty state.
+  const agentBusy = collab.peers.some((p) => p.kind === "agent");
+
+  if (!streaming && isPending) {
     return (
       <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
         <CircularProgress aria-label="Loading architecture diagram" />
       </Box>
     );
   }
-  if (isError) {
+  if (!streaming && isError) {
     return <Alert severity="error">Failed to load the design sources for the diagram.</Alert>;
   }
-  // CellDiagramView's own root is `flex: 1, minHeight: 0, display: 'flex'` —
-  // it fills its flex-column parent directly; no extra wrapper needed (an
-  // extra `height: '100%'` Box here would just re-introduce the sizing bug
-  // this component was written to avoid).
-  return <CellDiagramView project={project} />;
+
+  // The diagram fills the pane. While streaming, a thin toolbar row carries the
+  // "Designing…" badge; otherwise the diagram takes the whole pane. Both view
+  // components have a `flex: 1, minHeight: 0` root, so the flex column lets them
+  // fill the space without re-introducing the sizing bug they were written to
+  // avoid.
+  return (
+    <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
+      {streaming && (
+        <Box
+          sx={{
+            px: 1.5,
+            py: 1,
+            display: "flex",
+            alignItems: "center",
+            borderBottom: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Chip size="small" color="primary" variant="outlined" label="Designing…" />
+        </Box>
+      )}
+      <CellDiagramView
+        source={(streaming ? liveSource : dsl) ?? undefined}
+        emptyState={
+          agentBusy ? (
+            <Typography variant="body2">
+              Waiting for the agent to lay out the architecture…
+            </Typography>
+          ) : undefined
+        }
+      />
+    </Box>
+  );
 }

--- a/apps/console/src/features/spec/components/SpecFileList.tsx
+++ b/apps/console/src/features/spec/components/SpecFileList.tsx
@@ -219,9 +219,9 @@ export function SpecFileList({
             </Tooltip>
           )}
         </Box>
-        {design.hasComponents || design.overview.length > 0 ? (
+        {design.hasComponents || design.hasCellDsl || design.overview.length > 0 ? (
           <List dense disablePadding>
-            {design.hasComponents &&
+            {(design.hasComponents || design.hasCellDsl) &&
               row({ kind: "cell-diagram" }, "Architecture", <Network size={16} />)}
             {design.overview.map((f) =>
               row(

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -31,6 +31,7 @@ type BuildResponse = components["schemas"]["BuildResponse"];
 const mockNavigate = vi.fn();
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
+  useSearch: () => ({}),
 }));
 
 // --- oxygen-ui: only useAppShell needs a stub (it throws outside an

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -34,7 +34,7 @@ import {
   useAppShell,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft, Hammer, Sparkles } from "@wso2/oxygen-ui-icons-react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
 import {
   useBuildPreflight,
@@ -56,6 +56,7 @@ import { WireframePanel } from "./WireframePanel";
 import { OpenApiView } from "@aep/ui-openapi-view";
 import { DesignView } from "@aep/ui-design-view";
 import type { SpecSelection } from "../api/designTree";
+import { DESIGN_CELL_PATH } from "../api/designTree";
 import { useSession } from "../../../auth/SessionContext";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
@@ -136,15 +137,37 @@ export function SpecView({ projectName }: { projectName: string }) {
       .filter((e): e is NonNullable<typeof e> => e !== null)
       .sort((a, b) => a.path.localeCompare(b.path));
   }, [spec.data, collab.docPaths]);
-  // Default selection: the first requirements file (the seeded PRD).
+  // A live design turn is signalled by `?generate=design` (the Generate-design
+  // CTA) and, more durably, by an agent peer streaming design.cell into the
+  // room. In either case the Architecture (cell-diagram) tab is where the user
+  // wants to be, so we auto-select it.
+  const generate = (
+    useSearch({ strict: false }) as { generate?: "requirements" | "design" }
+  ).generate;
+  const agentInRoom = collab.peers.some((p) => p.kind === "agent");
+  const hasDesignCell = files.some((f) => f.path === DESIGN_CELL_PATH);
+
+  // On the Generate-design signal, jump to the Architecture tab immediately
+  // (before design.cell even exists) so the empty/streaming cell is shown.
+  // AppLayout strips the param right after auto-sending, so this fires once.
+  useEffect(() => {
+    if (generate === "design") setSelection({ kind: "cell-diagram" });
+  }, [generate]);
+
+  // Default selection: while a design turn is actively producing design.cell,
+  // default to Architecture (covers a reload mid-turn); otherwise the first
+  // requirements file (the seeded PRD). A manual click sets `selection` and
+  // always wins over this default.
   const firstRequirements = files.find((f) => f.group === "requirements");
   const effectiveSelection: SpecSelection =
     selection ??
-    (firstRequirements
-      ? { kind: "file", path: firstRequirements.path }
-      : files[0]
-        ? { kind: "file", path: files[0].path }
-        : { kind: "file", path: "" });
+    (agentInRoom && hasDesignCell
+      ? { kind: "cell-diagram" }
+      : firstRequirements
+        ? { kind: "file", path: firstRequirements.path }
+        : files[0]
+          ? { kind: "file", path: files[0].path }
+          : { kind: "file", path: "" });
 
   // The concrete file entry when the selection is a file (else null: the
   // synthetic cell-diagram / wireframe views render their own panels).
@@ -527,7 +550,7 @@ export function SpecView({ projectName }: { projectName: string }) {
               }
             >
               {effectiveSelection.kind === "cell-diagram" ? (
-                <CellDiagramPanel projectName={projectName} files={files} />
+                <CellDiagramPanel projectName={projectName} files={files} collab={collab} />
               ) : effectiveSelection.kind === "wireframe" ? (
                 <WireframePanel
                   projectName={projectName}

--- a/apps/console/src/features/spec/derive/deriveCellDiagram.test.ts
+++ b/apps/console/src/features/spec/derive/deriveCellDiagram.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { deriveCellDiagramProject } from "./deriveCellDiagram";
+import { deriveCellDsl } from "./deriveCellDiagram";
 
 const designJson = (name: string, deps: unknown[] = []) =>
   JSON.stringify({
@@ -33,30 +33,29 @@ const designJson = (name: string, deps: unknown[] = []) =>
     dependencies: deps,
   });
 
-describe("deriveCellDiagramProject", () => {
-  it("projects component design.json contents into a cell-diagram project", () => {
-    const project = deriveCellDiagramProject({
+describe("deriveCellDsl", () => {
+  it("derives the cell DSL from component design.json contents", () => {
+    const dsl = deriveCellDsl("shop", {
       "specs/design/components/orders/design.json": designJson("orders"),
       "specs/design/components/web/design.json": designJson("web", [
         { kind: "component", name: "orders" },
       ]),
     });
-    expect(project).not.toBeNull();
-    expect(project!.components.map((c) => c.id).sort()).toEqual(["orders", "web"]);
+    expect(dsl).not.toBeNull();
+    expect(dsl).toContain("title shop");
+    expect(dsl).toContain("component orders as");
+    expect(dsl).toContain("component web as");
+    expect(dsl).toContain("web -> orders");
   });
 
   it("returns null when there are no component design.json files", () => {
-    expect(deriveCellDiagramProject({})).toBeNull();
+    expect(deriveCellDsl("shop", {})).toBeNull();
   });
 
-  it("degrades a malformed design.json to a default component (never throws)", () => {
-    // @aep/design-projection's projectComponent is deliberately defensive: a
-    // parse failure degrades to a default "service" component rather than
-    // throwing, so one bad source never wedges the whole diagram.
-    const project = deriveCellDiagramProject({
+  it("skips a malformed design.json (never throws)", () => {
+    const dsl = deriveCellDsl("shop", {
       "specs/design/components/x/design.json": "{ not json",
     });
-    expect(project).not.toBeNull();
-    expect(project!.components.map((c) => c.id)).toEqual(["x"]);
+    expect(dsl).toBeNull();
   });
 });

--- a/apps/console/src/features/spec/derive/deriveCellDiagram.ts
+++ b/apps/console/src/features/spec/derive/deriveCellDiagram.ts
@@ -16,29 +16,28 @@
  * under the License.
  */
 
-import {
-  buildProjectDesign,
-  toCellDiagramProject,
-  type CellDiagramProject,
-} from "@aep/design-projection";
+import { toCellDsl } from "@aep/design-projection";
 
 /**
- * Whole-architecture cell-diagram projection. `designJsonByRepoPath` maps
- * repo-relative `specs/design/components/<c>/design.json` paths to their
- * content (the projection's COMPONENT_DESIGN_JSON_RE requires the `specs/`
- * prefix — mapping.ts's SpecFileEntry.path already carries it). Returns null
- * when there are no components or a source is malformed — a bad source
- * never throws into the render tree.
+ * Whole-architecture cell DSL, derived DIRECTLY from the component design.json
+ * bundle. `designJsonByRepoPath` maps repo-relative
+ * `specs/design/components/<c>/design.json` paths to their content (the
+ * converter's regex requires the `specs/` prefix — mapping.ts's
+ * SpecFileEntry.path already carries it). `projectName` becomes the diagram
+ * title. Returns null when there are no valid components — a bad source never
+ * throws into the render tree.
+ *
+ * This replaces the old `buildProjectDesign → toCellDiagramProject → wso2ToDsl`
+ * path, which flattened dependency kind/resourceType and so placed nodes on the
+ * wrong cell boundary. `toCellDsl` applies the same boundary rules the agent's
+ * streamed design.cell uses, so the reloaded (derived) diagram matches it.
  */
-export function deriveCellDiagramProject(
+export function deriveCellDsl(
+  projectName: string,
   designJsonByRepoPath: Record<string, string>,
-): CellDiagramProject | null {
-  if (Object.keys(designJsonByRepoPath).length === 0) return null;
+): string | null {
   try {
-    const project = toCellDiagramProject(
-      buildProjectDesign("project", designJsonByRepoPath),
-    );
-    return project.components.length > 0 ? project : null;
+    return toCellDsl(projectName, designJsonByRepoPath);
   } catch {
     return null;
   }

--- a/packages/design-projection/src/cell-dsl.ts
+++ b/packages/design-projection/src/cell-dsl.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * design.json → cell DSL (design.cell) direct converter.
+ *
+ * The lossy `buildProjectDesign` → `toCellDiagramProject` → `wso2ToDsl` path
+ * flattens away dependency `kind`/`resourceType`, so it cannot place nodes on
+ * the right cell boundary. This converter reads the raw design.json files and
+ * emits the SAME cell DSL the agent streams into `design.cell`, applying the
+ * AEP boundary rules (the `cell-architecture-dsl` skill's placement table):
+ *
+ *   - own components (a `components/<name>/` folder) → inside the cell
+ *   - platform-resource, non-thunder (postgres/cache/…)  → inside as a `database`
+ *   - platform-resource `thunder-app`                    → east `identity-server`
+ *   - org-service                                        → east `service`
+ *   - external                                           → south `service`
+ *   - component (sibling) dependency                     → internal edge only
+ *   - exposure "internet" → `north -> comp`; "intranet" → `west -> comp`
+ *
+ * Pure and tolerant: malformed design.json files are skipped; returns `null`
+ * when no valid component remains.
+ */
+
+const COMPONENT_RE = /^specs\/design\/components\/([^/]+)\/design\.json$/;
+
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+/** kebab/snake id → Title Case label ("ceramics-webapp" → "Ceramics Webapp"). */
+function titleCase(id: string): string {
+  return id
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Quote a label for the DSL (labels can contain spaces). */
+function quote(label: string): string {
+  return `"${label.replace(/"/g, "")}"`;
+}
+
+interface ParsedComponent {
+  id: string;
+  type: string;
+  exposure: string;
+  dependencies: { kind: string; name: string; resourceType?: string }[];
+}
+
+function parseComponent(id: string, raw: string | undefined): ParsedComponent | null {
+  let dj: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw ?? "");
+    if (!parsed || typeof parsed !== "object") return null;
+    dj = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const deps: ParsedComponent["dependencies"] = [];
+  if (Array.isArray(dj.dependencies)) {
+    for (const d of dj.dependencies) {
+      if (!d || typeof d !== "object") continue;
+      const rec = d as Record<string, unknown>;
+      const kind = str(rec.kind);
+      const name = str(rec.name);
+      if (!kind || !name) continue;
+      const resourceType = str(rec.resourceType);
+      deps.push(resourceType ? { kind, name, resourceType } : { kind, name });
+    }
+  }
+  return {
+    id,
+    type: str(dj.type) ?? "service",
+    exposure: str(dj.exposure) ?? "intranet",
+    dependencies: deps,
+  };
+}
+
+type Boundary = "east" | "south";
+
+interface ExternalDecl {
+  boundary: Boundary;
+  type: string;
+}
+
+/**
+ * Convert a design.json bundle to the cell DSL. `files` maps repo-relative
+ * paths (`specs/design/components/<id>/design.json`, …) to their content.
+ */
+export function toCellDsl(projectName: string, files: Record<string, string>): string | null {
+  const ids = Object.keys(files)
+    .map((p) => COMPONENT_RE.exec(p)?.[1])
+    .filter((id): id is string => id !== undefined)
+    .sort();
+
+  const components = ids
+    .map((id) => parseComponent(id, files[`specs/design/components/${id}/design.json`]))
+    .filter((c): c is ParsedComponent => c !== null);
+
+  if (components.length === 0) return null;
+
+  const componentIds = new Set(components.map((c) => c.id));
+
+  // Nodes that live INSIDE the cell but are not their own component folder
+  // (e.g. a postgres platform-resource) — declared as components, deduped.
+  const innerResources = new Map<string, string>(); // name -> type
+  // External nodes on a boundary, deduped by name (first declaration wins).
+  const externals = new Map<string, ExternalDecl>();
+  const exposureEdges: string[] = []; // `north -> comp` / `west -> comp`
+  const depEdges: string[] = []; // `comp -> target`
+
+  for (const c of components) {
+    if (c.exposure === "internet") exposureEdges.push(`north -> ${c.id}`);
+    else if (c.exposure === "intranet") exposureEdges.push(`west -> ${c.id}`);
+
+    for (const dep of c.dependencies) {
+      if (dep.kind === "component") {
+        // Sibling hop — internal edge only (target already declared).
+        depEdges.push(`${c.id} -> ${dep.name}`);
+        continue;
+      }
+      if (dep.kind === "platform-resource") {
+        if (dep.resourceType === "thunder-app") {
+          if (!externals.has(dep.name)) externals.set(dep.name, { boundary: "east", type: "identity-server" });
+        } else if (!componentIds.has(dep.name)) {
+          // A backing datastore/cache lives inside the project's cell.
+          if (!innerResources.has(dep.name)) innerResources.set(dep.name, "database");
+        }
+        depEdges.push(`${c.id} -> ${dep.name}`);
+        continue;
+      }
+      if (dep.kind === "org-service") {
+        if (!externals.has(dep.name)) externals.set(dep.name, { boundary: "east", type: "service" });
+        depEdges.push(`${c.id} -> ${dep.name}`);
+        continue;
+      }
+      if (dep.kind === "external") {
+        if (!externals.has(dep.name)) externals.set(dep.name, { boundary: "south", type: "service" });
+        depEdges.push(`${c.id} -> ${dep.name}`);
+        continue;
+      }
+      // Unknown kind: skip (validated elsewhere; not a diagram node).
+    }
+  }
+
+  const lines: string[] = [`title ${projectName}`, ""];
+
+  for (const c of components) {
+    lines.push(`component ${c.id} as ${quote(titleCase(c.id))} ${c.type}`);
+  }
+  for (const [name, type] of innerResources) {
+    lines.push(`component ${name} as ${quote(titleCase(name))} ${type}`);
+  }
+
+  if (externals.size > 0) {
+    lines.push("");
+    for (const [name, decl] of externals) {
+      lines.push(`${decl.boundary} ${name} as ${quote(titleCase(name))} ${decl.type}`);
+    }
+  }
+
+  if (exposureEdges.length > 0) {
+    lines.push("");
+    lines.push(...exposureEdges);
+  }
+  if (depEdges.length > 0) {
+    lines.push("");
+    lines.push(...depEdges);
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/packages/design-projection/src/index.ts
+++ b/packages/design-projection/src/index.ts
@@ -19,3 +19,4 @@
 export * from "./types.js";
 export * from "./project-design.js";
 export * from "./cell-diagram.js";
+export * from "./cell-dsl.js";

--- a/packages/design-projection/test/cell-dsl.test.ts
+++ b/packages/design-projection/test/cell-dsl.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toCellDsl } from "../src/cell-dsl.js";
+
+// The real ceramics-store bundle from the design-cell iteration.
+const BUNDLE: Record<string, string> = {
+  "specs/design/components/ceramics-api/design.json": JSON.stringify({
+    name: "ceramics-api",
+    type: "service",
+    exposure: "internet",
+    dependencies: [
+      { kind: "platform-resource", name: "ceramics-db", resourceType: "postgres" },
+      { kind: "platform-resource", name: "user-auth", resourceType: "thunder-app" },
+      { kind: "external", name: "payment-provider" },
+      { kind: "external", name: "email-provider" },
+    ],
+  }),
+  "specs/design/components/ceramics-webapp/design.json": JSON.stringify({
+    name: "ceramics-webapp",
+    type: "web-application",
+    exposure: "internet",
+    dependencies: [
+      { kind: "component", name: "ceramics-api" },
+      { kind: "platform-resource", name: "user-auth", resourceType: "thunder-app" },
+    ],
+  }),
+};
+
+test("places each dependency kind on the correct boundary", () => {
+  const dsl = toCellDsl("Handmade Ceramics", BUNDLE);
+  assert.ok(dsl);
+  const lines = dsl.split("\n");
+
+  assert.equal(lines[0], "title Handmade Ceramics");
+
+  // Own components, inside the cell.
+  assert.ok(dsl.includes('component ceramics-api as "Ceramics Api" service'));
+  assert.ok(dsl.includes('component ceramics-webapp as "Ceramics Webapp" web-application'));
+  // postgres platform-resource → inside as a database component.
+  assert.ok(dsl.includes('component ceramics-db as "Ceramics Db" database'));
+
+  // thunder-app → east identity-server, declared exactly once despite two uses.
+  assert.equal(dsl.match(/^east user-auth /gm)?.length, 1);
+  assert.ok(dsl.includes('east user-auth as "User Auth" identity-server'));
+
+  // externals → south.
+  assert.ok(dsl.includes('south payment-provider as "Payment Provider" service'));
+  assert.ok(dsl.includes('south email-provider as "Email Provider" service'));
+
+  // exposure internet → north exposure edges for both exposed components.
+  assert.ok(dsl.includes("north -> ceramics-api"));
+  assert.ok(dsl.includes("north -> ceramics-webapp"));
+
+  // dependency edges present.
+  assert.ok(dsl.includes("ceramics-webapp -> ceramics-api"));
+  assert.ok(dsl.includes("ceramics-api -> ceramics-db"));
+  assert.ok(dsl.includes("ceramics-api -> user-auth"));
+  assert.ok(dsl.includes("ceramics-webapp -> user-auth"));
+  assert.ok(dsl.includes("ceramics-api -> payment-provider"));
+
+  // No invented keywords.
+  assert.ok(!/^\s*resource /m.test(dsl));
+  assert.ok(!/^\s*external /m.test(dsl));
+});
+
+test("intranet exposure maps to the west gateway", () => {
+  const dsl = toCellDsl("Proj", {
+    "specs/design/components/internal-api/design.json": JSON.stringify({
+      name: "internal-api",
+      type: "service",
+      exposure: "intranet",
+      dependencies: [],
+    }),
+  });
+  assert.ok(dsl);
+  assert.ok(dsl.includes("west -> internal-api"));
+  assert.ok(!dsl.includes("north ->"));
+});
+
+test("is deterministic (components sorted by id)", () => {
+  const a = toCellDsl("P", BUNDLE);
+  const b = toCellDsl("P", BUNDLE);
+  assert.equal(a, b);
+  // ceramics-api declared before ceramics-webapp.
+  const dsl = a!;
+  assert.ok(dsl.indexOf("component ceramics-api") < dsl.indexOf("component ceramics-webapp"));
+});
+
+test("skips malformed design.json and returns null when none remain", () => {
+  assert.equal(toCellDsl("P", {}), null);
+  assert.equal(
+    toCellDsl("P", { "specs/design/components/broken/design.json": "{ not json" }),
+    null,
+  );
+  // One broken, one valid → only the valid one is emitted.
+  const dsl = toCellDsl("P", {
+    "specs/design/components/broken/design.json": "{ not json",
+    "specs/design/components/ok/design.json": JSON.stringify({ name: "ok", type: "service", exposure: "intranet" }),
+  });
+  assert.ok(dsl);
+  assert.ok(dsl.includes("component ok as"));
+  assert.ok(!dsl.includes("broken"));
+});

--- a/packages/ui/cell-diagram-react/package.json
+++ b/packages/ui/cell-diagram-react/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@aep/ui-cell-diagram-react",
+  "version": "0.1.1",
+  "private": true,
+  "type": "module",
+  "description": "Cell architecture diagram renderer (React + xyflow) over the cell DSL. Vendored in-house from @kanushka/cell-diagram-react.",
+  "main": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@dagrejs/dagre": "^1.1.5",
+    "@xyflow/react": "^12.8.4",
+    "html-to-image": "^1.11.13"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "19.1.6",
+    "@types/react-dom": "19.0.2",
+    "@vitejs/plugin-react-swc": "4.2.0",
+    "jsdom": "^25.0.1",
+    "typescript": "5.9.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/ui/cell-diagram-react/src/compiler/compileCellSource.ts
+++ b/packages/ui/cell-diagram-react/src/compiler/compileCellSource.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  BoundaryDirection,
+  CellDiagramModel,
+  CompileResult,
+  Diagnostic,
+  ExternalNode,
+  ParsedCellDocument,
+  ParsedComponent,
+  ParsedEdge
+} from "../domain/cellModel";
+import { parseCellDsl } from "../parser/parseCellDsl";
+
+const boundaryDirections = new Set<string>(["north", "east", "south", "west"]);
+const inboundDirections = new Set<string>(["north", "west"]);
+const outboundDirections = new Set<string>(["east", "south"]);
+
+function edgeId(direction: string, source: string, target: string, line: number) {
+  return `${direction}-${source}-${target}-${line}`;
+}
+
+function isBoundaryDirection(value: string): value is BoundaryDirection {
+  return boundaryDirections.has(value);
+}
+
+function directionLabel(direction: string) {
+  return direction.charAt(0).toUpperCase() + direction.slice(1);
+}
+
+function createLookup(items: Array<ParsedComponent | ExternalNode>) {
+  const lookup = new Map<string, string>();
+  const duplicates = new Set<string>();
+
+  items.forEach((item) => {
+    [item.id, item.label].filter(Boolean).forEach((key) => {
+      const name = String(key);
+      if (lookup.has(name) && lookup.get(name) !== item.id) {
+        duplicates.add(name);
+        lookup.delete(name);
+        return;
+      }
+
+      if (!duplicates.has(name)) {
+        lookup.set(name, item.id);
+      }
+    });
+  });
+
+  return lookup;
+}
+
+function normalizeEdge(
+  edge: ParsedEdge,
+  componentLookup: Map<string, string>,
+  externalLookup: Map<string, string>,
+  externalMap: Map<string, ExternalNode>
+): ParsedEdge {
+  const source =
+    edge.kind === "exposure" && isBoundaryDirection(edge.source)
+      ? edge.source
+      : componentLookup.get(edge.source) ?? externalLookup.get(edge.source) ?? edge.source;
+  const target =
+    edge.kind === "exposure" && isBoundaryDirection(edge.target)
+      ? edge.target
+      : componentLookup.get(edge.target) ?? externalLookup.get(edge.target) ?? edge.target;
+  const sourceExternal = externalMap.get(externalLookup.get(edge.source) ?? edge.source);
+  const targetExternal = externalMap.get(externalLookup.get(edge.target) ?? edge.target);
+
+  if (edge.kind === "internal" && sourceExternal && !targetExternal) {
+    return {
+      ...edge,
+      id: edgeId(sourceExternal.direction, sourceExternal.id, target, edge.line),
+      source: sourceExternal.id,
+      target,
+      direction: sourceExternal.direction,
+      kind: "inbound"
+    };
+  }
+
+  if (edge.kind === "internal" && targetExternal && !sourceExternal) {
+    return {
+      ...edge,
+      id: edgeId(targetExternal.direction, source, targetExternal.id, edge.line),
+      source,
+      target: targetExternal.id,
+      direction: targetExternal.direction,
+      kind: "outbound"
+    };
+  }
+
+  return {
+    ...edge,
+    source,
+    target
+  };
+}
+
+function validateEdgeDirection(edge: ParsedEdge): Diagnostic[] {
+  if (edge.kind === "inbound" && !inboundDirections.has(edge.direction)) {
+    return [
+      {
+        severity: "error",
+        message: `${directionLabel(edge.direction)} boundary connections must flow out of the cell.`,
+        line: edge.line,
+        column: 1
+      }
+    ];
+  }
+
+  if (edge.kind === "outbound" && !outboundDirections.has(edge.direction)) {
+    return [
+      {
+        severity: "error",
+        message: `${directionLabel(edge.direction)} boundary connections must flow into the cell.`,
+        line: edge.line,
+        column: 1
+      }
+    ];
+  }
+
+  if (edge.kind !== "exposure") {
+    return [];
+  }
+
+  const startsAtGateway = edge.source === edge.direction && isBoundaryDirection(edge.source);
+  const endsAtGateway = edge.target === edge.direction && isBoundaryDirection(edge.target);
+
+  if (startsAtGateway && !inboundDirections.has(edge.direction)) {
+    return [
+      {
+        severity: "error",
+        message: `${directionLabel(edge.direction)} boundary connections must flow out of the cell. Use "${edge.target} -> ${edge.direction}".`,
+        line: edge.line,
+        column: 1
+      }
+    ];
+  }
+
+  if (endsAtGateway && !outboundDirections.has(edge.direction)) {
+    return [
+      {
+        severity: "error",
+        message: `${directionLabel(edge.direction)} boundary connections must flow into the cell. Use "${edge.direction} -> ${edge.source}".`,
+        line: edge.line,
+        column: 1
+      }
+    ];
+  }
+
+  return [];
+}
+
+function inferredComponents(components: ParsedComponent[], edges: ParsedEdge[]) {
+  const componentMap = new Map<string, ParsedComponent>(components.map((component) => [component.id, component]));
+
+  function ensureComponent(id: string) {
+    if (!componentMap.has(id)) {
+      componentMap.set(id, { id });
+    }
+  }
+
+  edges.forEach((edge) => {
+    if (edge.kind === "internal") {
+      ensureComponent(edge.source);
+      ensureComponent(edge.target);
+      return;
+    }
+
+    if (edge.kind === "inbound") {
+      ensureComponent(edge.target);
+      return;
+    }
+
+    if (edge.kind === "outbound" || edge.kind === "exposure") {
+      if (isBoundaryDirection(edge.source)) {
+        ensureComponent(edge.target);
+      } else {
+        ensureComponent(edge.source);
+      }
+    }
+  });
+
+  return Array.from(componentMap.values());
+}
+
+export interface CompiledCellParts {
+  components: ParsedComponent[];
+  externals: ExternalNode[];
+  edges: ParsedEdge[];
+  diagnostics: Diagnostic[];
+}
+
+export function compileCellDocument(document: ParsedCellDocument): CompiledCellParts {
+  const componentLookup = createLookup(document.components);
+  const declaredExternalMap = new Map<string, ExternalNode>(document.externals.map((e) => [e.id, e]));
+  const externalLookup = createLookup(document.externals);
+  const normalizedEdges = document.edges.map((edge) =>
+    normalizeEdge(edge, componentLookup, externalLookup, declaredExternalMap)
+  );
+  const components = inferredComponents(document.components, normalizedEdges);
+  const diagnostics = normalizedEdges.flatMap(validateEdgeDirection);
+
+  const externalMap = new Map<string, ExternalNode>(declaredExternalMap);
+  normalizedEdges.forEach((edge) => {
+    if (edge.kind === "inbound" && edge.direction !== "internal") {
+      externalMap.set(edge.source, externalMap.get(edge.source) ?? { id: edge.source, direction: edge.direction, line: edge.line });
+    }
+    if (edge.kind === "outbound" && edge.direction !== "internal") {
+      externalMap.set(edge.target, externalMap.get(edge.target) ?? { id: edge.target, direction: edge.direction, line: edge.line });
+    }
+  });
+
+  return { components, externals: Array.from(externalMap.values()), edges: normalizedEdges, diagnostics };
+}
+
+export function compileCellSource(source: string): CompileResult {
+  const parsed = parseCellDsl(source);
+  const compiled = compileCellDocument(parsed.document);
+  const diagnostics = [...parsed.diagnostics, ...compiled.diagnostics];
+  if (diagnostics.length > 0) {
+    return { model: null, diagnostics };
+  }
+  const model: CellDiagramModel = {
+    title: parsed.document.title,
+    version: parsed.document.version,
+    components: compiled.components,
+    externals: compiled.externals,
+    edges: compiled.edges
+  };
+  return { model, diagnostics: [] };
+}

--- a/packages/ui/cell-diagram-react/src/compiler/compileProject.test.ts
+++ b/packages/ui/cell-diagram-react/src/compiler/compileProject.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compileProject } from "./compileProject";
+
+describe("compileProject", () => {
+  it("wraps a single-cell document in a one-cell ProjectModel", () => {
+    const result = compileProject(`component API service\nnorth -> API`);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.cells).toHaveLength(1);
+    expect(result.model?.cells[0].id).toBe("main");
+    expect(result.model?.cells[0].components.map((c) => c.id)).toEqual(["API"]);
+    expect(result.model?.crossEdges).toEqual([]);
+    expect(result.model?.sharedExternals).toEqual([]);
+  });
+
+  it("marks an external used by two cells as shared", () => {
+    const source = [
+      "cell orders {", "  component api", "  api -> east s3", "}",
+      "cell inventory {", "  component api", "  api -> south s3", "}"
+    ].join("\n");
+    const result = compileProject(source);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.sharedExternals.map((e) => e.id)).toEqual(["s3"]);
+    expect(result.model?.cells.flatMap((c) => c.externals.map((e) => e.id))).not.toContain("s3");
+  });
+
+  it("keeps a single-use external cell-local", () => {
+    const source = ["cell orders {", "  component api", "  api -> east s3", "}", "cell inventory {", "  component api", "}"].join("\n");
+    const result = compileProject(source);
+    expect(result.model?.sharedExternals).toEqual([]);
+    expect(result.model?.cells[0].externals.map((e) => e.id)).toEqual(["s3"]);
+  });
+
+  it("resolves a connected cross edge", () => {
+    const ok = compileProject("cell a {\n  x -> b.y\n}\ncell b {\n  component y\n}");
+    expect(ok.diagnostics).toEqual([]);
+    expect(ok.model?.crossEdges[0]).toMatchObject({ sourceCell: "a", targetCell: "b", mode: "connected" });
+  });
+
+  it("reports an unknown target cell", () => {
+    const bad = compileProject("cell a {\n  x -> zzz.y\n}");
+    expect(bad.model).toBeNull();
+    expect(bad.diagnostics.some((d) => /unknown cell/i.test(d.message))).toBe(true);
+  });
+
+  it("reports an unknown source cell for a top-level cross edge", () => {
+    const result = compileProject("cell b {\n  component y\n}\nzzz.x -> b.y");
+    expect(result.model).toBeNull();
+    expect(result.diagnostics.some((d) => /unknown cell/i.test(d.message))).toBe(true);
+  });
+
+  it("keeps cell version and label", () => {
+    const result = compileProject("cell orders as \"Order Cell\" {\n  version v2\n  component api\n}");
+    expect(result.model?.cells[0]).toMatchObject({ id: "orders", label: "Order Cell", version: "v2" });
+  });
+
+  describe("tolerant mode", () => {
+    it("returns a partial model alongside diagnostics instead of null", () => {
+      const result = compileProject("cell a {\n  x -> zzz.y\n}", { tolerant: true });
+      expect(result.model).not.toBeNull();
+      expect(result.model?.cells[0].id).toBe("a");
+      expect(result.diagnostics.some((d) => /unknown cell/i.test(d.message))).toBe(true);
+    });
+
+    it("renders an unclosed trailing cell block", () => {
+      const result = compileProject("cell a {\n  component api", { tolerant: true });
+      expect(result.model?.cells.map((c) => c.id)).toEqual(["a"]);
+      expect(result.model?.cells[0].components.map((c) => c.id)).toEqual(["api"]);
+      expect(result.diagnostics.some((d) => /unbalanced/i.test(d.message))).toBe(true);
+    });
+
+    it("does not change the default (non-tolerant) behavior", () => {
+      const result = compileProject("cell a {\n  x -> zzz.y\n}");
+      expect(result.model).toBeNull();
+    });
+
+    it("yields a monotonically growing model over successive DSL prefixes", () => {
+      const lines = [
+        "title Shop",
+        "cell orders {",
+        "  component api",
+        "  component worker",
+        "  api -> worker",
+        "}",
+        "cell inventory {",
+        "  component store",
+        "}"
+      ];
+      let previousCount = -1;
+      for (let n = 1; n <= lines.length; n++) {
+        const prefix = lines.slice(0, n).join("\n");
+        const result = compileProject(prefix, { tolerant: true });
+        expect(result.model).not.toBeNull();
+        const count = result.model!.cells.reduce((sum, c) => sum + c.components.length, 0);
+        expect(count).toBeGreaterThanOrEqual(previousCount);
+        previousCount = count;
+      }
+      expect(previousCount).toBe(3);
+    });
+  });
+});

--- a/packages/ui/cell-diagram-react/src/compiler/compileProject.ts
+++ b/packages/ui/cell-diagram-react/src/compiler/compileProject.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CellModel, CrossEdge, Diagnostic, ExternalNode, ProjectCompileResult, ProjectModel } from "../domain/cellModel";
+import { parseProject, ParsedCrossEdgeResolved } from "../parser/parseProject";
+import { compileCellDocument } from "./compileCellSource";
+
+function resolveCrossEdges(
+  parsed: ParsedCrossEdgeResolved[],
+  cellsById: Map<string, CellModel>
+): { edges: CrossEdge[]; diagnostics: Diagnostic[] } {
+  const edges: CrossEdge[] = [];
+  const diagnostics: Diagnostic[] = [];
+  parsed.forEach((edge) => {
+    if (!cellsById.has(edge.sourceCell)) {
+      diagnostics.push({ severity: "error", message: `Unknown cell "${edge.sourceCell}".`, line: edge.line, column: 1 });
+      return;
+    }
+    if (!cellsById.has(edge.targetCell)) {
+      diagnostics.push({ severity: "error", message: `Unknown cell "${edge.targetCell}".`, line: edge.line, column: 1 });
+      return;
+    }
+    edges.push({
+      id: edge.id,
+      sourceCell: edge.sourceCell,
+      sourceComp: edge.sourceComp,
+      targetCell: edge.targetCell,
+      targetComp: edge.targetComp,
+      exit: edge.exit,
+      entry: edge.entry,
+      mode: edge.mode,
+      label: edge.label,
+      line: edge.line
+    });
+  });
+  return { edges, diagnostics };
+}
+
+export interface CompileProjectOptions {
+  /**
+   * Best-effort mode: return the constructed model even when diagnostics exist,
+   * instead of collapsing to `model: null`. Used for streaming a growing DSL
+   * prefix (e.g. a live `design.cell`) where trailing lines are transiently
+   * incomplete. Default behavior (any diagnostic => `model: null`) is unchanged.
+   */
+  tolerant?: boolean;
+}
+
+export function compileProject(source: string, options: CompileProjectOptions = {}): ProjectCompileResult {
+  const { project, diagnostics: parseDiagnostics } = parseProject(source);
+  const diagnostics: Diagnostic[] = [...parseDiagnostics];
+
+  const cells: CellModel[] = project.cells.map((cell) => {
+    const compiled = compileCellDocument(cell.document);
+    diagnostics.push(...compiled.diagnostics);
+    return {
+      id: cell.id,
+      label: cell.label,
+      version: cell.document.version,
+      components: compiled.components,
+      externals: compiled.externals,
+      edges: compiled.edges
+    };
+  });
+
+  // Group externals by id across all cells; used by >=2 cells => shared.
+  // First cell to declare a shared external's id wins for direction/line; label/type are backfilled from any use site that provides them.
+  const usage = new Map<string, { cells: Set<string>; node: ExternalNode }>();
+  cells.forEach((cell) => {
+    cell.externals.forEach((ext) => {
+      const entry = usage.get(ext.id) ?? { cells: new Set<string>(), node: ext };
+      entry.cells.add(cell.id);
+      if (!entry.node.label && ext.label) { entry.node = { ...entry.node, label: ext.label }; }
+      if (!entry.node.type && ext.type) { entry.node = { ...entry.node, type: ext.type }; }
+      usage.set(ext.id, entry);
+    });
+  });
+
+  const sharedIds = new Set(Array.from(usage.entries()).filter(([, v]) => v.cells.size >= 2).map(([id]) => id));
+  const sharedExternals: ExternalNode[] = Array.from(sharedIds).map((id) => usage.get(id)!.node);
+  const scopedCells: CellModel[] = cells.map((cell) => ({
+    ...cell,
+    externals: cell.externals.filter((ext) => !sharedIds.has(ext.id))
+  }));
+
+  const cellsById = new Map(scopedCells.map((cell) => [cell.id, cell]));
+  const { edges: crossEdges, diagnostics: crossDiagnostics } = resolveCrossEdges(project.crossEdges, cellsById);
+  diagnostics.push(...crossDiagnostics);
+
+  if (diagnostics.length > 0 && !options.tolerant) {
+    return { model: null, diagnostics };
+  }
+
+  const model: ProjectModel = { title: project.title, cells: scopedCells, crossEdges, sharedExternals };
+  return { model, diagnostics };
+}

--- a/packages/ui/cell-diagram-react/src/domain/cellModel.ts
+++ b/packages/ui/cell-diagram-react/src/domain/cellModel.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type BoundaryDirection = "north" | "east" | "south" | "west";
+export type EdgeDirection = BoundaryDirection | "internal";
+export type EdgeKind = "internal" | "inbound" | "outbound" | "exposure";
+
+export interface Diagnostic {
+  severity: "error";
+  message: string;
+  line: number;
+  column: number;
+}
+
+export interface ParsedComponent {
+  id: string;
+  label?: string;
+  type?: string;
+  line?: number;
+}
+
+export interface ParsedExternal {
+  id: string;
+  direction: BoundaryDirection;
+  label?: string;
+  type?: string;
+  line?: number;
+}
+
+export interface ParsedEdge {
+  id: string;
+  source: string;
+  target: string;
+  direction: EdgeDirection;
+  kind: EdgeKind;
+  label?: string;
+  line: number;
+}
+
+export interface ParsedCellDocument {
+  title?: string;
+  version?: string;
+  components: ParsedComponent[];
+  externals: ParsedExternal[];
+  edges: ParsedEdge[];
+}
+
+export type ExternalNode = ParsedExternal;
+
+export interface CellDiagramModel {
+  title?: string;
+  version?: string;
+  components: ParsedComponent[];
+  externals: ExternalNode[];
+  edges: ParsedEdge[];
+}
+
+export interface ParseResult {
+  document: ParsedCellDocument;
+  diagnostics: Diagnostic[];
+}
+
+export interface CompileResult {
+  model: CellDiagramModel | null;
+  diagnostics: Diagnostic[];
+}
+
+export type CrossExit = "east" | "south";
+export type CrossEntry = "west" | "north";
+export type CrossMode = "connected" | "decoupled";
+
+export interface CrossEdge {
+  id: string;
+  sourceCell: string;
+  sourceComp: string;
+  targetCell: string;
+  targetComp: string;
+  exit: CrossExit;
+  entry: CrossEntry;
+  mode: CrossMode;
+  label?: string;
+  line: number;
+}
+
+export interface CellModel {
+  id: string;
+  label?: string;
+  version?: string;
+  components: ParsedComponent[];
+  externals: ExternalNode[];
+  edges: ParsedEdge[];
+}
+
+export interface ProjectModel {
+  title?: string;
+  cells: CellModel[];
+  crossEdges: CrossEdge[];
+  sharedExternals: ExternalNode[];
+}
+
+export interface ProjectCompileResult {
+  model: ProjectModel | null;
+  diagnostics: Diagnostic[];
+}

--- a/packages/ui/cell-diagram-react/src/globals.d.ts
+++ b/packages/ui/cell-diagram-react/src/globals.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Side-effect CSS imports (this package's own diagram.css and xyflow's
+// stylesheet) carry no types; declaring the module keeps `tsc` happy when the
+// package is typechecked standalone. Bundlers (Vite) handle the actual CSS.
+declare module "*.css";

--- a/packages/ui/cell-diagram-react/src/index.ts
+++ b/packages/ui/cell-diagram-react/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { compileProject } from "./compiler/compileProject";
+export { compileCellSource } from "./compiler/compileCellSource";
+export { parseProject } from "./parser/parseProject";
+export { DiagramCanvas } from "./renderer/DiagramCanvas";
+export { CellDiagram } from "./renderer/CellDiagram";
+
+export type {
+  ProjectModel,
+  ProjectCompileResult,
+  CellModel,
+  CrossEdge,
+  ExternalNode,
+  ParsedComponent,
+  ParsedExternal,
+  ParsedEdge,
+  Diagnostic,
+  BoundaryDirection
+} from "./domain/cellModel";
+export type { CellDiagramProps } from "./renderer/CellDiagram";

--- a/packages/ui/cell-diagram-react/src/parser/cellDsl.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/cellDsl.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compileCellSource } from "../compiler/compileCellSource";
+import { defaultSampleSource } from "../test/defaultSample";
+import { parseCellDsl } from "./parseCellDsl";
+
+const orderSystemSource = `title OrderCell
+version v1
+
+component WebApp web-app
+component OrderAPI api
+component OrderService service
+component OrderDB database
+component EventPublisher event
+
+north CustomerApp -> WebApp : HTTPS
+west AdminPortal -> OrderAPI : backoffice
+
+WebApp -> OrderAPI
+OrderAPI -> OrderService
+OrderService -> OrderDB
+OrderService -> EventPublisher : order.created
+
+OrderService -> east InventoryAPI : reserve stock
+OrderService -> south Stripe : payment`;
+
+describe("parseCellDsl", () => {
+  it("keeps metadata optional", () => {
+    const result = parseCellDsl(`component API service
+north -> API`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.title).toBeUndefined();
+    expect(result.document.version).toBeUndefined();
+  });
+
+  it("parses component declarations without type labels", () => {
+    const result = parseCellDsl(`component usersAPI
+component api as OrderAPI
+
+north -> usersAPI`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.components).toEqual([
+      { id: "usersAPI", label: undefined, type: undefined, line: 1 },
+      { id: "api", label: "OrderAPI", type: undefined, line: 2 }
+    ]);
+  });
+
+  it("parses metadata, components, internal dependencies, and boundary dependencies", () => {
+    const result = parseCellDsl(orderSystemSource);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.title).toBe("OrderCell");
+    expect(result.document.version).toBe("v1");
+    expect(result.document.components).toHaveLength(5);
+    expect(result.document.edges).toEqual([
+      {
+        id: "north-CustomerApp-WebApp-10",
+        source: "CustomerApp",
+        target: "WebApp",
+        direction: "north",
+        kind: "inbound",
+        label: "HTTPS",
+        line: 10
+      },
+      {
+        id: "west-AdminPortal-OrderAPI-11",
+        source: "AdminPortal",
+        target: "OrderAPI",
+        direction: "west",
+        kind: "inbound",
+        label: "backoffice",
+        line: 11
+      },
+      {
+        id: "internal-WebApp-OrderAPI-13",
+        source: "WebApp",
+        target: "OrderAPI",
+        direction: "internal",
+        kind: "internal",
+        label: undefined,
+        line: 13
+      },
+      {
+        id: "internal-OrderAPI-OrderService-14",
+        source: "OrderAPI",
+        target: "OrderService",
+        direction: "internal",
+        kind: "internal",
+        label: undefined,
+        line: 14
+      },
+      {
+        id: "internal-OrderService-OrderDB-15",
+        source: "OrderService",
+        target: "OrderDB",
+        direction: "internal",
+        kind: "internal",
+        label: undefined,
+        line: 15
+      },
+      {
+        id: "internal-OrderService-EventPublisher-16",
+        source: "OrderService",
+        target: "EventPublisher",
+        direction: "internal",
+        kind: "internal",
+        label: "order.created",
+        line: 16
+      },
+      {
+        id: "east-OrderService-InventoryAPI-18",
+        source: "OrderService",
+        target: "InventoryAPI",
+        direction: "east",
+        kind: "outbound",
+        label: "reserve stock",
+        line: 18
+      },
+      {
+        id: "south-OrderService-Stripe-19",
+        source: "OrderService",
+        target: "Stripe",
+        direction: "south",
+        kind: "outbound",
+        label: "payment",
+        line: 19
+      }
+    ]);
+  });
+
+  it("reports line and column diagnostics for duplicate components and unknown syntax", () => {
+    const result = parseCellDsl(`title Broken
+component API service
+component API service
+API -- DB`);
+
+    expect(result.diagnostics).toEqual([
+      {
+        severity: "error",
+        message: "Component \"API\" is already defined.",
+        line: 3,
+        column: 11
+      },
+      {
+        severity: "error",
+        message: "Unknown statement. Expected title, version, component, or dependency arrow.",
+        line: 4,
+        column: 1
+      }
+    ]);
+  });
+
+  it("parses boundary gateway exposure arrows", () => {
+    const result = parseCellDsl(`title UntitledCell
+
+component API service
+
+west -> API
+API -> south`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.edges).toEqual([
+      {
+        id: "west-west-API-5",
+        source: "west",
+        target: "API",
+        direction: "west",
+        kind: "exposure",
+        label: undefined,
+        line: 5
+      },
+      {
+        id: "south-API-south-6",
+        source: "API",
+        target: "south",
+        direction: "south",
+        kind: "exposure",
+        label: undefined,
+        line: 6
+      }
+    ]);
+  });
+
+  it("rejects reserved keywords used as a component id", () => {
+    const result = parseCellDsl(`component north service`);
+
+    expect(result.document.components).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      {
+        severity: "error",
+        message: '"north" is a reserved keyword and cannot be used as a component id.',
+        line: 1,
+        column: 11
+      }
+    ]);
+  });
+
+  it("rejects reserved keywords used as an external id", () => {
+    const result = parseCellDsl(`north as api`);
+
+    expect(result.document.externals).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      {
+        severity: "error",
+        message: '"as" is a reserved keyword and cannot be used as an external id.',
+        line: 1,
+        column: 7
+      }
+    ]);
+  });
+
+  it("still allows reserved keywords as labels", () => {
+    const result = parseCellDsl(`component api as component`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.components).toEqual([{ id: "api", label: "component", type: undefined, line: 1 }]);
+  });
+
+  it("parses aliased components and predeclared boundary externals", () => {
+    const result = parseCellDsl(`component WebApp web-app
+component odb as OrderDB database
+
+north CustomerApp
+west ap as AdminPortal webapp
+south CustomerDB database
+east inv as InventoryAPI`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.components).toEqual([
+      { id: "WebApp", type: "web-app", label: undefined, line: 1 },
+      { id: "odb", type: "database", label: "OrderDB", line: 2 }
+    ]);
+    expect(result.document.externals).toEqual([
+      { id: "CustomerApp", direction: "north", label: undefined, type: undefined, line: 4 },
+      { id: "ap", direction: "west", label: "AdminPortal", type: "webapp", line: 5 },
+      { id: "CustomerDB", direction: "south", label: undefined, type: "database", line: 6 },
+      { id: "inv", direction: "east", label: "InventoryAPI", type: undefined, line: 7 }
+    ]);
+  });
+
+  it("parses quoted multi-word labels for components and externals", () => {
+    const result = parseCellDsl(`component ldb as "Datastore" database
+component odb as "Order Datastore"
+south adb as "Azure Postgre" database
+east inv as "Inventory API"`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.components).toEqual([
+      { id: "ldb", label: "Datastore", type: "database", line: 1 },
+      { id: "odb", label: "Order Datastore", type: undefined, line: 2 }
+    ]);
+    expect(result.document.externals).toEqual([
+      { id: "adb", direction: "south", label: "Azure Postgre", type: "database", line: 3 },
+      { id: "inv", direction: "east", label: "Inventory API", type: undefined, line: 4 }
+    ]);
+  });
+
+  it("keeps the unquoted multi-word heuristic for backward compatibility", () => {
+    const result = parseCellDsl(`component ldb as Datastore database
+south adb as Azure Postgre database`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.document.components).toEqual([{ id: "ldb", label: "Datastore", type: "database", line: 1 }]);
+    expect(result.document.externals).toEqual([
+      { id: "adb", direction: "south", label: "Azure Postgre", type: "database", line: 2 }
+    ]);
+  });
+});
+
+describe("compileCellSource", () => {
+  it("compiles the bundled default sample", () => {
+    const result = compileCellSource(defaultSampleSource);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.components.map((component) => component.id)).toEqual(["WebApp", "orders", "odb", "ep"]);
+    expect(result.model?.externals.map((external) => `${external.direction}:${external.id}`)).toEqual([
+      "north:ca",
+      "north:pp",
+      "west:ap",
+      "east:inventories",
+      "east:customers",
+      "south:Stripe",
+      "south:SendGrid"
+    ]);
+  });
+
+  it("creates a normalized model and external nodes for the order system sample", () => {
+    const result = compileCellSource(orderSystemSource);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model).toMatchObject({
+      title: "OrderCell",
+      version: "v1"
+    });
+    expect(result.model?.components.map((component) => component.id)).toEqual([
+      "WebApp",
+      "OrderAPI",
+      "OrderService",
+      "OrderDB",
+      "EventPublisher"
+    ]);
+    expect(result.model?.externals.map((external) => `${external.direction}:${external.id}`)).toEqual([
+      "north:CustomerApp",
+      "west:AdminPortal",
+      "east:InventoryAPI",
+      "south:Stripe"
+    ]);
+  });
+
+  it("infers internal components from dependency usage", () => {
+    const result = compileCellSource(`north -> usersAPI
+WebApp -> OrderAPI
+north Customer -> WebApp
+OrderAPI -> south Stripe`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.components).toEqual([
+      { id: "usersAPI" },
+      { id: "WebApp" },
+      { id: "OrderAPI" }
+    ]);
+    expect(result.model?.externals.map((external) => `${external.direction}:${external.id}`)).toEqual([
+      "north:Customer",
+      "south:Stripe"
+    ]);
+    expect(result.model?.edges).toEqual([
+      expect.objectContaining({
+        source: "north",
+        target: "usersAPI",
+        direction: "north",
+        kind: "exposure"
+      }),
+      expect.objectContaining({
+        source: "WebApp",
+        target: "OrderAPI",
+        direction: "internal",
+        kind: "internal"
+      }),
+      expect.objectContaining({
+        source: "Customer",
+        target: "WebApp",
+        direction: "north",
+        kind: "inbound"
+      }),
+      expect.objectContaining({
+        source: "OrderAPI",
+        target: "Stripe",
+        direction: "south",
+        kind: "outbound"
+      })
+    ]);
+  });
+
+  it("normalizes predeclared external dependencies with inferred internal components", () => {
+    const result = compileCellSource(`north CustomerApp webapp
+east InventoryAPI api
+
+CustomerApp -> WebApp : HTTPS
+OrderAPI -> InventoryAPI : reserve stock`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.components).toEqual([{ id: "WebApp" }, { id: "OrderAPI" }]);
+    expect(result.model?.externals).toEqual([
+      { id: "CustomerApp", direction: "north", label: undefined, type: "webapp", line: 1 },
+      { id: "InventoryAPI", direction: "east", label: undefined, type: "api", line: 2 }
+    ]);
+    expect(result.model?.edges).toEqual([
+      expect.objectContaining({
+        source: "CustomerApp",
+        target: "WebApp",
+        direction: "north",
+        kind: "inbound",
+        label: "HTTPS"
+      }),
+      expect.objectContaining({
+        source: "OrderAPI",
+        target: "InventoryAPI",
+        direction: "east",
+        kind: "outbound",
+        label: "reserve stock"
+      })
+    ]);
+  });
+
+  it("compiles gateway exposures without creating external nodes", () => {
+    const result = compileCellSource(`component usersAPI
+
+north -> usersAPI
+usersAPI -> east`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.components).toEqual([{ id: "usersAPI", label: undefined, type: undefined, line: 1 }]);
+    expect(result.model?.externals).toEqual([]);
+    expect(result.model?.edges).toEqual([
+      expect.objectContaining({
+        source: "north",
+        target: "usersAPI",
+        direction: "north",
+        kind: "exposure"
+      }),
+      expect.objectContaining({
+        source: "usersAPI",
+        target: "east",
+        direction: "east",
+        kind: "exposure"
+      })
+    ]);
+  });
+
+  it("rejects boundary arrows that violate inbound and outbound cell architecture directions", () => {
+    const result = compileCellSource(`component usersAPI api
+
+usersAPI -> north
+usersAPI -> west
+east -> usersAPI
+south -> usersAPI
+east InventoryAPI -> usersAPI
+usersAPI -> north CustomerApp`);
+
+    expect(result.model).toBeNull();
+    expect(result.diagnostics).toEqual([
+      {
+        severity: "error",
+        message: "North boundary connections must flow into the cell. Use \"north -> usersAPI\".",
+        line: 3,
+        column: 1
+      },
+      {
+        severity: "error",
+        message: "West boundary connections must flow into the cell. Use \"west -> usersAPI\".",
+        line: 4,
+        column: 1
+      },
+      {
+        severity: "error",
+        message: "East boundary connections must flow out of the cell. Use \"usersAPI -> east\".",
+        line: 5,
+        column: 1
+      },
+      {
+        severity: "error",
+        message: "South boundary connections must flow out of the cell. Use \"usersAPI -> south\".",
+        line: 6,
+        column: 1
+      },
+      {
+        severity: "error",
+        message: "East boundary connections must flow out of the cell.",
+        line: 7,
+        column: 1
+      },
+      {
+        severity: "error",
+        message: "North boundary connections must flow into the cell.",
+        line: 8,
+        column: 1
+      }
+    ]);
+  });
+
+  it("uses declarations to resolve aliases and plain arrows involving externals", () => {
+    const result = compileCellSource(`component WebApp web-app
+component api as OrderAPI api
+component odb as OrderDB database
+
+north CustomerApp webapp
+east inv as InventoryAPI api
+
+CustomerApp -> WebApp : HTTPS
+WebApp -> api
+api -> odb
+api -> inv : reserve stock`);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.model?.title).toBeUndefined();
+    expect(result.model?.components).toEqual([
+      { id: "WebApp", type: "web-app", label: undefined, line: 1 },
+      { id: "api", type: "api", label: "OrderAPI", line: 2 },
+      { id: "odb", type: "database", label: "OrderDB", line: 3 }
+    ]);
+    expect(result.model?.externals).toEqual([
+      { id: "CustomerApp", direction: "north", label: undefined, type: "webapp", line: 5 },
+      { id: "inv", direction: "east", label: "InventoryAPI", type: "api", line: 6 }
+    ]);
+    expect(result.model?.edges).toEqual([
+      expect.objectContaining({
+        source: "CustomerApp",
+        target: "WebApp",
+        direction: "north",
+        kind: "inbound",
+        label: "HTTPS"
+      }),
+      expect.objectContaining({
+        source: "WebApp",
+        target: "api",
+        direction: "internal",
+        kind: "internal"
+      }),
+      expect.objectContaining({
+        source: "api",
+        target: "odb",
+        direction: "internal",
+        kind: "internal"
+      }),
+      expect.objectContaining({
+        source: "api",
+        target: "inv",
+        direction: "east",
+        kind: "outbound",
+        label: "reserve stock"
+      })
+    ]);
+  });
+});

--- a/packages/ui/cell-diagram-react/src/parser/crossEdge.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/crossEdge.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseDirToken, parseCrossEdge } from "./crossEdge";
+
+describe("parseDirToken", () => {
+  it("defaults to east/west when no token is given", () => {
+    expect(parseDirToken(undefined)).toEqual({ exit: "east", entry: "west" });
+  });
+  it("expands a bare east to east/west", () => {
+    expect(parseDirToken("east")).toEqual({ exit: "east", entry: "west" });
+  });
+  it("parses east-north", () => {
+    expect(parseDirToken("east-north")).toEqual({ exit: "east", entry: "north" });
+  });
+  it("parses south-north and south-west", () => {
+    expect(parseDirToken("south-north")).toEqual({ exit: "south", entry: "north" });
+    expect(parseDirToken("south-west")).toEqual({ exit: "south", entry: "west" });
+  });
+  it("rejects a bare south (no explicit entry)", () => {
+    expect(parseDirToken("south")).toEqual({ error: "bare-south" });
+  });
+  it("rejects an inbound exit or outbound entry", () => {
+    expect(parseDirToken("west")).toEqual({ error: "bad-token" });
+    expect(parseDirToken("east-south")).toEqual({ error: "bad-token" });
+  });
+});
+
+describe("parseCrossEdge", () => {
+  it("parses an inline cross edge with a bare local source", () => {
+    expect(parseCrossEdge("api -> east-north products.api : get stock", 12)).toEqual({
+      sourceCell: null, sourceComp: "api", targetCell: "products", targetComp: "api",
+      exit: "east", entry: "north", label: "get stock", line: 12
+    });
+  });
+  it("parses a project-level cross edge with both ends qualified", () => {
+    expect(parseCrossEdge("orders.api -> products.stock", 3)).toEqual({
+      sourceCell: "orders", sourceComp: "api", targetCell: "products", targetComp: "stock",
+      exit: "east", entry: "west", label: undefined, line: 3
+    });
+  });
+  it("returns null when the target is not qualified (not a cross edge)", () => {
+    expect(parseCrossEdge("api -> east InventoryAPI", 1)).toBeNull();
+  });
+  it("returns a bare-south error result", () => {
+    expect(parseCrossEdge("api -> south products.api", 5)).toEqual({ error: "bare-south", line: 5 });
+  });
+  it("propagates a bad-token error result", () => {
+    expect(parseCrossEdge("api -> west products.api", 1)).toEqual({ error: "bad-token", line: 1 });
+  });
+});

--- a/packages/ui/cell-diagram-react/src/parser/crossEdge.ts
+++ b/packages/ui/cell-diagram-react/src/parser/crossEdge.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CrossEntry, CrossExit } from "../domain/cellModel";
+import { splitLabel } from "./labels";
+
+export type DirTokenResult =
+  | { exit: CrossExit; entry: CrossEntry }
+  | { error: "bare-south" | "bad-token" };
+
+const outbound = new Set<CrossExit>(["east", "south"]);
+const inbound = new Set<CrossEntry>(["west", "north"]);
+
+export function parseDirToken(token: string | undefined): DirTokenResult {
+  if (!token) { return { exit: "east", entry: "west" }; }
+  const parts = token.split("-");
+  const exit = parts[0] as CrossExit;
+  if (!outbound.has(exit)) { return { error: "bad-token" }; }
+  if (parts.length === 1) {
+    if (exit === "south") { return { error: "bare-south" }; }
+    return { exit, entry: "west" };
+  }
+  if (parts.length !== 2) { return { error: "bad-token" }; }
+  const entry = parts[1] as CrossEntry;
+  if (!inbound.has(entry)) { return { error: "bad-token" }; }
+  return { exit, entry };
+}
+
+export interface ParsedCrossEdge {
+  sourceCell: string | null;
+  sourceComp: string;
+  targetCell: string;
+  targetComp: string;
+  exit: CrossExit;
+  entry: CrossEntry;
+  label?: string;
+  line: number;
+}
+
+export type CrossEdgeParse = ParsedCrossEdge | { error: "bare-south" | "bad-token"; line: number } | null;
+
+function qualified(token: string): { cell: string; comp: string } | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) { return null; }
+  return { cell: token.slice(0, dot), comp: token.slice(dot + 1) };
+}
+
+export function parseCrossEdge(statement: string, line: number): CrossEdgeParse {
+  const { body, label } = splitLabel(statement);
+  const arrow = body.split(/\s*->\s*/);
+  if (arrow.length !== 2 || !arrow[0] || !arrow[1]) { return null; }
+
+  const rightTokens = arrow[1].trim().split(/\s+/);
+  let dirToken: string | undefined;
+  let targetToken: string;
+  if (rightTokens.length === 2) { dirToken = rightTokens[0]; targetToken = rightTokens[1]; }
+  else if (rightTokens.length === 1) { targetToken = rightTokens[0]; }
+  else { return null; }
+
+  const target = qualified(targetToken);
+  if (!target) { return null; }
+
+  const leftToken = arrow[0].trim();
+  const source = qualified(leftToken);
+
+  const dir = parseDirToken(dirToken);
+  if ("error" in dir) { return { error: dir.error, line }; }
+
+  return {
+    sourceCell: source ? source.cell : null,
+    sourceComp: source ? source.comp : leftToken,
+    targetCell: target.cell,
+    targetComp: target.comp,
+    exit: dir.exit, entry: dir.entry, label, line
+  };
+}

--- a/packages/ui/cell-diagram-react/src/parser/labels.ts
+++ b/packages/ui/cell-diagram-react/src/parser/labels.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export function splitLabel(statement: string): { body: string; label: string | undefined } {
+  const index = statement.indexOf(":");
+  if (index === -1) {
+    return { body: statement.trim(), label: undefined };
+  }
+
+  const label = statement.slice(index + 1).trim();
+  return {
+    body: statement.slice(0, index).trim(),
+    label: label.length > 0 ? label : undefined
+  };
+}

--- a/packages/ui/cell-diagram-react/src/parser/parseCellDsl.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseCellDsl.ts
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  BoundaryDirection,
+  Diagnostic,
+  EdgeDirection,
+  ParsedCellDocument,
+  ParsedComponent,
+  ParsedEdge,
+  ParsedExternal,
+  ParseResult
+} from "../domain/cellModel";
+import { splitLabel } from "./labels";
+
+const boundaryDirections = new Set<BoundaryDirection>(["north", "east", "south", "west"]);
+const reservedKeywords = new Set(["title", "version", "component", "as", ...boundaryDirections]);
+
+function tokenize(statement: string): string[] {
+  const tokens: string[] = [];
+  const pattern = /"([^"]*)"|(\S+)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(statement)) !== null) {
+    tokens.push(match[1] !== undefined ? match[1] : match[2]);
+  }
+
+  return tokens;
+}
+
+function edgeId(direction: EdgeDirection, source: string, target: string, line: number) {
+  return `${direction}-${source}-${target}-${line}`;
+}
+
+function parseTypedDeclaration(tokens: string[]) {
+  const id = tokens[0];
+
+  if (!id) {
+    return null;
+  }
+
+  if (tokens[1] === "as") {
+    const labelAndTypeTokens = tokens.slice(2);
+
+    if (labelAndTypeTokens.length === 0) {
+      return null;
+    }
+
+    if (labelAndTypeTokens.length === 1) {
+      return { id, label: labelAndTypeTokens[0], type: undefined };
+    }
+
+    return {
+      id,
+      label: labelAndTypeTokens.slice(0, -1).join(" "),
+      type: labelAndTypeTokens.at(-1)
+    };
+  }
+
+  if (tokens.length === 1) {
+    return { id, label: undefined, type: undefined };
+  }
+
+  return { id, label: undefined, type: tokens.slice(1).join(" ") };
+}
+
+function parseExternalDeclaration(statement: string, line: number): ParsedExternal | null {
+  const tokens = tokenize(statement);
+  const direction = tokens[0] as BoundaryDirection;
+
+  if (!boundaryDirections.has(direction) || tokens.length < 2) {
+    return null;
+  }
+
+  const id = tokens[1];
+
+  if (tokens[2] === "as") {
+    const labelAndTypeTokens = tokens.slice(3);
+
+    if (labelAndTypeTokens.length === 0) {
+      return null;
+    }
+
+    const label =
+      labelAndTypeTokens.length === 1 ? labelAndTypeTokens[0] : labelAndTypeTokens.slice(0, -1).join(" ");
+    const type = labelAndTypeTokens.length === 1 ? undefined : labelAndTypeTokens.at(-1);
+
+    return {
+      id,
+      direction,
+      label,
+      type,
+      line
+    };
+  }
+
+  return {
+    id,
+    direction,
+    label: undefined,
+    type: tokens.length > 2 ? tokens.slice(2).join(" ") : undefined,
+    line
+  };
+}
+
+function parseArrow(statement: string, line: number): ParsedEdge | null {
+  const { body, label } = splitLabel(statement);
+  const parts = body.split(/\s*->\s*/);
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+
+  const leftTokens = parts[0].trim().split(/\s+/);
+  const rightTokens = parts[1].trim().split(/\s+/);
+
+  if (leftTokens.length === 1 && boundaryDirections.has(leftTokens[0] as BoundaryDirection)) {
+    const direction = leftTokens[0] as BoundaryDirection;
+    const target = rightTokens.join(" ");
+    return {
+      id: edgeId(direction, direction, target, line),
+      source: direction,
+      target,
+      direction,
+      kind: "exposure",
+      label,
+      line
+    };
+  }
+
+  if (rightTokens.length === 1 && boundaryDirections.has(rightTokens[0] as BoundaryDirection)) {
+    const direction = rightTokens[0] as BoundaryDirection;
+    const source = leftTokens.join(" ");
+    return {
+      id: edgeId(direction, source, direction, line),
+      source,
+      target: direction,
+      direction,
+      kind: "exposure",
+      label,
+      line
+    };
+  }
+
+  if (leftTokens.length === 2 && boundaryDirections.has(leftTokens[0] as BoundaryDirection)) {
+    const direction = leftTokens[0] as BoundaryDirection;
+    const source = leftTokens[1];
+    const target = rightTokens.join(" ");
+    return {
+      id: edgeId(direction, source, target, line),
+      source,
+      target,
+      direction,
+      kind: "inbound",
+      label,
+      line
+    };
+  }
+
+  if (rightTokens.length >= 2 && boundaryDirections.has(rightTokens[0] as BoundaryDirection)) {
+    const direction = rightTokens[0] as BoundaryDirection;
+    const source = leftTokens.join(" ");
+    const target = rightTokens.slice(1).join(" ");
+    return {
+      id: edgeId(direction, source, target, line),
+      source,
+      target,
+      direction,
+      kind: "outbound",
+      label,
+      line
+    };
+  }
+
+  const source = leftTokens.join(" ");
+  const target = rightTokens.join(" ");
+  return {
+    id: edgeId("internal", source, target, line),
+    source,
+    target,
+    direction: "internal",
+    kind: "internal",
+    label,
+    line
+  };
+}
+
+function unknownStatement(line: number): Diagnostic {
+  return {
+    severity: "error",
+    message: "Unknown statement. Expected title, version, component, or dependency arrow.",
+    line,
+    column: 1
+  };
+}
+
+export function parseCellDsl(source: string): ParseResult {
+  const components: ParsedComponent[] = [];
+  const externals: ParsedExternal[] = [];
+  const edges: ParsedEdge[] = [];
+  const diagnostics: Diagnostic[] = [];
+  const componentNames = new Set<string>();
+  const externalNames = new Set<string>();
+  let title: string | undefined;
+  let version: string | undefined;
+
+  source.split(/\r?\n/).forEach((rawLine, index) => {
+    const line = index + 1;
+    const statement = rawLine.trim();
+
+    if (!statement || statement.startsWith("#") || statement.startsWith("//")) {
+      return;
+    }
+
+    if (statement.startsWith("title ")) {
+      title = statement.slice("title ".length).trim() || undefined;
+      return;
+    }
+
+    if (statement.startsWith("version ")) {
+      version = statement.slice("version ".length).trim() || undefined;
+      return;
+    }
+
+    if (statement.startsWith("component ")) {
+      const declaration = parseTypedDeclaration(tokenize(statement).slice(1));
+
+      if (!declaration) {
+        diagnostics.push({
+          severity: "error",
+          message: "Component statements must use: component <id> [as <label>] [type].",
+          line,
+          column: 1
+        });
+        return;
+      }
+
+      const { id } = declaration;
+
+      if (reservedKeywords.has(id)) {
+        diagnostics.push({
+          severity: "error",
+          message: `"${id}" is a reserved keyword and cannot be used as a component id.`,
+          line,
+          column: rawLine.indexOf(id) + 1
+        });
+        return;
+      }
+
+      if (componentNames.has(id)) {
+        diagnostics.push({
+          severity: "error",
+          message: `Component "${id}" is already defined.`,
+          line,
+          column: rawLine.indexOf(id) + 1
+        });
+        return;
+      }
+
+      componentNames.add(id);
+      components.push({ ...declaration, line });
+      return;
+    }
+
+    if (!statement.includes("->") && boundaryDirections.has(tokenize(statement)[0] as BoundaryDirection)) {
+      const external = parseExternalDeclaration(statement, line);
+
+      if (!external) {
+        diagnostics.push({
+          severity: "error",
+          message: "External statements must use: <direction> <id> [as <label>] [type].",
+          line,
+          column: 1
+        });
+        return;
+      }
+
+      if (reservedKeywords.has(external.id)) {
+        diagnostics.push({
+          severity: "error",
+          message: `"${external.id}" is a reserved keyword and cannot be used as an external id.`,
+          line,
+          column: rawLine.indexOf(external.id) + 1
+        });
+        return;
+      }
+
+      if (externalNames.has(external.id)) {
+        diagnostics.push({
+          severity: "error",
+          message: `External "${external.id}" is already defined.`,
+          line,
+          column: rawLine.indexOf(external.id) + 1
+        });
+        return;
+      }
+
+      externalNames.add(external.id);
+      externals.push(external);
+      return;
+    }
+
+    if (statement.includes("->")) {
+      const edge = parseArrow(statement, line);
+      if (edge) {
+        edges.push(edge);
+        return;
+      }
+    }
+
+    diagnostics.push(unknownStatement(line));
+  });
+
+  const document: ParsedCellDocument = {
+    title,
+    version,
+    components,
+    externals,
+    edges
+  };
+
+  return { document, diagnostics };
+}

--- a/packages/ui/cell-diagram-react/src/parser/parseProject.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseProject.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseProject } from "./parseProject";
+
+describe("parseProject", () => {
+  it("parses a single implicit cell (backward compatible)", () => {
+    const result = parseProject(`component API service\nnorth -> API`);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.project.title).toBeUndefined();
+    expect(result.project.cells).toHaveLength(1);
+    expect(result.project.cells[0].id).toBe("main");
+    expect(result.project.cells[0].document.components.map((c) => c.id)).toEqual(["API"]);
+    expect(result.project.crossEdges).toEqual([]);
+  });
+
+  it("parses two cells, a project title, and an inline cross edge", () => {
+    const source = [
+      "title Commerce",
+      "cell orders {",
+      "  component api",
+      "  api -> east products.api : get stock",
+      "}",
+      "cell products {",
+      "  component api",
+      "}"
+    ].join("\n");
+    const result = parseProject(source);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.project.title).toBe("Commerce");
+    expect(result.project.cells.map((c) => c.id)).toEqual(["orders", "products"]);
+    expect(result.project.crossEdges).toEqual([
+      {
+        id: "cross-orders-api-products-api-4",
+        sourceCell: "orders",
+        sourceComp: "api",
+        targetCell: "products",
+        targetComp: "api",
+        exit: "east",
+        entry: "west",
+        mode: "connected",
+        label: "get stock",
+        line: 4
+      }
+    ]);
+  });
+
+  it("stamps the owning cell on an inline cross edge with unqualified source", () => {
+    const source = "cell a {\n  x -> b.y\n}\ncell b {\n  component y\n}";
+    const result = parseProject(source);
+    expect(result.project.crossEdges[0]).toMatchObject({ sourceCell: "a", sourceComp: "x", targetCell: "b", targetComp: "y", mode: "connected" });
+  });
+
+  it("parses a project-level cross edge outside blocks", () => {
+    const source = "cell a {\n  component x\n}\ncell b {\n  component y\n}\na.x -> south-north b.y";
+    const result = parseProject(source);
+    expect(result.project.crossEdges[0]).toMatchObject({ sourceCell: "a", sourceComp: "x", targetCell: "b", targetComp: "y", exit: "south", entry: "north", mode: "decoupled" });
+  });
+
+  it("flags a bare-south cross edge", () => {
+    const source = "cell a {\n  x -> south b.y\n}\ncell b {\n  component y\n}";
+    const result = parseProject(source);
+    expect(result.diagnostics.some((d) => /south/i.test(d.message))).toBe(true);
+  });
+
+  it("flags top-level component statements mixed with cell blocks", () => {
+    const source = "component loose\ncell a {\n  component x\n}";
+    const result = parseProject(source);
+    expect(result.diagnostics.some((d) => /outside a cell/i.test(d.message))).toBe(true);
+  });
+
+  it("rejects an unqualified source on a top-level cross edge", () => {
+    const source = "cell a {\n  component x\n}\nx -> b.y";
+    const result = parseProject(source);
+    expect(result.diagnostics.some((d) => /qualified source/i.test(d.message))).toBe(true);
+    expect(result.project.crossEdges).toEqual([]);
+  });
+
+  it("flags a top-level bare-south cross edge", () => {
+    const source = "cell a {\n  component x\n}\ncell b {\n  component y\n}\na.x -> south b.y";
+    const result = parseProject(source);
+    expect(result.diagnostics.some((d) => /south/i.test(d.message))).toBe(true);
+    expect(result.project.crossEdges).toEqual([]);
+  });
+
+  it("flags a bad-token in-block cross edge", () => {
+    const source = "cell a {\n  x -> west b.y\n}\ncell b {\n  component y\n}";
+    const result = parseProject(source);
+    expect(result.diagnostics.some((d) => /exit must be east or south/i.test(d.message))).toBe(true);
+  });
+
+  it("ignores a top-level comment line", () => {
+    const source = "# a comment\ncell a {\n  component x\n}";
+    const result = parseProject(source);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats an empty title as undefined", () => {
+    const source = "title \ncell a {\n  component x\n}";
+    const result = parseProject(source);
+    expect(result.project.title).toBeUndefined();
+  });
+
+  it("preserves original line numbers across blank lines for an implicit single cell", () => {
+    const source = "component API service\n\nnorth -> API\n\ncomponent Extra\n\nAPI -> Extra";
+    const result = parseProject(source);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.project.cells[0].document.edges.map((e) => e.line)).toEqual([3, 7]);
+  });
+
+  it("preserves original line numbers across blank lines inside a cell block", () => {
+    const source = [
+      "title Commerce",       // line 1
+      "",                     // line 2
+      "cell orders {",        // line 3
+      "  component api",      // line 4
+      "",                     // line 5
+      "  api -> odb",         // line 6
+      "}"                     // line 7
+    ].join("\n");
+    const result = parseProject(source);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.project.cells[0].document.edges.map((e) => e.line)).toEqual([6]);
+  });
+});

--- a/packages/ui/cell-diagram-react/src/parser/parseProject.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseProject.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CrossEntry, CrossExit, Diagnostic, ParsedCellDocument } from "../domain/cellModel";
+import { parseCellDsl } from "./parseCellDsl";
+import { CellBlock, SourceLine, splitCells } from "./splitCells";
+import { ParsedCrossEdge, parseCrossEdge } from "./crossEdge";
+
+export interface ParsedCell {
+  id: string;
+  label?: string;
+  document: ParsedCellDocument;
+}
+
+export interface ParsedCrossEdgeResolved {
+  id: string;
+  sourceCell: string;
+  sourceComp: string;
+  targetCell: string;
+  targetComp: string;
+  exit: CrossExit;
+  entry: CrossEntry;
+  mode: "connected" | "decoupled";
+  label?: string;
+  line: number;
+}
+
+export interface ParsedProject {
+  title?: string;
+  cells: ParsedCell[];
+  crossEdges: ParsedCrossEdgeResolved[];
+}
+
+export interface ParseProjectResult {
+  project: ParsedProject;
+  diagnostics: Diagnostic[];
+}
+
+function crossEdgeId(sourceCell: string, sourceComp: string, targetCell: string, targetComp: string, line: number) {
+  return `cross-${sourceCell}-${sourceComp}-${targetCell}-${targetComp}-${line}`;
+}
+
+function cellBodySource(lines: SourceLine[]): string {
+  if (lines.length === 0) {
+    return "";
+  }
+  const parts: string[] = [];
+  let cursor = 1;
+  lines.forEach((entry) => {
+    while (cursor < entry.line) {
+      parts.push("");
+      cursor++;
+    }
+    parts.push(entry.text);
+    cursor = entry.line + 1;
+  });
+  return parts.join("\n");
+}
+
+function buildResolvedEdge(cross: ParsedCrossEdge, sourceCell: string): ParsedCrossEdgeResolved {
+  return {
+    id: crossEdgeId(sourceCell, cross.sourceComp, cross.targetCell, cross.targetComp, cross.line),
+    sourceCell,
+    sourceComp: cross.sourceComp,
+    targetCell: cross.targetCell,
+    targetComp: cross.targetComp,
+    exit: cross.exit,
+    entry: cross.entry,
+    mode: cross.exit === "east" ? "connected" : "decoupled",
+    label: cross.label,
+    line: cross.line
+  };
+}
+
+function directionErrorMessage(error: "bare-south" | "bad-token"): string {
+  return error === "bare-south"
+    ? "A south cross-cell link needs an explicit entry, e.g. `south-north`. Use `east` for a connected link."
+    : "Invalid cross-cell direction. Exit must be east or south; entry must be west or north.";
+}
+
+export function parseProject(source: string): ParseProjectResult {
+  const split = splitCells(source);
+  const diagnostics: Diagnostic[] = [...split.diagnostics];
+  const crossEdges: ParsedCrossEdgeResolved[] = [];
+
+  const cells: ParsedCell[] = split.cells.map((block: CellBlock) => {
+    const keptLines: SourceLine[] = [];
+    block.lines.forEach((entry) => {
+      const cross = parseCrossEdge(entry.text, entry.line);
+      if (cross === null) {
+        keptLines.push(entry);
+        return;
+      }
+      if ("error" in cross) {
+        diagnostics.push({ severity: "error", message: directionErrorMessage(cross.error), line: cross.line, column: 1 });
+        return;
+      }
+      const sourceCell = cross.sourceCell ?? block.id;
+      crossEdges.push(buildResolvedEdge(cross, sourceCell));
+    });
+
+    const parsed = parseCellDsl(cellBodySource(keptLines));
+    diagnostics.push(...parsed.diagnostics);
+    return { id: block.id, label: block.label, document: parsed.document };
+  });
+
+  let title: string | undefined = split.implicit ? cells[0]?.document.title : undefined;
+
+  split.topLevel.forEach((entry) => {
+    if (entry.text.startsWith("title ")) {
+      title = entry.text.slice("title ".length).trim() || undefined;
+      return;
+    }
+    if (entry.text.startsWith("#") || entry.text.startsWith("//")) {
+      return;
+    }
+    const cross = parseCrossEdge(entry.text, entry.line);
+    if (cross && "error" in cross) {
+      diagnostics.push({ severity: "error", message: directionErrorMessage(cross.error), line: cross.line, column: 1 });
+      return;
+    }
+    if (cross) {
+      if (!cross.sourceCell) {
+        diagnostics.push({
+          severity: "error",
+          message: "A cross-cell edge outside a cell block must use a qualified source, e.g. `a.x -> b.y`.",
+          line: cross.line,
+          column: 1
+        });
+        return;
+      }
+      crossEdges.push(buildResolvedEdge(cross, cross.sourceCell));
+      return;
+    }
+    diagnostics.push({
+      severity: "error",
+      message: "Only `title`, comments, and cross-cell edges are allowed outside a cell block.",
+      line: entry.line,
+      column: 1
+    });
+  });
+
+  return { project: { title, cells, crossEdges }, diagnostics };
+}

--- a/packages/ui/cell-diagram-react/src/parser/splitCells.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/splitCells.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { splitCells } from "./splitCells";
+
+describe("splitCells", () => {
+  it("returns a single implicit block when there are no cell braces", () => {
+    const result = splitCells(`component API service\nnorth -> API`);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.implicit).toBe(true);
+    expect(result.cells).toHaveLength(1);
+    expect(result.cells[0].id).toBe("main");
+    expect(result.cells[0].lines.map((l) => l.text)).toEqual(["component API service", "north -> API"]);
+    expect(result.cells[0].lines.map((l) => l.line)).toEqual([1, 2]);
+    expect(result.topLevel).toEqual([]);
+  });
+
+  it("splits explicit cell blocks and keeps original line numbers", () => {
+    const source = [
+      "title Project",
+      "cell orders as \"Order Cell\" {",
+      "  component api",
+      "}",
+      "cell products {",
+      "  component api",
+      "}"
+    ].join("\n");
+    const result = splitCells(source);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.implicit).toBe(false);
+    expect(result.topLevel.map((l) => l.text)).toEqual(["title Project"]);
+    expect(result.cells).toHaveLength(2);
+    expect(result.cells[0]).toMatchObject({ id: "orders", label: "Order Cell", headerLine: 2 });
+    expect(result.cells[0].lines).toEqual([{ text: "component api", line: 3 }]);
+    expect(result.cells[1]).toMatchObject({ id: "products", label: undefined, headerLine: 5 });
+    expect(result.cells[1].lines).toEqual([{ text: "component api", line: 6 }]);
+  });
+
+  it("reports an unbalanced-brace diagnostic", () => {
+    const result = splitCells(`cell a {\n  component x`);
+    expect(result.diagnostics).toEqual([
+      { severity: "error", message: "Unbalanced braces: a cell block was not closed.", line: 1, column: 1 }
+    ]);
+  });
+
+  it("auto-closes an unclosed trailing block so its lines survive", () => {
+    const result = splitCells(`cell a {\n  component x`);
+    expect(result.cells).toHaveLength(1);
+    expect(result.cells[0]).toMatchObject({ id: "a", headerLine: 1 });
+    expect(result.cells[0].lines).toEqual([{ text: "component x", line: 2 }]);
+  });
+
+  it("reports a nested cell header", () => {
+    const result = splitCells(`cell a {\n  cell b {\n  }\n}`);
+    expect(result.diagnostics[0]).toMatchObject({ message: "Nested cells are not supported.", line: 2 });
+  });
+
+  it("reports a malformed cell header", () => {
+    const result = splitCells(`cell orders as bad name {\n}`);
+    expect(result.diagnostics[0]).toEqual({
+      severity: "error",
+      message: 'Malformed cell header. Use: cell <id> [as "label"] {',
+      line: 1,
+      column: 1
+    });
+  });
+
+  it("reports an unexpected closing brace", () => {
+    const result = splitCells(`}\n`);
+    expect(result.diagnostics).toEqual([
+      { severity: "error", message: "Unexpected closing brace.", line: 1, column: 1 }
+    ]);
+  });
+
+  it("treats an empty quoted label as undefined", () => {
+    const result = splitCells(`cell x as "" {\n}`);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.cells[0]).toMatchObject({ id: "x", label: undefined });
+  });
+});

--- a/packages/ui/cell-diagram-react/src/parser/splitCells.ts
+++ b/packages/ui/cell-diagram-react/src/parser/splitCells.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Diagnostic } from "../domain/cellModel";
+
+export interface SourceLine {
+  text: string;
+  line: number;
+}
+
+export interface CellBlock {
+  id: string;
+  label?: string;
+  headerLine: number;
+  lines: SourceLine[];
+}
+
+export interface SplitResult {
+  implicit: boolean;
+  cells: CellBlock[];
+  topLevel: SourceLine[];
+  diagnostics: Diagnostic[];
+}
+
+const headerPattern = /^cell\s+(\S+)(?:\s+as\s+(?:"([^"]*)"|(\S+)))?\s*\{$/;
+
+export function splitCells(source: string): SplitResult {
+  const rawLines = source.split(/\r?\n/);
+  const hasBlocks = rawLines.some(
+    (line) => /^\s*cell\s+\S+.*\{\s*$/.test(line) || /^\s*}\s*$/.test(line)
+  );
+
+  if (!hasBlocks) {
+    const lines = rawLines
+      .map((text, index) => ({ text: text.trim(), line: index + 1 }))
+      .filter((entry) => entry.text.length > 0);
+    return { implicit: true, cells: [{ id: "main", headerLine: 0, lines }], topLevel: [], diagnostics: [] };
+  }
+
+  const cells: CellBlock[] = [];
+  const topLevel: SourceLine[] = [];
+  const diagnostics: Diagnostic[] = [];
+  let current: CellBlock | null = null;
+
+  for (let index = 0; index < rawLines.length; index++) {
+    const line = index + 1;
+    const trimmed = rawLines[index].trim();
+    if (trimmed.length === 0) { continue; }
+
+    const header = headerPattern.exec(trimmed);
+    if (header) {
+      if (current) {
+        diagnostics.push({ severity: "error", message: "Nested cells are not supported.", line, column: 1 });
+        continue;
+      }
+      current = { id: header[1], label: (header[2] || header[3]) || undefined, headerLine: line, lines: [] };
+      continue;
+    }
+
+    if (!current && /^cell\s/.test(trimmed)) {
+      diagnostics.push({ severity: "error", message: 'Malformed cell header. Use: cell <id> [as "label"] {', line, column: 1 });
+      continue;
+    }
+
+    if (trimmed === "}") {
+      if (!current) {
+        diagnostics.push({ severity: "error", message: "Unexpected closing brace.", line, column: 1 });
+        continue;
+      }
+      cells.push(current);
+      current = null;
+      continue;
+    }
+
+    if (current) { current.lines.push({ text: trimmed, line }); }
+    else { topLevel.push({ text: trimmed, line }); }
+  }
+
+  if (current) {
+    // Auto-close the still-open block at EOF so a growing DSL prefix (streaming
+    // a `design.cell`) still yields the in-progress cell. The diagnostic remains,
+    // so non-tolerant compiles keep collapsing to `model: null` as before.
+    cells.push(current);
+    diagnostics.push({ severity: "error", message: "Unbalanced braces: a cell block was not closed.", line: current.headerLine, column: 1 });
+  }
+
+  return { implicit: false, cells, topLevel, diagnostics };
+}

--- a/packages/ui/cell-diagram-react/src/renderer/CellDiagram.test.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/CellDiagram.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { CellDiagram } from "./CellDiagram";
+
+describe("CellDiagram", () => {
+  it("renders a component node from DSL source", () => {
+    render(<CellDiagram source={"component api service\nnorth -> api"} />);
+    expect(screen.getByText("api")).toBeInTheDocument();
+  });
+
+  it("reports diagnostics for invalid source and renders the empty state", () => {
+    const onDiagnostics = vi.fn();
+    render(<CellDiagram source={"api -> north"} onDiagnostics={onDiagnostics} />);
+    expect(onDiagnostics).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ severity: "error" })])
+    );
+    expect(screen.getByText(/Fix the DSL errors/i)).toBeInTheDocument();
+  });
+
+  it("renders a directly-provided model without a source", () => {
+    render(<CellDiagram model={{ cells: [{ id: "c", components: [{ id: "api" }], externals: [], edges: [] }], crossEdges: [], sharedExternals: [] }} />);
+    expect(screen.getByText("api")).toBeInTheDocument();
+  });
+
+  it("renders a partial diagram from an incomplete source in tolerant mode", () => {
+    render(<CellDiagram tolerant source={"cell orders {\n  component api"} />);
+    expect(screen.getByText("api")).toBeInTheDocument();
+    expect(screen.queryByText(/Fix the DSL errors/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/CellDiagram.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/CellDiagram.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useMemo, type CSSProperties } from "react";
+import { compileProject } from "../compiler/compileProject";
+import type { Diagnostic, ProjectModel } from "../domain/cellModel";
+import { DiagramCanvas } from "./DiagramCanvas";
+
+export interface CellDiagramProps {
+  /** Cell DSL source text; compiled internally. */
+  source?: string;
+  /** Pre-compiled model; used when `source` is not provided. */
+  model?: ProjectModel;
+  className?: string;
+  style?: CSSProperties;
+  /** Called with parse/compile diagnostics whenever `source` changes. */
+  onDiagnostics?: (diagnostics: Diagnostic[]) => void;
+  /**
+   * Best-effort compile: render the partial diagram from a still-incomplete
+   * `source` (e.g. a streaming `design.cell`) instead of the error placeholder.
+   */
+  tolerant?: boolean;
+}
+
+export function CellDiagram({ source, model, className, style, onDiagnostics, tolerant }: CellDiagramProps) {
+  const compiled = useMemo(
+    () => (source !== undefined ? compileProject(source, { tolerant }) : null),
+    [source, tolerant]
+  );
+
+  useEffect(() => {
+    if (compiled) {
+      onDiagnostics?.(compiled.diagnostics);
+    }
+  }, [compiled, onDiagnostics]);
+
+  const resolvedModel = source !== undefined ? compiled?.model ?? null : model ?? null;
+
+  return (
+    <div className={className} style={{ width: "100%", height: "100%", ...style }}>
+      <DiagramCanvas model={resolvedModel} />
+    </div>
+  );
+}

--- a/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.test.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { compileProject } from "../compiler/compileProject";
+
+export const fitViewSpy = vi.fn();
+export const zoomInSpy = vi.fn();
+export const zoomOutSpy = vi.fn();
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  return {
+    ...actual,
+    useReactFlow: () => ({ fitView: fitViewSpy, zoomIn: zoomInSpy, zoomOut: zoomOutSpy }),
+    useViewport: () => ({ x: 0, y: 0, zoom: 1 })
+  };
+});
+
+import { DiagramCanvas } from "./DiagramCanvas";
+
+function buildModel(source: string) {
+  const compiled = compileProject(source);
+  if (!compiled.model) {
+    throw new Error("expected a valid model");
+  }
+  return compiled.model;
+}
+
+describe("DiagramCanvas insets", () => {
+  beforeEach(() => {
+    fitViewSpy.mockClear();
+    zoomInSpy.mockClear();
+    zoomOutSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to zero padding when no insets are supplied", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} />);
+
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: expect.objectContaining({ top: "112px", bottom: "112px", left: "0px", right: "0px" })
+      })
+    );
+  });
+
+  it("adds left breathing room on top of the open editor inset", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} insets={{ left: 260, right: 220 }} />);
+
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: expect.objectContaining({ left: "372px", right: "220px" })
+      })
+    );
+  });
+
+  it("re-fits with new padding when insets change", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { rerender } = render(<DiagramCanvas model={model} insets={{ left: 260, right: 0 }} />);
+    fitViewSpy.mockClear();
+
+    rerender(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} />);
+
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: expect.objectContaining({ left: "0px", right: "0px" })
+      })
+    );
+  });
+
+  it("does not re-fit on a re-render where the model and insets are unchanged", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { rerender } = render(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} />);
+    fitViewSpy.mockClear();
+
+    rerender(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} />);
+
+    expect(fitViewSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-fits when the visible layout key changes", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { rerender } = render(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} fitKey="mobile-code" />);
+    fitViewSpy.mockClear();
+
+    rerender(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} fitKey="mobile-diagram" />);
+
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: expect.objectContaining({ left: "0px", right: "0px" })
+      })
+    );
+  });
+
+  it("schedules a post-paint re-fit when the visible layout key changes", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    let postPaintFit: FrameRequestCallback | undefined;
+    const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      postPaintFit = callback;
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+
+    const { rerender } = render(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} fitKey="mobile-code" />);
+    fitViewSpy.mockClear();
+    requestAnimationFrameSpy.mockClear();
+
+    rerender(<DiagramCanvas model={model} insets={{ left: 0, right: 0 }} fitKey="mobile-diagram" />);
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+    expect(fitViewSpy).toHaveBeenCalledTimes(1);
+
+    postPaintFit?.(0);
+
+    expect(fitViewSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("DiagramCanvas component styling", () => {
+  it("does not mark API components with a special color class", () => {
+    const model = buildModel("component books api");
+    render(<DiagramCanvas model={model} />);
+
+    expect(screen.getByText("books").closest(".component-node")).not.toHaveClass("component-node--api");
+  });
+
+  it("renders internal component subtype text inside the component circle", () => {
+    const model = buildModel("component books api");
+    render(<DiagramCanvas model={model} />);
+
+    expect(screen.getByText("api").closest(".component-node")).toBeInTheDocument();
+  });
+
+  it("still renders boundary dependency subtype text inside external circles", () => {
+    const model = buildModel("component books\neast users api\nbooks -> users");
+    render(<DiagramCanvas model={model} />);
+
+    expect(screen.getByText("api").closest(".external-node")).toBeInTheDocument();
+  });
+});
+
+describe("DiagramCanvas zoom controls", () => {
+  it("shows the current zoom level as a percentage", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} />);
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("wires the zoom in, zoom out, and fit buttons to the React Flow instance", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} insets={{ left: 10, right: 20 }} />);
+    fitViewSpy.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fit diagram to view" }));
+
+    expect(zoomInSpy).toHaveBeenCalledTimes(1);
+    expect(zoomOutSpy).toHaveBeenCalledTimes(1);
+    expect(fitViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: expect.objectContaining({ left: "122px", right: "20px" })
+      })
+    );
+  });
+
+  it("no longer renders the default React Flow controls widget", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { container } = render(<DiagramCanvas model={model} />);
+
+    expect(container.querySelector(".react-flow__controls")).not.toBeInTheDocument();
+  });
+
+  // TODO: restore this assertion when the PNG/SVG image export feature is
+  // re-enabled in DiagramCanvas (ExportControls is currently commented out).
+  it("does not render image export controls while the feature is disabled", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} />);
+    expect(screen.queryByRole("button", { name: /export png/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /export svg/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.tsx
@@ -1,0 +1,447 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Background,
+  EdgeLabelRenderer,
+  Handle,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  useInternalNode,
+  useReactFlow,
+  useViewport,
+  type Edge,
+  type EdgeProps,
+  type InternalNode,
+  type Node,
+  type NodeProps,
+  getBezierPath,
+  getSmoothStepPath
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import "./diagram.css";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { ProjectModel } from "../domain/cellModel";
+import { FitScreenIcon, ZoomInIcon, ZoomOutIcon } from "../ui/ControlIcons";
+// TODO: re-enable when the PNG/SVG image export feature is complete.
+// import { exportPng, exportSvg } from "./exportImage";
+import { getFloatingAnchors, shapeForNodeType, type NodeRect } from "./floatingGeometry";
+import { toReactFlow } from "./flowLayout";
+import { connectionIdsForNode, edgeConnectionId, highlightedNodeIdsForConnections } from "./highlightModel";
+
+function CellBoundaryNode({ data }: NodeProps) {
+  const width = Number(data.width);
+  const height = Number(data.height);
+  const title = typeof data.title === "string" && data.title.trim() ? data.title : undefined;
+  const version = typeof data.version === "string" && data.version.trim() ? data.version : undefined;
+
+  return (
+    <div className="cell-boundary" data-cell-shape="octagon" style={{ width, height }}>
+      <svg className="cell-boundary__outline" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+        <polygon
+          data-cell-outline="octagon"
+          points="30,0 70,0 100,30 100,70 70,100 30,100 0,70 0,30"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3.5"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      {title || version ? (
+        <div className="cell-boundary__title" data-cell-title-placement="northwest-outside">
+          {title ? <span>{title}</span> : null}
+          {version ? <small>{version}</small> : null}
+        </div>
+      ) : null}
+      <div className="cell-gate-label cell-gate-label--north" data-gate-label="north" data-gate-placement="outside">
+        North
+      </div>
+      <div className="cell-gate-label cell-gate-label--east" data-gate-label="east" data-gate-placement="outside">
+        East
+      </div>
+      <div className="cell-gate-label cell-gate-label--south" data-gate-label="south" data-gate-placement="outside">
+        South
+      </div>
+      <div className="cell-gate-label cell-gate-label--west" data-gate-label="west" data-gate-placement="outside">
+        West
+      </div>
+    </div>
+  );
+}
+
+function ComponentNode({ data }: NodeProps) {
+  const nodeId = String(data.nodeId);
+  const componentType =
+    typeof data.componentType === "string" && data.componentType.trim() ? data.componentType : undefined;
+
+  return (
+    <div className="component-node" data-node-shape="circle" data-diagram-node-id={nodeId}>
+      <Handle id="component-top-target" type="target" position={Position.Top} />
+      <Handle id="component-top-source" type="source" position={Position.Top} />
+      <Handle id="component-left-target" type="target" position={Position.Left} />
+      <Handle id="component-left-source" type="source" position={Position.Left} />
+      <span>{String(data.label)}</span>
+      {componentType ? <small>{componentType}</small> : null}
+      <Handle id="component-right-source" type="source" position={Position.Right} />
+      <Handle id="component-bottom-source" type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+function ExternalNode({ data }: NodeProps) {
+  const direction = String(data.direction);
+  const nodeId = String(data.nodeId);
+
+  return (
+    <div className={`external-node external-node--${direction}`} data-external-shape="circle" data-diagram-node-id={nodeId}>
+      <Handle id="external-left-target" type="target" position={Position.Left} />
+      <Handle id="external-top-target" type="target" position={Position.Top} />
+      <span>{String(data.label)}</span>
+      {data.externalType ? <small>{String(data.externalType)}</small> : null}
+      <Handle id="external-right-source" type="source" position={Position.Right} />
+      <Handle id="external-bottom-source" type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+function GatewayNode({ data }: NodeProps) {
+  const direction = String(data.direction);
+  const nodeId = String(data.nodeId);
+
+  return (
+    <div className={`gateway-node gateway-node--${direction}`} data-gateway-bound={direction} data-diagram-node-id={nodeId}>
+      <Handle id="gateway-top-target" type="target" position={Position.Top} />
+      <Handle id="gateway-left-target" type="target" position={Position.Left} />
+      <Handle id="gateway-right-source" type="source" position={Position.Right} />
+      <Handle id="gateway-bottom-source" type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+function EdgeLabel({ label, x, y }: { label: EdgeProps["label"]; x: number; y: number }) {
+  if (!label) {
+    return null;
+  }
+  return (
+    <EdgeLabelRenderer>
+      <div className="edge-label" style={{ transform: `translate(-50%, -50%) translate(${x}px,${y}px)` }}>
+        {label}
+      </div>
+    </EdgeLabelRenderer>
+  );
+}
+
+function makePathEdge(computePath: (props: EdgeProps) => [string, number, number, ...unknown[]]) {
+  return function PathEdge(props: EdgeProps) {
+    const [edgePath, labelX, labelY] = computePath(props);
+    return (
+      <>
+        <path className="react-flow__edge-path" d={edgePath} markerEnd={props.markerEnd} />
+        <EdgeLabel label={props.label} x={labelX} y={labelY} />
+      </>
+    );
+  };
+}
+
+const LabeledEdge = makePathEdge((props) => getBezierPath(props));
+const StepEdge = makePathEdge((props) => getSmoothStepPath({ ...props, borderRadius: 0 }));
+
+const FALLBACK_NODE_SIZE: Record<string, number> = {
+  component: 112,
+  external: 106,
+  gateway: 34
+};
+
+function toNodeRect(node: InternalNode): NodeRect {
+  const fallback = FALLBACK_NODE_SIZE[node.type ?? ""] ?? 40;
+  const { x, y } = node.internals.positionAbsolute;
+  return {
+    x,
+    y,
+    width: node.measured?.width ?? fallback,
+    height: node.measured?.height ?? fallback,
+    shape: shapeForNodeType(node.type)
+  };
+}
+
+function dominantPositions(dx: number, dy: number): { source: Position; target: Position } {
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0
+      ? { source: Position.Right, target: Position.Left }
+      : { source: Position.Left, target: Position.Right };
+  }
+  return dy >= 0
+    ? { source: Position.Bottom, target: Position.Top }
+    : { source: Position.Top, target: Position.Bottom };
+}
+
+// Floating edge: attaches to each node's perimeter at the point facing the other node,
+// so component circles no longer snap to four fixed handles.
+function FloatingEdge(props: EdgeProps) {
+  const sourceNode = useInternalNode(props.source);
+  const targetNode = useInternalNode(props.target);
+
+  if (!sourceNode || !targetNode) {
+    return null;
+  }
+
+  const { sx, sy, tx, ty } = getFloatingAnchors(toNodeRect(sourceNode), toNodeRect(targetNode));
+  const positions = dominantPositions(tx - sx, ty - sy);
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition: positions.source,
+    targetX: tx,
+    targetY: ty,
+    targetPosition: positions.target
+  });
+
+  return (
+    <>
+      <path className="react-flow__edge-path" d={edgePath} markerEnd={props.markerEnd} />
+      <EdgeLabel label={props.label} x={labelX} y={labelY} />
+    </>
+  );
+}
+
+const nodeTypes = {
+  cellBoundary: memo(CellBoundaryNode),
+  component: memo(ComponentNode),
+  external: memo(ExternalNode),
+  gateway: memo(GatewayNode)
+};
+
+const edgeTypes = {
+  smoothstep: memo(LabeledEdge),
+  step: memo(StepEdge),
+  floating: memo(FloatingEdge)
+};
+
+function sameConnectionIds(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+export interface DiagramCanvasInsets {
+  left: number;
+  right: number;
+}
+
+const DEFAULT_INSETS: DiagramCanvasInsets = { left: 0, right: 0 };
+const FIT_VIEW_VERTICAL_PADDING: `${number}px` = "112px";
+const FIT_VIEW_LEFT_PADDING = 112;
+
+interface FitPadding {
+  top: `${number}px`;
+  bottom: `${number}px`;
+  left: `${number}px`;
+  right: `${number}px`;
+}
+
+function buildFitPadding(insets: DiagramCanvasInsets): FitPadding {
+  const leftPadding = insets.left > 0 ? insets.left + FIT_VIEW_LEFT_PADDING : 0;
+
+  return {
+    top: FIT_VIEW_VERTICAL_PADDING,
+    bottom: FIT_VIEW_VERTICAL_PADDING,
+    left: `${leftPadding}px`,
+    right: `${insets.right}px`
+  };
+}
+
+function FitViewController({
+  insets,
+  model,
+  fitKey
+}: {
+  insets: DiagramCanvasInsets;
+  model: ProjectModel;
+  fitKey?: string;
+}) {
+  const { fitView } = useReactFlow();
+  const { left, right } = insets;
+
+  useEffect(() => {
+    const fitOptions = { padding: buildFitPadding({ left, right }), duration: 200 };
+    fitView(fitOptions);
+    const postPaintFit = window.requestAnimationFrame(() => fitView(fitOptions));
+
+    // model is only used to re-trigger the fit when the diagram data itself changes
+    // (switching documents), not on every re-render (e.g. focus-click highlighting).
+    return () => window.cancelAnimationFrame(postPaintFit);
+  }, [left, right, fitView, model, fitKey]);
+
+  return null;
+}
+
+function ZoomControls({ insets }: { insets: DiagramCanvasInsets }) {
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const { zoom } = useViewport();
+
+  return (
+    <div className="zoom-controls">
+      <button type="button" className="zoom-controls__button" aria-label="Zoom out" onClick={() => zoomOut()}>
+        <ZoomOutIcon size={16} />
+      </button>
+      <span className="zoom-controls__level">{Math.round(zoom * 100)}%</span>
+      <button type="button" className="zoom-controls__button" aria-label="Zoom in" onClick={() => zoomIn()}>
+        <ZoomInIcon size={16} />
+      </button>
+      <button
+        type="button"
+        className="zoom-controls__button zoom-controls__button--fit"
+        aria-label="Fit diagram to view"
+        onClick={() => fitView({ padding: buildFitPadding(insets), duration: 200 })}
+      >
+        <FitScreenIcon size={16} />
+      </button>
+    </div>
+  );
+}
+
+// TODO: re-enable when the PNG/SVG image export feature is complete.
+// function ExportControls({ filename }: { filename: string }) {
+//   const { getNodes } = useReactFlow();
+//   function viewportElement(): HTMLElement | null {
+//     return document.querySelector(".react-flow__viewport");
+//   }
+//   async function handleExport(kind: "png" | "svg") {
+//     const viewport = viewportElement();
+//     if (!viewport) { return; }
+//     try {
+//       const args = { nodes: getNodes(), viewport, filename };
+//       if (kind === "png") { await exportPng(args); } else { await exportSvg(args); }
+//     } catch (error) {
+//       console.error(`Diagram ${kind.toUpperCase()} export failed`, error);
+//     }
+//   }
+//   return (
+//     <div className="export-controls">
+//       <button type="button" className="export-controls__button" aria-label="Export PNG" onClick={() => handleExport("png")}>PNG</button>
+//       <button type="button" className="export-controls__button" aria-label="Export SVG" onClick={() => handleExport("svg")}>SVG</button>
+//     </div>
+//   );
+// }
+
+interface DiagramCanvasProps {
+  model: ProjectModel | null;
+  insets?: DiagramCanvasInsets;
+  fitKey?: string;
+}
+
+export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: DiagramCanvasProps) {
+  const [activeConnectionIds, setActiveConnectionIds] = useState<string[]>([]);
+  const flow = useMemo<ReturnType<typeof toReactFlow>>(
+    () => (model ? toReactFlow(model) : { nodes: [], edges: [], cellSize: { width: 0, height: 0 } }),
+    [model]
+  );
+  const activeConnectionIdSet = useMemo(() => new Set(activeConnectionIds), [activeConnectionIds]);
+  const highlightedNodeIds = useMemo(() => {
+    if (activeConnectionIdSet.size === 0) {
+      return new Set<string>();
+    }
+
+    return highlightedNodeIdsForConnections(flow.edges, activeConnectionIdSet);
+  }, [activeConnectionIdSet, flow.edges]);
+  const getConnectionIdsForNode = useCallback(
+    (nodeId: string) => connectionIdsForNode(flow.edges, nodeId),
+    [flow.edges]
+  );
+  const setActiveConnections = useCallback((connectionIds: string[]) => {
+    setActiveConnectionIds((current) => (sameConnectionIds(current, connectionIds) ? current : connectionIds));
+  }, []);
+  const isFocusView = activeConnectionIdSet.size > 0;
+  const nodes = useMemo<Node[]>(
+    () =>
+      flow.nodes.map((node) => ({
+        ...node,
+        className: isFocusView
+          ? highlightedNodeIds.has(node.id)
+            ? "connection-highlight-node"
+            : "connection-dimmed-node"
+          : node.className
+      })),
+    [flow.nodes, highlightedNodeIds, isFocusView]
+  );
+  const edges = useMemo<Edge[]>(
+    () =>
+      flow.edges.map((edge) => ({
+        ...edge,
+        className: [
+          edge.className,
+          isFocusView
+            ? activeConnectionIdSet.has(edgeConnectionId(edge))
+              ? "connection-highlight-edge"
+              : "connection-dimmed-edge"
+            : ""
+        ]
+          .filter(Boolean)
+          .join(" ")
+      })),
+    [activeConnectionIdSet, flow.edges, isFocusView]
+  );
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setActiveConnections([]);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setActiveConnections]);
+
+  if (!model) {
+    return (
+      <div className="empty-canvas">
+        <span>Fix the DSL errors to render the diagram.</span>
+      </div>
+    );
+  }
+
+  return (
+    <ReactFlowProvider>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        minZoom={0.25}
+        maxZoom={1.35}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable
+        proOptions={{ hideAttribution: true }}
+        onNodeClick={(_, node) => setActiveConnections(getConnectionIdsForNode(node.id))}
+        onPaneClick={() => setActiveConnections([])}
+      >
+        <FitViewController insets={insets} model={model} fitKey={fitKey} />
+        <Background color="#cbd5e1" gap={22} />
+        <ZoomControls insets={insets} />
+        {/* TODO: re-enable when the PNG/SVG image export feature is complete.
+        <ExportControls filename={model.title?.trim() || "cell-diagram"} /> */}
+        <div className="focus-hint" data-focus-mode={isFocusView ? "active" : "idle"}>
+          {isFocusView
+            ? "Focus view: click outside or press Esc to return to the full diagram."
+            : "Click a component to focus its connections."}
+        </div>
+      </ReactFlow>
+    </ReactFlowProvider>
+  );
+}

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css
@@ -1,0 +1,361 @@
+:root {
+  --muted: #64748b;
+  --line: #d6dee8;
+  --north: #0284c7;
+  --east: #ea580c;
+  --south: #059669;
+  --west: #7c3aed;
+  --panel-edge-offset: 14px;
+}
+
+.zoom-controls {
+  position: absolute;
+  right: var(--panel-edge-offset);
+  bottom: var(--panel-edge-offset);
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: #ffffff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+}
+
+.zoom-controls__button {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  color: #334155;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.zoom-controls__button:hover {
+  background: #f1f5f9;
+}
+
+.zoom-controls__level {
+  min-width: 34px;
+  text-align: center;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.cell-boundary {
+  position: relative;
+  aspect-ratio: 1;
+  color: #263447;
+  background: transparent;
+  border: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.cell-boundary__outline {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.cell-boundary__title {
+  position: absolute;
+  left: 20px;
+  top: -54px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid #d6dee8;
+  border-radius: 8px;
+  font-weight: 900;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.cell-boundary__title small {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.cell-gate-label {
+  position: absolute;
+  z-index: 1;
+  padding: 5px 9px;
+  color: #334155;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid #d6dee8;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 900;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.cell-gate-label--north {
+  left: 30%;
+  top: -30px;
+  color: var(--north);
+  transform: translateX(-50%);
+}
+
+.cell-gate-label--east {
+  right: -54px;
+  top: 28%;
+  color: var(--east);
+  transform: translateY(-50%) rotate(90deg);
+}
+
+.cell-gate-label--south {
+  left: 70%;
+  bottom: -30px;
+  color: var(--south);
+  transform: translateX(-50%);
+}
+
+.cell-gate-label--west {
+  left: -54px;
+  top: 72%;
+  color: var(--west);
+  transform: translateY(-50%) rotate(-90deg);
+}
+
+.component-node {
+  width: 112px;
+  height: 112px;
+  display: grid;
+  gap: 3px;
+  place-content: center;
+  place-items: center;
+  padding: 14px;
+  text-align: center;
+  color: #172033;
+  background: #ffffff;
+  border: 2px solid #334155;
+  border-radius: 50%;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+}
+
+.component-node span {
+  max-width: 84px;
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+}
+
+.component-node small {
+  color: var(--muted);
+  max-width: 78px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+
+.external-node {
+  width: 106px;
+  height: 106px;
+  display: grid;
+  gap: 3px;
+  place-content: center;
+  place-items: center;
+  padding: 13px;
+  text-align: center;
+  background: #ffffff;
+  border: 2px solid #64748b;
+  border-radius: 50%;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.1);
+}
+
+.external-node span {
+  max-width: 80px;
+  color: #172033;
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+
+.external-node small {
+  color: var(--muted);
+  max-width: 78px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+
+.external-node--north {
+  border-color: var(--north);
+}
+
+.external-node--east {
+  border-color: var(--east);
+}
+
+.external-node--south {
+  border-color: var(--south);
+}
+
+.external-node--west {
+  border-color: var(--west);
+}
+
+.gateway-node {
+  width: 34px;
+  height: 34px;
+  background: #ffffff;
+  border: 4px solid #334155;
+  border-radius: 50%;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
+}
+
+.gateway-node--north {
+  border-color: var(--north);
+}
+
+.gateway-node--east {
+  border-color: var(--east);
+}
+
+.gateway-node--south {
+  border-color: var(--south);
+}
+
+.gateway-node--west {
+  border-color: var(--west);
+}
+
+.react-flow__handle {
+  width: 7px;
+  height: 7px;
+  opacity: 0;
+}
+
+.edge-label {
+  position: absolute;
+  max-width: 150px;
+  padding: 4px 7px;
+  color: #334155;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid #d6dee8;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+  pointer-events: none;
+}
+
+.react-flow__edge-path {
+  stroke: #475569;
+  stroke-width: 2;
+  transition: stroke-width 140ms ease, opacity 140ms ease, filter 140ms ease;
+}
+
+.edge-north .react-flow__edge-path {
+  stroke: var(--north);
+}
+
+.edge-east .react-flow__edge-path {
+  stroke: var(--east);
+}
+
+.edge-south .react-flow__edge-path {
+  stroke: var(--south);
+}
+
+.edge-west .react-flow__edge-path {
+  stroke: var(--west);
+}
+
+.connection-highlight-edge .react-flow__edge-path {
+  opacity: 1;
+  stroke-width: 4;
+  filter: drop-shadow(0 2px 5px rgba(15, 23, 42, 0.24));
+}
+
+.connection-dimmed-edge .react-flow__edge-path {
+  opacity: 0.18;
+}
+
+.connection-highlight-node .component-node,
+.connection-highlight-node .external-node,
+.connection-highlight-node .gateway-node {
+  box-shadow: 0 0 0 6px rgba(14, 165, 233, 0.18), 0 18px 34px rgba(15, 23, 42, 0.2);
+}
+
+.connection-dimmed-node .component-node,
+.connection-dimmed-node .external-node,
+.connection-dimmed-node .gateway-node {
+  opacity: 0.34;
+}
+
+.focus-hint {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  z-index: 5;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  color: #334155;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #d6dee8;
+  border-radius: 999px;
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.1);
+  font-size: 12px;
+  font-weight: 850;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.focus-hint[data-focus-mode="active"] {
+  color: #0f172a;
+  border-color: #93c5fd;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.16);
+}
+
+.empty-canvas {
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  background: #f8fafc;
+  font-weight: 800;
+}
+
+.export-controls { position: absolute; top: 16px; right: 16px; z-index: 5; display: flex; gap: 6px; }
+.export-controls__button { padding: 6px 10px; font-size: 12px; font-weight: 600; border-radius: 8px; border: 1px solid #cbd5e1; background: #ffffff; color: #334155; cursor: pointer; }
+.export-controls__button:hover { background: #f1f5f9; }
+
+.react-flow__edge.edge-cross .react-flow__edge-path {
+  stroke: #7c3aed;
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+}
+
+@media (max-width: 640px) {
+  .zoom-controls {
+    right: 8px;
+    bottom: 8px;
+  }
+
+  .focus-hint {
+    left: 8px;
+    right: 8px;
+    bottom: 54px;
+    transform: none;
+    text-align: center;
+  }
+}

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const styles = readFileSync(join(process.cwd(), "src/renderer/diagram.css"), "utf8");
+
+function ruleFor(selector: string) {
+  const escaped = selector.replace(/[.#[\]]/g, (match) => `\\${match}`);
+  const pattern = new RegExp(`${escaped} \\{[\\s\\S]*?\\}`);
+  return styles.match(pattern)?.[0] ?? "";
+}
+
+describe("diagram interaction styles", () => {
+  it("does not resize nodes while highlighting connections", () => {
+    const highlightRule = styles.match(/\.connection-highlight-node \.component-node,[\s\S]*?\}/)?.[0] ?? "";
+    expect(highlightRule).not.toBe("");
+    expect(highlightRule).not.toContain("transform:");
+  });
+
+  it("sizes component and boundary dependency subtype labels consistently", () => {
+    const componentRule = ruleFor(".component-node small");
+    const externalRule = ruleFor(".external-node small");
+
+    expect(componentRule).toContain("font-size: 10px;");
+    expect(componentRule).not.toContain("text-transform:");
+    expect(externalRule).toContain("font-size: 10px;");
+    expect(externalRule).not.toContain("text-transform:");
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/exportImage.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/exportImage.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { computeExportTransform, sanitizeFilename } from "./exportImage";
+
+describe("computeExportTransform", () => {
+  it("scales a wide diagram to fit width and centers it with padding", () => {
+    const bounds = { x: 0, y: 0, width: 800, height: 400 };
+    const t = computeExportTransform(bounds, { width: 1000, height: 1000, padding: 0.1 });
+    expect(t.zoom).toBeCloseTo(1, 5);
+    expect(t.x).toBeCloseTo(100, 5);
+    expect(t.y).toBeCloseTo(300, 5);
+  });
+  it("never scales above 1x (no upscaling blur)", () => {
+    const bounds = { x: 0, y: 0, width: 100, height: 100 };
+    const t = computeExportTransform(bounds, { width: 1000, height: 1000, padding: 0 });
+    expect(t.zoom).toBeLessThanOrEqual(1);
+  });
+  it("offsets by the bounds origin so off-origin diagrams are captured", () => {
+    const bounds = { x: 200, y: 100, width: 400, height: 400 };
+    const t = computeExportTransform(bounds, { width: 400, height: 400, padding: 0 });
+    expect(t.zoom).toBeCloseTo(1, 5);
+    expect(t.x).toBeCloseTo(-200, 5);
+    expect(t.y).toBeCloseTo(-100, 5);
+  });
+  it("returns a neutral transform for empty/degenerate bounds (no NaN)", () => {
+    const t = computeExportTransform({ x: 0, y: 0, width: 0, height: 0 }, { width: 400, height: 400, padding: 0 });
+    expect(t).toEqual({ x: 0, y: 0, zoom: 1 });
+    expect(Number.isNaN(t.x)).toBe(false);
+    expect(Number.isNaN(t.y)).toBe(false);
+    expect(Number.isNaN(t.zoom)).toBe(false);
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("replaces path and reserved characters with a dash", () => {
+    expect(sanitizeFilename("a/b:c")).toBe("a-b-c");
+  });
+  it("falls back to cell-diagram for empty input", () => {
+    expect(sanitizeFilename("")).toBe("cell-diagram");
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/exportImage.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/exportImage.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { toPng, toSvg } from "html-to-image";
+import { getNodesBounds, type Node } from "@xyflow/react";
+
+export interface ExportBounds { x: number; y: number; width: number; height: number; }
+export interface ExportTarget { width: number; height: number; padding: number; }
+export interface ExportTransform { x: number; y: number; zoom: number; }
+
+function isPositiveFinite(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+export function sanitizeFilename(name: string): string {
+  const cleaned = name.replace(/[\\/:*?"<>|]+/g, "-").trim();
+  return cleaned || "cell-diagram";
+}
+
+export function computeExportTransform(bounds: ExportBounds, target: ExportTarget): ExportTransform {
+  if (!isPositiveFinite(bounds.width) || !isPositiveFinite(bounds.height)) {
+    return { x: 0, y: 0, zoom: 1 };
+  }
+  const usableWidth = target.width * (1 - target.padding);
+  const usableHeight = target.height * (1 - target.padding);
+  const zoom = Math.min(usableWidth / bounds.width, usableHeight / bounds.height, 1);
+  const x = target.width / 2 - (bounds.x + bounds.width / 2) * zoom;
+  const y = target.height / 2 - (bounds.y + bounds.height / 2) * zoom;
+  return { x, y, zoom };
+}
+
+const EXPORT_WIDTH = 2000;
+const EXPORT_HEIGHT = 1400;
+const EXPORT_PADDING = 0.08;
+
+function triggerDownload(dataUrl: string, filename: string) {
+  const anchor = document.createElement("a");
+  anchor.href = dataUrl;
+  anchor.download = filename;
+  anchor.click();
+}
+
+interface CaptureArgs { nodes: Node[]; viewport: HTMLElement; filename: string; }
+
+function captureOptions(nodes: Node[]) {
+  const bounds = getNodesBounds(nodes);
+  const transform = computeExportTransform(bounds, { width: EXPORT_WIDTH, height: EXPORT_HEIGHT, padding: EXPORT_PADDING });
+  return {
+    width: EXPORT_WIDTH,
+    height: EXPORT_HEIGHT,
+    style: {
+      width: `${EXPORT_WIDTH}px`,
+      height: `${EXPORT_HEIGHT}px`,
+      transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.zoom})`
+    }
+  };
+}
+
+export async function exportPng({ nodes, viewport, filename }: CaptureArgs) {
+  const options = captureOptions(nodes);
+  const dataUrl = await toPng(viewport, { ...options, pixelRatio: 2, backgroundColor: "#ffffff" });
+  triggerDownload(dataUrl, `${sanitizeFilename(filename)}.png`);
+}
+
+export async function exportSvg({ nodes, viewport, filename }: CaptureArgs) {
+  const options = captureOptions(nodes);
+  const dataUrl = await toSvg(viewport, { ...options, backgroundColor: "#ffffff" });
+  triggerDownload(dataUrl, `${sanitizeFilename(filename)}.svg`);
+}

--- a/packages/ui/cell-diagram-react/src/renderer/floatingGeometry.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/floatingGeometry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { getFloatingAnchors, shapeForNodeType, type NodeRect } from "./floatingGeometry";
+
+function circle(x: number, y: number, size: number): NodeRect {
+  return { x, y, width: size, height: size, shape: "circle" };
+}
+
+function rect(x: number, y: number, width: number, height: number): NodeRect {
+  return { x, y, width, height, shape: "rect" };
+}
+
+describe("getFloatingAnchors", () => {
+  it("anchors two circles on the perimeter along the center-to-center line", () => {
+    // Two 100px circles, centers at (50,50) and (250,50): purely horizontal.
+    const source = circle(0, 0, 100);
+    const target = circle(200, 0, 100);
+
+    const { sx, sy, tx, ty } = getFloatingAnchors(source, target);
+
+    // Source exits at its right edge, target enters at its left edge.
+    expect(sx).toBeCloseTo(100);
+    expect(sy).toBeCloseTo(50);
+    expect(tx).toBeCloseTo(200);
+    expect(ty).toBeCloseTo(50);
+  });
+
+  it("places the circle anchor on the perimeter for a diagonal connection", () => {
+    // 100px circle centered at (50,50), radius 50. Target up and to the right.
+    const source = circle(0, 0, 100);
+    const target = circle(400, -300, 100);
+
+    const { sx, sy } = getFloatingAnchors(source, target);
+
+    // Anchor must sit exactly on the circle: distance from center == radius.
+    const dist = Math.hypot(sx - 50, sy - 50);
+    expect(dist).toBeCloseTo(50);
+    // And it points toward the target (right and up from center).
+    expect(sx).toBeGreaterThan(50);
+    expect(sy).toBeLessThan(50);
+  });
+
+  it("anchors a box node on its border facing the other node", () => {
+    // Small 40px box centered at (20,20); circle target straight to the right (center y=20).
+    const source = rect(0, 0, 40, 40);
+    const target = circle(200, -30, 100);
+
+    const { sx, sy } = getFloatingAnchors(source, target);
+
+    // Exits at the box's right border, vertically centered.
+    expect(sx).toBeCloseTo(40);
+    expect(sy).toBeCloseTo(20);
+  });
+
+  it("treats component and external nodes as circles and gateways as boxes", () => {
+    expect(shapeForNodeType("component")).toBe("circle");
+    expect(shapeForNodeType("external")).toBe("circle");
+    expect(shapeForNodeType("gateway")).toBe("rect");
+    expect(shapeForNodeType(undefined)).toBe("rect");
+  });
+
+  it("does not divide by zero when centers coincide", () => {
+    const source = circle(0, 0, 100);
+    const target = circle(0, 0, 100);
+
+    const anchors = getFloatingAnchors(source, target);
+
+    expect(Number.isFinite(anchors.sx)).toBe(true);
+    expect(Number.isFinite(anchors.sy)).toBe(true);
+    expect(Number.isFinite(anchors.tx)).toBe(true);
+    expect(Number.isFinite(anchors.ty)).toBe(true);
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/floatingGeometry.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/floatingGeometry.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type NodeShape = "circle" | "rect";
+
+/** Component and external nodes are circles; everything else (gateways) is a box. */
+export function shapeForNodeType(type: string | undefined): NodeShape {
+  return type === "component" || type === "external" ? "circle" : "rect";
+}
+
+export interface NodeRect {
+  /** Absolute top-left position. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  shape: NodeShape;
+}
+
+export interface FloatingAnchors {
+  /** Source anchor on the source node perimeter. */
+  sx: number;
+  sy: number;
+  /** Target anchor on the target node perimeter. */
+  tx: number;
+  ty: number;
+}
+
+interface Center {
+  cx: number;
+  cy: number;
+}
+
+function center(node: NodeRect): Center {
+  return { cx: node.x + node.width / 2, cy: node.y + node.height / 2 };
+}
+
+/**
+ * Distance from a node center to its perimeter along the unit direction (dx, dy).
+ * Circles use the radius; boxes use the nearest border crossing.
+ */
+function perimeterDistance(node: NodeRect, dx: number, dy: number): number {
+  if (node.shape === "circle") {
+    return node.width / 2;
+  }
+
+  const halfWidth = node.width / 2;
+  const halfHeight = node.height / 2;
+  const scaleX = dx === 0 ? Number.POSITIVE_INFINITY : halfWidth / Math.abs(dx);
+  const scaleY = dy === 0 ? Number.POSITIVE_INFINITY : halfHeight / Math.abs(dy);
+  return Math.min(scaleX, scaleY);
+}
+
+export function getFloatingAnchors(source: NodeRect, target: NodeRect): FloatingAnchors {
+  const { cx: scx, cy: scy } = center(source);
+  const { cx: tcx, cy: tcy } = center(target);
+
+  const deltaX = tcx - scx;
+  const deltaY = tcy - scy;
+  const length = Math.hypot(deltaX, deltaY);
+
+  if (length === 0) {
+    return { sx: scx, sy: scy, tx: tcx, ty: tcy };
+  }
+
+  const ux = deltaX / length;
+  const uy = deltaY / length;
+
+  const sourceReach = perimeterDistance(source, ux, uy);
+  const targetReach = perimeterDistance(target, ux, uy);
+
+  return {
+    sx: scx + ux * sourceReach,
+    sy: scy + uy * sourceReach,
+    tx: tcx - ux * targetReach,
+    ty: tcy - uy * targetReach
+  };
+}

--- a/packages/ui/cell-diagram-react/src/renderer/flowLayout.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/flowLayout.test.ts
@@ -1,0 +1,660 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ProjectModel } from "../domain/cellModel";
+import { toReactFlow } from "./flowLayout";
+import { compileProject } from "../compiler/compileProject";
+
+describe("toReactFlow", () => {
+  it("routes boundary edges through gateway circles for active bounds", () => {
+    const project: ProjectModel = {
+      title: "Orders",
+      cells: [
+        {
+          id: "main",
+          version: "v1",
+          components: [{ id: "OrderAPI", type: "api", line: 3 }],
+          externals: [
+            { id: "CustomerApp", direction: "north" },
+            { id: "Stripe", direction: "south" }
+          ],
+          edges: [
+            {
+              id: "north-CustomerApp-OrderAPI-4",
+              source: "CustomerApp",
+              target: "OrderAPI",
+              direction: "north",
+              kind: "inbound",
+              line: 4
+            },
+            {
+              id: "south-OrderAPI-Stripe-5",
+              source: "OrderAPI",
+              target: "Stripe",
+              direction: "south",
+              kind: "outbound",
+              line: 5
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+
+    expect(flow.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "gateway-north",
+          type: "gateway",
+          data: expect.objectContaining({ direction: "north" })
+        }),
+        expect.objectContaining({
+          id: "gateway-south",
+          type: "gateway",
+          data: expect.objectContaining({ direction: "south" })
+        })
+      ])
+    );
+    expect(flow.nodes.find((node) => node.id === "gateway-east")).toBeUndefined();
+    expect(flow.nodes.find((node) => node.id === "gateway-west")).toBeUndefined();
+    expect(flow.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "north-CustomerApp-OrderAPI-4-external-gateway",
+          data: expect.objectContaining({
+            connectionId: "north-CustomerApp-OrderAPI-4",
+            connectedNodeIds: ["external-CustomerApp", "gateway-north", "OrderAPI"]
+          }),
+          source: "external-CustomerApp",
+          sourceHandle: "external-bottom-source",
+          target: "gateway-north",
+          targetHandle: "gateway-top-target"
+        }),
+        expect.objectContaining({
+          id: "north-CustomerApp-OrderAPI-4-gateway-component",
+          data: expect.objectContaining({
+            connectionId: "north-CustomerApp-OrderAPI-4",
+            connectedNodeIds: ["external-CustomerApp", "gateway-north", "OrderAPI"]
+          }),
+          source: "gateway-north",
+          sourceHandle: "gateway-bottom-source",
+          target: "OrderAPI",
+          targetHandle: "component-top-target"
+        }),
+        expect.objectContaining({
+          id: "south-OrderAPI-Stripe-5-component-gateway",
+          source: "OrderAPI",
+          sourceHandle: "component-bottom-source",
+          target: "gateway-south",
+          targetHandle: "gateway-top-target"
+        }),
+        expect.objectContaining({
+          id: "south-OrderAPI-Stripe-5-gateway-external",
+          source: "gateway-south",
+          sourceHandle: "gateway-bottom-source",
+          target: "external-Stripe",
+          targetHandle: "external-top-target"
+        })
+      ])
+    );
+  });
+
+  it("keeps north and south external components far enough apart for edge labels", () => {
+    const project: ProjectModel = {
+      title: "Orders",
+      cells: [
+        {
+          id: "main",
+          version: "v1",
+          components: [{ id: "OrderAPI", type: "api", line: 3 }],
+          externals: [
+            { id: "CustomerApp", direction: "north" },
+            { id: "PartnerPortal", direction: "north" },
+            { id: "Stripe", direction: "south" },
+            { id: "SendGrid", direction: "south" }
+          ],
+          edges: [
+            {
+              id: "north-CustomerApp-OrderAPI-4",
+              source: "CustomerApp",
+              target: "OrderAPI",
+              direction: "north",
+              kind: "inbound",
+              label: "HTTPS",
+              line: 4
+            },
+            {
+              id: "north-PartnerPortal-OrderAPI-5",
+              source: "PartnerPortal",
+              target: "OrderAPI",
+              direction: "north",
+              kind: "inbound",
+              label: "REST",
+              line: 5
+            },
+            {
+              id: "south-OrderAPI-Stripe-6",
+              source: "OrderAPI",
+              target: "Stripe",
+              direction: "south",
+              kind: "outbound",
+              label: "payment",
+              line: 6
+            },
+            {
+              id: "south-OrderAPI-SendGrid-7",
+              source: "OrderAPI",
+              target: "SendGrid",
+              direction: "south",
+              kind: "outbound",
+              label: "email",
+              line: 7
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+    const cell = flow.nodes.find((node) => node.id === "cell-main");
+    const customerApp = flow.nodes.find((node) => node.id === "external-CustomerApp");
+    const partnerPortal = flow.nodes.find((node) => node.id === "external-PartnerPortal");
+    const stripe = flow.nodes.find((node) => node.id === "external-Stripe");
+    const sendGrid = flow.nodes.find((node) => node.id === "external-SendGrid");
+
+    expect(cell).toBeDefined();
+    expect(customerApp).toBeDefined();
+    expect(partnerPortal).toBeDefined();
+    expect(stripe).toBeDefined();
+    expect(sendGrid).toBeDefined();
+
+    const cellBottom = cell!.position.y + Number(cell!.data.height);
+
+    expect(Math.abs(customerApp!.position.x - partnerPortal!.position.x)).toBeGreaterThanOrEqual(230);
+    expect(Math.abs(stripe!.position.x - sendGrid!.position.x)).toBeGreaterThanOrEqual(230);
+    expect(cell!.position.y - customerApp!.position.y).toBeGreaterThanOrEqual(200);
+    expect(stripe!.position.y - cellBottom).toBeGreaterThanOrEqual(100);
+    expect(sendGrid!.position.y - cellBottom).toBeGreaterThanOrEqual(100);
+  });
+
+  it("routes gateway exposure edges without creating external nodes", () => {
+    const project: ProjectModel = {
+      title: "UntitledCell",
+      cells: [
+        {
+          id: "main",
+          components: [{ id: "API", type: "service", line: 3 }],
+          externals: [],
+          edges: [
+            {
+              id: "north-north-API-5",
+              source: "north",
+              target: "API",
+              direction: "north",
+              kind: "exposure",
+              line: 5
+            },
+            {
+              id: "east-API-east-6",
+              source: "API",
+              target: "east",
+              direction: "east",
+              kind: "exposure",
+              line: 6
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+
+    expect(flow.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "gateway-north",
+          type: "gateway",
+          data: expect.objectContaining({ direction: "north" })
+        }),
+        expect.objectContaining({
+          id: "gateway-east",
+          type: "gateway",
+          data: expect.objectContaining({ direction: "east" })
+        })
+      ])
+    );
+    expect(flow.nodes.some((node) => node.id.startsWith("external-"))).toBe(false);
+    expect(flow.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "north-north-API-5-gateway-component",
+          data: expect.objectContaining({
+            connectionId: "north-north-API-5",
+            connectedNodeIds: ["gateway-north", "API"]
+          }),
+          source: "gateway-north",
+          sourceHandle: "gateway-bottom-source",
+          target: "API",
+          targetHandle: "component-top-target"
+        }),
+        expect.objectContaining({
+          id: "east-API-east-6-component-gateway",
+          data: expect.objectContaining({
+            connectionId: "east-API-east-6",
+            connectedNodeIds: ["API", "gateway-east"]
+          }),
+          source: "API",
+          sourceHandle: "component-right-source",
+          target: "gateway-east",
+          targetHandle: "gateway-left-target"
+        })
+      ])
+    );
+  });
+
+  it("draws internal component dependencies as floating edges with an arrow head", () => {
+    const project: ProjectModel = {
+      cells: [
+        {
+          id: "main",
+          components: [
+            { id: "WebApp", type: "web-app", line: 1 },
+            { id: "OrderAPI", type: "api", line: 2 }
+          ],
+          externals: [],
+          edges: [
+            {
+              id: "internal-WebApp-OrderAPI-3",
+              source: "WebApp",
+              target: "OrderAPI",
+              direction: "internal",
+              kind: "internal",
+              line: 3
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+    const internalEdge = flow.edges.find((edge) => edge.id === "internal-WebApp-OrderAPI-3");
+
+    expect(internalEdge?.type).toBe("floating");
+    // A React Flow arrow marker (orient="auto") is used so it aligns to the path tangent.
+    expect(internalEdge?.markerEnd).toEqual(
+      expect.objectContaining({ type: "arrow", color: "#475569" })
+    );
+  });
+
+  it("floats internal component edges but keeps gateway edges on fixed-handle routing", () => {
+    const project: ProjectModel = {
+      cells: [
+        {
+          id: "main",
+          components: [{ id: "OrderAPI", type: "api", line: 1 }],
+          externals: [{ id: "Stripe", direction: "east", line: 2 }],
+          edges: [
+            {
+              id: "east-OrderAPI-Stripe-3",
+              source: "OrderAPI",
+              target: "Stripe",
+              direction: "east",
+              kind: "outbound",
+              line: 3
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+    const componentGateway = flow.edges.find((edge) => edge.id === "east-OrderAPI-Stripe-3-component-gateway");
+    const gatewayExternal = flow.edges.find((edge) => edge.id === "east-OrderAPI-Stripe-3-gateway-external");
+
+    // Gateway edges keep their fixed-handle routing (only component-to-component edges float).
+    expect(componentGateway?.type).toBe("smoothstep");
+    expect(componentGateway?.sourceHandle).toBe("component-right-source");
+    expect(componentGateway?.markerEnd).toBeUndefined();
+    // The terminal segment landing on the external carries the colored arrow marker.
+    expect(gatewayExternal?.type).toBe("smoothstep");
+    expect(gatewayExternal?.markerEnd).toEqual(
+      expect.objectContaining({ type: "arrow", color: "#ea580c" })
+    );
+  });
+
+  it("uses display labels and external types from declarations", () => {
+    const project: ProjectModel = {
+      cells: [
+        {
+          id: "main",
+          components: [{ id: "api", label: "OrderAPI", type: "api", line: 1 }],
+          externals: [{ id: "inv", label: "InventoryAPI", type: "api", direction: "east", line: 2 }],
+          edges: [
+            {
+              id: "east-api-inv-3",
+              source: "api",
+              target: "inv",
+              direction: "east",
+              kind: "outbound",
+              line: 3
+            }
+          ]
+        }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+
+    const flow = toReactFlow(project);
+
+    expect(flow.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "api",
+          data: expect.objectContaining({
+            label: "OrderAPI",
+            componentType: "api"
+          })
+        }),
+        expect.objectContaining({
+          id: "external-inv",
+          data: expect.objectContaining({
+            label: "InventoryAPI",
+            externalType: "api"
+          })
+        })
+      ])
+    );
+  });
+
+  it("keeps single-cell node ids un-namespaced", () => {
+    const project: ProjectModel = {
+      cells: [{ id: "main", components: [{ id: "api" }], externals: [], edges: [] }],
+      crossEdges: [],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    expect(flow.nodes.some((n) => n.id === "api")).toBe(true);
+    expect(flow.nodes.some((n) => n.id === "cell-main")).toBe(true);
+  });
+
+  it("namespaces component ids and lays out multiple cells without overlapping", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    expect(flow.nodes.some((n) => n.id === "orders::api")).toBe(true);
+    expect(flow.nodes.some((n) => n.id === "products::api")).toBe(true);
+    const ordersCell = flow.nodes.find((n) => n.id === "cell-orders")!;
+    const productsCell = flow.nodes.find((n) => n.id === "cell-products")!;
+    // With no cross-cell edges, dagre (rankdir LR) places both cells in the same rank
+    // and separates them along the perpendicular axis, so position differs on y here.
+    expect(ordersCell.position).not.toEqual(productsCell.position);
+  });
+
+  it("positions a shared external once between the cells that use it", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [],
+      sharedExternals: [{ id: "s3", direction: "east" }]
+    };
+    const flow = toReactFlow(project);
+    const sharedNodes = flow.nodes.filter((n) => n.id === "external-s3");
+    expect(sharedNodes).toHaveLength(1);
+  });
+
+  it("renders one shared external end-to-end via compileProject and connects both cells' edges to it", () => {
+    const source = `cell orders {
+  component api
+  api -> east s3
+}
+
+cell products {
+  component api
+  api -> south s3
+}`;
+    const compiled = compileProject(source);
+    expect(compiled.diagnostics).toEqual([]);
+    const flow = toReactFlow(compiled.model!);
+
+    const sharedNodes = flow.nodes.filter((n) => n.id === "external-s3");
+    expect(sharedNodes).toHaveLength(1);
+
+    expect(flow.edges.some((e) => e.target === "external-s3")).toBe(true);
+    expect(flow.edges.some((e) => e.source === "external-s3")).toBe(false);
+    // no edge should ever target/source a per-cell-qualified id for a SHARED external
+    expect(
+      flow.edges.some(
+        (e) =>
+          e.target === "external-orders-s3" ||
+          e.source === "external-orders-s3" ||
+          e.target === "external-products-s3" ||
+          e.source === "external-products-s3"
+      )
+    ).toBe(false);
+  });
+
+  it("emits a connected cross edge as component -> gateway -> gateway -> component using step edges", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "x1",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "east",
+          entry: "west",
+          mode: "connected",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    const crossEdges = flow.edges.filter((e) => e.id.startsWith("x1"));
+    expect(crossEdges).toHaveLength(3);
+    expect(crossEdges.every((e) => e.type === "step")).toBe(true);
+    expect(crossEdges.some((e) => e.source === "gateway-orders-east" && e.target === "gateway-products-west")).toBe(
+      true
+    );
+    expect(crossEdges.some((e) => e.source === "orders::api" && e.target === "gateway-orders-east")).toBe(true);
+    expect(crossEdges.some((e) => e.source === "gateway-products-west" && e.target === "products::api")).toBe(true);
+  });
+
+  it("renders a decoupled cross edge as two boundary stub chains instead of one joined line", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "d1",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "south",
+          entry: "north",
+          mode: "decoupled",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    expect(flow.edges.some((e) => e.id.startsWith("d1-"))).toBe(true);
+    expect(
+      flow.edges.some((e) => e.source === "gateway-orders-south" && e.target === "gateway-products-north")
+    ).toBe(false);
+  });
+
+  it("emits two independent boundary stubs for a decoupled cross edge (no inter-cell segment)", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "d1",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "south",
+          entry: "north",
+          mode: "decoupled",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+
+    expect(flow.nodes.some((n) => n.id === "xstub-d1-out")).toBe(true);
+    expect(flow.nodes.some((n) => n.id === "xstub-d1-in")).toBe(true);
+
+    const outStub = flow.nodes.find((n) => n.id === "xstub-d1-out")!;
+    const inStub = flow.nodes.find((n) => n.id === "xstub-d1-in")!;
+    expect(outStub.data.label).toBe("products.api");
+    expect(inStub.data.label).toBe("orders.api");
+
+    const stubEdges = flow.edges.filter((e) => e.id.startsWith("d1-"));
+    expect(stubEdges).toHaveLength(4);
+    expect(stubEdges.every((e) => e.type === "step")).toBe(true);
+
+    // no edge directly joins the two cells' gateways (that's the defining trait of decoupled mode)
+    expect(
+      flow.edges.some((e) => e.source === "gateway-orders-south" && e.target === "gateway-products-north")
+    ).toBe(false);
+
+    // the two chains are independently connected (distinct connectionIds)
+    const outChainIds = new Set(stubEdges.filter((e) => e.id.startsWith("d1-out")).map((e) => e.data?.connectionId));
+    const inChainIds = new Set(stubEdges.filter((e) => e.id.startsWith("d1-in")).map((e) => e.data?.connectionId));
+    expect(outChainIds.size).toBe(1);
+    expect(inChainIds.size).toBe(1);
+    expect(Array.from(outChainIds)[0]).not.toBe(Array.from(inChainIds)[0]);
+  });
+
+  it("emits a gateway for a decoupled cross edge's exit/entry directions", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "d1",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "south",
+          entry: "north",
+          mode: "decoupled",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    expect(flow.nodes.some((n) => n.id === "gateway-orders-south")).toBe(true);
+    expect(flow.nodes.some((n) => n.id === "gateway-products-north")).toBe(true);
+  });
+
+  it("emits gateways for cross-edge exit/entry directions even without other boundary usage", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "x1",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "east",
+          entry: "west",
+          mode: "connected",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    expect(flow.nodes.some((n) => n.id === "gateway-orders-east")).toBe(true);
+    expect(flow.nodes.some((n) => n.id === "gateway-products-west")).toBe(true);
+  });
+
+  it("handles a mixed-axis connected cross edge (east exit into north entry)", () => {
+    const project: ProjectModel = {
+      cells: [
+        { id: "orders", components: [{ id: "api" }], externals: [], edges: [] },
+        { id: "products", components: [{ id: "api" }], externals: [], edges: [] }
+      ],
+      crossEdges: [
+        {
+          id: "x2",
+          sourceCell: "orders",
+          sourceComp: "api",
+          targetCell: "products",
+          targetComp: "api",
+          exit: "east",
+          entry: "north",
+          mode: "connected",
+          line: 1
+        }
+      ],
+      sharedExternals: []
+    };
+    const flow = toReactFlow(project);
+    const middleSegment = flow.edges.find((e) => e.id === "x2-gateway-gateway");
+    expect(middleSegment?.source).toBe("gateway-orders-east");
+    expect(middleSegment?.target).toBe("gateway-products-north");
+    const lastSegment = flow.edges.find((e) => e.id === "x2-gateway-component");
+    expect(lastSegment?.targetHandle).toBe("component-top-target");
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/flowLayout.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/flowLayout.ts
@@ -1,0 +1,722 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import dagre from "@dagrejs/dagre";
+import { MarkerType, type Edge, type Node } from "@xyflow/react";
+import { CellModel, ProjectModel } from "../domain/cellModel";
+
+type FlowNodeData = Record<string, unknown>;
+type BoundaryDirection = "north" | "east" | "south" | "west";
+
+const componentSize = 112;
+const externalSize = 106;
+const gatewaySize = 34;
+const componentWidth = componentSize;
+const componentHeight = componentSize;
+const cellPadding = 142;
+const defaultCellSize = 640;
+const externalGapByDirection: Record<BoundaryDirection, number> = {
+  north: 220,
+  east: 150,
+  south: 220,
+  west: 150
+};
+const externalStepByDirection: Record<BoundaryDirection, number> = {
+  north: 240,
+  east: 172,
+  south: 240,
+  west: 172
+};
+
+export function layoutCell(cell: CellModel) {
+  const graph = new dagre.graphlib.Graph();
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({
+    rankdir: "LR",
+    ranksep: 72,
+    nodesep: 44,
+    marginx: 20,
+    marginy: 20
+  });
+
+  cell.components.forEach((component) => {
+    graph.setNode(component.id, { width: componentWidth, height: componentHeight });
+  });
+
+  cell.edges
+    .filter((edge) => edge.kind === "internal")
+    .forEach((edge) => {
+      graph.setEdge(edge.source, edge.target);
+    });
+
+  dagre.layout(graph);
+
+  const nodes = cell.components.map((component) => {
+    const position = graph.node(component.id) ?? { x: 0, y: 0 };
+    return {
+      component,
+      x: position.x - componentWidth / 2,
+      y: position.y - componentHeight / 2
+    };
+  });
+
+  const bounds = nodes.reduce(
+    (current, node) => ({
+      minX: Math.min(current.minX, node.x),
+      minY: Math.min(current.minY, node.y),
+      maxX: Math.max(current.maxX, node.x + componentWidth),
+      maxY: Math.max(current.maxY, node.y + componentHeight)
+    }),
+    {
+      minX: Number.POSITIVE_INFINITY,
+      minY: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      maxY: Number.NEGATIVE_INFINITY
+    }
+  );
+
+  if (nodes.length === 0) {
+    return {
+      nodes,
+      width: defaultCellSize,
+      height: defaultCellSize
+    };
+  }
+
+  const contentWidth = bounds.maxX - bounds.minX + cellPadding * 2;
+  const contentHeight = bounds.maxY - bounds.minY + cellPadding * 2;
+  const cellSize = Math.max(defaultCellSize, contentWidth, contentHeight);
+  const extraX = (cellSize - contentWidth) / 2;
+  const extraY = (cellSize - contentHeight) / 2;
+
+  return {
+    nodes: nodes.map((node) => ({
+      ...node,
+      x: node.x - bounds.minX + cellPadding + extraX,
+      y: node.y - bounds.minY + cellPadding + extraY
+    })),
+    width: cellSize,
+    height: cellSize
+  };
+}
+
+function externalPosition(
+  direction: BoundaryDirection,
+  index: number,
+  count: number,
+  cellWidth: number,
+  cellHeight: number
+) {
+  const gap = externalGapByDirection[direction];
+  const step = externalStepByDirection[direction];
+  const offset = (index - (count - 1) / 2) * step;
+
+  if (direction === "north") {
+    return { x: cellWidth / 2 + offset - externalSize / 2, y: -gap };
+  }
+
+  if (direction === "south") {
+    return { x: cellWidth / 2 + offset - externalSize / 2, y: cellHeight + gap - externalSize };
+  }
+
+  if (direction === "west") {
+    return { x: -gap - externalSize, y: cellHeight / 2 + offset - externalSize / 2 };
+  }
+
+  return { x: cellWidth + gap, y: cellHeight / 2 + offset - externalSize / 2 };
+}
+
+function gatewayPosition(direction: BoundaryDirection, cellWidth: number, cellHeight: number) {
+  if (direction === "north") {
+    return { x: cellWidth / 2 - gatewaySize / 2, y: -gatewaySize / 2 };
+  }
+
+  if (direction === "south") {
+    return { x: cellWidth / 2 - gatewaySize / 2, y: cellHeight - gatewaySize / 2 };
+  }
+
+  if (direction === "west") {
+    return { x: -gatewaySize / 2, y: cellHeight / 2 - gatewaySize / 2 };
+  }
+
+  return { x: cellWidth - gatewaySize / 2, y: cellHeight / 2 - gatewaySize / 2 };
+}
+
+function componentHandle(direction: string, type: "source" | "target") {
+  if (direction === "north") {
+    return type === "source" ? "component-top-source" : "component-top-target";
+  }
+
+  if (direction === "south") {
+    return type === "source" ? "component-bottom-source" : "component-top-target";
+  }
+
+  if (direction === "west") {
+    return type === "source" ? "component-left-source" : "component-left-target";
+  }
+
+  return type === "source" ? "component-right-source" : "component-left-target";
+}
+
+function externalSourceHandle(direction: string) {
+  if (direction === "north") {
+    return "external-bottom-source";
+  }
+
+  if (direction === "west") {
+    return "external-right-source";
+  }
+
+  return "external-right-source";
+}
+
+function externalTargetHandle(direction: string) {
+  if (direction === "south") {
+    return "external-top-target";
+  }
+
+  return "external-left-target";
+}
+
+function gatewaySourceHandle(direction: string) {
+  if (direction === "north") {
+    return "gateway-bottom-source";
+  }
+
+  if (direction === "south") {
+    return "gateway-bottom-source";
+  }
+
+  if (direction === "west") {
+    return "gateway-right-source";
+  }
+
+  return "gateway-right-source";
+}
+
+function gatewayTargetHandle(direction: string) {
+  if (direction === "north") {
+    return "gateway-top-target";
+  }
+
+  if (direction === "south") {
+    return "gateway-top-target";
+  }
+
+  if (direction === "west") {
+    return "gateway-left-target";
+  }
+
+  return "gateway-left-target";
+}
+
+function internalEdgeHandles() {
+  return {
+    sourceHandle: "component-right-source",
+    targetHandle: "component-left-target"
+  };
+}
+
+function connectionData(connectionId: string, connectedNodeIds: string[]) {
+  return {
+    connectionId,
+    connectedNodeIds
+  };
+}
+
+// Arrow-head colors mirror the per-direction edge stroke colors in diagram.css.
+const EDGE_ARROW_COLORS: Record<string, string> = {
+  north: "#0284c7",
+  east: "#ea580c",
+  south: "#059669",
+  west: "#7c3aed"
+};
+const DEFAULT_ARROW_COLOR = "#475569";
+const CROSS_ARROW_COLOR = "#7c3aed";
+
+// A React Flow arrow marker (orient="auto" so it aligns to the path tangent),
+// colored to match the edge. Used on the terminal segment of each logical edge.
+// markerUnits "userSpaceOnUse" keeps the head a fixed size, so it does not balloon
+// when a selected/highlighted edge thickens its stroke.
+function arrowMarker(color: string) {
+  return {
+    type: MarkerType.Arrow,
+    color,
+    width: 25,
+    height: 25,
+    strokeWidth: 1.6,
+    markerUnits: "userSpaceOnUse"
+  };
+}
+
+function directionArrow(direction: string) {
+  return arrowMarker(EDGE_ARROW_COLORS[direction] ?? DEFAULT_ARROW_COLOR);
+}
+
+function namespaced(cellId: string, id: string, multi: boolean) {
+  return multi ? `${cellId}::${id}` : id;
+}
+
+function gatewayNodeId(cellId: string, direction: string, multi: boolean) {
+  return multi ? `gateway-${cellId}-${direction}` : `gateway-${direction}`;
+}
+
+function externalNodeId(cellId: string, externalId: string, multi: boolean) {
+  return multi ? `external-${cellId}-${externalId}` : `external-${externalId}`;
+}
+
+function emitCellEdges(cell: CellModel, multi: boolean, sharedExternalIds: Set<string>, edges: Edge[]) {
+  const resolve = (compId: string) => namespaced(cell.id, compId, multi);
+  const gwId = (direction: string) => gatewayNodeId(cell.id, direction, multi);
+  const extId = (externalId: string) =>
+    sharedExternalIds.has(externalId) ? `external-${externalId}` : externalNodeId(cell.id, externalId, multi);
+
+  cell.edges.forEach((edge) => {
+    if (edge.kind === "internal") {
+      const handles = internalEdgeHandles();
+      const data = connectionData(edge.id, [resolve(edge.source), resolve(edge.target)]);
+      edges.push({
+        id: edge.id,
+        data,
+        source: resolve(edge.source),
+        sourceHandle: handles.sourceHandle,
+        target: resolve(edge.target),
+        targetHandle: handles.targetHandle,
+        label: edge.label,
+        type: "floating",
+        animated: false,
+        markerEnd: directionArrow(edge.direction),
+        className: `edge-${edge.direction}`
+      });
+      return;
+    }
+
+    if (edge.kind === "inbound") {
+      const gatewayId = gwId(edge.direction);
+      const externalId = extId(edge.source);
+      const data = connectionData(edge.id, [externalId, gatewayId, resolve(edge.target)]);
+      edges.push(
+        {
+          id: `${edge.id}-external-gateway`,
+          data,
+          source: externalId,
+          sourceHandle: externalSourceHandle(edge.direction),
+          target: gatewayId,
+          targetHandle: gatewayTargetHandle(edge.direction),
+          label: edge.label,
+          type: "smoothstep",
+          animated: true,
+          className: `edge-${edge.direction}`
+        },
+        {
+          id: `${edge.id}-gateway-component`,
+          data,
+          source: gatewayId,
+          sourceHandle: gatewaySourceHandle(edge.direction),
+          target: resolve(edge.target),
+          targetHandle: componentHandle(edge.direction, "target"),
+          type: "smoothstep",
+          animated: true,
+          markerEnd: directionArrow(edge.direction),
+          className: `edge-${edge.direction}`
+        }
+      );
+      return;
+    }
+
+    if (edge.kind === "exposure") {
+      const gatewayId = gwId(edge.direction);
+      const startsAtGateway = edge.source === edge.direction;
+
+      if (startsAtGateway) {
+        const data = connectionData(edge.id, [gatewayId, resolve(edge.target)]);
+        edges.push({
+          id: `${edge.id}-gateway-component`,
+          data,
+          source: gatewayId,
+          sourceHandle: gatewaySourceHandle(edge.direction),
+          target: resolve(edge.target),
+          targetHandle: componentHandle(edge.direction, "target"),
+          label: edge.label,
+          type: "smoothstep",
+          animated: true,
+          markerEnd: directionArrow(edge.direction),
+          className: `edge-${edge.direction}`
+        });
+        return;
+      }
+
+      const data = connectionData(edge.id, [resolve(edge.source), gatewayId]);
+      edges.push({
+        id: `${edge.id}-component-gateway`,
+        data,
+        source: resolve(edge.source),
+        sourceHandle: componentHandle(edge.direction, "source"),
+        target: gatewayId,
+        targetHandle: gatewayTargetHandle(edge.direction),
+        label: edge.label,
+        type: "smoothstep",
+        animated: true,
+        className: `edge-${edge.direction}`
+      });
+      return;
+    }
+
+    const gatewayId = gwId(edge.direction);
+    const externalId = extId(edge.target);
+    const data = connectionData(edge.id, [resolve(edge.source), gatewayId, externalId]);
+    edges.push(
+      {
+        id: `${edge.id}-component-gateway`,
+        data,
+        source: resolve(edge.source),
+        sourceHandle: componentHandle(edge.direction, "source"),
+        target: gatewayId,
+        targetHandle: gatewayTargetHandle(edge.direction),
+        type: "smoothstep",
+        animated: true,
+        className: `edge-${edge.direction}`
+      },
+      {
+        id: `${edge.id}-gateway-external`,
+        data,
+        source: gatewayId,
+        sourceHandle: gatewaySourceHandle(edge.direction),
+        target: externalId,
+        targetHandle: externalTargetHandle(edge.direction),
+        label: edge.label,
+        type: "smoothstep",
+        animated: true,
+        markerEnd: directionArrow(edge.direction),
+        className: `edge-${edge.direction}`
+      }
+    );
+  });
+}
+
+function emitCrossEdges(project: ProjectModel, multi: boolean, edges: Edge[]) {
+  project.crossEdges.forEach((edge) => {
+    if (edge.mode !== "connected") {
+      return;
+    }
+
+    const srcComp = namespaced(edge.sourceCell, edge.sourceComp, multi);
+    const tgtComp = namespaced(edge.targetCell, edge.targetComp, multi);
+    const srcGate = gatewayNodeId(edge.sourceCell, edge.exit, multi);
+    const tgtGate = gatewayNodeId(edge.targetCell, edge.entry, multi);
+    const data = connectionData(edge.id, [srcComp, srcGate, tgtGate, tgtComp]);
+
+    edges.push(
+      {
+        id: `${edge.id}-component-gateway`,
+        data,
+        source: srcComp,
+        sourceHandle: componentHandle(edge.exit, "source"),
+        target: srcGate,
+        targetHandle: gatewayTargetHandle(edge.exit),
+        type: "step",
+        animated: true,
+        className: "edge-cross"
+      },
+      {
+        id: `${edge.id}-gateway-gateway`,
+        data,
+        source: srcGate,
+        sourceHandle: gatewaySourceHandle(edge.exit),
+        target: tgtGate,
+        targetHandle: gatewayTargetHandle(edge.entry),
+        label: edge.label,
+        type: "step",
+        animated: true,
+        className: "edge-cross"
+      },
+      {
+        id: `${edge.id}-gateway-component`,
+        data,
+        source: tgtGate,
+        sourceHandle: gatewaySourceHandle(edge.entry),
+        target: tgtComp,
+        targetHandle: componentHandle(edge.entry, "target"),
+        type: "step",
+        animated: true,
+        markerEnd: arrowMarker(CROSS_ARROW_COLOR),
+        className: "edge-cross"
+      }
+    );
+  });
+}
+
+function emitDecoupledCrossEdges(
+  project: ProjectModel,
+  multi: boolean,
+  cellBoxes: Map<string, { originX: number; originY: number; width: number; height: number }>,
+  nodes: Node<FlowNodeData>[],
+  edges: Edge[]
+) {
+  project.crossEdges.forEach((edge) => {
+    if (edge.mode !== "decoupled") {
+      return;
+    }
+
+    const srcBox = cellBoxes.get(edge.sourceCell);
+    const tgtBox = cellBoxes.get(edge.targetCell);
+    if (!srcBox || !tgtBox) {
+      return;
+    }
+
+    const srcComp = namespaced(edge.sourceCell, edge.sourceComp, multi);
+    const tgtComp = namespaced(edge.targetCell, edge.targetComp, multi);
+    const srcGate = gatewayNodeId(edge.sourceCell, edge.exit, multi);
+    const tgtGate = gatewayNodeId(edge.targetCell, edge.entry, multi);
+    const stubOutId = `xstub-${edge.id}-out`;
+    const stubInId = `xstub-${edge.id}-in`;
+
+    const outPosition = externalPosition(edge.exit, 0, 1, srcBox.width, srcBox.height);
+    const inPosition = externalPosition(edge.entry, 0, 1, tgtBox.width, tgtBox.height);
+
+    nodes.push({
+      id: stubOutId,
+      type: "external",
+      position: { x: srcBox.originX + outPosition.x, y: srcBox.originY + outPosition.y },
+      data: {
+        nodeId: stubOutId,
+        label: `${edge.targetCell}.${edge.targetComp}`,
+        externalType: undefined,
+        direction: edge.exit
+      },
+      draggable: false
+    });
+    nodes.push({
+      id: stubInId,
+      type: "external",
+      position: { x: tgtBox.originX + inPosition.x, y: tgtBox.originY + inPosition.y },
+      data: {
+        nodeId: stubInId,
+        label: `${edge.sourceCell}.${edge.sourceComp}`,
+        externalType: undefined,
+        direction: edge.entry
+      },
+      draggable: false
+    });
+
+    const outData = connectionData(`${edge.id}-out`, [srcComp, srcGate, stubOutId]);
+    edges.push(
+      {
+        id: `${edge.id}-out-component-gateway`,
+        data: outData,
+        source: srcComp,
+        sourceHandle: componentHandle(edge.exit, "source"),
+        target: srcGate,
+        targetHandle: gatewayTargetHandle(edge.exit),
+        type: "step",
+        animated: true,
+        className: "edge-cross"
+      },
+      {
+        id: `${edge.id}-out-gateway-external`,
+        data: outData,
+        source: srcGate,
+        sourceHandle: gatewaySourceHandle(edge.exit),
+        target: stubOutId,
+        targetHandle: externalTargetHandle(edge.exit),
+        label: edge.label,
+        type: "step",
+        animated: true,
+        markerEnd: arrowMarker(CROSS_ARROW_COLOR),
+        className: "edge-cross"
+      }
+    );
+
+    const inData = connectionData(`${edge.id}-in`, [stubInId, tgtGate, tgtComp]);
+    edges.push(
+      {
+        id: `${edge.id}-in-external-gateway`,
+        data: inData,
+        source: stubInId,
+        sourceHandle: externalSourceHandle(edge.entry),
+        target: tgtGate,
+        targetHandle: gatewayTargetHandle(edge.entry),
+        type: "step",
+        animated: true,
+        className: "edge-cross"
+      },
+      {
+        id: `${edge.id}-in-gateway-component`,
+        data: inData,
+        source: tgtGate,
+        sourceHandle: gatewaySourceHandle(edge.entry),
+        target: tgtComp,
+        targetHandle: componentHandle(edge.entry, "target"),
+        type: "step",
+        animated: true,
+        markerEnd: arrowMarker(CROSS_ARROW_COLOR),
+        className: "edge-cross"
+      }
+    );
+  });
+}
+
+export function toReactFlow(project: ProjectModel) {
+  const multi = project.cells.length > 1;
+  const nodes: Node<FlowNodeData>[] = [];
+  const edges: Edge[] = [];
+
+  const cellBoxes = new Map<string, { originX: number; originY: number; width: number; height: number }>();
+  const sharedExternalIds = new Set(project.sharedExternals.map((ext) => ext.id));
+
+  const layouts = new Map<string, ReturnType<typeof layoutCell>>();
+  project.cells.forEach((cell) => layouts.set(cell.id, layoutCell(cell)));
+
+  const gatewayDirectionsByCell = new Map<string, Set<BoundaryDirection>>();
+  project.cells.forEach((cell) => {
+    const dirs = new Set<BoundaryDirection>();
+    cell.externals.forEach((external) => dirs.add(external.direction as BoundaryDirection));
+    cell.edges
+      .filter((edge) => edge.kind === "exposure" || edge.kind === "inbound" || edge.kind === "outbound")
+      .forEach((edge) => dirs.add(edge.direction as BoundaryDirection));
+    gatewayDirectionsByCell.set(cell.id, dirs);
+  });
+  project.crossEdges.forEach((edge) => {
+    gatewayDirectionsByCell.get(edge.sourceCell)?.add(edge.exit);
+    gatewayDirectionsByCell.get(edge.targetCell)?.add(edge.entry);
+  });
+
+  const cellGraph = new dagre.graphlib.Graph();
+  cellGraph.setDefaultEdgeLabel(() => ({}));
+  cellGraph.setGraph({ rankdir: "LR", ranksep: 260, nodesep: 200, marginx: 60, marginy: 60 });
+
+  project.cells.forEach((cell) => {
+    const layout = layouts.get(cell.id)!;
+    cellGraph.setNode(`cell-${cell.id}`, { width: layout.width, height: layout.height });
+  });
+  project.sharedExternals.forEach((ext) => {
+    cellGraph.setNode(`external-${ext.id}`, { width: externalSize, height: externalSize });
+  });
+  project.crossEdges
+    .filter((edge) => edge.mode === "connected")
+    .forEach((edge) => cellGraph.setEdge(`cell-${edge.sourceCell}`, `cell-${edge.targetCell}`));
+
+  dagre.layout(cellGraph);
+
+  project.cells.forEach((cell) => {
+    const layout = layouts.get(cell.id)!;
+    const g = cellGraph.node(`cell-${cell.id}`) ?? { x: layout.width / 2, y: layout.height / 2 };
+    const originX = g.x - layout.width / 2;
+    const originY = g.y - layout.height / 2;
+    cellBoxes.set(cell.id, { originX, originY, width: layout.width, height: layout.height });
+
+    nodes.push({
+      id: `cell-${cell.id}`,
+      type: "cellBoundary",
+      position: { x: originX, y: originY },
+      data: {
+        title: cell.label ?? (multi ? cell.id : project.title),
+        version: cell.version,
+        width: layout.width,
+        height: layout.height
+      },
+      draggable: false,
+      selectable: false
+    });
+
+    layout.nodes.forEach(({ component, x, y }) => {
+      const id = namespaced(cell.id, component.id, multi);
+      nodes.push({
+        id,
+        type: "component",
+        position: { x: originX + x, y: originY + y },
+        data: { nodeId: id, label: component.label ?? component.id, componentType: component.type },
+        draggable: false
+      });
+    });
+
+    const byDirection = cell.externals.reduce<Record<string, string[]>>((groups, external) => {
+      groups[external.direction] = [...(groups[external.direction] ?? []), external.id];
+      return groups;
+    }, {});
+
+    const gatewayDirections = gatewayDirectionsByCell.get(cell.id) ?? new Set<BoundaryDirection>();
+    Array.from(gatewayDirections).forEach((direction) => {
+      const position = gatewayPosition(direction, layout.width, layout.height);
+      const id = gatewayNodeId(cell.id, direction, multi);
+      nodes.push({
+        id,
+        type: "gateway",
+        position: { x: originX + position.x, y: originY + position.y },
+        data: { nodeId: id, direction },
+        draggable: false
+      });
+    });
+
+    cell.externals.forEach((external) => {
+      const peers = byDirection[external.direction] ?? [];
+      const position = externalPosition(
+        external.direction as BoundaryDirection,
+        peers.indexOf(external.id),
+        peers.length,
+        layout.width,
+        layout.height
+      );
+      const id = externalNodeId(cell.id, external.id, multi);
+      nodes.push({
+        id,
+        type: "external",
+        position: { x: originX + position.x, y: originY + position.y },
+        data: {
+          nodeId: id,
+          label: external.label ?? external.id,
+          externalType: external.type,
+          direction: external.direction
+        },
+        draggable: false
+      });
+    });
+
+    emitCellEdges(cell, multi, sharedExternalIds, edges);
+  });
+
+  emitCrossEdges(project, multi, edges);
+  emitDecoupledCrossEdges(project, multi, cellBoxes, nodes, edges);
+
+  project.sharedExternals.forEach((ext) => {
+    const g = cellGraph.node(`external-${ext.id}`) ?? { x: 0, y: 0 };
+    nodes.push({
+      id: `external-${ext.id}`,
+      type: "external",
+      position: { x: g.x - externalSize / 2, y: g.y - externalSize / 2 },
+      data: {
+        nodeId: `external-${ext.id}`,
+        label: ext.label ?? ext.id,
+        externalType: ext.type,
+        direction: ext.direction ?? "east"
+      },
+      draggable: false
+    });
+  });
+
+  const xs = nodes.flatMap((n) => [n.position.x, n.position.x + (n.width ?? 0)]);
+  const ys = nodes.flatMap((n) => [n.position.y, n.position.y + (n.height ?? 0)]);
+  const minX = xs.length ? Math.min(...xs) : 0;
+  const minY = ys.length ? Math.min(...ys) : 0;
+  const maxX = xs.length ? Math.max(...xs) : 0;
+  const maxY = ys.length ? Math.max(...ys) : 0;
+  const width = maxX - minX + 400;
+  const height = maxY - minY + 400;
+
+  return { nodes, edges, cellSize: { width, height } };
+}

--- a/packages/ui/cell-diagram-react/src/renderer/highlightModel.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/highlightModel.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compileProject } from "../compiler/compileProject";
+import { defaultSampleSource } from "../test/defaultSample";
+import { toReactFlow } from "./flowLayout";
+import { connectionIdsForNode, highlightedNodeIdsForConnections } from "./highlightModel";
+
+describe("highlightModel", () => {
+  it("finds every connection linked to a hovered component", () => {
+    const compiled = compileProject(defaultSampleSource);
+
+    expect(compiled.model).not.toBeNull();
+
+    const flow = toReactFlow(compiled.model!);
+    const connectionIds = connectionIdsForNode(flow.edges, "orders");
+    const highlightedNodeIds = highlightedNodeIdsForConnections(flow.edges, new Set(connectionIds));
+
+    expect(connectionIds).toEqual(
+      expect.arrayContaining([
+        "north-pp-orders-15",
+        "west-ap-orders-16",
+        "internal-WebApp-orders-18",
+        "internal-orders-odb-19",
+        "internal-orders-ep-20",
+        "east-orders-inventories-22",
+        "east-orders-customers-23",
+        "south-orders-Stripe-24",
+        "south-orders-SendGrid-25"
+      ])
+    );
+    expect(Array.from(highlightedNodeIds)).toEqual(
+      expect.arrayContaining([
+        "orders",
+        "odb",
+        "ep",
+        "gateway-east",
+        "external-inventories",
+        "gateway-south",
+        "external-Stripe"
+      ])
+    );
+  });
+
+  it("groups highlighted nodes for a namespaced cross-cell connection", () => {
+    const edges = [
+      {
+        id: "x1-component-gateway",
+        data: {
+          connectionId: "x1",
+          connectedNodeIds: ["orders::api", "gateway-orders-east", "gateway-products-west", "products::api"]
+        }
+      }
+    ];
+    const highlighted = highlightedNodeIdsForConnections(edges, new Set(["x1"]));
+    expect(highlighted.has("orders::api")).toBe(true);
+    expect(highlighted.has("products::api")).toBe(true);
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/highlightModel.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/highlightModel.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface HighlightableEdge {
+  id: string;
+  data?: Record<string, unknown> | null;
+}
+
+export function edgeConnectionId(edge: HighlightableEdge) {
+  return String(edge.data?.connectionId ?? edge.id);
+}
+
+export function connectionIdsForNode(edges: HighlightableEdge[], nodeId: string) {
+  return Array.from(
+    new Set(
+      edges
+        .filter((edge) => {
+          const connectedNodeIds = edge.data?.connectedNodeIds;
+          return Array.isArray(connectedNodeIds) && connectedNodeIds.map(String).includes(nodeId);
+        })
+        .map(edgeConnectionId)
+    )
+  );
+}
+
+export function highlightedNodeIdsForConnections(edges: HighlightableEdge[], connectionIds: Set<string>) {
+  return edges.reduce<Set<string>>((nodeIds, edge) => {
+    const connectedNodeIds = edge.data?.connectedNodeIds;
+
+    if (connectionIds.has(edgeConnectionId(edge)) && Array.isArray(connectedNodeIds)) {
+      connectedNodeIds.forEach((nodeId) => nodeIds.add(String(nodeId)));
+    }
+
+    return nodeIds;
+  }, new Set<string>());
+}

--- a/packages/ui/cell-diagram-react/src/test/defaultSample.ts
+++ b/packages/ui/cell-diagram-react/src/test/defaultSample.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const defaultSampleSource = `component WebApp web-app
+component orders as Orders api
+component odb as OrderDB database
+component ep as "Event Publisher" event
+
+north ca as "Customer App" webapp
+north pp as "Partner Portal" webapp
+west ap as "Admin Portal" webapp
+east inventories api
+east customers api
+south Stripe payment
+south SendGrid email
+
+ca -> WebApp : HTTPS
+pp -> orders : REST
+ap -> orders : backoffice
+
+WebApp -> orders
+orders -> odb
+orders -> ep : order.created
+
+orders -> inventories : reserve stock
+orders -> customers : customer profile
+orders -> Stripe : payment
+orders -> SendGrid : email
+
+north -> orders`;

--- a/packages/ui/cell-diagram-react/src/test/setup.ts
+++ b/packages/ui/cell-diagram-react/src/test/setup.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "@testing-library/jest-dom/vitest";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, "ResizeObserver", {
+  writable: true,
+  configurable: true,
+  value: ResizeObserverMock
+});
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  writable: true,
+  configurable: true,
+  value: ResizeObserverMock
+});
+
+Range.prototype.getClientRects = function () {
+  return {
+    length: 0,
+    item: () => null,
+    [Symbol.iterator]: function* () {}
+  } as DOMRectList;
+};
+
+Range.prototype.getBoundingClientRect = function () {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  };
+};

--- a/packages/ui/cell-diagram-react/src/ui/ControlIcons.tsx
+++ b/packages/ui/cell-diagram-react/src/ui/ControlIcons.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface ControlIconProps {
+  size?: number;
+}
+
+function ControlIcon({ children, size = 16 }: ControlIconProps & { children: React.ReactNode }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+      <path d="M0 0h32v32H0z" fill="none" />
+      {children}
+    </svg>
+  );
+}
+
+export function ZoomInIcon({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path fill="currentColor" d="M17 15V8h-2v7H8v2h7v7h2v-7h7v-2z" />
+    </ControlIcon>
+  );
+}
+
+export function ZoomOutIcon({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path fill="currentColor" d="M8 15h16v2H8z" />
+    </ControlIcon>
+  );
+}
+
+export function FitScreenIcon({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path
+        fill="currentColor"
+        d="M8 2H2v6h2V4h4zm16 0h6v6h-2V4h-4zM8 30H2v-6h2v4h4zm16 0h6v-6h-2v4h-4zm0-6H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2M8 10v12h16V10Z"
+      />
+    </ControlIcon>
+  );
+}

--- a/packages/ui/cell-diagram-react/tsconfig.build.json
+++ b/packages/ui/cell-diagram-react/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  // Emits only .d.ts to dist/ (consumed via package.json "types"). Runtime is
+  // the raw src (package.json "main"), which the app's bundler compiles — so
+  // this build never needs to emit JS or copy CSS. Tests are excluded so their
+  // vitest-inferred types don't leak into the public declarations.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
+}

--- a/packages/ui/cell-diagram-react/tsconfig.json
+++ b/packages/ui/cell-diagram-react/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
+    // Vendored in-house from @kanushka/cell-diagram-react and kept byte-identical
+    // to upstream so it can be re-synced. Upstream was authored without these two
+    // (stricter-than-default) repo-wide flags, so they're scoped off here rather
+    // than rewriting library internals. Re-enable if this package is forked for real.
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false,
+    // Consumed as source (main = src/index.ts); no published .d.ts, so declaration
+    // emit is off — this also avoids TS2742 portability checks on inferred vitest
+    // spy types in the vendored tests.
+    "declaration": false,
+    "declarationMap": false,
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/ui/cell-diagram-react/vitest.config.ts
+++ b/packages/ui/cell-diagram-react/vitest.config.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/test/setup.ts",
+  },
+});

--- a/packages/ui/cell-diagram-view/package.json
+++ b/packages/ui/cell-diagram-view/package.json
@@ -10,8 +10,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@aep/design-projection": "workspace:*",
-    "@wso2/cell-diagram": "0.2.0"
+    "@aep/ui-cell-diagram-react": "workspace:*"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/ui/cell-diagram-view/src/CellDiagramInner.tsx
+++ b/packages/ui/cell-diagram-view/src/CellDiagramInner.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Lazy-loaded leaf: keeps the renderer's heavy transitive deps (@xyflow,
+// dagre) and its stylesheet out of the main bundle until the diagram is
+// actually shown. The component self-imports its CSS, so no separate
+// stylesheet import is needed here. `tolerant` lets a still-growing
+// `design.cell` render its partial diagram instead of the error placeholder.
+import { CellDiagram } from "@aep/ui-cell-diagram-react";
+
+export default function CellDiagramInner({ source }: { source: string }) {
+  return <CellDiagram source={source} tolerant style={{ width: "100%", height: "100%" }} />;
+}

--- a/packages/ui/cell-diagram-view/src/CellDiagramView.tsx
+++ b/packages/ui/cell-diagram-view/src/CellDiagramView.tsx
@@ -18,32 +18,30 @@
 
 import type React from "react";
 import { lazy, memo, Suspense } from "react";
-import type { Project } from "@wso2/cell-diagram";
-import type { CellDiagramProject } from "@aep/design-projection";
 import { Box, CircularProgress, Typography } from "@wso2/oxygen-ui";
 
-const CellDiagram = lazy(() =>
-  import("@wso2/cell-diagram").then((m) => ({ default: m.CellDiagram })),
-);
+// Lazy-loaded leaf keeps the renderer's heavy transitive deps (@xyflow, dagre)
+// and its stylesheet out of the main bundle until the diagram is actually
+// shown. The diagram is driven entirely by a cell DSL `source` string.
+const CellDiagram = lazy(() => import("./CellDiagramInner.js"));
 
 export interface CellDiagramViewProps {
   /**
-   * Whole-architecture projection from `@aep/design-projection`
-   * (`toCellDiagramProject(buildProjectDesign(...))`). Structurally a
-   * `@wso2/cell-diagram` `Project`; the only divergence is `type: string` vs
-   * the lib's `ComponentType` enum, which the diagram accepts — hence the
-   * single internal cast. `null`/absent renders the empty state.
+   * Cell DSL source text. Rendered in tolerant mode so a still-growing
+   * `design.cell` (streamed live) draws its partial diagram instead of an
+   * error placeholder. Blank/undefined → the empty state.
    */
-  project?: CellDiagramProject | null;
+  source?: string | undefined;
   /** Optional override for the empty-state copy. */
   emptyState?: React.ReactNode;
 }
 
 export const CellDiagramView = memo(function CellDiagramView({
-  project,
+  source,
   emptyState,
 }: CellDiagramViewProps) {
-  if (!project || project.components.length === 0) {
+  const hasSource = typeof source === "string" && source.trim().length > 0;
+  if (!hasSource) {
     return (
       <Box
         sx={{
@@ -67,12 +65,6 @@ export const CellDiagramView = memo(function CellDiagramView({
   }
 
   return (
-    // position: 'relative' establishes a containing block for the library's
-    // zoom/fit control panel: its `DiagramContainer` (the direct parent of
-    // the absolutely-positioned control panel) sets no `position` of its
-    // own, so without an ancestor here the controls escape to the nearest
-    // positioned ancestor in the whole page (effectively the viewport),
-    // landing wherever the page happens to end rather than inside this pane.
     <Box sx={{ flex: 1, minHeight: 0, display: "flex", position: "relative" }}>
       <Suspense
         fallback={
@@ -81,7 +73,7 @@ export const CellDiagramView = memo(function CellDiagramView({
           </Box>
         }
       >
-        <CellDiagram project={project as unknown as Project} />
+        <CellDiagram source={source} />
       </Suspense>
     </Box>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,14 +235,57 @@ importers:
         specifier: ^4.21.0
         version: 4.22.4
 
+  packages/ui/cell-diagram-react:
+    dependencies:
+      '@dagrejs/dagre':
+        specifier: ^1.1.5
+        version: 1.1.8
+      '@xyflow/react':
+        specifier: ^12.8.4
+        version: 12.11.2(@types/react-dom@19.0.2(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
+      react:
+        specifier: ^19.0.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.0.2(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.9.4
+      '@types/react':
+        specifier: 19.1.6
+        version: 19.1.6
+      '@types/react-dom':
+        specifier: 19.0.2
+        version: 19.0.2(@types/react@19.1.6)
+      '@vitejs/plugin-react-swc':
+        specifier: 4.2.0
+        version: 4.2.0(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/ui/cell-diagram-view:
     dependencies:
-      '@aep/design-projection':
+      '@aep/ui-cell-diagram-react':
         specifier: workspace:*
-        version: link:../../design-projection
-      '@wso2/cell-diagram':
-        specifier: 0.2.0
-        version: 0.2.0(@types/react@19.1.6)(pathfinding@0.4.18)(paths-js@0.4.11)(resize-observer-polyfill@1.5.1)
+        version: link:../cell-diagram-react
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -583,6 +626,9 @@ packages:
       zod:
         optional: true
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -716,9 +762,20 @@ packages:
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-calc@3.2.1':
     resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
@@ -727,12 +784,25 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-color-parser@4.1.9':
     resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -748,18 +818,26 @@ packages:
       css-tree:
         optional: true
 
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dagrejs/dagre@1.1.8':
+    resolution: {integrity: sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==}
+
+  '@dagrejs/graphlib@2.2.4':
+    resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
+    engines: {node: '>17.0.0'}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
 
   '@emotion/cache@11.14.0':
     resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
-
-  '@emotion/hash@0.8.0':
-    resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -1151,56 +1229,6 @@ packages:
   '@lifeomic/attempt@3.1.0':
     resolution: {integrity: sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==}
 
-  '@material-ui/core@4.12.4':
-    resolution: {integrity: sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==}
-    engines: {node: '>=8.0.0'}
-    deprecated: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@material-ui/styles@4.11.5':
-    resolution: {integrity: sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==}
-    engines: {node: '>=8.0.0'}
-    deprecated: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@material-ui/system@4.12.2':
-    resolution: {integrity: sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==}
-    engines: {node: '>=8.0.0'}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@material-ui/types@5.1.0':
-    resolution: {integrity: sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==}
-    peerDependencies:
-      '@types/react': '*'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@material-ui/utils@4.11.3':
-    resolution: {integrity: sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==}
-    engines: {node: '>=8.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
@@ -1221,51 +1249,8 @@ packages:
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
-  '@mui/base@5.0.0-beta.6':
-    resolution: {integrity: sha512-jcHy6HwOX7KzRhRtL8nvIvUlxvLx2Fl6NMRCyUSQSvMTyfou9kndekz0H4HJaXvG1Y4WEifk23RYedOlrD1kEQ==}
-    engines: {node: '>=12.0.0'}
-    deprecated: This package has been replaced by @base-ui/react
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/core-downloads-tracker@5.18.0':
-    resolution: {integrity: sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==}
-
   '@mui/core-downloads-tracker@7.3.11':
     resolution: {integrity: sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==}
-
-  '@mui/icons-material@5.15.21':
-    resolution: {integrity: sha512-yqkq1MbdkmX5ZHyvZTBuAaA6RkvoqkoAgwBSx9Oh0L0jAfj9T/Ih/NhMNjkl8PWVSonjfDUkKroBnjRyo/1M9Q==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@mui/material': ^5.0.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/material@5.13.7':
-    resolution: {integrity: sha512-+n453jDDm88zZM3b5YK29nZ7gXY+s+rryH9ovDbhmfSkOlFtp+KSqbXy5cTaC/UlDqDM7sYYJGq8BmJov3v9Tg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
 
   '@mui/material@7.3.4':
     resolution: {integrity: sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==}
@@ -1287,16 +1272,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@5.17.1':
-    resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@mui/private-theming@7.3.11':
     resolution: {integrity: sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==}
     engines: {node: '>=14.0.0'}
@@ -1305,19 +1280,6 @@ packages:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@mui/styled-engine@5.18.0':
-    resolution: {integrity: sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
         optional: true
 
   '@mui/styled-engine@7.3.10':
@@ -1331,22 +1293,6 @@ packages:
       '@emotion/react':
         optional: true
       '@emotion/styled':
-        optional: true
-
-  '@mui/system@5.18.0':
-    resolution: {integrity: sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
         optional: true
 
   '@mui/system@7.3.11':
@@ -1365,14 +1311,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.2.24':
-    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@mui/types@7.4.12':
     resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
     peerDependencies:
@@ -1385,16 +1323,6 @@ packages:
     resolution: {integrity: sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@5.17.1':
-    resolution: {integrity: sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1525,42 +1453,6 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
-  '@projectstorm/geometry@6.7.4':
-    resolution: {integrity: sha512-9jTcQPzg+qT9OUMCUGmpkyk0ChHMobFL5d542dY5sb54bki35cawvQj2gMsIdNJ4WGxnuM+DKSSzm4JX35lGtw==}
-
-  '@projectstorm/react-canvas-core@6.7.4':
-    resolution: {integrity: sha512-sY32kT//gQe5aw6RHkmKrbzBq9iWyfwyvvfRTplGPE1ll3zOBVCjbf3tdfw6vATCden+WR0TmirtBo2j3exiBg==}
-    peerDependencies:
-      lodash: 4.*
-      react: 16.* || 17.*
-
-  '@projectstorm/react-diagrams-core@6.7.4':
-    resolution: {integrity: sha512-AeqH1u58Ugk8mif/GgLEUeOMmTPaWDpl1isA1OJHCPGMbvAytRfv5mrGMvG2E+pYDB29BQ4Yo2z9/TbAy6/nvA==}
-    peerDependencies:
-      lodash: 4.*
-      react: 18.*
-      resize-observer-polyfill: ^1.5.1
-
-  '@projectstorm/react-diagrams-defaults@6.7.4':
-    resolution: {integrity: sha512-j3pRlZq1Z5yIGKpI7VtVkvNK/kXKB2abNMVXTSLUECA4iRubPKDn08w6q4jg1nBZXLGidrHsrELqW+53G9VvLA==}
-    peerDependencies:
-      '@emotion/react': ^11.*
-      '@emotion/styled': ^11.*
-      lodash: 4.*
-      react: 18.*
-
-  '@projectstorm/react-diagrams-routing@6.7.4':
-    resolution: {integrity: sha512-mB8YaRkNF6gdTlYvL0Cxc6m6XLwh7wvmjIsiEO6kW3j1uSvH7R7Gbl/iDYOdc0zUMqH9+pD+M064tWC4oAXa9A==}
-    peerDependencies:
-      dagre: ^0.8.5
-      lodash: 4.*
-      pathfinding: ^0.4.18
-      paths-js: ^0.4.11
-      react: 18.*
-
-  '@projectstorm/react-diagrams@6.7.4':
-    resolution: {integrity: sha512-xK/bi7DqHKv15XZRESeSpvSmAVArJIXkV6E1mybSc/24toGmoE2imcS+puxG6wGS56NhR0gIrUiT5UYwBvyD5A==}
 
   '@radix-ui/primitive@1.0.0':
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
@@ -2513,17 +2405,11 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
@@ -2693,9 +2579,6 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@wso2/cell-diagram@0.2.0':
-    resolution: {integrity: sha512-XtGywdnD2py/5mf/76xMEf7v8194lOv9XVDtSIHpbk14VQknU3Fxi9jbdQUxdVbSGRxn5lImSf+76sx9PQBI6Q==}
-
   '@wso2/oxygen-ui-icons-react@0.11.0':
     resolution: {integrity: sha512-fAb5/eHoALCId8873ogu4aHHHvOtJ90tInwTInXDlQtKZph51gAxeLb4svCSw0YjkPwbIV/Ak5OjUu9sAn0mqw==}
     peerDependencies:
@@ -2708,6 +2591,22 @@ packages:
       '@wso2/oxygen-ui-icons-react': '>=0.1.0'
       react: 19.2.3
       react-dom: 19.2.3
+
+  '@xyflow/react@12.11.2':
+    resolution: {integrity: sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.79':
+    resolution: {integrity: sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2791,6 +2690,9 @@ packages:
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -2915,6 +2817,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -2925,10 +2830,6 @@ packages:
 
   clsx@1.1.1:
     resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
-    engines: {node: '>=6'}
-
-  clsx@1.2.1:
-    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
 
   clsx@2.1.1:
@@ -2944,6 +2845,10 @@ packages:
 
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -3031,14 +2936,12 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-vendor@2.0.8:
-    resolution: {integrity: sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==}
-
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
-  csstype@2.6.21:
-    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3199,8 +3102,9 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  dagre@0.8.5:
-    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -3232,6 +3136,10 @@ packages:
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3280,6 +3188,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -3300,6 +3212,10 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.49.0:
@@ -3475,6 +3391,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3538,15 +3458,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graphlib@2.1.8:
-    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
-
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-
-  gsap@3.12.7:
-    resolution: {integrity: sha512-V4GsyVamhmKefvcAKaoy0h6si0xX7ogwBoBSs2CTJwt7luW0oZzC0LhdkyuKV8PJAXr7Yaj8pMjCKD4GJ+eEMg==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -3557,6 +3471,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -3572,9 +3490,6 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  heap@0.2.5:
-    resolution: {integrity: sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg==}
-
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -3582,9 +3497,16 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -3593,12 +3515,13 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3697,9 +3620,6 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
-  is-in-browser@1.1.3:
-    resolution: {integrity: sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==}
-
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -3770,6 +3690,15 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -3813,30 +3742,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  jss-plugin-camel-case@10.10.0:
-    resolution: {integrity: sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==}
-
-  jss-plugin-default-unit@10.10.0:
-    resolution: {integrity: sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==}
-
-  jss-plugin-global@10.10.0:
-    resolution: {integrity: sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==}
-
-  jss-plugin-nested@10.10.0:
-    resolution: {integrity: sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==}
-
-  jss-plugin-props-sort@10.10.0:
-    resolution: {integrity: sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==}
-
-  jss-plugin-rule-value-function@10.10.0:
-    resolution: {integrity: sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==}
-
-  jss-plugin-vendor-prefixer@10.10.0:
-    resolution: {integrity: sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==}
-
-  jss@10.10.0:
-    resolution: {integrity: sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==}
 
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
@@ -3900,15 +3805,15 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -4044,8 +3949,16 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -4116,6 +4029,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4194,6 +4110,9 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -4227,13 +4146,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathfinding@0.4.18:
-    resolution: {integrity: sha512-R0TGEQ9GRcFCDvAWlJAWC+KGJ9SLbW4c0nuZRcioVlXVTlw+F5RvXQ8SQgSqI9KXWC1ew95vgmIiyaWTlCe9Ag==}
-
-  paths-js@0.4.11:
-    resolution: {integrity: sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==}
-    engines: {node: '>=0.11.0'}
 
   perfect-freehand@1.2.0:
     resolution: {integrity: sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==}
@@ -4311,9 +4223,6 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
-
-  popper.js@1.16.1-lts:
-    resolution: {integrity: sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -4420,11 +4329,6 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
-
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -4435,9 +4339,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
@@ -4491,10 +4392,6 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -4532,9 +4429,6 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4568,6 +4462,12 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -4582,9 +4482,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4738,9 +4635,6 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4756,8 +4650,15 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.4.6:
     resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.4.6:
     resolution: {integrity: sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==}
@@ -4771,9 +4672,17 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -4836,11 +4745,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4850,9 +4754,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5081,6 +4982,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5091,9 +4996,22 @@ packages:
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -5312,6 +5230,14 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
@@ -5484,12 +5410,26 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@csstools/color-helpers@5.1.0': {}
+
   '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5497,6 +5437,10 @@ snapshots:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5506,7 +5450,15 @@ snapshots:
     optionalDependencies:
       css-tree: 3.2.1
 
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dagrejs/dagre@1.1.8':
+    dependencies:
+      '@dagrejs/graphlib': 2.2.4
+
+  '@dagrejs/graphlib@2.2.4': {}
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -5532,8 +5484,6 @@ snapshots:
       '@emotion/weak-memoize': 0.4.0
       stylis: 4.2.0
 
-  '@emotion/hash@0.8.0': {}
-
   '@emotion/hash@0.9.2': {}
 
   '@emotion/is-prop-valid@1.4.0':
@@ -5541,22 +5491,6 @@ snapshots:
       '@emotion/memoize': 0.9.0
 
   '@emotion/memoize@0.9.0': {}
-
-  '@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.1.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3)':
     dependencies:
@@ -5584,21 +5518,6 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.1.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -5615,10 +5534,6 @@ snapshots:
       - supports-color
 
   '@emotion/unitless@0.10.0': {}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.3)':
     dependencies:
@@ -5926,71 +5841,6 @@ snapshots:
 
   '@lifeomic/attempt@3.1.0': {}
 
-  '@material-ui/core@4.12.4(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@material-ui/styles': 4.11.5(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@material-ui/system': 4.12.2(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@material-ui/types': 5.1.0(@types/react@19.1.6)
-      '@material-ui/utils': 4.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.6)
-      clsx: 1.2.1
-      hoist-non-react-statics: 3.3.2
-      popper.js: 1.16.1-lts
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 16.13.1
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@material-ui/styles@4.11.5(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/hash': 0.8.0
-      '@material-ui/types': 5.1.0(@types/react@19.1.6)
-      '@material-ui/utils': 4.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 1.2.1
-      csstype: 2.6.21
-      hoist-non-react-statics: 3.3.2
-      jss: 10.10.0
-      jss-plugin-camel-case: 10.10.0
-      jss-plugin-default-unit: 10.10.0
-      jss-plugin-global: 10.10.0
-      jss-plugin-nested: 10.10.0
-      jss-plugin-props-sort: 10.10.0
-      jss-plugin-rule-value-function: 10.10.0
-      jss-plugin-vendor-prefixer: 10.10.0
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@material-ui/system@4.12.2(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@material-ui/utils': 4.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      csstype: 2.6.21
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@material-ui/types@5.1.0(@types/react@19.1.6)':
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@material-ui/utils@4.11.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 16.13.1
-
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
@@ -6030,53 +5880,7 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@mui/base@5.0.0-beta.6(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/is-prop-valid': 1.4.0
-      '@mui/types': 7.4.12(@types/react@19.1.6)
-      '@mui/utils': 5.17.1(@types/react@19.1.6)(react@18.3.1)
-      '@popperjs/core': 2.11.8
-      clsx: 1.2.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@mui/core-downloads-tracker@5.18.0': {}
-
   '@mui/core-downloads-tracker@7.3.11': {}
-
-  '@mui/icons-material@5.15.21(@mui/material@5.13.7(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/material': 5.13.7(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@mui/material@5.13.7(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/base': 5.0.0-beta.6(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/core-downloads-tracker': 5.18.0
-      '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@18.3.1)
-      '@mui/types': 7.4.12(@types/react@19.1.6)
-      '@mui/utils': 5.17.1(@types/react@19.1.6)(react@18.3.1)
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.6)
-      clsx: 1.2.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 18.3.1
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
-      '@types/react': 19.1.6
 
   '@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -6099,15 +5903,6 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3)
       '@types/react': 19.1.6
 
-  '@mui/private-theming@5.17.1(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/utils': 5.17.1(@types/react@19.1.6)(react@18.3.1)
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.1.6
-
   '@mui/private-theming@7.3.11(@types/react@19.1.6)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -6116,18 +5911,6 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.1.6
-
-  '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
 
   '@mui/styled-engine@7.3.10(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -6141,22 +5924,6 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.6)(react@19.2.3)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3)
-
-  '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/private-theming': 5.17.1(@types/react@19.1.6)(react@18.3.1)
-      '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@19.1.6)
-      '@mui/utils': 5.17.1(@types/react@19.1.6)(react@18.3.1)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
-      '@types/react': 19.1.6
 
   '@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3)':
     dependencies:
@@ -6174,10 +5941,6 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3)
       '@types/react': 19.1.6
 
-  '@mui/types@7.2.24(@types/react@19.1.6)':
-    optionalDependencies:
-      '@types/react': 19.1.6
-
   '@mui/types@7.4.12(@types/react@19.1.6)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -6187,18 +5950,6 @@ snapshots:
   '@mui/types@9.1.1(@types/react@19.1.6)':
     dependencies:
       '@babel/runtime': 7.29.7
-    optionalDependencies:
-      '@types/react': 19.1.6
-
-  '@mui/utils@5.17.1(@types/react@19.1.6)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@mui/types': 7.2.24(@types/react@19.1.6)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 19.2.7
     optionalDependencies:
       '@types/react': 19.1.6
 
@@ -6331,62 +6082,6 @@ snapshots:
     optional: true
 
   '@popperjs/core@2.11.8': {}
-
-  '@projectstorm/geometry@6.7.4': {}
-
-  '@projectstorm/react-canvas-core@6.7.4(lodash@4.18.1)(react@18.3.1)':
-    dependencies:
-      '@projectstorm/geometry': 6.7.4
-      lodash: 4.18.1
-      react: 18.3.1
-
-  '@projectstorm/react-diagrams-core@6.7.4(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)':
-    dependencies:
-      '@projectstorm/geometry': 6.7.4
-      '@projectstorm/react-canvas-core': 6.7.4(lodash@4.18.1)(react@18.3.1)
-      lodash: 4.18.1
-      react: 18.3.1
-      resize-observer-polyfill: 1.5.1
-
-  '@projectstorm/react-diagrams-defaults@6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)':
-    dependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
-      '@projectstorm/react-diagrams-core': 6.7.4(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      lodash: 4.18.1
-      react: 18.3.1
-    transitivePeerDependencies:
-      - resize-observer-polyfill
-
-  '@projectstorm/react-diagrams-routing@6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(dagre@0.8.5)(lodash@4.18.1)(pathfinding@0.4.18)(paths-js@0.4.11)(react@18.3.1)(resize-observer-polyfill@1.5.1)':
-    dependencies:
-      '@projectstorm/geometry': 6.7.4
-      '@projectstorm/react-diagrams-core': 6.7.4(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-defaults': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      dagre: 0.8.5
-      lodash: 4.18.1
-      pathfinding: 0.4.18
-      paths-js: 0.4.11
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@emotion/react'
-      - '@emotion/styled'
-      - resize-observer-polyfill
-
-  '@projectstorm/react-diagrams@6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(dagre@0.8.5)(lodash@4.18.1)(pathfinding@0.4.18)(paths-js@0.4.11)(react@18.3.1)(resize-observer-polyfill@1.5.1)':
-    dependencies:
-      '@projectstorm/react-diagrams-core': 6.7.4(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-defaults': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-routing': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(dagre@0.8.5)(lodash@4.18.1)(pathfinding@0.4.18)(paths-js@0.4.11)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-    transitivePeerDependencies:
-      - '@emotion/react'
-      - '@emotion/styled'
-      - dagre
-      - lodash
-      - pathfinding
-      - paths-js
-      - react
-      - resize-observer-polyfill
 
   '@radix-ui/primitive@1.0.0':
     dependencies:
@@ -7342,17 +7037,11 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash@4.17.24': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.20.0':
     dependencies:
@@ -7568,34 +7257,6 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  '@wso2/cell-diagram@0.2.0(@types/react@19.1.6)(pathfinding@0.4.18)(paths-js@0.4.11)(resize-observer-polyfill@1.5.1)':
-    dependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.6)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
-      '@material-ui/core': 4.12.4(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/icons-material': 5.15.21(@mui/material@5.13.7(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@19.1.6)(react@18.3.1)
-      '@mui/material': 5.13.7(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@projectstorm/geometry': 6.7.4
-      '@projectstorm/react-canvas-core': 6.7.4(lodash@4.18.1)(react@18.3.1)
-      '@projectstorm/react-diagrams': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(dagre@0.8.5)(lodash@4.18.1)(pathfinding@0.4.18)(paths-js@0.4.11)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-core': 6.7.4(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-defaults': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(lodash@4.18.1)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@projectstorm/react-diagrams-routing': 6.7.4(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@18.3.1))(@types/react@19.1.6)(react@18.3.1))(dagre@0.8.5)(lodash@4.18.1)(pathfinding@0.4.18)(paths-js@0.4.11)(react@18.3.1)(resize-observer-polyfill@1.5.1)
-      '@types/lodash': 4.17.24
-      '@types/node': 18.19.130
-      dagre: 0.8.5
-      gsap: 3.12.7
-      lodash: 4.18.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - '@types/react'
-      - pathfinding
-      - paths-js
-      - resize-observer-polyfill
-      - supports-color
-
   '@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3)':
     dependencies:
       lucide-react: 1.16.0(react@19.2.3)
@@ -7627,6 +7288,31 @@ snapshots:
       - moment-hijri
       - moment-jalaali
       - supports-color
+
+  '@xyflow/react@12.11.2(@types/react-dom@19.0.2(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@xyflow/system': 0.0.79
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.1.6)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.6
+      '@types/react-dom': 19.0.2(@types/react@19.1.6)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.79':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   accepts@2.0.0:
     dependencies:
@@ -7700,6 +7386,8 @@ snapshots:
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
+
+  asynckit@0.4.0: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -7842,6 +7530,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  classcat@5.0.5: {}
+
   cli-width@4.1.0: {}
 
   cliui@8.0.1:
@@ -7852,8 +7542,6 @@ snapshots:
 
   clsx@1.1.1: {}
 
-  clsx@1.2.1: {}
-
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -7863,6 +7551,10 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@1.4.0: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -7930,14 +7622,12 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  css-vendor@2.0.8:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      is-in-browser: 1.1.3
-
   css.escape@1.5.1: {}
 
-  csstype@2.6.21: {}
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -8125,10 +7815,10 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
-  dagre@0.8.5:
+  data-urls@5.0.0:
     dependencies:
-      graphlib: 2.1.8
-      lodash: 4.18.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-urls@7.0.0:
     dependencies:
@@ -8158,6 +7848,8 @@ snapshots:
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -8198,6 +7890,8 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  entities@6.0.1: {}
+
   entities@8.0.0: {}
 
   error-ex@1.3.4:
@@ -8213,6 +7907,13 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   es-toolkit@1.49.0: {}
 
@@ -8442,6 +8143,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fractional-indexing@3.2.0: {}
@@ -8493,19 +8202,17 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  graphlib@2.1.8:
-    dependencies:
-      lodash: 4.18.1
-
   graphql@16.14.2: {}
-
-  gsap@3.12.7: {}
 
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -8540,19 +8247,23 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.1
 
-  heap@0.2.5: {}
-
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
 
   hono@4.12.27: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -8564,14 +8275,19 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6(supports-color@10.2.2):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  hyphenate-style-name@1.1.0: {}
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.6.3:
     dependencies:
@@ -8645,8 +8361,6 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
-  is-in-browser@1.1.3: {}
-
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
@@ -8690,6 +8404,34 @@ snapshots:
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@29.1.1:
     dependencies:
@@ -8739,52 +8481,6 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
-
-  jss-plugin-camel-case@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      hyphenate-style-name: 1.1.0
-      jss: 10.10.0
-
-  jss-plugin-default-unit@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      jss: 10.10.0
-
-  jss-plugin-global@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      jss: 10.10.0
-
-  jss-plugin-nested@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      jss: 10.10.0
-      tiny-warning: 1.0.3
-
-  jss-plugin-props-sort@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      jss: 10.10.0
-
-  jss-plugin-rule-value-function@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      jss: 10.10.0
-      tiny-warning: 1.0.3
-
-  jss-plugin-vendor-prefixer@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      css-vendor: 2.0.8
-      jss: 10.10.0
-
-  jss@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      csstype: 3.2.3
-      is-in-browser: 1.1.3
-      tiny-warning: 1.0.3
 
   jwt-decode@4.0.0: {}
 
@@ -8839,13 +8535,13 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
-  lodash@4.18.1: {}
-
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
 
@@ -9121,7 +8817,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -9188,6 +8890,8 @@ snapshots:
   node-releases@2.0.50: {}
 
   normalize-path@3.0.0: {}
+
+  nwsapi@2.2.24: {}
 
   object-assign@4.1.1: {}
 
@@ -9277,6 +8981,10 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -9298,12 +9006,6 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pathfinding@0.4.18:
-    dependencies:
-      heap: 0.2.5
-
-  paths-js@0.4.11: {}
 
   perfect-freehand@1.2.0: {}
 
@@ -9379,8 +9081,6 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
-
-  popper.js@1.16.1-lts: {}
 
   postcss@8.5.16:
     dependencies:
@@ -9515,12 +9215,6 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -9529,8 +9223,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
-
-  react-is@18.3.1: {}
 
   react-is@19.2.7: {}
 
@@ -9584,15 +9276,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
-  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -9601,10 +9284,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@19.2.3: {}
 
@@ -9643,8 +9322,6 @@ snapshots:
   require-from-string@2.0.2: {}
 
   reselect@5.2.0: {}
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -9716,6 +9393,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
@@ -9729,10 +9410,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -9878,8 +9555,6 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tiny-warning@1.0.3: {}
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -9891,7 +9566,13 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.4.6: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.4.6:
     dependencies:
@@ -9903,9 +9584,17 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.4.6
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
@@ -9975,13 +9664,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@4.9.5: {}
-
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -10096,6 +9781,35 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.4
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -10148,13 +9862,26 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
   webworkify@1.5.0: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1:
     dependencies:

--- a/services/aep-api/internal/feature/artifacts/artifact_service.go
+++ b/services/aep-api/internal/feature/artifacts/artifact_service.go
@@ -211,8 +211,10 @@ var allowedRequirementExts = []string{".md", ".excalidraw", ".dsl"}
 // allowedDesignExts is the set of file extensions recognised inside
 // `specs/design/`. Markdown holds prose + frontmatter; YAML is OpenAPI specs;
 // JSON is the post-#70 component `design.json` (structured facts, save-gated
-// against the published schema) plus the FE-derived `*.gen.json` projections.
-var allowedDesignExts = []string{".md", ".yaml", ".yml", ".json"}
+// against the published schema) plus the FE-derived `*.gen.json` projections;
+// `.cell` is the project-level cell-diagram DSL (design.cell) that drives the
+// live architecture diagram.
+var allowedDesignExts = []string{".md", ".yaml", ".yml", ".json", ".cell"}
 
 func hasAllowedDesignExt(name string) bool {
 	lower := strings.ToLower(name)

--- a/services/aep-api/internal/feature/genai/steering.go
+++ b/services/aep-api/internal/feature/genai/steering.go
@@ -27,9 +27,9 @@ var steeringByUseCase = map[string]string{
 	useCaseRequirementsGenerate: "\n\nGenerate the requirements document at specs/requirements/requirements.md from the direction above. Write clear, well-structured markdown.",
 	useCaseRequirementsChat: "\n\nApply the requested change to the current requirements draft, or answer the question if no change is requested. " +
 		"Requirements files live under specs/requirements/ (main document: specs/requirements/requirements.md) — when creating a file that does not exist yet, always use that full path, never a bare filename.",
-	useCaseDesignGenerate: "\n\nGenerate the design under specs/design/ from the approved requirements in specs/requirements/. Load every relevant skill in ONE loadSkill call, then emit files in EXACTLY this order: " +
-		"(1) a concise specs/design/design.md, (2) EVERY component's design.json — they drive the live architecture diagram, so all of them come before any other artifact, " +
-		"(3) wireframes.dsl per web app, (4) openapi.yaml per service LAST. The skills define each artifact.",
+	useCaseDesignGenerate: "\n\nGenerate the design under specs/design/ from the approved requirements in specs/requirements/. Load every relevant skill in ONE loadSkill call (including cell-architecture-dsl), then emit files in EXACTLY this order: " +
+		"(1) specs/design/design.cell — the live architecture diagram (see the cell-architecture-dsl skill for grammar + boundary rules): write it in a SINGLE addFile; the platform streams it into the live diagram line by line as you write; " +
+		"(2) a concise specs/design/design.md; (3) EVERY component's design.json — the component ids MUST match design.cell, and every design.cell edge touching a component MUST appear as a dependency in that component's design.json (and vice versa); (4) wireframes.dsl per web app; (5) openapi.yaml per service LAST. The skills define each artifact.",
 	// useCaseGeneral is the no-useCase turn (the "useCase" field was omitted):
 	// a generic spec turn that is NOT scoped to requirements or design. The
 	// steering names neither flow — it only tells the model where the spec

--- a/services/aep-api/internal/platform/agentfold/fold_test.go
+++ b/services/aep-api/internal/platform/agentfold/fold_test.go
@@ -366,6 +366,7 @@ func TestManifestOfAndIsEmpty(t *testing.T) {
 func TestSnapshotFilter(t *testing.T) {
 	if !KeepInTurnSnapshot("specs/requirements/requirements.md") ||
 		!KeepInTurnSnapshot("a.dsl") ||
+		!KeepInTurnSnapshot("specs/design/design.cell") ||
 		!KeepInTurnSnapshot("specs/design/components/x/design.json") {
 		t.Fatal("keep-filter rejects agent-authored sources")
 	}

--- a/services/aep-api/internal/platform/agentfold/snapshot_filter.go
+++ b/services/aep-api/internal/platform/agentfold/snapshot_filter.go
@@ -29,9 +29,10 @@ import (
 )
 
 // KeepInTurnSnapshot mirrors keepInTurnSnapshot: keep agent-authored sources
-// (*.md, *.dsl, a design.json basename) and drop everything else.
+// (*.md, *.dsl, *.cell, a design.json basename) and drop everything else.
+// *.cell is the project-level cell-diagram DSL (design.cell).
 func KeepInTurnSnapshot(path string) bool {
-	if strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".dsl") {
+	if strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".dsl") || strings.HasSuffix(path, ".cell") {
 		return true
 	}
 	base := path

--- a/services/aep-api/skills/embedded/cell-architecture-dsl/SKILL.md
+++ b/services/aep-api/skills/embedded/cell-architecture-dsl/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: cell-architecture-dsl
+description: Use when writing or editing specs/design/design.cell — the cell-based architecture diagram DSL that drives the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the incremental write protocol.
+metadata:
+  aep:
+    kind: platform
+---
+
+
+# Cell architecture DSL (design.cell)
+
+`specs/design/design.cell` is a small, project-level text file describing the
+architecture as a **cell**. The console renders it live as you write it, so it
+is the FIRST design artifact you emit — before design.md and the component
+design.json files. The component ids here MUST match the
+`components/<name>/design.json` names you write afterwards.
+
+## Cell-based architecture in AEP
+
+The **cell is the project boundary**, drawn as an octagon. Your project's own
+components live *inside* it. Anything the project talks to that lives *outside*
+the project is drawn on one of the four boundaries, and which boundary encodes
+what kind of thing it is:
+
+- **north** = public / internet gateway. A component exposed to the internet
+  (`design.json` `exposure: "internet"`) is reached through north:
+  `north -> <component>`.
+- **west** = org / intranet gateway. A component exposed only inside the org
+  (`exposure: "intranet"`) is reached through west: `west -> <component>`.
+- **east** = org / platform dependencies OUTSIDE the project — shared platform
+  services and other projects' services. Thunder auth (a `thunder-app`
+  platform-resource) and any `org-service` dependency go on **east**.
+- **south** = third-party / external dependencies — SaaS and other systems
+  outside the platform (`external`-kind dependencies: payment, email, …).
+
+**Placement, keyed by the component's `design.json` dependency `kind`:**
+
+| What it is | design.json signal | Where it goes |
+|---|---|---|
+| Your own component (service, web-app, worker) | a `components/<name>/` folder | INSIDE the cell — `component …` |
+| Project-scoped resource (db, cache, object store) | `platform-resource` (postgres/redis/…) | INSIDE the cell — `component <id> … database` |
+| Auth (Thunder) | `platform-resource` `thunder-app` | **east** — `east <id> as "Thunder Auth" identity-server` |
+| Another project's / org service | `org-service` | **east** |
+| Third-party SaaS / external system | `external` | **south** |
+| Exposed to the internet | `exposure: "internet"` | **north** exposure edge `north -> comp` |
+| Exposed to the org only | `exposure: "intranet"` | **west** exposure edge `west -> comp` |
+
+Rule of thumb: **if a dependency lives inside the project, it's a `component`
+inside the cell; if it lives outside, it leaves the cell through a boundary**
+(north/west for who calls in, east/south for what the project calls out to).
+
+## Grammar
+
+Line-based: one statement per line, whitespace trimmed, blank lines ignored.
+Whole-line comments only — a line whose first non-space char is `#` or `//`.
+Wrap multi-word values in double quotes (`"Ceramics API"`). Reserved ids you
+cannot use for a component/external: `title version component as north east
+south west`.
+
+**Title** — `title <text>` (rest of line).
+
+**Component** (inside the cell) — `component <id> [as <label>] [type]`
+- The optional `type` is the LAST bare token. **There is no `:` before it.**
+- Without `as`, everything after the id is the type. With `as`, one trailing
+  token is the label; if there are two or more, the LAST is the type and the
+  rest is the label.
+- `component ceramics-api` → id only.
+- `component ceramics-api service` → id + type `service`.
+- `component ceramics-api as "Ceramics API" service` → id, label, type.
+
+**External** (on a boundary) — `<direction> <id> [as <label>] [type]` where
+direction is `north|east|south|west`. Same label/type rule as component. The
+line must NOT contain `->`.
+- `east user-auth as "Thunder Auth" identity-server`
+- `south payment-provider as "Payment Provider" service`
+
+**Edges** — `A -> B [: label]`. Everything after the first `:` is the label.
+The kind is inferred from the tokens:
+
+| Form | Meaning |
+|---|---|
+| `webapp -> api` | internal: component → component |
+| `north -> api` | exposure: internet gateway exposes `api` |
+| `west -> api` | exposure: intranet gateway exposes `api` |
+| `north client -> api` | inbound: external `client` on north → `api` |
+| `api -> east user-auth` | outbound: `api` → external `user-auth` on east |
+
+**Ergonomic style (preferred):** declare externals first with their boundary,
+then write plain `a -> b` arrows — the compiler reclassifies an edge that
+touches a declared external into the right inbound/outbound form automatically.
+So after `east user-auth …` and `south payment-provider …`, you just write
+`ceramics-api -> user-auth` and `ceramics-api -> payment-provider`.
+
+**Boundary validation (hard errors):** north/west are inbound only, east/south
+are outbound only. `api -> north x` and `east x -> api` are rejected.
+
+**One cell is the norm.** Because the cell = the project, a plain list of
+components + externals + edges (no wrapper) is a single implicit cell — that is
+what you almost always write. Multi-cell blocks (`cell <id> { … }` with
+cross-cell edges) are only for modelling several projects together; skip them
+for a single project.
+
+## Common mistakes (do NOT do these)
+
+- ❌ `resource user-auth "…"` / `external payment "…"` — **there is no
+  `resource` or `external` keyword.** Externals are a `<direction> <id>` line.
+- ❌ `component api "Ceramics API"` — a bare quoted string after the id is read
+  as the *type*, not a label. Use `as`: `component api as "Ceramics API"
+  service`.
+- ❌ `component api as "Ceramics API" : service` — no colon before the type.
+- ❌ Putting Thunder/payment/email *inside* the cell as components. Auth and
+  org services go **east**; third-party SaaS goes **south**.
+
+## Worked example
+
+```
+title Handmade Ceramics Online Store
+
+component ceramics-webapp as "Ceramics Storefront" web-application
+component ceramics-api as "Ceramics API" service
+
+east user-auth as "Thunder Auth" identity-server
+south payment-provider as "Payment Provider" service
+south email-provider as "Email Provider" service
+
+north -> ceramics-webapp
+
+ceramics-webapp -> ceramics-api
+ceramics-webapp -> user-auth
+ceramics-api -> user-auth
+ceramics-api -> payment-provider
+ceramics-api -> email-provider
+```
+
+## Write it in one addFile — the platform streams it
+
+Write the whole `specs/design/design.cell` in a **single `addFile`**. The
+platform streams the file into the live architecture diagram line by line as you
+write it, so the diagram already grows one node at a time — you do NOT need
+incremental `editFile`s, and you should not use them here. Emit the file in a
+readable order (title, then components, then boundary externals, then edges) so
+the diagram builds up sensibly as it streams.
+
+To regenerate an existing design.cell, `removeFile specs/design/design.cell`
+then `addFile` the new version (the fresh add re-streams the diagram); do not
+patch it with anchored edits.

--- a/services/aep-api/skills/embedded/cell-architecture-dsl/SKILL.md
+++ b/services/aep-api/skills/embedded/cell-architecture-dsl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cell-architecture-dsl
-description: Use when writing or editing specs/design/design.cell — the cell-based architecture diagram DSL that drives the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the incremental write protocol.
+description: Use when generating or editing a design — write specs/design/design.cell FIRST (before design.md and the component design.json files). It is the cell-based architecture diagram DSL that streams into the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the single-addFile write protocol.
 metadata:
   aep:
     kind: platform

--- a/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
+++ b/services/aep-api/skills/embedded/high-level-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: high-level-architecture
-description: Use when turning requirements into a design — creating or restructuring specs/design/design.md, deciding which components the system decomposes into, or writing a component's design.json.
+description: Use when turning requirements into a design — creating or restructuring specs/design/design.md, deciding which components the system decomposes into, writing the specs/design/design.cell architecture diagram, or writing a component's design.json.
 metadata:
   aep:
     kind: platform
@@ -13,11 +13,34 @@ Derive the design tree from `requirements.md`. The design lives under
 `specs/design/` — never at the bundle root.
 
 ```
+specs/design/design.cell                      # project-level architecture diagram DSL (this skill) — emit FIRST
 specs/design/design.md                        # the top-level design (this skill)
 specs/design/components/<name>/design.json    # one per component (structured facts)
 specs/design/components/<name>/openapi.yaml   # services only (openapi-conventions skill)
 specs/design/components/<name>/wireframes.dsl  # web-applications only (excalidraw-wireframes skill)
 ```
+
+## The architecture diagram — design.cell
+
+`specs/design/design.cell` is a single project-level file holding the
+cell-diagram DSL. Emit it **FIRST**, before design.md and the component
+design.json files: it is small, it fixes the component decomposition up front,
+and the console streams it into the live architecture diagram as you write, so
+the user watches the architecture take shape.
+
+**Load the `cell-architecture-dsl` skill before writing design.cell.** It
+carries the full grammar, the AEP boundary semantics (own components inside the
+cell; Thunder auth and org services on east; third-party SaaS on south;
+internet/intranet exposure on north/west), and the single-`addFile` write
+protocol. Do not guess the syntax — `resource`/`external` are NOT keywords, and
+the node `type` is a bare trailing token with no colon.
+
+**design.cell is the architecture contract.** The rest of the design must match
+it: every `components/<name>/design.json` uses the SAME component id as its
+`design.cell` node, and every edge in design.cell that touches a component
+appears as a `dependencies[]` entry on that component's design.json (and vice
+versa — an interaction in design.json must be an edge in design.cell). A
+mismatch between the two is a defect, not a stylistic choice.
 
 ## The top-level design.md
 

--- a/services/agents/src/collab/streaming-add.test.ts
+++ b/services/agents/src/collab/streaming-add.test.ts
@@ -100,6 +100,41 @@ test("streams markdown addFile incrementally, line-by-line, converging to full c
   assert.deepEqual(writer.rollbackDangling(), []);
 });
 
+const CELL_PATH = "specs/design/design.cell";
+const CELL =
+  "title Shop\n\ncomponent web as \"Web\" web-application\ncomponent api as \"API\" service\n\nweb -> api\n";
+
+test("streams a .cell addFile incrementally, line-by-line, converging to full content", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+
+  await feed(writer, addFileParts("c1", CELL_PATH, CELL));
+  writer.observe(toolResult("c1", true, CELL_PATH));
+  await writer.drain();
+
+  assert.ok(peer.sets.length >= 2, `expected incremental writes, got ${peer.sets.length}`);
+  assert.ok(peer.sets.every((s) => s.path === CELL_PATH), "all writes target design.cell");
+  for (let i = 1; i < peer.sets.length; i++) {
+    assert.ok(
+      peer.sets[i]!.content.startsWith(peer.sets[i - 1]!.content),
+      `write ${i} must extend write ${i - 1}`,
+    );
+  }
+  assert.equal(peer.sets.at(-1)!.content, CELL, "final write is the whole DSL body");
+  assert.deepEqual(peer.deletes, []);
+  assert.deepEqual(writer.rollbackDangling(), []);
+});
+
+test("rolls back a truncated .cell stream", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+  const parts = addFileParts("c1", CELL_PATH, CELL);
+  await feed(writer, parts.slice(0, Math.floor(parts.length * 0.6)));
+  assert.ok(peer.sets.length >= 1, "should have optimistically written a partial preview");
+  assert.deepEqual(writer.rollbackDangling(), [CELL_PATH]);
+  assert.deepEqual(peer.deletes, [CELL_PATH]);
+});
+
 test("path resolves before any content is written", async () => {
   const peer = new FakePeer();
   const writer = new StreamingDocWriter(peer, new FileBundle({}));

--- a/services/agents/src/collab/streaming-add.ts
+++ b/services/agents/src/collab/streaming-add.ts
@@ -36,9 +36,12 @@
  *    ProseMirror fragment (~30× the Yjs traffic + rewrites earlier text); line
  *    boundaries are clean.
  *
- * Scope (v1): room-mode, MARKDOWN addFile only (no content-gate ⇒ no deferred
- * -validation risk). Non-md / already-existing paths are skipped (execute owns
- * them). Non-finalized streams (truncation / reject) are rolled back.
+ * Scope (v1): room-mode, MARKDOWN and `.cell` addFile only — neither has a
+ * content-gate, so there is no deferred-validation risk (unlike design.json).
+ * `.cell` is the project-level architecture DSL; streaming it line-by-line
+ * draws the diagram live as the model writes it. Non-md/`.cell` / already-
+ * existing paths are skipped (execute owns them). Non-finalized streams
+ * (truncation / reject) are rolled back.
  */
 
 import { parsePartialJson } from "ai";
@@ -46,6 +49,11 @@ import { isMarkdownPath } from "@aep/collab-doc";
 import type { FileBundle, StreamPart } from "@aep/agent-stream";
 import type { RoomPeer } from "./room-peer.js";
 import { ADD_FILE } from "../agents/main/tools/files.js";
+
+/** Paths safe to optimistically stream: markdown (Y.XmlFragment) or `.cell` DSL (Y.Text). */
+function isStreamablePath(path: string): boolean {
+  return isMarkdownPath(path) || path.endsWith(".cell");
+}
 
 interface CallState {
   /** Accumulated tool-input args text (JSON) for this tool call. */
@@ -123,7 +131,7 @@ export class StreamingDocWriter {
         // Gate exactly once: content having started means `path` is final.
         if (!s.streaming) {
           const path = await this.decodePath(s.buf);
-          if (path && isMarkdownPath(path) && !this.bundle.has(path)) {
+          if (path && isStreamablePath(path) && !this.bundle.has(path)) {
             s.streaming = true;
             s.path = path;
           } else {

--- a/services/agents/src/conversation/load-workspace.test.ts
+++ b/services/agents/src/conversation/load-workspace.test.ts
@@ -38,6 +38,7 @@ test("readSnapshot walks recursively with POSIX keys and applies the turn filter
   const root = makeTree({
     "specs/requirements/requirements.md": "# Req\n",
     "specs/design/design.md": "# Design\n",
+    "specs/design/design.cell": "title Shop\n",
     "specs/design/system.dsl": "workspace {}\n",
     "specs/design/components/api/design.json": "{}\n",
     // Everything below must be EXCLUDED from the turn input:
@@ -53,6 +54,7 @@ test("readSnapshot walks recursively with POSIX keys and applies the turn filter
     const snap = readSnapshot(root);
     assert.deepEqual(Object.keys(snap).sort(), [
       "specs/design/components/api/design.json",
+      "specs/design/design.cell",
       "specs/design/design.md",
       "specs/design/system.dsl",
       "specs/requirements/requirements.md",

--- a/services/agents/src/conversation/load-workspace.ts
+++ b/services/agents/src/conversation/load-workspace.ts
@@ -48,11 +48,13 @@ import type { SkillCatalogEntry, SkillSource, LoadedSkillBody } from "../agents/
 
 /**
  * The turn-snapshot filter — mirrors aep-api `genai.keepInSnapshot`: keep
- * agent-authored sources (`*.md`, `*.dsl`, component `design.json`) and drop
- * everything else (derived `.excalidraw`/`*.gen.json` projections, code, …).
+ * agent-authored sources (`*.md`, `*.dsl`, `*.cell`, component `design.json`)
+ * and drop everything else (derived `.excalidraw`/`*.gen.json` projections,
+ * code, …). `*.cell` is the project-level cell-diagram DSL (design.cell) that
+ * drives the live architecture diagram.
  */
 export function keepInTurnSnapshot(path: string): boolean {
-  if (path.endsWith(".md") || path.endsWith(".dsl")) return true;
+  if (path.endsWith(".md") || path.endsWith(".dsl") || path.endsWith(".cell")) return true;
   return basename(path) === "design.json";
 }
 

--- a/skills/cell-architecture-dsl/SKILL.md
+++ b/skills/cell-architecture-dsl/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: cell-architecture-dsl
+description: Use when writing or editing specs/design/design.cell — the cell-based architecture diagram DSL that drives the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the incremental write protocol.
+metadata:
+  aep:
+    kind: platform
+---
+
+
+# Cell architecture DSL (design.cell)
+
+`specs/design/design.cell` is a small, project-level text file describing the
+architecture as a **cell**. The console renders it live as you write it, so it
+is the FIRST design artifact you emit — before design.md and the component
+design.json files. The component ids here MUST match the
+`components/<name>/design.json` names you write afterwards.
+
+## Cell-based architecture in AEP
+
+The **cell is the project boundary**, drawn as an octagon. Your project's own
+components live *inside* it. Anything the project talks to that lives *outside*
+the project is drawn on one of the four boundaries, and which boundary encodes
+what kind of thing it is:
+
+- **north** = public / internet gateway. A component exposed to the internet
+  (`design.json` `exposure: "internet"`) is reached through north:
+  `north -> <component>`.
+- **west** = org / intranet gateway. A component exposed only inside the org
+  (`exposure: "intranet"`) is reached through west: `west -> <component>`.
+- **east** = org / platform dependencies OUTSIDE the project — shared platform
+  services and other projects' services. Thunder auth (a `thunder-app`
+  platform-resource) and any `org-service` dependency go on **east**.
+- **south** = third-party / external dependencies — SaaS and other systems
+  outside the platform (`external`-kind dependencies: payment, email, …).
+
+**Placement, keyed by the component's `design.json` dependency `kind`:**
+
+| What it is | design.json signal | Where it goes |
+|---|---|---|
+| Your own component (service, web-app, worker) | a `components/<name>/` folder | INSIDE the cell — `component …` |
+| Project-scoped resource (db, cache, object store) | `platform-resource` (postgres/redis/…) | INSIDE the cell — `component <id> … database` |
+| Auth (Thunder) | `platform-resource` `thunder-app` | **east** — `east <id> as "Thunder Auth" identity-server` |
+| Another project's / org service | `org-service` | **east** |
+| Third-party SaaS / external system | `external` | **south** |
+| Exposed to the internet | `exposure: "internet"` | **north** exposure edge `north -> comp` |
+| Exposed to the org only | `exposure: "intranet"` | **west** exposure edge `west -> comp` |
+
+Rule of thumb: **if a dependency lives inside the project, it's a `component`
+inside the cell; if it lives outside, it leaves the cell through a boundary**
+(north/west for who calls in, east/south for what the project calls out to).
+
+## Grammar
+
+Line-based: one statement per line, whitespace trimmed, blank lines ignored.
+Whole-line comments only — a line whose first non-space char is `#` or `//`.
+Wrap multi-word values in double quotes (`"Ceramics API"`). Reserved ids you
+cannot use for a component/external: `title version component as north east
+south west`.
+
+**Title** — `title <text>` (rest of line).
+
+**Component** (inside the cell) — `component <id> [as <label>] [type]`
+- The optional `type` is the LAST bare token. **There is no `:` before it.**
+- Without `as`, everything after the id is the type. With `as`, one trailing
+  token is the label; if there are two or more, the LAST is the type and the
+  rest is the label.
+- `component ceramics-api` → id only.
+- `component ceramics-api service` → id + type `service`.
+- `component ceramics-api as "Ceramics API" service` → id, label, type.
+
+**External** (on a boundary) — `<direction> <id> [as <label>] [type]` where
+direction is `north|east|south|west`. Same label/type rule as component. The
+line must NOT contain `->`.
+- `east user-auth as "Thunder Auth" identity-server`
+- `south payment-provider as "Payment Provider" service`
+
+**Edges** — `A -> B [: label]`. Everything after the first `:` is the label.
+The kind is inferred from the tokens:
+
+| Form | Meaning |
+|---|---|
+| `webapp -> api` | internal: component → component |
+| `north -> api` | exposure: internet gateway exposes `api` |
+| `west -> api` | exposure: intranet gateway exposes `api` |
+| `north client -> api` | inbound: external `client` on north → `api` |
+| `api -> east user-auth` | outbound: `api` → external `user-auth` on east |
+
+**Ergonomic style (preferred):** declare externals first with their boundary,
+then write plain `a -> b` arrows — the compiler reclassifies an edge that
+touches a declared external into the right inbound/outbound form automatically.
+So after `east user-auth …` and `south payment-provider …`, you just write
+`ceramics-api -> user-auth` and `ceramics-api -> payment-provider`.
+
+**Boundary validation (hard errors):** north/west are inbound only, east/south
+are outbound only. `api -> north x` and `east x -> api` are rejected.
+
+**One cell is the norm.** Because the cell = the project, a plain list of
+components + externals + edges (no wrapper) is a single implicit cell — that is
+what you almost always write. Multi-cell blocks (`cell <id> { … }` with
+cross-cell edges) are only for modelling several projects together; skip them
+for a single project.
+
+## Common mistakes (do NOT do these)
+
+- ❌ `resource user-auth "…"` / `external payment "…"` — **there is no
+  `resource` or `external` keyword.** Externals are a `<direction> <id>` line.
+- ❌ `component api "Ceramics API"` — a bare quoted string after the id is read
+  as the *type*, not a label. Use `as`: `component api as "Ceramics API"
+  service`.
+- ❌ `component api as "Ceramics API" : service` — no colon before the type.
+- ❌ Putting Thunder/payment/email *inside* the cell as components. Auth and
+  org services go **east**; third-party SaaS goes **south**.
+
+## Worked example
+
+```
+title Handmade Ceramics Online Store
+
+component ceramics-webapp as "Ceramics Storefront" web-application
+component ceramics-api as "Ceramics API" service
+
+east user-auth as "Thunder Auth" identity-server
+south payment-provider as "Payment Provider" service
+south email-provider as "Email Provider" service
+
+north -> ceramics-webapp
+
+ceramics-webapp -> ceramics-api
+ceramics-webapp -> user-auth
+ceramics-api -> user-auth
+ceramics-api -> payment-provider
+ceramics-api -> email-provider
+```
+
+## Write it in one addFile — the platform streams it
+
+Write the whole `specs/design/design.cell` in a **single `addFile`**. The
+platform streams the file into the live architecture diagram line by line as you
+write it, so the diagram already grows one node at a time — you do NOT need
+incremental `editFile`s, and you should not use them here. Emit the file in a
+readable order (title, then components, then boundary externals, then edges) so
+the diagram builds up sensibly as it streams.
+
+To regenerate an existing design.cell, `removeFile specs/design/design.cell`
+then `addFile` the new version (the fresh add re-streams the diagram); do not
+patch it with anchored edits.

--- a/skills/cell-architecture-dsl/SKILL.md
+++ b/skills/cell-architecture-dsl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cell-architecture-dsl
-description: Use when writing or editing specs/design/design.cell — the cell-based architecture diagram DSL that drives the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the incremental write protocol.
+description: Use when generating or editing a design — write specs/design/design.cell FIRST (before design.md and the component design.json files). It is the cell-based architecture diagram DSL that streams into the live architecture diagram. Covers the grammar, the AEP boundary semantics (where each dependency goes), and the single-addFile write protocol.
 metadata:
   aep:
     kind: platform

--- a/skills/high-level-architecture/SKILL.md
+++ b/skills/high-level-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: high-level-architecture
-description: Use when turning requirements into a design — creating or restructuring specs/design/design.md, deciding which components the system decomposes into, or writing a component's design.json.
+description: Use when turning requirements into a design — creating or restructuring specs/design/design.md, deciding which components the system decomposes into, writing the specs/design/design.cell architecture diagram, or writing a component's design.json.
 metadata:
   aep:
     kind: platform
@@ -13,11 +13,34 @@ Derive the design tree from `requirements.md`. The design lives under
 `specs/design/` — never at the bundle root.
 
 ```
+specs/design/design.cell                      # project-level architecture diagram DSL (this skill) — emit FIRST
 specs/design/design.md                        # the top-level design (this skill)
 specs/design/components/<name>/design.json    # one per component (structured facts)
 specs/design/components/<name>/openapi.yaml   # services only (openapi-conventions skill)
 specs/design/components/<name>/wireframes.dsl  # web-applications only (excalidraw-wireframes skill)
 ```
+
+## The architecture diagram — design.cell
+
+`specs/design/design.cell` is a single project-level file holding the
+cell-diagram DSL. Emit it **FIRST**, before design.md and the component
+design.json files: it is small, it fixes the component decomposition up front,
+and the console streams it into the live architecture diagram as you write, so
+the user watches the architecture take shape.
+
+**Load the `cell-architecture-dsl` skill before writing design.cell.** It
+carries the full grammar, the AEP boundary semantics (own components inside the
+cell; Thunder auth and org services on east; third-party SaaS on south;
+internet/intranet exposure on north/west), and the single-`addFile` write
+protocol. Do not guess the syntax — `resource`/`external` are NOT keywords, and
+the node `type` is a bare trailing token with no colon.
+
+**design.cell is the architecture contract.** The rest of the design must match
+it: every `components/<name>/design.json` uses the SAME component id as its
+`design.cell` node, and every edge in design.cell that touches a component
+appears as a `dependencies[]` entry on that component's design.json (and vice
+versa — an interaction in design.json must be an edge in design.cell). A
+mismatch between the two is a defect, not a stylistic choice.
 
 ## The top-level design.md
 


### PR DESCRIPTION
Adds a cell-diagram renderer driven by a small architecture DSL, and saves the initial architecture as `specs/design/design.cell`. Reuses the addFile streaming (#205) to draw the diagram live as the DSL is written; the derived design.json path renders the same diagram after commit. Removes the legacy `@wso2/cell-diagram` renderer.

Closes #209. Related to #68.


https://github.com/user-attachments/assets/abfe7498-dcd5-4f1e-949c-fccfdd980a2e

