### PR TITLE
fix(auth): gateway injects groups claim; APIs derive role from it (not sub)

### DIFF
--- a/deployments/helm-charts/wso2-ae-oc-extensions/templates/traits/api-configuration.yaml
+++ b/deployments/helm-charts/wso2-ae-oc-extensions/templates/traits/api-configuration.yaml
@@ -192,7 +192,7 @@ spec:
               url: "http://${metadata.componentName}.${metadata.namespace}:${parameters.upstreamPort > 0 ? parameters.upstreamPort : workload.endpoints[parameters.endpointName].port}${parameters.upstreamBasePath}"
           policies: >-
             ${(environmentConfigs.cors.enabled ? [{"name": "cors", "version": "v1", "params": {"allowedOrigins": environmentConfigs.cors.allowedOrigins, "allowedMethods": environmentConfigs.cors.allowedMethods, "allowedHeaders": environmentConfigs.cors.allowedHeaders, "allowCredentials": environmentConfigs.cors.allowCredentials}}] : [])
-              + (environmentConfigs.jwtAuth.enabled ? [{"name": "jwt-auth", "version": "v1", "params": {"issuers": environmentConfigs.jwtAuth.issuers, "audiences": environmentConfigs.jwtAuth.audience, "claimMappings": {"sub": "x-user-id", "username": "x-user-name", "ouHandle": "x-user-ou"}}}] : [])
+              + (environmentConfigs.jwtAuth.enabled ? [{"name": "jwt-auth", "version": "v1", "params": {"issuers": environmentConfigs.jwtAuth.issuers, "audiences": environmentConfigs.jwtAuth.audience, "claimMappings": {"sub": "x-user-id", "username": "x-user-name", "ouHandle": "x-user-ou", "groups": "x-user-groups"}}}] : [])
               + (environmentConfigs.rateLimit.enabled ? [{"name": "basic-ratelimit", "version": "v1", "params": {"limits": environmentConfigs.rateLimit.limits}}] : [])
               + (environmentConfigs.addHeaders.enabled ? [{"name": "add-headers", "version": "v1", "params": {"requestHeaders": environmentConfigs.addHeaders.requestHeaders, "responseHeaders": environmentConfigs.addHeaders.responseHeaders}}] : [])}
           operations: ${parameters.operations}

--- a/deployments/manifests/api-platform/api-configuration-trait.yaml
+++ b/deployments/manifests/api-platform/api-configuration-trait.yaml
@@ -257,7 +257,7 @@ spec:
               url: "http://${metadata.componentName}.${metadata.namespace}:${parameters.upstreamPort > 0 ? parameters.upstreamPort : workload.endpoints[parameters.endpointName].port}${parameters.upstreamBasePath}"
           policies: >-
             ${(environmentConfigs.cors.enabled ? [{"name": "cors", "version": "v1", "params": {"allowedOrigins": environmentConfigs.cors.allowedOrigins, "allowedMethods": environmentConfigs.cors.allowedMethods, "allowedHeaders": environmentConfigs.cors.allowedHeaders, "allowCredentials": environmentConfigs.cors.allowCredentials}}] : [])
-              + (environmentConfigs.jwtAuth.enabled ? [{"name": "jwt-auth", "version": "v1", "params": {"issuers": environmentConfigs.jwtAuth.issuers, "audiences": environmentConfigs.jwtAuth.audience, "claimMappings": {"sub": "x-user-id", "username": "x-user-name", "ouHandle": "x-user-ou"}}}] : [])
+              + (environmentConfigs.jwtAuth.enabled ? [{"name": "jwt-auth", "version": "v1", "params": {"issuers": environmentConfigs.jwtAuth.issuers, "audiences": environmentConfigs.jwtAuth.audience, "claimMappings": {"sub": "x-user-id", "username": "x-user-name", "ouHandle": "x-user-ou", "groups": "x-user-groups"}}}] : [])
               + (environmentConfigs.rateLimit.enabled ? [{"name": "basic-ratelimit", "version": "v1", "params": {"limits": environmentConfigs.rateLimit.limits}}] : [])
               + (environmentConfigs.addHeaders.enabled ? [{"name": "add-headers", "version": "v1", "params": {"requestHeaders": environmentConfigs.addHeaders.requestHeaders, "responseHeaders": environmentConfigs.addHeaders.responseHeaders}}] : [])}
           operations: ${parameters.operations}

--- a/services/aep-api/skills/embedded/api-management/SKILL.md
+++ b/services/aep-api/skills/embedded/api-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-management
-description: How the platform's API gateway validates JWTs, injects X-User-Id from the sub claim, attaches CORS, and how to design + write services and consumers that match. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
+description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups and returning 403 (not 401) for no role. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
 ---
 
 
@@ -26,9 +26,18 @@ output from reality.
   NOT validate JWTs.
 - The gateway injects identity headers (lowercase claim → mixed-case
   header):
-  - `sub → X-User-Id` (canonical caller identifier — REQUIRED, always present on protected requests)
+  - `sub → X-User-Id` (the caller's canonical id — REQUIRED, always present on protected requests)
+  - `groups → X-User-Groups` (the caller's role groups — a JSON array; present when the user is in any group; drives RBAC)
   - `username → X-User-Name` (display, optional)
   - `ouHandle → X-User-Ou` (multi-tenant, optional)
+- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject:
+  stamp it as the owner of THIS service's own rows, but never use it as a
+  lookup key into another service's directory (e.g. employee-service) — an
+  IdP subject is not an employee id, so the lookup 404s. Resolve the
+  caller's ROLE from `X-User-Groups`, the SAME groups claim the SPA reads
+  (see `thunder-authentication`). An authenticated caller with no
+  recognized role is a **403**, never a 401 — a 401 tells the SPA the
+  token expired, so it restarts sign-in and loops forever.
 - The gateway attaches an Envoy CORS filter to every `visibility: external`
   HTTPRoute via the `api-configuration` ClusterTrait. Your service does
   NOT add CORS middleware. Doubling produces two `Access-Control-Allow-Origin`
@@ -83,7 +92,7 @@ output from reality.
   component`) MUST also carry an instruction line of the form:
   `Upstream <name>: read the URL from <NAME_UPPER_SNAKE>_URL via the runtime-config shim.`
 - Protected `service` `componentAgentInstructions` MUST say (verbatim or close):
-  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects X-User-Id (from JWT sub claim) on every request. Read X-User-Id to identify the caller; reject (401) when missing. Per-user records MUST be keyed on X-User-Id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an IdP subject is not an employee id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
 - In the OpenAPI you author for a protected `service`, document the
   injected `X-User-Id` header under `parameters` so consumers know it's
   required-but-injected (the gateway adds it; clients don't set it). The
@@ -96,14 +105,20 @@ For every task targeting a `service` with `exposesAPI.auth: end-user-required`:
 - Scope: "Do NOT implement `/auth/login`, `/auth/register`, or any
   token-issuance endpoint. The platform gateway validates the JWT and
   the `api-configuration` trait's `jwt-auth` policy injects `X-User-Id`
-  (from JWT `sub` claim) on every request. Read `X-User-Id`; reject
-  (401) when missing. Per-user records MUST be keyed on `X-User-Id`."
+  and `X-User-Groups` on every request. Stamp `X-User-Id` as the owner of
+  this service's own rows; reject 401 when it is missing."
+- Scope (only when the spec has roles): "Resolve the caller's role from
+  `X-User-Groups` (a JSON array of the caller's Thunder groups — the SAME
+  claim the SPA reads). Reject **403** — never 401 — for an authenticated
+  caller with no recognized role. NEVER resolve identity by looking
+  `X-User-Id` up in an org-directory dependency; an IdP subject is not an
+  employee id."
 - Scope: "Do NOT validate JWTs in code; do NOT add CORS middleware. The
   gateway handles both."
-- Acceptance criteria: "Every protected endpoint rejects requests
-  missing `X-User-Id` with 401; with a valid `X-User-Id`, returns only
-  data owned by that subject. `/health` is exempt and returns 200
-  without auth."
+- Acceptance criteria: "Requests missing `X-User-Id` get 401; an
+  authenticated caller with no recognized role gets 403 (not 401), so the
+  SPA does not loop; a caller with a role sees only data their role
+  permits. `/health` is exempt and returns 200 without auth."
 
 For every task whose component has one or more `external`-kind
 `dependencies` entries, add **one Scope bullet per entry** of the form:
@@ -165,6 +180,36 @@ func updateTodo(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+When the spec has roles, resolve the caller's role from `X-User-Groups`
+(the same groups the SPA reads) — NOT by looking `X-User-Id` up in an
+org-directory service. Return **403** (never 401) when no group maps to a
+role, so the SPA does not loop:
+
+```go
+func callerRole(r *http.Request) string { // "" = no recognized role
+    for _, g := range parseGroups(r.Header.Get("X-User-Groups")) {
+        lg := strings.ToLower(g)
+        switch { // adapt the keywords to the spec's role names
+        case strings.Contains(lg, "admin"):   return "admin"
+        case strings.Contains(lg, "auditor"): return "auditor"
+        }
+    }
+    return ""
+}
+
+// X-User-Groups is a JSON array (e.g. ["Compliance Admin"]); accept a
+// comma-separated fallback too.
+func parseGroups(h string) []string {
+    h = strings.TrimSpace(h)
+    if h == "" { return nil }
+    var arr []string
+    if strings.HasPrefix(h, "[") && json.Unmarshal([]byte(h), &arr) == nil {
+        return arr
+    }
+    return strings.Split(h, ",")
+}
+```
+
 Gate per-user queries with `AND user_id = ?`. Do NOT validate JWTs in
 code. Do NOT add CORS middleware. Errors as `application/problem+json`
 with a top-level `type`, `title`, `status`.
@@ -203,3 +248,4 @@ addition is in the Architect sub-section above (document the injected
 | CORS error in browser when calling upstream | Backend wrongly ships its own CORS middleware (doubled headers), OR upstream's `workload.yaml` lacks `visibility: external` | Remove the middleware; confirm `visibility: external` on upstream's `workload.yaml`. |
 | Every protected request 401s in test | Test calls don't carry `X-User-Id`; in production the gateway sets it, in test you set it manually | In integration tests, set `X-User-Id` directly on the request; don't try to mint a JWT. |
 | `/health` returns 401 | Handler accidentally went through `mustUserID` middleware | Carve out `/health` (and any other public path) before the auth gate. |
+| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed org-directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403** for an authenticated caller with no role; never key an org-directory lookup on `X-User-Id`. |

--- a/services/aep-api/skills/embedded/thunder-authentication/SKILL.md
+++ b/services/aep-api/skills/embedded/thunder-authentication/SKILL.md
@@ -65,7 +65,9 @@ instead of deriving it from YOUR dependency name) produces a
   and `ouId`/`ouName`/`ouHandle` (their organization), beside standard
   `profile`/`email`. The platform requests the `group`/`ou` scopes by default,
   so a role-aware SPA reads roles from `user.profile.groups` — it never decodes
-  the access token for them.
+  the access token for them. The protected backend reads the SAME `groups`
+  from the gateway-injected `X-User-Groups` header (see `api-management`), so
+  the SPA and API resolve the caller's role identically.
 - Default Thunder admin user (dev clusters): `admin` / `admin` in the
   `Administrators` group. Real orgs add their own users via Thunder's
   admin console / SCIM.

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-management
-description: How the platform's API gateway validates JWTs, injects X-User-Id from the sub claim, attaches CORS, and how to design + write services and consumers that match. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
+description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups and returning 403 (not 401) for no role. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
 ---
 
 
@@ -26,9 +26,18 @@ output from reality.
   NOT validate JWTs.
 - The gateway injects identity headers (lowercase claim → mixed-case
   header):
-  - `sub → X-User-Id` (canonical caller identifier — REQUIRED, always present on protected requests)
+  - `sub → X-User-Id` (the caller's canonical id — REQUIRED, always present on protected requests)
+  - `groups → X-User-Groups` (the caller's role groups — a JSON array; present when the user is in any group; drives RBAC)
   - `username → X-User-Name` (display, optional)
   - `ouHandle → X-User-Ou` (multi-tenant, optional)
+- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject:
+  stamp it as the owner of THIS service's own rows, but never use it as a
+  lookup key into another service's directory (e.g. employee-service) — an
+  IdP subject is not an employee id, so the lookup 404s. Resolve the
+  caller's ROLE from `X-User-Groups`, the SAME groups claim the SPA reads
+  (see `thunder-authentication`). An authenticated caller with no
+  recognized role is a **403**, never a 401 — a 401 tells the SPA the
+  token expired, so it restarts sign-in and loops forever.
 - The gateway attaches an Envoy CORS filter to every `visibility: external`
   HTTPRoute via the `api-configuration` ClusterTrait. Your service does
   NOT add CORS middleware. Doubling produces two `Access-Control-Allow-Origin`
@@ -83,7 +92,7 @@ output from reality.
   component`) MUST also carry an instruction line of the form:
   `Upstream <name>: read the URL from <NAME_UPPER_SNAKE>_URL via the runtime-config shim.`
 - Protected `service` `componentAgentInstructions` MUST say (verbatim or close):
-  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects X-User-Id (from JWT sub claim) on every request. Read X-User-Id to identify the caller; reject (401) when missing. Per-user records MUST be keyed on X-User-Id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an IdP subject is not an employee id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
 - In the OpenAPI you author for a protected `service`, document the
   injected `X-User-Id` header under `parameters` so consumers know it's
   required-but-injected (the gateway adds it; clients don't set it). The
@@ -96,14 +105,20 @@ For every task targeting a `service` with `exposesAPI.auth: end-user-required`:
 - Scope: "Do NOT implement `/auth/login`, `/auth/register`, or any
   token-issuance endpoint. The platform gateway validates the JWT and
   the `api-configuration` trait's `jwt-auth` policy injects `X-User-Id`
-  (from JWT `sub` claim) on every request. Read `X-User-Id`; reject
-  (401) when missing. Per-user records MUST be keyed on `X-User-Id`."
+  and `X-User-Groups` on every request. Stamp `X-User-Id` as the owner of
+  this service's own rows; reject 401 when it is missing."
+- Scope (only when the spec has roles): "Resolve the caller's role from
+  `X-User-Groups` (a JSON array of the caller's Thunder groups — the SAME
+  claim the SPA reads). Reject **403** — never 401 — for an authenticated
+  caller with no recognized role. NEVER resolve identity by looking
+  `X-User-Id` up in an org-directory dependency; an IdP subject is not an
+  employee id."
 - Scope: "Do NOT validate JWTs in code; do NOT add CORS middleware. The
   gateway handles both."
-- Acceptance criteria: "Every protected endpoint rejects requests
-  missing `X-User-Id` with 401; with a valid `X-User-Id`, returns only
-  data owned by that subject. `/health` is exempt and returns 200
-  without auth."
+- Acceptance criteria: "Requests missing `X-User-Id` get 401; an
+  authenticated caller with no recognized role gets 403 (not 401), so the
+  SPA does not loop; a caller with a role sees only data their role
+  permits. `/health` is exempt and returns 200 without auth."
 
 For every task whose component has one or more `external`-kind
 `dependencies` entries, add **one Scope bullet per entry** of the form:
@@ -165,6 +180,36 @@ func updateTodo(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+When the spec has roles, resolve the caller's role from `X-User-Groups`
+(the same groups the SPA reads) — NOT by looking `X-User-Id` up in an
+org-directory service. Return **403** (never 401) when no group maps to a
+role, so the SPA does not loop:
+
+```go
+func callerRole(r *http.Request) string { // "" = no recognized role
+    for _, g := range parseGroups(r.Header.Get("X-User-Groups")) {
+        lg := strings.ToLower(g)
+        switch { // adapt the keywords to the spec's role names
+        case strings.Contains(lg, "admin"):   return "admin"
+        case strings.Contains(lg, "auditor"): return "auditor"
+        }
+    }
+    return ""
+}
+
+// X-User-Groups is a JSON array (e.g. ["Compliance Admin"]); accept a
+// comma-separated fallback too.
+func parseGroups(h string) []string {
+    h = strings.TrimSpace(h)
+    if h == "" { return nil }
+    var arr []string
+    if strings.HasPrefix(h, "[") && json.Unmarshal([]byte(h), &arr) == nil {
+        return arr
+    }
+    return strings.Split(h, ",")
+}
+```
+
 Gate per-user queries with `AND user_id = ?`. Do NOT validate JWTs in
 code. Do NOT add CORS middleware. Errors as `application/problem+json`
 with a top-level `type`, `title`, `status`.
@@ -203,3 +248,4 @@ addition is in the Architect sub-section above (document the injected
 | CORS error in browser when calling upstream | Backend wrongly ships its own CORS middleware (doubled headers), OR upstream's `workload.yaml` lacks `visibility: external` | Remove the middleware; confirm `visibility: external` on upstream's `workload.yaml`. |
 | Every protected request 401s in test | Test calls don't carry `X-User-Id`; in production the gateway sets it, in test you set it manually | In integration tests, set `X-User-Id` directly on the request; don't try to mint a JWT. |
 | `/health` returns 401 | Handler accidentally went through `mustUserID` middleware | Carve out `/health` (and any other public path) before the auth gate. |
+| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed org-directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403** for an authenticated caller with no role; never key an org-directory lookup on `X-User-Id`. |

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -65,7 +65,9 @@ instead of deriving it from YOUR dependency name) produces a
   and `ouId`/`ouName`/`ouHandle` (their organization), beside standard
   `profile`/`email`. The platform requests the `group`/`ou` scopes by default,
   so a role-aware SPA reads roles from `user.profile.groups` — it never decodes
-  the access token for them.
+  the access token for them. The protected backend reads the SAME `groups`
+  from the gateway-injected `X-User-Groups` header (see `api-management`), so
+  the SPA and API resolve the caller's role identically.
 - Default Thunder admin user (dev clusters): `admin` / `admin` in the
   `Administrators` group. Real orgs add their own users via Thunder's
   admin console / SCIM.


### PR DESCRIPTION
## Summary

End-user RBAC was broken end-to-end: a signed-in user looped back to the login page. Root-caused and **validated live** on the compliance demo (Compliance Admin logs in → API returns 200 → the admin view renders). Two independent gaps:

### 1. The gateway never surfaced the caller's role
The `api-configuration` ClusterTrait's `jwt-auth` policy mapped only `sub` / `username` / `ouHandle` — not the JWT **`groups`** claim that carries the role. Added `groups → x-user-groups` to `claimMappings` (both the manifest and the helm template). The gateway now injects `X-User-Groups` (a JSON array of the caller's Thunder role groups) on every protected request. The `thunder-app` operator already emits `groups` (`scopeClaims.group`), so nothing else was needed there.

### 2. Generated APIs keyed identity on the IdP `sub`
They looked `X-User-Id` (the opaque IdP subject) up in an org-directory service (employee-service) — which 404s, since a subject is not an employee id — and answered **401**. The SPA reads 401 as "token expired" and restarts sign-in → infinite loop.

## Skill fix (so future generated apps are born correct)

`api-management` + `thunder-authentication` (re-vendored into aep-api):
- **Identity ≠ authorization:** `X-User-Id` stamps ownership of the service's own rows; the caller's **role** comes from `X-User-Groups` — the same groups the SPA's `deriveRole` reads (SPA and API now resolve role identically).
- An authenticated caller with no recognized role is a **403, never 401**.
- **Never** key an org-directory lookup on `X-User-Id`.
- Added a `callerRole` / `parseGroups` helper (handles the JSON-array header) and a login-loop pitfall row.

## Testing

- `go test`/`go vet` unaffected (docs + trait + vendored skills only); `vendor-skills` re-run, embedded copies verified identical to source.
- Validated on the running cluster: gateway injects `x-user-groups`; `GET /controls|/teams|/products` return 200; the Compliance Admin view renders. Requires demo users to be in their Thunder role groups (`ae-compliance-app-demo`'s `seed-compliance-users.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte
