### PR TITLE
feat(api-management): resolve caller directory attributes via X-User-Name

### DIFF
--- a/services/aep-api/skills/embedded/api-management/SKILL.md
+++ b/services/aep-api/skills/embedded/api-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-management
-description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups and returning 403 (not 401) for no role. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
+description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups (403, not 401, for no role) and, when scoping needs them, the caller's directory attributes (e.g. their team/unit, their own id) via X-User-Name. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
 ---
 
 
@@ -28,16 +28,28 @@ output from reality.
   header):
   - `sub → X-User-Id` (the caller's canonical id — REQUIRED, always present on protected requests)
   - `groups → X-User-Groups` (the caller's role groups — a JSON array; present when the user is in any group; drives RBAC)
-  - `username → X-User-Name` (display, optional)
+  - `username → X-User-Name` (the caller's username — the join key for
+    resolving the caller to an org-directory record; may be absent, so
+    handle that)
   - `ouHandle → X-User-Ou` (multi-tenant, optional)
-- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject:
-  stamp it as the owner of THIS service's own rows, but never use it as a
-  lookup key into another service's directory (e.g. employee-service) — an
-  IdP subject is not an employee id, so the lookup 404s. Resolve the
-  caller's ROLE from `X-User-Groups`, the SAME groups claim the SPA reads
-  (see `thunder-authentication`). An authenticated caller with no
-  recognized role is a **403**, never a 401 — a 401 tells the SPA the
-  token expired, so it restarts sign-in and loops forever.
+- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject —
+  not a record key in any other service, so a directory lookup keyed on it
+  404s. Split the two questions a caller raises:
+  - **Role** (what may they do) comes from `X-User-Groups`, the SAME groups
+    claim the SPA reads (see `thunder-authentication`). An authenticated
+    caller with no recognized role is a **403**, never a 401 — a 401 tells
+    the SPA the token expired, so it restarts sign-in and loops forever.
+  - **Directory attributes** (which unit is theirs, their own id in the
+    directory) come from the caller's **directory record**: resolve it by
+    `X-User-Name` — the username, which the directory keys on — and read the
+    attributes from that record. A group name is a role, not an identity, so
+    never parse an attribute out of it, and never match `X-User-Id` against a
+    stored record id. `X-User-Name` is gateway-set from the validated token
+    (a client cannot spoof it), so it is safe to authorize on; but a username
+    can be renamed, so use it to LOOK UP the record, not as a stored row key —
+    key this service's own rows on the stable `X-User-Id`. The directory
+    service and its exact join field are org-specific; `internal-services`
+    owns them.
 - The gateway attaches an Envoy CORS filter to every `visibility: external`
   HTTPRoute via the `api-configuration` ClusterTrait. Your service does
   NOT add CORS middleware. Doubling produces two `Access-Control-Allow-Origin`
@@ -92,7 +104,12 @@ output from reality.
   component`) MUST also carry an instruction line of the form:
   `Upstream <name>: read the URL from <NAME_UPPER_SNAKE>_URL via the runtime-config shim.`
 - Protected `service` `componentAgentInstructions` MUST say (verbatim or close):
-  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an IdP subject is not an employee id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an opaque subject is not a directory key. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+- When the spec's roles scope by the caller's own directory attributes (e.g.
+  a caller sees only rows for THEIR unit, or only rows assigned to THEIR
+  directory id) AND the component declares an org-directory dependency, add
+  one instruction line:
+  `Scope by the caller's directory record: resolve the caller by X-User-Name against <directory-dependency>, read the needed attribute (their unit / their id) from that record, and filter on it. Do NOT derive it from a group name and do NOT match X-User-Id against a stored record id — X-User-Id is an opaque subject, not a directory key.`
 - In the OpenAPI you author for a protected `service`, document the
   injected `X-User-Id` header under `parameters` so consumers know it's
   required-but-injected (the gateway adds it; clients don't set it). The
@@ -111,8 +128,18 @@ For every task targeting a `service` with `exposesAPI.auth: end-user-required`:
   `X-User-Groups` (a JSON array of the caller's Thunder groups — the SAME
   claim the SPA reads). Reject **403** — never 401 — for an authenticated
   caller with no recognized role. NEVER resolve identity by looking
-  `X-User-Id` up in an org-directory dependency; an IdP subject is not an
-  employee id."
+  `X-User-Id` up in an org-directory dependency; an opaque subject is not a
+  directory key."
+- Scope (only when roles scope by the caller's own directory attributes):
+  "Resolve the caller's **directory record** by `X-User-Name` against the
+  org-directory dependency; read the caller's own attribute (unit / directory
+  id) from it and filter on that. Do NOT derive it from a group name; do NOT
+  match `X-User-Id` against a stored record id (an opaque subject is not a
+  directory key). When `X-User-Name` is absent or resolves to no record,
+  return **403** (not 401)."
+- Acceptance criteria (directory-scoped roles): "Two callers whose directory
+  records differ each see only their own scoped rows, resolved via the
+  caller's directory record — not via a group name or an `X-User-Id` match."
 - Scope: "Do NOT validate JWTs in code; do NOT add CORS middleware. The
   gateway handles both."
 - Acceptance criteria: "Requests missing `X-User-Id` get 401; an
@@ -210,6 +237,38 @@ func parseGroups(h string) []string {
 }
 ```
 
+When roles scope by the caller's own directory attributes — their unit, their
+own id in the directory — resolve the caller's **directory record** by
+`X-User-Name`, then filter on that record's fields. `X-User-Name` is the join
+key; never match `X-User-Id` (an opaque subject) against a stored record id,
+and never parse an attribute out of a group name. Absent/unresolved → 403:
+
+```go
+// resolveCaller looks the caller up in the org directory by username
+// (X-User-Name). ok == false → answer 403, never 401.
+func resolveCaller(r *http.Request) (DirectoryRecord, bool) {
+    username := r.Header.Get("X-User-Name")
+    if username == "" {
+        return DirectoryRecord{}, false
+    }
+    return directory.FindByUsername(r.Context(), username) // GET <dir>/...?username=...
+}
+
+func listScoped(w http.ResponseWriter, r *http.Request) {
+    switch callerRole(r) {
+    case "":      /* 403: no role */ return
+    case "admin": // no filter — sees everything
+    default:      // scoped to the caller's own directory attribute
+        rec, ok := resolveCaller(r); if !ok { /* 403 */ return }
+        // filter the query on rec.Unit or rec.ID — the attribute the spec
+        // scopes by — NOT r.Header.Get("X-User-Id") and NOT a group name.
+    }
+}
+```
+
+The directory's real endpoint, its username field, and the dependency wiring
+are org-specific — `internal-services` owns them; do not hardcode a roster.
+
 Gate per-user queries with `AND user_id = ?`. Do NOT validate JWTs in
 code. Do NOT add CORS middleware. Errors as `application/problem+json`
 with a top-level `type`, `title`, `status`.
@@ -249,3 +308,4 @@ addition is in the Architect sub-section above (document the injected
 | Every protected request 401s in test | Test calls don't carry `X-User-Id`; in production the gateway sets it, in test you set it manually | In integration tests, set `X-User-Id` directly on the request; don't try to mint a JWT. |
 | `/health` returns 401 | Handler accidentally went through `mustUserID` middleware | Carve out `/health` (and any other public path) before the auth gate. |
 | Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed org-directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403** for an authenticated caller with no role; never key an org-directory lookup on `X-User-Id`. |
+| A role-scoped caller signs in but sees no rows | Scope derived the caller's attribute from a group NAME (empty for a generic role group), or matched the caller's `X-User-Id` (an opaque subject) against a stored directory id (never equal) | Scope by the caller's **directory record**: resolve it via `X-User-Name`, read the attribute (unit / id) from it, filter on that. Role still comes from `X-User-Groups`. |

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-management
-description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups and returning 403 (not 401) for no role. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
+description: How the platform's API gateway validates JWTs, injects identity headers (X-User-Id from sub, X-User-Groups for role), attaches CORS, and how to design + write services and consumers that match — including resolving the caller's role from X-User-Groups (403, not 401, for no role) and, when scoping needs them, the caller's directory attributes (e.g. their team/unit, their own id) via X-User-Name. Apply to any service with exposesAPI.auth set, and to any consumer with a dependency (a `component`-kind sibling OR an `external`-kind upstream API) that calls a protected API.
 ---
 
 
@@ -28,16 +28,28 @@ output from reality.
   header):
   - `sub → X-User-Id` (the caller's canonical id — REQUIRED, always present on protected requests)
   - `groups → X-User-Groups` (the caller's role groups — a JSON array; present when the user is in any group; drives RBAC)
-  - `username → X-User-Name` (display, optional)
+  - `username → X-User-Name` (the caller's username — the join key for
+    resolving the caller to an org-directory record; may be absent, so
+    handle that)
   - `ouHandle → X-User-Ou` (multi-tenant, optional)
-- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject:
-  stamp it as the owner of THIS service's own rows, but never use it as a
-  lookup key into another service's directory (e.g. employee-service) — an
-  IdP subject is not an employee id, so the lookup 404s. Resolve the
-  caller's ROLE from `X-User-Groups`, the SAME groups claim the SPA reads
-  (see `thunder-authentication`). An authenticated caller with no
-  recognized role is a **403**, never a 401 — a 401 tells the SPA the
-  token expired, so it restarts sign-in and loops forever.
+- **Identity is not authorization.** `X-User-Id` is an OPAQUE IdP subject —
+  not a record key in any other service, so a directory lookup keyed on it
+  404s. Split the two questions a caller raises:
+  - **Role** (what may they do) comes from `X-User-Groups`, the SAME groups
+    claim the SPA reads (see `thunder-authentication`). An authenticated
+    caller with no recognized role is a **403**, never a 401 — a 401 tells
+    the SPA the token expired, so it restarts sign-in and loops forever.
+  - **Directory attributes** (which unit is theirs, their own id in the
+    directory) come from the caller's **directory record**: resolve it by
+    `X-User-Name` — the username, which the directory keys on — and read the
+    attributes from that record. A group name is a role, not an identity, so
+    never parse an attribute out of it, and never match `X-User-Id` against a
+    stored record id. `X-User-Name` is gateway-set from the validated token
+    (a client cannot spoof it), so it is safe to authorize on; but a username
+    can be renamed, so use it to LOOK UP the record, not as a stored row key —
+    key this service's own rows on the stable `X-User-Id`. The directory
+    service and its exact join field are org-specific; `internal-services`
+    owns them.
 - The gateway attaches an Envoy CORS filter to every `visibility: external`
   HTTPRoute via the `api-configuration` ClusterTrait. Your service does
   NOT add CORS middleware. Doubling produces two `Access-Control-Allow-Origin`
@@ -92,7 +104,12 @@ output from reality.
   component`) MUST also carry an instruction line of the form:
   `Upstream <name>: read the URL from <NAME_UPPER_SNAKE>_URL via the runtime-config shim.`
 - Protected `service` `componentAgentInstructions` MUST say (verbatim or close):
-  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an IdP subject is not an employee id. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+  `No /auth/* endpoints. The API Platform gateway validates the JWT and the api-configuration trait's jwt-auth policy injects identity headers on every request: X-User-Id (the caller's opaque IdP subject) and X-User-Groups (the caller's role groups, a JSON array). Stamp X-User-Id as the owner of this service's own rows (reject 401 when missing). Resolve the caller's ROLE from X-User-Groups — the same groups the SPA reads — and reject 403 (NOT 401) when the caller has no recognized role. NEVER look the caller up in an org-directory dependency by X-User-Id — an opaque subject is not a directory key. Do NOT validate JWTs yourself; do NOT add CORS middleware (the gateway handles CORS).`
+- When the spec's roles scope by the caller's own directory attributes (e.g.
+  a caller sees only rows for THEIR unit, or only rows assigned to THEIR
+  directory id) AND the component declares an org-directory dependency, add
+  one instruction line:
+  `Scope by the caller's directory record: resolve the caller by X-User-Name against <directory-dependency>, read the needed attribute (their unit / their id) from that record, and filter on it. Do NOT derive it from a group name and do NOT match X-User-Id against a stored record id — X-User-Id is an opaque subject, not a directory key.`
 - In the OpenAPI you author for a protected `service`, document the
   injected `X-User-Id` header under `parameters` so consumers know it's
   required-but-injected (the gateway adds it; clients don't set it). The
@@ -111,8 +128,18 @@ For every task targeting a `service` with `exposesAPI.auth: end-user-required`:
   `X-User-Groups` (a JSON array of the caller's Thunder groups — the SAME
   claim the SPA reads). Reject **403** — never 401 — for an authenticated
   caller with no recognized role. NEVER resolve identity by looking
-  `X-User-Id` up in an org-directory dependency; an IdP subject is not an
-  employee id."
+  `X-User-Id` up in an org-directory dependency; an opaque subject is not a
+  directory key."
+- Scope (only when roles scope by the caller's own directory attributes):
+  "Resolve the caller's **directory record** by `X-User-Name` against the
+  org-directory dependency; read the caller's own attribute (unit / directory
+  id) from it and filter on that. Do NOT derive it from a group name; do NOT
+  match `X-User-Id` against a stored record id (an opaque subject is not a
+  directory key). When `X-User-Name` is absent or resolves to no record,
+  return **403** (not 401)."
+- Acceptance criteria (directory-scoped roles): "Two callers whose directory
+  records differ each see only their own scoped rows, resolved via the
+  caller's directory record — not via a group name or an `X-User-Id` match."
 - Scope: "Do NOT validate JWTs in code; do NOT add CORS middleware. The
   gateway handles both."
 - Acceptance criteria: "Requests missing `X-User-Id` get 401; an
@@ -210,6 +237,38 @@ func parseGroups(h string) []string {
 }
 ```
 
+When roles scope by the caller's own directory attributes — their unit, their
+own id in the directory — resolve the caller's **directory record** by
+`X-User-Name`, then filter on that record's fields. `X-User-Name` is the join
+key; never match `X-User-Id` (an opaque subject) against a stored record id,
+and never parse an attribute out of a group name. Absent/unresolved → 403:
+
+```go
+// resolveCaller looks the caller up in the org directory by username
+// (X-User-Name). ok == false → answer 403, never 401.
+func resolveCaller(r *http.Request) (DirectoryRecord, bool) {
+    username := r.Header.Get("X-User-Name")
+    if username == "" {
+        return DirectoryRecord{}, false
+    }
+    return directory.FindByUsername(r.Context(), username) // GET <dir>/...?username=...
+}
+
+func listScoped(w http.ResponseWriter, r *http.Request) {
+    switch callerRole(r) {
+    case "":      /* 403: no role */ return
+    case "admin": // no filter — sees everything
+    default:      // scoped to the caller's own directory attribute
+        rec, ok := resolveCaller(r); if !ok { /* 403 */ return }
+        // filter the query on rec.Unit or rec.ID — the attribute the spec
+        // scopes by — NOT r.Header.Get("X-User-Id") and NOT a group name.
+    }
+}
+```
+
+The directory's real endpoint, its username field, and the dependency wiring
+are org-specific — `internal-services` owns them; do not hardcode a roster.
+
 Gate per-user queries with `AND user_id = ?`. Do NOT validate JWTs in
 code. Do NOT add CORS middleware. Errors as `application/problem+json`
 with a top-level `type`, `title`, `status`.
@@ -249,3 +308,4 @@ addition is in the Architect sub-section above (document the injected
 | Every protected request 401s in test | Test calls don't carry `X-User-Id`; in production the gateway sets it, in test you set it manually | In integration tests, set `X-User-Id` directly on the request; don't try to mint a JWT. |
 | `/health` returns 401 | Handler accidentally went through `mustUserID` middleware | Carve out `/health` (and any other public path) before the auth gate. |
 | Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed org-directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403** for an authenticated caller with no role; never key an org-directory lookup on `X-User-Id`. |
+| A role-scoped caller signs in but sees no rows | Scope derived the caller's attribute from a group NAME (empty for a generic role group), or matched the caller's `X-User-Id` (an opaque subject) against a stored directory id (never equal) | Scope by the caller's **directory record**: resolve it via `X-User-Name`, read the attribute (unit / id) from it, filter on that. Role still comes from `X-User-Groups`. |


### PR DESCRIPTION
## Why

PR #212 taught generated APIs to resolve the caller's **role** from `X-User-Groups` and to **never** key an org-directory lookup on the opaque `X-User-Id`. But that left only a *prohibition* — no positive rule for scoping by the caller's own **directory attributes** (their unit/team, their own directory id).

With just the prohibition, generation improvised, and both failure modes shipped in a real generated app:
- **Team-scoped role** → parsed the team out of a *group name* (empty for a generic role group) → saw no rows.
- **Assignment-scoped role** → compared `X-User-Id` (a UUID) against a stored directory id like `e-006` → never equal → saw no rows.

## What

Adds the **positive target** across the skill's existing tiers (platform facts · architect · tech-lead · coding agent · pitfalls), matching the shape the role rule already uses:

> Resolve the caller to their **directory record** via `X-User-Name` (the username the directory keys on), then filter on that record's fields.

Key points baked in:
- **`X-User-Name` safety** — gateway-set from the validated token (a client cannot spoof it), so safe to authorize on; but it is a **join key, not a stored row key** (usernames can be renamed) — own rows stay keyed on the stable `X-User-Id`.
- **Absent / unresolved `X-User-Name` → 403**, never 401 (consistent with the no-role rule; avoids the SPA re-signin loop).
- **Kept generic** — no service names, no roster specifics (`DirectoryRecord` / "unit" / "org-directory dependency"). The org-specific directory and its exact join field are deferred to **`internal-services`** via cross-reference. Also strips pre-existing "employee id" phrasing → "directory key".
- The conditional guidance only fires when roles scope by directory attributes **and** the component declares an org-directory dependency, so it doesn't bloat every protected service.

Re-vendored `services/aep-api/skills/embedded/` (source + embedded kept in sync; CI `vendor-skills-check` enforces this).

## Follow-up (not in this PR)
The `X-User-Name` join only works if the org directory actually stores a username. That's the org-side (`internal-services`) counterpart plus, for the compliance demo, a real `employee-service` change (its `Employee` struct has no `username` field today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte