### PR TITLE
Wireframes flow DSL — structure carries layout, the compiler computes pixels

### DIFF
--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -80,7 +80,7 @@ describe("WireframePanel streaming", () => {
 
     // More lines arrive: the scene grows in place.
     act(() => {
-      ytext.insert(ytext.length, '  heading "Browse products" 40,84\n  button "View cart" 1050,84 150x40 primary\n');
+      ytext.insert(ytext.length, '  heading "Browse products"\n  button "View cart" primary\n');
     });
     const grown = Number(screen.getByTestId("excalidraw").dataset.elements);
     expect(grown).toBeGreaterThan(first);
@@ -93,7 +93,7 @@ describe("WireframePanel streaming", () => {
     renderPanel(makeCollab(ytext));
 
     act(() => {
-      ytext.insert(0, 'screen Catalog "Shop"\n  heading "Browse" 40,84\n');
+      ytext.insert(0, 'screen Catalog "Shop"\n  heading "Browse"\n');
     });
     const good = Number(screen.getByTestId("excalidraw").dataset.elements);
     expect(good).toBeGreaterThan(0);

--- a/apps/console/src/features/spec/derive/deriveWireframe.test.ts
+++ b/apps/console/src/features/spec/derive/deriveWireframe.test.ts
@@ -20,8 +20,8 @@ import { describe, expect, it } from "vitest";
 import { deriveWireframeScene } from "./deriveWireframe";
 
 const dsl = `screen Home
-  heading "Welcome" 40,40
-  button "Go" 40,100 120x40`;
+  heading "Welcome"
+  button "Go" primary`;
 
 describe("deriveWireframeScene", () => {
   it("compiles a wireframes .dsl into an excalidraw scene with elements", () => {
@@ -46,14 +46,16 @@ describe("deriveWireframeScene", () => {
   it("compiles every line-boundary prefix of a streaming source", () => {
     const full = `screen Catalog "Shoppers browse products"
   navbar "Shop"
-  heading "Browse products" 40,84
-  table "Product | Price" 40,152 600x200
+  row
+    heading "Browse products"
+    right
+    button "View cart" primary -> Cart
+  table "Product | Price"
     row "Mug | $18"
-  button "View cart" 1050,84 150x40 primary -> Cart
 
 screen Cart "Review and check out"
   navbar "Shop"
-  heading "Your cart" 40,84
+  heading "Your cart"
 `;
     const lines = full.split("\n");
     for (let i = 1; i <= lines.length; i++) {

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -464,17 +464,52 @@ const storefrontDesignJson = `{
   ]
 }`;
 
-const storefrontWireframesDsl = `screen Catalog
-  navbar "Demo Shop | Catalog | Cart | Orders" 0,0
-  heading "Browse products" 40,60
-  input "Search products" 40,110 400x36
-  card "Product grid" 40,160 760x420
+const storefrontWireframesDsl = `screen Catalog "Shoppers browse and search the product catalogue"
+  navbar "Demo Shop | Catalog | Cart | Orders | Account"
+  row
+    heading "Browse products"
+    right
+    search "Search products, brands, SKUs"
+    select "Category: All"
+  tabs "All | New in | On sale | Bestsellers"
+  row
+    card "Wireless Headphones\n$89"
+      badge "In stock" success
+    card "Mechanical Keyboard\n$129"
+      badge "Low stock" warning
+    card "4K Monitor\n$349"
+      badge "In stock" success
+    card "USB-C Hub\n$39"
+      badge "In stock" success
+  row
+    right
+    button "View cart" primary -> Cart
 
-screen Cart
-  navbar "Demo Shop | Catalog | Cart | Orders" 0,0
-  heading "Your cart" 40,60
-  table "Product | Qty | Price" 40,110 760x300
-  button "Checkout" 40,430 160x40
+screen Cart "Shopper reviews items and checks out"
+  navbar "Demo Shop | Catalog | Cart | Orders | Account"
+  heading "Your cart"
+  split 60/40
+    left
+      table "Product | Qty | Price | Subtotal"
+        row "Wireless Headphones | 1 | $89.00 | $89.00"
+        row "USB-C Hub | 2 | $39.00 | $78.00"
+        row "Mechanical Keyboard | 1 | $129.00 | $129.00"
+      button "Continue shopping" -> Catalog
+    right
+      card "Order summary"
+        text "Subtotal: $296.00"
+        text "Shipping: $6.00"
+        text "Total: $302.00"
+        checkbox "Ship to billing address" active
+        button "Checkout" primary -> Orders
+
+screen Orders "Shopper tracks past orders and their status"
+  navbar "Demo Shop | Catalog | Cart | Orders | Account"
+  heading "Your orders"
+  table "Order | Placed | Items | Total | Status"
+    row "#10432 | Jul 8, 2026 | 3 | $302.00 | Shipped"
+    row "#10391 | Jun 27, 2026 | 1 | $89.00 | Delivered"
+    row "#10355 | Jun 15, 2026 | 2 | $168.00 | Delivered"
 `;
 
 const catalogApiDesignJson = `{

--- a/packages/agent-stream/src/contracts/sse-events.ts
+++ b/packages/agent-stream/src/contracts/sse-events.ts
@@ -54,7 +54,7 @@ export type ErrCode =
   | "INVALID_YAML"
   | "INVALID_JSON"
   | "SCHEMA_VIOLATION"
-  | "LAYOUT_VIOLATION"
+  | "INVALID_DSL"
   | "PROTECTED_PATH";
 
 /** A candidate line echoed back for NOT_UNIQUE / NOT_FOUND re-anchoring. */

--- a/packages/agent-stream/src/wireframe-layout.ts
+++ b/packages/agent-stream/src/wireframe-layout.ts
@@ -17,25 +17,25 @@
  */
 
 /**
- * Wireframes `.dsl` layout write-gate. The Excalidraw compiler renders every
- * coordinate verbatim (no auto-layout), so a mis-placed element ships as a
- * broken drawing: boxes off the frame edge, under the navbar/sidebar chrome,
- * or half-covering each other. Guidance alone proved unreliable — the model
- * occasionally slips on the arithmetic — so, like the design.json schema gate,
- * an invalid layout aborts the write with a self-correctable error and the
- * bundle stays byte-for-byte unchanged. Syntax stays ungated (a partial or
- * unparseable body is the compile path's concern, and the streaming preview
- * needs unparseable prefixes to pass through).
+ * Wireframes `.dsl` write-gate. The flow dialect computes all geometry from
+ * structure, so overlap/out-of-frame are inexpressible and no longer gated —
+ * what remains the agent's job is SYNTAX: an unknown keyword, a misplaced
+ * `left`/`right`/table-`row`, or the retired coordinate dialect would be
+ * silently dropped by the tolerant compile path, which is how content quietly
+ * goes missing from a wireframe. So, like the design.json schema gate, a
+ * syntactically invalid write aborts with a line-numbered, self-correctable
+ * error and the bundle stays byte-for-byte unchanged. Streamed previews stay
+ * tolerant; only the committed write is strict.
  */
 
-import { validateWireframeLayout } from "@aep/excalidraw-dsl";
+import { validateWireframeSyntax } from "@aep/excalidraw-dsl";
 
-export interface WireframeLayoutProblem {
-  code: "LAYOUT_VIOLATION";
+export interface WireframeSyntaxProblem {
+  code: "INVALID_DSL";
   message: string;
 }
 
-/** Cap the echoed issues so one bad screen doesn't flood the tool result. */
+/** Cap the echoed issues so one bad file doesn't flood the tool result. */
 const MAX_ISSUES = 8;
 
 /** `erd`/`domain` basenames are the domain-model DSL — a different grammar. */
@@ -47,24 +47,24 @@ function isWireframesDslPath(path: string): boolean {
 
 /**
  * Validate a candidate wireframes `.dsl` body for `path`. Returns null when
- * the path is not a wireframes DSL or the layout is clean; otherwise the
+ * the path is not a wireframes DSL or the syntax is clean; otherwise the
  * problem, phrased for the model's self-correction.
  */
 export function checkWireframeLayout(
   path: string,
   content: string,
-): WireframeLayoutProblem | null {
+): WireframeSyntaxProblem | null {
   if (!isWireframesDslPath(path)) return null;
-  const issues = validateWireframeLayout(content);
+  const issues = validateWireframeSyntax(content);
   if (issues.length === 0) return null;
   const shown = issues.slice(0, MAX_ISSUES);
   const more = issues.length - shown.length;
   return {
-    code: "LAYOUT_VIOLATION",
+    code: "INVALID_DSL",
     message:
-      `${path} has ${issues.length} layout problem${issues.length === 1 ? "" : "s"} — the compiler draws coordinates verbatim, so these would render broken. The file is unchanged:\n` +
+      `${path} has ${issues.length} DSL syntax problem${issues.length === 1 ? "" : "s"} — invalid lines would be silently dropped from the wireframe. The file is unchanged:\n` +
       shown.map((s) => `- ${s}`).join("\n") +
       (more > 0 ? `\n(+${more} more)` : "") +
-      `\nRe-emit the WHOLE corrected file in ONE retry: fix every problem listed above, then re-check EVERY element near the right/bottom edges (x+width and y+height inside the frame) and every row of side-by-side elements (each starts past the previous one's x+width) — not just the flagged ones, so the retry passes in one shot.`,
+      `\nRe-emit the WHOLE corrected file in ONE retry, fixing every line listed above. Layout is computed from structure (stack / row / split) — never write x,y coordinates.`,
   };
 }

--- a/packages/agent-stream/test/wireframe-layout-gate.test.ts
+++ b/packages/agent-stream/test/wireframe-layout-gate.test.ts
@@ -17,10 +17,10 @@
  */
 
 /**
- * Write-gate behavior for wireframes `.dsl` layout: the compiler renders
- * coordinates verbatim, so out-of-frame and partially-overlapping elements are
- * rejected at write time with coordinates the model can self-correct from —
- * the same seam as the design.json schema gate.
+ * Write-gate behavior for wireframes `.dsl` syntax: the flow dialect computes
+ * geometry from structure, so the gate polices STRUCTURE — invalid lines would
+ * be silently dropped by the tolerant compile, which is how content quietly
+ * goes missing. Same seam as the design.json schema gate.
  */
 
 import { test } from "node:test";
@@ -34,55 +34,56 @@ const PATH = "specs/design/components/shop-webapp/wireframes.dsl";
 const CLEAN = `screen Dashboard "Admin overview"
   navbar "Hub"
   sidebar "Home | Reports"
-  heading "Overview" 280,84
-  card "Open items | 47 | across 5 projects" 280,160 280x160
-  card "Overdue | 12 | needs escalation" 576,160 280x160
+  row
+    heading "Good morning"
+    right
+    button "New audit" primary
+  row
+    card "Open items | 47 | across 5 projects"
+    card "Overdue | 12 | needs escalation"
+  table "A | B"
+    row "1 | 2"
 `;
 
-const OVERLAPPING = `screen Dashboard "Admin overview"
+const LEGACY = `screen Dashboard "Admin overview"
   navbar "Hub"
-  card "Overdue | 12 | needs escalation" 780,160 280x160
-  card "Open findings | 5 | 2 high severity" 1020,160 280x160
+  heading "Overview" 280,84
+  card "Open | 47 | stuff" 280,160 280x160
 `;
 
-test("accepts a clean wireframe layout", () => {
+const TYPO = `screen Dashboard
+  navbar "Hub"
+  crd "Open items | 47 | across 5 projects"
+`;
+
+test("accepts a clean flow-dialect wireframe", () => {
   assert.equal(checkWireframeLayout(PATH, CLEAN), null);
 });
 
-test("rejects partially overlapping elements with coordinates in the message", () => {
-  const problem = checkWireframeLayout(PATH, OVERLAPPING);
-  assert.equal(problem?.code, "LAYOUT_VIOLATION");
-  assert.match(problem!.message, /Overdue/);
-  assert.match(problem!.message, /Open findings/);
-  assert.match(problem!.message, /x1020/);
+test("rejects the retired coordinate dialect with line numbers", () => {
+  const problem = checkWireframeLayout(PATH, LEGACY);
+  assert.equal(problem?.code, "INVALID_DSL");
+  assert.match(problem!.message, /line 3/);
+  assert.match(problem!.message, /coordinates/);
 });
 
-test("rejects an element extending past the frame", () => {
-  const problem = checkWireframeLayout(
-    PATH,
-    `screen S\n  select "All frameworks" 1230,104 168x36\n`,
-  );
-  assert.equal(problem?.code, "LAYOUT_VIOLATION");
-  assert.match(problem!.message, /frame/);
+test("rejects an unknown element kind (a typo would silently vanish)", () => {
+  const problem = checkWireframeLayout(PATH, TYPO);
+  assert.equal(problem?.code, "INVALID_DSL");
+  assert.match(problem!.message, /line 3/);
+  assert.match(problem!.message, /crd/);
 });
 
 test("ignores non-wireframe paths and non-dsl files", () => {
-  assert.equal(checkWireframeLayout("specs/requirements/requirements.md", OVERLAPPING), null);
-  assert.equal(
-    checkWireframeLayout("specs/design/components/api/erd.dsl", OVERLAPPING),
-    null,
-  );
+  assert.equal(checkWireframeLayout("specs/requirements/requirements.md", LEGACY), null);
+  assert.equal(checkWireframeLayout("specs/design/components/api/erd.dsl", LEGACY), null);
 });
 
-test("does not gate syntax — an unparseable .dsl passes this gate", () => {
-  assert.equal(checkWireframeLayout(PATH, "garbage {{{"), null);
-});
-
-test("FileBundle.addFile rejects an overlapping wireframe and stays unchanged", () => {
+test("FileBundle.addFile rejects a bad wireframe and stays unchanged", () => {
   const bundle = new FileBundle({});
-  const res = bundle.addFile(PATH, OVERLAPPING);
+  const res = bundle.addFile(PATH, TYPO);
   assert.equal(res.ok, false);
-  if (!res.ok) assert.equal(res.code, "LAYOUT_VIOLATION");
+  if (!res.ok) assert.equal(res.code, "INVALID_DSL");
   assert.equal(bundle.has(PATH), false);
 });
 
@@ -93,14 +94,14 @@ test("FileBundle.addFile applies a clean wireframe", () => {
   assert.equal(bundle.has(PATH), true);
 });
 
-test("FileBundle.editFile that introduces an overlap is rejected, file unchanged", () => {
+test("FileBundle.editFile that introduces bad syntax is rejected, file unchanged", () => {
   const bundle = new FileBundle({ [PATH]: CLEAN });
   const res = bundle.editFile(
     PATH,
-    'card "Overdue | 12 | needs escalation" 576,160 280x160',
-    'card "Overdue | 12 | needs escalation" 500,160 280x160',
+    '    card "Overdue | 12 | needs escalation"',
+    '    crd "Overdue | 12 | needs escalation"',
   );
   assert.equal(res.ok, false);
-  if (!res.ok) assert.equal(res.code, "LAYOUT_VIOLATION");
-  assert.match(bundle.read(PATH) ?? "", /576,160/);
+  if (!res.ok) assert.equal(res.code, "INVALID_DSL");
+  assert.match(bundle.read(PATH) ?? "", /card "Overdue/);
 });

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -87,6 +87,9 @@ interface WireframeElement {
   rows?: string[][];
   /** Screen this element navigates to, from a trailing `-> ScreenName`. */
   navTo?: string;
+  /** True when the author gave an explicit `WxH` (layout keeps it). */
+  wSet?: boolean;
+  hSet?: boolean;
 }
 
 interface WireframeScreen {
@@ -344,77 +347,406 @@ export function validateWireframeLayout(dsl: string): string[] {
 // ---------- Wireframes parser ----------
 
 const QUOTED = /"((?:[^"\\]|\\.)*)"/;
-const COORDS = /(\d+)\s*,\s*(\d+)/;
 const SIZE = /(\d+)\s*x\s*(\d+)/;
+/** The retired coordinate dialect's `x,y` token — its presence means "regenerate". */
+const LEGACY_COORDS = /(?:^|\s)\d+\s*,\s*\d+(?:\s|$)/;
+
+// ---------- Flow tree (parse output, pre-layout) ----------
+//
+// The DSL carries STRUCTURE (stack / row / split / card nesting); the layout
+// pass below computes every pixel. Overlap and out-of-frame are inexpressible.
+
+interface ElNode {
+  type: 'el';
+  el: WireframeElement;
+  /** Nested children — only a `card` container carries them. */
+  children: ElNode[];
+}
+interface RowNode {
+  type: 'row';
+  children: ElNode[];
+  /** Index in `children` where right-edge packing starts; -1 = none. */
+  rightFrom: number;
+}
+interface SplitNode {
+  type: 'split';
+  leftPct: number;
+  left: FlowNode[];
+  right: FlowNode[];
+}
+type FlowNode = ElNode | RowNode | SplitNode;
+
+interface FlowScreen extends WireframeScreen {
+  chrome: WireframeElement[];
+  tree: FlowNode[];
+  /** True when the screen declared an explicit height (it stays a minimum). */
+  hDeclared: boolean;
+}
 
 function parseWireframesDsl(dsl: string): WireframeAst {
+  const { ast, legacy } = buildWireframes(dsl, null);
+  if (legacy) {
+    throw new Error(
+      'this file uses the retired coordinate dialect (absolute x,y positions) — regenerate the wireframes to get the flow dialect',
+    );
+  }
+  return ast;
+}
+
+/**
+ * Strict-syntax check for the write-gate: unknown keywords, misplaced
+ * `left`/`right`/table-`row` lines, and retired-dialect coordinates are
+ * reported with line numbers. The compile path stays tolerant (bad lines are
+ * skipped) so streamed prefixes keep previewing.
+ */
+export function validateWireframeSyntax(dsl: string): string[] {
+  const errors: string[] = [];
+  buildWireframes(dsl, errors);
+  return errors;
+}
+
+interface Ctx {
+  level: number;
+  kind: 'root' | 'row' | 'split' | 'col' | 'card' | 'table';
+  nodes?: FlowNode[]; // root / col
+  row?: RowNode;
+  split?: SplitNode;
+  card?: ElNode;
+  table?: WireframeElement;
+}
+
+function buildWireframes(
+  dsl: string,
+  errors: string[] | null,
+): { ast: WireframeAst; legacy: boolean } {
   const ast: WireframeAst = { screens: [], flows: [] };
-  let currentScreen: WireframeScreen | null = null;
+  let screen: FlowScreen | null = null;
+  let stack: Ctx[] = [];
   let inFlow = false;
+  let legacy = false;
+  const err = (no: number, msg: string) => errors?.push(`line ${no}: ${msg}`);
 
-  for (const rawLine of dsl.split(/\r?\n/)) {
-    const line = rawLine.replace(/\s+$/, '');
-    if (line.trim().length === 0) continue;
-    if (line.trim().startsWith('//') || line.trim().startsWith('#')) continue;
+  const lines = dsl.split(/\r?\n/);
+  for (let no = 1; no <= lines.length; no++) {
+    const raw = lines[no - 1]!.replace(/\s+$/, '');
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('//') || trimmed.startsWith('#')) continue;
+    const level = Math.floor((raw.length - raw.replace(/^[ \t]+/, '').length + 1) / 2);
 
-    const indented = /^\s+/.test(line);
-    const trimmed = line.trim();
-
-    if (!indented) {
-      // Top-level: screen / flow.
-      // `screen <Name> ["what this view is for"] [WxH]` — the quoted
-      // description (optional) renders as a subtitle under the screen title.
+    if (level === 0) {
       const screenMatch =
         /^screen\s+([\w-]+)(?:\s+"((?:[^"\\]|\\.)*)")?(?:\s+(\d+)\s*x\s*(\d+))?\s*$/i.exec(trimmed);
       if (screenMatch) {
-        currentScreen = {
+        screen = {
           name: screenMatch[1]!.trim(),
           width: screenMatch[3] ? parseInt(screenMatch[3], 10) : DEFAULT_SCREEN_W,
           height: screenMatch[4] ? parseInt(screenMatch[4], 10) : DEFAULT_SCREEN_H,
+          hDeclared: Boolean(screenMatch[4]),
           elements: [],
+          chrome: [],
+          tree: [],
         };
-        if (screenMatch[2]) currentScreen.description = unescapeQuoted(screenMatch[2]);
-        ast.screens.push(currentScreen);
+        if (screenMatch[2]) screen.description = unescapeQuoted(screenMatch[2]);
+        ast.screens.push(screen);
+        stack = [{ level: 0, kind: 'root', nodes: screen.tree }];
         inFlow = false;
         continue;
       }
       if (/^flow\b/i.test(trimmed)) {
-        currentScreen = null;
+        screen = null;
         inFlow = true;
         continue;
       }
-      // Unknown top-level — bail out of any nesting.
-      currentScreen = null;
+      screen = null;
       inFlow = false;
+      err(no, `unknown top-level line ${JSON.stringify(trimmed.slice(0, 40))} — expected \`screen <Name>\``);
       continue;
     }
 
     if (inFlow) {
       const flowMatch = /^([\w-]+)\s*->\s*([\w-]+)$/.exec(trimmed);
-      if (flowMatch) {
-        ast.flows.push({ from: flowMatch[1]!, to: flowMatch[2]! });
+      if (flowMatch) ast.flows.push({ from: flowMatch[1]!, to: flowMatch[2]! });
+      continue;
+    }
+    if (!screen) continue;
+
+    // Find the container this line nests under.
+    while (stack.length > 1 && stack[stack.length - 1]!.level >= level) stack.pop();
+    const parent = stack[stack.length - 1]!;
+
+    // Where a plain stacked node would land in this context.
+    const stackTarget = (): FlowNode[] | null =>
+      parent.kind === 'root' || parent.kind === 'col' ? parent.nodes! : null;
+
+    // --- table body row: `row "cell | cell"` ------------------------------
+    if (/^row\s+"/i.test(trimmed)) {
+      if (parent.kind === 'table' && parent.table) {
+        const q = QUOTED.exec(trimmed);
+        if (q) (parent.table.rows ??= []).push(splitItems(unescapeQuoted(q[1]!)));
+      } else {
+        err(no, 'a quoted `row "…"` is table data and must nest under a `table`');
       }
       continue;
     }
-
-    if (currentScreen) {
-      // `row "a | b | c"` attaches a body row to the screen's most recent
-      // table, so tables can show realistic data instead of empty rules.
-      const rowMatch = /^row\b/i.exec(trimmed);
-      if (rowMatch) {
-        const lastTable = [...currentScreen.elements].reverse().find((e) => e.kind === 'table');
-        if (lastTable) {
-          const q = QUOTED.exec(trimmed.slice(rowMatch[0].length));
-          if (q) (lastTable.rows ??= []).push(splitItems(unescapeQuoted(q[1]!)));
-        }
+    // --- layout row --------------------------------------------------------
+    if (/^row\s*$/i.test(trimmed)) {
+      const target = stackTarget();
+      if (!target) {
+        err(no, 'a layout `row` can only sit in a screen or split-column stack');
         continue;
       }
-      const el = parseWireframeElement(trimmed);
-      if (el) currentScreen.elements.push(el);
+      const rowNode: RowNode = { type: 'row', children: [], rightFrom: -1 };
+      target.push(rowNode);
+      stack.push({ level, kind: 'row', row: rowNode });
+      continue;
     }
+    // --- split + its columns ----------------------------------------------
+    const splitMatch = /^split\s+(\d+)\s*\/\s*(\d+)\s*$/i.exec(trimmed);
+    if (splitMatch) {
+      const target = stackTarget();
+      if (!target) {
+        err(no, '`split` can only sit in a screen stack');
+        continue;
+      }
+      const node: SplitNode = {
+        type: 'split',
+        leftPct: parseInt(splitMatch[1]!, 10),
+        left: [],
+        right: [],
+      };
+      target.push(node);
+      stack.push({ level, kind: 'split', split: node });
+      continue;
+    }
+    if (/^(left|right)\s*$/i.test(trimmed)) {
+      const word = trimmed.toLowerCase() as 'left' | 'right';
+      if (parent.kind === 'split' && parent.split) {
+        stack.push({
+          level,
+          kind: 'col',
+          nodes: word === 'left' ? parent.split.left : parent.split.right,
+        });
+      } else if (word === 'right' && parent.kind === 'row' && parent.row) {
+        parent.row.rightFrom = parent.row.children.length;
+      } else {
+        err(no, `\`${word}\` only makes sense under a \`split\` (column group) or inside a \`row\` (right-packing marker)`);
+      }
+      continue;
+    }
+    // --- element ------------------------------------------------------------
+    const parsed = parseWireframeElement(trimmed);
+    if (!parsed) {
+      err(no, `unknown element ${JSON.stringify(trimmed.split(/\s/)[0])} — not a DSL keyword or element kind`);
+      continue;
+    }
+    if (parsed.legacy) {
+      legacy = true;
+      err(no, 'absolute x,y coordinates are retired — the layout is computed from structure (stack / row / split); remove the coordinates');
+      continue;
+    }
+    const el = parsed.el;
+    if (el.kind === 'navbar' || el.kind === 'sidebar') {
+      screen.chrome.push(el);
+      continue;
+    }
+    const elNode: ElNode = { type: 'el', el, children: [] };
+    if (parent.kind === 'row' && parent.row) {
+      parent.row.children.push(elNode);
+    } else if (parent.kind === 'card' && parent.card) {
+      parent.card.children.push(elNode);
+    } else {
+      const target = stackTarget();
+      if (!target) {
+        err(no, `an element cannot nest under a \`${parent.kind}\` here`);
+        continue;
+      }
+      target.push(elNode);
+    }
+    // Containers accept children: a card layers its children inside itself;
+    // a table takes `row "…"` data lines.
+    if (el.kind === 'card') stack.push({ level, kind: 'card', card: elNode });
+    else if (el.kind === 'table') stack.push({ level, kind: 'table', table: el });
   }
 
-  return ast;
+  for (const s of ast.screens) layoutScreen(s as FlowScreen);
+  return { ast, legacy };
+}
+
+// ---------- Flow layout engine ----------
+//
+// Pure geometry: walks the flow tree computing every {x,y,w,h} in
+// screen-local coordinates. Deterministic; unit-tested via the rendered
+// scene and the validateWireframeLayout oracle.
+
+const STACK_GAP = 24;
+const ROW_GAP = 16;
+const CARD_PAD = 16;
+const CARD_CHILD_GAP = 12;
+const SPLIT_GUTTER = 40;
+const MARGIN = 40;
+const CONTENT_TOP = 76; // below the 56px navbar band
+
+/** Kinds that share a row's remaining width (everything else keeps intrinsic). */
+const FLEX_KINDS = new Set<WireframeKind>([
+  'card', 'input', 'select', 'search', 'textarea', 'chart', 'image', 'list',
+  'tabs', 'progress', 'table', 'rect',
+]);
+/** Kinds that take the full container width when stacked. */
+const FILL_KINDS = new Set<WireframeKind>(['table', 'chart', 'divider']);
+
+function resolveStackSize(el: WireframeElement, containerW: number): void {
+  if (!el.wSet && FILL_KINDS.has(el.kind)) el.width = containerW;
+  if (el.kind === 'table' && !el.hSet) {
+    el.height = 42 + Math.max(1, el.rows?.length ?? 1) * 38;
+  }
+  el.width = Math.min(el.width, containerW);
+}
+
+function layoutScreen(screen: FlowScreen): void {
+  const hasNavbar = screen.chrome.some((c) => c.kind === 'navbar');
+  const hasSidebar = screen.chrome.some((c) => c.kind === 'sidebar');
+  const x0 = hasSidebar ? 264 : MARGIN;
+  const w = screen.width - MARGIN - x0;
+  const y0 = hasNavbar ? CONTENT_TOP : MARGIN;
+  const out: WireframeElement[] = [];
+  const nextY = layoutStack(screen.tree, x0, w, y0, out);
+  const bottom = nextY - STACK_GAP; // drop the trailing gap
+  if (!screen.hDeclared || bottom + MARGIN > screen.height) {
+    screen.height = Math.max(screen.height, bottom + MARGIN);
+  }
+  screen.elements = [...screen.chrome, ...out];
+}
+
+/** Stack `nodes` top-to-bottom at x within width w; returns the next y cursor. */
+function layoutStack(
+  nodes: FlowNode[],
+  x: number,
+  w: number,
+  y: number,
+  out: WireframeElement[],
+): number {
+  for (const node of nodes) {
+    if (node.type === 'el') {
+      if (node.el.kind === 'card' && node.children.length > 0) {
+        resolveStackSize(node.el, w);
+        y += layoutCard(node, x, y, node.el.wSet ? node.el.width : w, out) + STACK_GAP;
+      } else {
+        resolveStackSize(node.el, w);
+        node.el.x = x;
+        node.el.y = y;
+        out.push(node.el);
+        y += node.el.height + STACK_GAP;
+      }
+    } else if (node.type === 'row') {
+      y += layoutRow(node, x, w, y, out) + STACK_GAP;
+    } else {
+      y += layoutSplit(node, x, w, y, out) + STACK_GAP;
+    }
+  }
+  return y;
+}
+
+/** Lay a row's children side by side within w; returns the row height. */
+function layoutRow(row: RowNode, x: number, w: number, y: number, out: WireframeElement[]): number {
+  const kids = row.children;
+  if (kids.length === 0) return 0;
+  const gaps = ROW_GAP * (kids.length - 1);
+
+  // Width distribution: explicit → keep; auto kinds → intrinsic; flexible
+  // kinds share the remainder equally; everything scales down if it can't fit.
+  const isFlex = (n: ElNode) => !n.el.wSet && FLEX_KINDS.has(n.el.kind);
+  const fixedSum = kids.filter((k) => !isFlex(k)).reduce((s, k) => s + k.el.width, 0);
+  const flexKids = kids.filter(isFlex);
+  if (flexKids.length > 0) {
+    const share = Math.max(60, Math.floor((w - gaps - fixedSum) / flexKids.length));
+    for (const k of flexKids) k.el.width = share;
+  }
+  const total = kids.reduce((s, k) => s + k.el.width, 0) + gaps;
+  if (total > w) {
+    const scale = (w - gaps) / (total - gaps);
+    for (const k of kids) k.el.width = Math.max(24, Math.floor(k.el.width * scale));
+  }
+
+  // Place: left group flows from x; the right group packs against x+w.
+  const rightFrom = row.rightFrom < 0 ? kids.length : row.rightFrom;
+  const heights: number[] = [];
+  const place = (k: ElNode, kx: number): void => {
+    if (k.el.kind === 'card' && k.children.length > 0) {
+      heights.push(layoutCard(k, kx, y, k.el.width, out));
+    } else {
+      if (k.el.kind === 'table' && !k.el.hSet) {
+        k.el.height = 42 + Math.max(1, k.el.rows?.length ?? 1) * 38;
+      }
+      k.el.x = kx;
+      k.el.y = y;
+      out.push(k.el);
+      heights.push(k.el.height);
+    }
+  };
+  let cx = x;
+  for (let i = 0; i < rightFrom; i++) {
+    place(kids[i]!, cx);
+    cx += kids[i]!.el.width + ROW_GAP;
+  }
+  let rx = x + w;
+  for (let i = kids.length - 1; i >= rightFrom; i--) {
+    rx -= kids[i]!.el.width;
+    place(kids[i]!, rx);
+    rx -= ROW_GAP;
+  }
+  return Math.max(...heights);
+}
+
+/** Two independent column stacks + the vertical divider; returns the height. */
+function layoutSplit(node: SplitNode, x: number, w: number, y: number, out: WireframeElement[]): number {
+  const pct = Math.min(90, Math.max(10, node.leftPct));
+  const leftW = Math.round(((w - SPLIT_GUTTER) * pct) / 100);
+  const rightW = w - SPLIT_GUTTER - leftW;
+  const leftBottom = layoutStack(node.left, x, leftW, y, out) - STACK_GAP;
+  const rightBottom = layoutStack(node.right, x + leftW + SPLIT_GUTTER, rightW, y, out) - STACK_GAP;
+  const h = Math.max(leftBottom, rightBottom, y + 40) - y;
+  out.push({
+    kind: 'divider',
+    label: '',
+    x: x + leftW + SPLIT_GUTTER / 2,
+    y,
+    width: 1,
+    height: h,
+  });
+  return h;
+}
+
+/**
+ * A card with nested children: the children stack inside the card's padding
+ * (below its title), `badge` children dock to the top-right corner, and the
+ * card grows around its content. Returns the card's height.
+ */
+function layoutCard(node: ElNode, x: number, y: number, w: number, out: WireframeElement[]): number {
+  const el = node.el;
+  el.x = x;
+  el.y = y;
+  el.width = w;
+  out.push(el);
+  const badges = node.children.filter((c) => c.el.kind === 'badge');
+  const rest = node.children.filter((c) => c.el.kind !== 'badge');
+  const innerX = x + CARD_PAD;
+  const innerW = w - 2 * CARD_PAD;
+  let cy = y + (el.label ? 44 : CARD_PAD);
+  for (const c of rest) {
+    resolveStackSize(c.el, innerW);
+    c.el.x = innerX;
+    c.el.y = cy;
+    out.push(c.el);
+    cy += c.el.height + CARD_CHILD_GAP;
+  }
+  const contentBottom = rest.length > 0 ? cy - CARD_CHILD_GAP : cy;
+  el.height = Math.max(el.hSet ? el.height : 0, contentBottom + CARD_PAD - y, 72);
+  for (const b of badges) {
+    b.el.x = x + w - CARD_PAD - b.el.width;
+    b.el.y = y + 12;
+    out.push(b.el);
+  }
+  return el.height;
 }
 
 /** Per-kind default sizes when no `WxH` is given. Texts auto-size to label. */
@@ -474,7 +806,9 @@ const VARIANT_RE = /\b(primary|secondary|danger|success|warning|info|ai|active|m
 
 const NAV_RE = /\s*->\s*([\w-]+)\s*$/;
 
-function parseWireframeElement(line: string): WireframeElement | null {
+function parseWireframeElement(
+  line: string,
+): { el: WireframeElement; legacy: boolean } | null {
   const kindMatch = KIND_RE.exec(line);
   if (!kindMatch) return null;
   const kind = kindMatch[1]!.toLowerCase() as WireframeKind;
@@ -490,29 +824,30 @@ function parseWireframeElement(line: string): WireframeElement | null {
   const label = labelMatch ? unescapeQuoted(labelMatch[1]!) : '';
   const afterLabel = labelMatch ? rest.slice(labelMatch.index + labelMatch[0].length).trim() : rest;
 
-  // navbar/sidebar are positioned by the renderer — coordinates are ignored
-  // and may be omitted entirely.
-  const coordsMatch = COORDS.exec(afterLabel);
-  if (!coordsMatch && kind !== 'navbar' && kind !== 'sidebar') return null;
-  const x = coordsMatch ? parseInt(coordsMatch[1]!, 10) : 0;
-  const y = coordsMatch ? parseInt(coordsMatch[2]!, 10) : 0;
+  // Positions come from the layout pass, never from the line. A bare `x,y`
+  // after the label is the retired coordinate dialect — flag it so the caller
+  // can steer regeneration instead of silently mis-rendering an old file.
+  const legacy = LEGACY_COORDS.test(` ${afterLabel} `);
 
   let { width, height } = defaultSize(kind, label);
-  const afterCoords = coordsMatch
-    ? afterLabel.slice(coordsMatch.index + coordsMatch[0].length)
-    : afterLabel;
-  const sizeMatch = SIZE.exec(afterCoords);
+  let wSet = false;
+  let hSet = false;
+  const sizeMatch = SIZE.exec(afterLabel);
   if (sizeMatch) {
     width = parseInt(sizeMatch[1]!, 10);
     height = parseInt(sizeMatch[2]!, 10);
+    wSet = true;
+    hSet = true;
   }
 
   // An optional trailing bareword opts the element into semantic color.
-  const variantMatch = VARIANT_RE.exec(afterCoords);
-  const el: WireframeElement = { kind, label, x, y, width, height };
+  const variantMatch = VARIANT_RE.exec(afterLabel);
+  const el: WireframeElement = { kind, label, x: 0, y: 0, width, height };
+  if (wSet) el.wSet = true;
+  if (hSet) el.hSet = true;
   if (variantMatch) el.variant = variantMatch[1]!.toLowerCase() as WireframeVariant;
   if (navTo) el.navTo = navTo;
-  return el;
+  return { el, legacy };
 }
 
 function unescapeQuoted(s: string): string {

--- a/packages/excalidraw-dsl/test/dsl.test.ts
+++ b/packages/excalidraw-dsl/test/dsl.test.ts
@@ -43,11 +43,11 @@ function compile(dsl: string): El[] {
 const DESKTOP = `screen Dashboard
   navbar "RiskHub | Dashboard | Risks | Reports"
   sidebar "Overview | My Risks | Audits | Settings"
-  heading "Risk Overview" 280,80
-  table "Risk | Owner | Severity | Status" 280,130 940x240
-  button "New risk" 280,400 140x40
+  heading "Risk Overview"
+  table "Risk | Owner | Severity | Status"
+  button "New risk"
 screen Detail
-  heading "Risk Detail" 280,80
+  heading "Risk Detail"
 flow
   Dashboard -> Detail
 `;
@@ -59,7 +59,7 @@ test("screens default to desktop 1280x800", () => {
 });
 
 test("an explicit screen size overrides the default", () => {
-  const els = compile("screen Modal 480x320\n  text \"hi\" 16,16\n");
+  const els = compile("screen Modal 480x320\n  text \"hi\"\n");
   assert.ok(els.some((e) => e.type === "rectangle" && e.width === 480 && e.height === 320));
 });
 
@@ -90,20 +90,18 @@ test("table renders a header row, column headers, and row lines", () => {
 });
 
 test("image placeholder renders a crossed box", () => {
-  const els = compile('screen S\n  image "logo" 16,16 200x120\n');
+  const els = compile('screen S\n  image "logo" 200x120\n');
   assert.equal(els.filter((e) => e.type === "line").length, 2);
 });
 
 test("primary actions and active navigation use the Oxygen brand color", () => {
   const els = compile(`screen S
   navbar "BrandApp | Home | Reports"
-  button "Create" 280,80 140x40 primary`);
-  // primary button fills brand orange
+  button "Create" primary`);
   assert.ok(
     els.some((e) => e.type === "rectangle" && e.backgroundColor === "#fa7b3f"),
     "primary button not brand-filled",
   );
-  // first navbar item (the app name) reads as active in brand
   assert.ok(
     els.some((e) => e.type === "text" && e.text === "BrandApp" && e.strokeColor === "#fa7b3f"),
     "active navbar item not branded",
@@ -111,37 +109,35 @@ test("primary actions and active navigation use the Oxygen brand color", () => {
 });
 
 test("legacy kinds (rect/ellipse/button/text) still parse and flows still mark", () => {
-  const els = compile(DESKTOP + "  rect \"x\" 16,16\n");
+  const els = compile(DESKTOP + "  rect \"x\"\n");
   const texts = els.filter((e) => e.type === "text");
-  // Screen-order markers still render in the corner.
   assert.ok(texts.some((t) => /^Screen \d+$/.test(t.text ?? "")), "screen number marker missing");
 });
 
 test("a screen description renders as a subtitle above the frame", () => {
   const els = compile(`screen Dashboard "Where managers monitor open risk"
-  heading "Risk" 280,80`);
+  heading "Risk"`);
   assert.ok(
     els.some((e) => e.type === "text" && e.text === "Where managers monitor open risk"),
     "screen description subtitle missing",
   );
-  // the screen name is still present and separate
   assert.ok(els.some((e) => e.type === "text" && e.text === "Dashboard"), "screen name missing");
 });
 
 test("a screen description does not break the optional size", () => {
   const els = compile(`screen Modal "Confirm deletion" 480x320
-  text "hi" 16,16`);
+  text "hi"`);
   assert.ok(els.some((e) => e.type === "rectangle" && e.width === 480 && e.height === 320), "sized frame missing");
   assert.ok(els.some((e) => e.type === "text" && e.text === "Confirm deletion"), "description missing");
 });
 
 test("a one-part card stays a simple panel title (back-compat)", () => {
-  const els = compile(`screen S\n  card "Remediation progress" 280,120 300x120`);
+  const els = compile(`screen S\n  card "Remediation progress" 300x120`);
   assert.ok(els.some((e) => e.type === "text" && e.text === "Remediation progress"), "panel title missing");
 });
 
 test("a multi-part card renders as a stat tile (label, big value, caption)", () => {
-  const els = compile(`screen S\n  card "Open items | 47 | across 5 active audits" 280,120 300x120`);
+  const els = compile(`screen S\n  card "Open items | 47 | across 5 active audits" 300x120`);
   for (const t of ["Open items", "47", "across 5 active audits"]) {
     assert.ok(els.some((e) => e.type === "text" && e.text === t), `tile part "${t}" missing`);
   }
@@ -152,56 +148,49 @@ test("a multi-part card renders as a stat tile (label, big value, caption)", () 
 
 test("the navbar groups links right and ends in a bell + account avatar", () => {
   const els = compile(`screen S\n  navbar "AuditHub | Dashboard | Reports"`);
-  // brand stays left in brand color
   const brand = els.find((e) => e.type === "text" && e.text === "AuditHub");
   assert.ok(brand && brand.strokeColor === "#fa7b3f", "brand not left/branded");
-  // nav links sit in the right half of the bar
   const link = els.find((e) => e.type === "text" && e.text === "Dashboard");
   assert.ok(link && link.x > 1280 / 2, "nav links not grouped right");
-  // bell + avatar → at least 2 ellipses near the right edge
   const rightEllipses = els.filter((e) => e.type === "ellipse" && e.x > 1280 - 120);
   assert.ok(rightEllipses.length >= 2, "bell/avatar missing from navbar");
 });
 
 test("a heading renders an underline rule beneath it", () => {
-  const before = compile(`screen S\n  text "x" 10,10`).filter((e) => e.type === "line").length;
-  const after = compile(`screen S\n  heading "Recent activity" 10,10`).filter((e) => e.type === "line").length;
+  const before = compile(`screen S\n  text "x"`).filter((e) => e.type === "line").length;
+  const after = compile(`screen S\n  heading "Recent activity"`).filter((e) => e.type === "line").length;
   assert.ok(after > before, "heading underline rule missing");
 });
 
 test("an element `-> Screen` renders a navigation marker beside that element", () => {
   const els = compile(`screen Catalog
-  button "View product" 40,600 160x44 -> ProductDetail
+  button "View product" -> ProductDetail
 screen ProductDetail
-  heading "Details" 40,80`);
-  // marker names the target screen + its number, next to the button
+  heading "Details"`);
   assert.ok(
     els.some((e) => e.type === "text" && /^→ Screen 2 · ProductDetail$/.test(e.text ?? "")),
     "element nav marker missing/mis-formatted",
   );
-  // the button label itself is intact (the -> suffix was stripped)
   assert.ok(els.some((e) => e.type === "text" && e.text === "View product"), "button label lost");
 });
 
 test("a `-> Screen` target that is a variant word is not mistaken for a variant", () => {
-  // 'info' is both a variant and could be a screen name — the -> target wins.
-  const els = compile(`screen A\n  button "Go" 10,10 120x40 -> Info\nscreen Info\n  heading "I" 10,10`);
+  const els = compile(`screen A\n  button "Go" -> Info\nscreen Info\n  heading "I"`);
   assert.ok(els.some((e) => e.type === "text" && /→ Screen 2 · Info/.test(e.text ?? "")), "nav to Info missing");
 });
 
 test("a `\\n` in a label becomes a real line break (card title + subtitle)", () => {
-  const els = compile(`screen S\n  card "Speckled Mug\\n$28 · In stock" 40,40 260x160`);
+  const els = compile(`screen S\n  card "Speckled Mug\\n$28 · In stock" 260x160`);
   const label = els.find((e) => e.type === "text" && /^Speckled Mug/.test(e.text ?? ""));
   assert.ok(label, "card label missing");
   assert.ok(label!.text!.includes("\n") && !label!.text!.includes("\\n"), "backslash-n not converted to newline");
 });
 
 test("a taller-than-wide divider draws a vertical rule (column separator)", () => {
-  const vert = compile(`screen S\n  divider "" 760,120 1x400`);
-  const horiz = compile(`screen S\n  divider "" 40,120 900x1`);
+  const vert = compile(`screen S\n  divider "" 1x400`);
+  const horiz = compile(`screen S\n  divider ""`);
   const vLine = vert.find((e) => e.type === "line") as (El & { points?: [number, number][] }) | undefined;
   const hLine = horiz.find((e) => e.type === "line") as (El & { points?: [number, number][] }) | undefined;
-  // vertical: dy dominates; horizontal: dx dominates
   assert.ok(vLine && vLine.points![1]![1] > vLine.points![1]![0], "divider not vertical when tall");
   assert.ok(hLine && hLine.points![1]![0] > hLine.points![1]![1], "divider not horizontal when wide");
 });
@@ -212,52 +201,56 @@ test("tryDslToExcalidraw reports a parse error instead of throwing", () => {
   if (!res.ok) assert.ok(res.error.length > 0);
 });
 
+test("tryDslToExcalidraw reports the retired coordinate dialect", () => {
+  const res = tryDslToExcalidraw("wireframes", 'screen S\n  heading "Hi" 280,84\n');
+  assert.equal(res.ok, false);
+  if (!res.ok) assert.match(res.error, /coordinate dialect|regenerate/i);
+});
+
 // ---------- Richer vocabulary ----------
 
 test("new primitives parse and render (tabs, list, badge, avatar, toggle, chart)", () => {
   const els = compile(`screen S
-  tabs "Overview | Activity | Settings" 280,80 480x40
-  list "Alpha | Beta | Gamma" 280,140 320x120
-  badge "Overdue" 640,80 90x28 danger
-  avatar "Jane Doe" 760,80 40x40
-  toggle "" 820,80 44x24 active
-  progress "60%" 280,300 240x10 info
-  chart "Spend by month" 280,340 320x180
-  select "Team" 280,540 300x36
-  search "Search risks" 620,540 320x36
-  textarea "Notes" 280,600 400x96
-  checkbox "Email me" 280,720 200x20 active
-  radio "Weekly" 500,720 200x20 active
-  divider "" 280,760 940x1
-  breadcrumb "Home / Risks / Detail" 280,60
-  link "View all" 900,80
+  tabs "Overview | Activity | Settings"
+  list "Alpha | Beta | Gamma"
+  row
+    badge "Overdue" danger
+    avatar "Jane Doe"
+    toggle "" active
+  progress "60%" info
+  chart "Spend by month"
+  row
+    select "Team"
+    search "Search risks"
+  textarea "Notes"
+  row
+    checkbox "Email me" active
+    radio "Weekly" active
+  divider ""
+  breadcrumb "Home / Risks / Detail"
+  link "View all"
 `);
-  // tabs: three labels present, first is ink, rest muted
   for (const t of ["Overview", "Activity", "Settings"]) {
     assert.ok(els.some((e) => e.type === "text" && e.text === t), `tab ${t} missing`);
   }
-  // list rows
   for (const t of ["Alpha", "Beta", "Gamma"]) {
     assert.ok(els.some((e) => e.type === "text" && e.text === t), `list item ${t} missing`);
   }
-  // avatar initials
   assert.ok(els.some((e) => e.type === "text" && e.text === "JD"), "avatar initials missing");
-  // ellipses exist (avatar / toggle knob / radio)
   assert.ok(els.some((e) => e.type === "ellipse"), "no ellipse rendered");
 });
 
 test("a trailing variant paints an element with semantic color", () => {
   const els = compile(`screen S
-  button "Delete" 280,80 140x40 danger
-  button "Save" 440,80 140x40 primary
-  badge "Live" 640,80 70x28 success
+  row
+    button "Delete" danger
+    button "Save" primary
+    badge "Live" success
 `);
-  // danger button: red border
   assert.ok(
     els.some((e) => e.type === "rectangle" && e.strokeColor === "#d92d20"),
     "danger accent not applied",
   );
-  // primary button: solid brand-orange fill + white text
   assert.ok(
     els.some((e) => e.type === "rectangle" && e.backgroundColor === "#fa7b3f"),
     "primary button not brand-filled",
@@ -266,7 +259,6 @@ test("a trailing variant paints an element with semantic color", () => {
     els.some((e) => e.type === "text" && e.text === "Save" && e.strokeColor === "#ffffff"),
     "primary button text not white",
   );
-  // success badge: green fill tint
   assert.ok(
     els.some((e) => e.type === "rectangle" && e.backgroundColor === "#e8f5e9"),
     "success badge tint missing",
@@ -277,12 +269,12 @@ test("status color (danger/success/warning/info) appears ONLY via variants", () 
   const els = compile(`screen S
   navbar "App | Home | Reports"
   sidebar "Overview | Settings"
-  tabs "A | B | C" 280,80 480x40
-  list "One | Two" 280,140 320x80
-  progress "40%" 280,240 240x10
-  avatar "Sam Lee" 640,80 40x40
-  chart "Trend" 280,300 320x180
-  select "Pick" 280,520 300x36
+  tabs "A | B | C"
+  list "One | Two"
+  progress "40%"
+  avatar "Sam Lee"
+  chart "Trend"
+  select "Pick"
 `);
   const leaked = els.filter(
     (e) =>
@@ -294,7 +286,7 @@ test("status color (danger/success/warning/info) appears ONLY via variants", () 
 
 test("table `row` lines render real cell content", () => {
   const els = compile(`screen S
-  table "Risk | Owner | Status" 280,120 900x200
+  table "Risk | Owner | Status"
     row "Edge servers | Platform | Open"
     row "Stale creds | Security | Overdue"
 `);
@@ -305,20 +297,18 @@ test("table `row` lines render real cell content", () => {
 
 test("long table cells are clipped to their column (no overflow into the next)", () => {
   const els = compile(`screen S
-  table "Claim | When" 0,0 400x120
+  table "Claim | When" 400x120
     row "Client dinner — Acme pitch and follow-up | Jul 8"
 `);
   const cell = els.find((e) => e.type === "text" && /^Client dinner/.test(e.text ?? ""));
   assert.ok(cell, "claim cell missing");
   assert.ok(cell!.text!.endsWith("…"), `expected truncation, got "${cell!.text}"`);
-  // the neighbour cell in the next column is untouched
   assert.ok(els.some((e) => e.type === "text" && e.text === "Jul 8"), "neighbour cell missing");
 });
 
 test("progress fill width tracks the fraction in the label", () => {
-  const half = compile(`screen S\n  progress "50%" 0,0 200x10\n`);
-  const full = compile(`screen S\n  progress "100%" 0,0 200x10\n`);
-  // The fill bar is the height-10 rect painted the default bar color (#6c757d).
+  const half = compile(`screen S\n  progress "50%" 200x10\n`);
+  const full = compile(`screen S\n  progress "100%" 200x10\n`);
   const fillW = (els: El[]) =>
     Math.max(
       ...els
@@ -329,21 +319,17 @@ test("progress fill width tracks the fraction in the label", () => {
 });
 
 test("a long text line is clipped to the screen's right edge with an ellipsis", () => {
-  const els = compile(`screen S
-  text "Auditor (K. Smith), 2026-01-28: Please attach the sign-off email for the Q3 access review cycle now" 800,220
-`);
-  const t = els.find((e) => e.type === "text" && /Auditor/.test(e.text));
+  const long = Array.from({ length: 6 }, () => "Please attach the sign-off email for the Q3 access review").join(" — ");
+  const els = compile(`screen S\n  text "${long}"\n`);
+  const t = els.find((e) => e.type === "text" && /^Please attach/.test(e.text ?? ""))!;
   assert.ok(t, "text element missing");
-  assert.ok(t.text.endsWith("…"), "long text should be truncated with an ellipsis");
-  // clipped text must not render past the 1280-wide screen's inner right edge
-  const approxRight = t.x + t.text.length * 14 * 0.52;
+  assert.ok(t.text!.endsWith("…"), "long text should be truncated with an ellipsis");
+  const approxRight = t.x + t.text!.length * 14 * 0.52;
   assert.ok(approxRight <= 1280, `clipped text should stay within the screen, got ~${Math.round(approxRight)}`);
 });
 
 test("a short text line is left untouched (no ellipsis)", () => {
-  const els = compile(`screen S
-  text "Owner: Platform team" 280,120
-`);
-  const t = els.find((e) => e.type === "text" && /Owner/.test(e.text));
+  const els = compile(`screen S\n  text "Owner: Platform team"\n`);
+  const t = els.find((e) => e.type === "text" && /Owner/.test(e.text ?? ""))!;
   assert.equal(t.text, "Owner: Platform team");
 });

--- a/packages/excalidraw-dsl/test/layout.test.ts
+++ b/packages/excalidraw-dsl/test/layout.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The flow layout engine: the DSL carries structure, the compiler computes
+ * every pixel. These tests pin the geometry contract; the no-overlap /
+ * in-frame invariant is asserted through validateWireframeLayout as oracle.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  dslToExcalidraw,
+  validateWireframeLayout,
+  validateWireframeSyntax,
+} from "../src/index.js";
+
+type El = {
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text?: string;
+  backgroundColor?: string;
+};
+
+function compile(dsl: string): El[] {
+  return JSON.parse(dslToExcalidraw("wireframes", dsl)).elements as El[];
+}
+
+/** The rendered box of the rect whose attached label text is `label`. */
+function boxOf(els: El[], label: string): El {
+  const t = els.find((e) => e.type === "text" && e.text === label);
+  assert.ok(t, `text "${label}" not rendered`);
+  // find the smallest rectangle containing that text (its container)
+  const rects = els.filter(
+    (e) =>
+      (e.type === "rectangle" || e.type === "ellipse") &&
+      t!.x >= e.x - 1 && t!.y >= e.y - 1 &&
+      t!.x + 1 <= e.x + e.width && t!.y + 1 <= e.y + e.height,
+  );
+  assert.ok(rects.length > 0, `no container box around "${label}"`);
+  return rects.sort((a, b) => a.width * a.height - b.width * b.height)[0]!;
+}
+
+test("stacked blocks land below each other with a gap, inside the content area", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  sidebar "Home | Reports"
+  heading "First"
+  heading "Second"
+`);
+  const first = els.find((e) => e.type === "text" && e.text === "First")!;
+  const second = els.find((e) => e.type === "text" && e.text === "Second")!;
+  const navBar = els.find((e) => e.type === "rectangle" && e.height === 56)!;
+  assert.ok(first.x >= 264, `content starts right of the sidebar, got x=${first.x}`);
+  assert.ok(first.y >= navBar.y + 56, "content clears the navbar band");
+  assert.ok(second.y > first.y + 20, "second block stacked below the first");
+});
+
+test("a row of three cards splits the width equally with gaps, same y", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  sidebar "A | B"
+  row
+    card "Open | 128 | six audits"
+    card "Overdue | 14 | follow up"
+    card "Review | 32 | awaiting"
+`);
+  const a = boxOf(els, "Open");
+  const b = boxOf(els, "Overdue");
+  const c = boxOf(els, "Review");
+  assert.equal(a.y, b.y);
+  assert.equal(b.y, c.y);
+  assert.ok(Math.abs(a.width - b.width) <= 1 && Math.abs(b.width - c.width) <= 1, "equal widths");
+  assert.ok(b.x >= a.x + a.width + 8, "gap between 1st and 2nd");
+  assert.ok(c.x + c.width <= 1240 + 1, `row ends inside the content area, got ${c.x + c.width}`);
+});
+
+test("`right` packs the rest of a row against the content's right edge", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  row
+    heading "Needs your attention"
+    right
+    button "New audit" primary
+`);
+  const btn = els.find((e) => e.type === "rectangle" && e.backgroundColor === "#fa7b3f")!;
+  assert.ok(btn, "primary button missing");
+  assert.ok(Math.abs(btn.x + btn.width - 1240) <= 1, `button right edge at 1240, got ${btn.x + btn.width}`);
+});
+
+test("split renders two independent columns with a vertical divider between", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  sidebar "A | B"
+  split 60/40
+    left
+      table "Version | By"
+        row "v3 | J. Alvarez"
+    right
+      card "Discussion"
+        text "K. Smith: please attach the sign-off"
+`);
+  const vline = els.find((e) => e.type === "line" && e.height > e.width && e.height > 60);
+  assert.ok(vline, "vertical divider missing");
+  const disc = els.find((e) => e.type === "text" && e.text === "Discussion")!;
+  assert.ok(disc.x > vline!.x, "right column content sits right of the divider");
+  const version = els.find((e) => e.type === "text" && e.text === "Version")!;
+  assert.ok(version.x < vline!.x, "left column content sits left of the divider");
+});
+
+test("children nested under a card render inside it and the card grows around them", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  card "Discussion"
+    text "First comment"
+    textarea "Add a comment…"
+    button "Post" primary
+`);
+  const title = els.find((e) => e.type === "text" && e.text === "Discussion")!;
+  const card = els
+    .filter((e) => e.type === "rectangle" && e.x <= title.x && e.y <= title.y)
+    .sort((a, b) => b.width * b.height - a.width * a.height)[0]!;
+  for (const label of ["First comment", "Add a comment…"]) {
+    const t = els.find((e) => e.type === "text" && e.text === label)!;
+    assert.ok(
+      t.x >= card.x && t.y >= card.y && t.y <= card.y + card.height,
+      `"${label}" inside the card (card ${card.y}..${card.y + card.height}, text y=${t.y})`,
+    );
+  }
+});
+
+test("a badge child docks to its card's top-right, inside the border", () => {
+  const els = compile(`screen S
+  navbar "Hub"
+  row
+    card "SOC2 Type II — 2024"
+      badge "On track" success
+    card "ISO 27001"
+      badge "At risk" warning
+`);
+  const badge = boxOf(els, "On track");
+  const card = boxOf(els, "SOC2 Type II — 2024"); // smallest container = the card
+  assert.ok(badge.x + badge.width <= card.x + card.width, "badge inside right border");
+  assert.ok(badge.x > card.x + card.width / 2, "badge in the right half");
+});
+
+test("the frame auto-grows below 800 when content stacks past it", () => {
+  const many = Array.from({ length: 12 }, (_, i) => `  card "Panel ${i} | ${i} | of many"`).join("\n");
+  const els = compile(`screen S\n  navbar "Hub"\n${many}\n`);
+  const frame = els.find((e) => e.type === "rectangle" && e.width === 1280)!;
+  assert.ok(frame.height > 800, `frame grew, got ${frame.height}`);
+});
+
+test("legacy coordinate dialect is rejected with a regenerate message", () => {
+  assert.throws(
+    () => compile(`screen S\n  heading "Overview" 280,84\n`),
+    /coordinate dialect|regenerate/i,
+  );
+});
+
+test("INVARIANT: flow output always passes the layout oracle (no overlap, in frame)", () => {
+  const screens = [
+    `screen Dash "Admin overview"
+  navbar "Hub"
+  sidebar "Home | Audits | Reports"
+  text "OPERATIONS" muted
+  row
+    heading "Good morning"
+    right
+    search "Search everything"
+    select "All frameworks"
+  row
+    card "Open | 128 | across audits"
+    card "Overdue | 14 | escalate"
+    card "Review | 32 | awaiting"
+    card "Findings | 5 | 2 high"
+  row
+    heading "Needs attention"
+    right
+    button "New audit" primary
+  table "A | B | C | D"
+    row "1 | 2 | 3 | 4"
+    row "5 | 6 | 7 | 8"
+`,
+    `screen Detail "One record"
+  navbar "Hub"
+  sidebar "Home | Audits"
+  breadcrumb "Audits / SOC2 / CC6.1"
+  row
+    heading "CC6.1 — Access Reviews"
+    badge "Needs Correction" danger
+  split 60/40
+    left
+      table "Version | By | Status"
+        row "v3 | J. Alvarez | Needs Correction"
+      button "Upload New Evidence" primary
+    right
+      card "Discussion"
+        text "K. Smith: attach the sign-off"
+        textarea "Add a comment…"
+        button "Post" primary
+      heading "Activity"
+      text "2d ago — correction requested"
+`,
+    `screen Form "Create a thing"
+  navbar "Shop | Catalog | Cart"
+  heading "New product"
+  input "Name"
+  row
+    select "Category"
+    select "Status"
+  textarea "Description"
+  row
+    right
+    button "Cancel"
+    button "Create" primary -> Dash
+`,
+  ];
+  for (const s of screens) {
+    assert.deepEqual(validateWireframeLayout(s), [], `oracle clean for:\n${s.slice(0, 40)}…`);
+  }
+});
+
+test("strict syntax: unknown keywords and misplaced groups are reported with line numbers", () => {
+  const errs = validateWireframeSyntax(`screen S
+  navbar "Hub"
+  bogus "what is this"
+  left
+`);
+  assert.ok(errs.some((e) => /line 3/.test(e) && /bogus/.test(e)), `unknown kind flagged: ${errs}`);
+  assert.ok(errs.some((e) => /line 4/.test(e) && /left/.test(e)), `stray left flagged: ${errs}`);
+});
+
+test("strict syntax: a clean flow file has no errors", () => {
+  assert.deepEqual(
+    validateWireframeSyntax(`screen S
+  navbar "Hub"
+  row
+    heading "Hi"
+    right
+    button "Go" primary
+  table "A | B"
+    row "1 | 2"
+`),
+    [],
+  );
+});

--- a/packages/excalidraw-dsl/test/validate.test.ts
+++ b/packages/excalidraw-dsl/test/validate.test.ts
@@ -16,111 +16,73 @@
  * under the License.
  */
 
+/**
+ * validateWireframeLayout is the ORACLE for the flow layout engine: overlap
+ * and out-of-frame are inexpressible in the dialect, so the oracle must come
+ * back clean for anything the engine lays out (asserted here and in
+ * layout.test.ts). validateWireframeSyntax is the write-gate's strict check.
+ */
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { validateWireframeLayout } from "../src/index.js";
+import { validateWireframeLayout, validateWireframeSyntax } from "../src/index.js";
 
-test("a clean screen produces no issues", () => {
+test("the oracle is clean for a dense flow screen (rows, split, card nesting)", () => {
   const issues = validateWireframeLayout(`screen Dashboard "Admin overview"
   navbar "Hub"
-  sidebar "Home | Reports"
-  heading "Overview" 280,84
-  card "Open items | 47 | across 5 projects" 280,160 280x160
-  card "Overdue | 12 | needs escalation" 576,160 280x160
-  table "A | B" 280,360 940x200
-  button "New" 1080,84 140x40 primary
+  sidebar "Home | Audits | Reports"
+  row
+    heading "Good morning"
+    right
+    search "Search"
+    select "All frameworks"
+  row
+    card "Open | 128 | across audits"
+    card "Overdue | 14 | escalate"
+    card "Review | 32 | awaiting"
+  split 60/40
+    left
+      table "A | B"
+        row "1 | 2"
+    right
+      card "Discussion"
+        text "hello"
+        badge "Open" info
 `);
   assert.deepEqual(issues, []);
 });
 
-test("two partially overlapping cards are flagged with coordinates", () => {
-  // Mirrors the real failure: "Overdue" 1180..1460 vs "Open findings" 1420..1700.
-  const issues = validateWireframeLayout(`screen S
-  card "Overdue | 12 | needs escalation" 1180,240 280x160
-  card "Open findings | 5 | 2 high severity" 1420,240 280x160
-`);
-  assert.ok(issues.some((i) => /Overdue/.test(i) && /Open findings/.test(i) && /overlap/i.test(i)),
-    `expected an overlap issue, got: ${JSON.stringify(issues)}`);
-});
-
-test("a badge fully inside a card is layering, not an overlap", () => {
-  const issues = validateWireframeLayout(`screen S
-  card "SOC 2 · EXTERNAL" 60,120 400x180
-  badge "On track" 354,132 90x28 success
-  text "68 of 92 controls" 76,260
-`);
-  assert.deepEqual(issues, []);
-});
-
-test("a badge straddling its card's border is a partial overlap", () => {
-  const issues = validateWireframeLayout(`screen S
-  card "SOC 2" 60,120 400x180
-  badge "On track" 420,132 90x28 success
-`);
-  assert.ok(issues.some((i) => /badge/.test(i) && /overlap/i.test(i)),
-    `expected the straddling badge flagged, got: ${JSON.stringify(issues)}`);
-});
-
-test("an element extending past the frame's right edge is flagged", () => {
-  // Mirrors the real failure: a select whose right edge passes 1280.
-  const issues = validateWireframeLayout(`screen S
-  select "All frameworks" 1230,104 168x36
-`);
-  assert.ok(issues.some((i) => /All frameworks/.test(i) && /frame/i.test(i)),
-    `expected an out-of-frame issue, got: ${JSON.stringify(issues)}`);
-});
-
-test("an element below the frame's bottom edge is flagged", () => {
-  const issues = validateWireframeLayout(`screen S
-  button "Save" 280,780 140x40
-`);
-  assert.ok(issues.some((i) => /Save/.test(i) && /frame/i.test(i)));
-});
-
-test("content under the sidebar rail is flagged only when a sidebar exists", () => {
-  const withRail = validateWireframeLayout(`screen S
-  sidebar "Home | Reports"
-  heading "Overview" 40,84
-`);
-  assert.ok(withRail.some((i) => /sidebar/i.test(i)),
-    `expected an under-sidebar issue, got: ${JSON.stringify(withRail)}`);
-
-  const noRail = validateWireframeLayout(`screen S
-  heading "Overview" 40,84
-`);
-  assert.deepEqual(noRail, []);
-});
-
-test("content under the navbar band is flagged only when a navbar exists", () => {
-  const withBar = validateWireframeLayout(`screen S
-  navbar "Hub"
-  text "EYEBROW" 280,40
-`);
-  assert.ok(withBar.some((i) => /navbar/i.test(i)),
-    `expected an under-navbar issue, got: ${JSON.stringify(withBar)}`);
-
-  const noBar = validateWireframeLayout(`screen S
-  text "EYEBROW" 280,40
-`);
-  assert.deepEqual(noBar, []);
-});
-
-test("free text is never overlap-checked (estimated widths would false-positive)", () => {
-  const issues = validateWireframeLayout(`screen S
-  heading "A very long heading that stretches far to the right side" 280,84
-  text "another long line of copy sitting near the heading row" 600,84
-`);
-  assert.deepEqual(issues, []);
-});
-
-test("unparseable DSL yields no layout issues (the compile gate owns syntax)", () => {
+test("the oracle returns no issues for unparseable or legacy sources (syntax owns those)", () => {
   assert.deepEqual(validateWireframeLayout("garbage {{{"), []);
+  assert.deepEqual(validateWireframeLayout('screen S\n  heading "Hi" 280,84\n'), []);
 });
 
-test("side-by-side elements sharing an edge do not overlap", () => {
-  const issues = validateWireframeLayout(`screen S
-  button "Cancel" 600,584 140x40
-  button "Create" 740,584 160x40 primary
+test("syntax: the retired coordinate dialect is reported with the line number", () => {
+  const errs = validateWireframeSyntax('screen S\n  heading "Overview" 280,84\n');
+  assert.ok(errs.some((e) => /line 2/.test(e) && /coordinates/.test(e)), `got: ${errs}`);
+});
+
+test("syntax: a quoted row outside a table is reported", () => {
+  const errs = validateWireframeSyntax('screen S\n  row "a | b"\n');
+  assert.ok(errs.some((e) => /line 2/.test(e) && /table/.test(e)), `got: ${errs}`);
+});
+
+test("syntax: split percentages parse and misplaced groups are reported", () => {
+  const ok = validateWireframeSyntax(`screen S
+  split 60/40
+    left
+      text "a"
+    right
+      text "b"
 `);
-  assert.deepEqual(issues, []);
+  assert.deepEqual(ok, []);
+  const bad = validateWireframeSyntax('screen S\n  right\n');
+  assert.ok(bad.some((e) => /line 2/.test(e)), `got: ${bad}`);
+});
+
+test("syntax: an explicit WxH is still legal anywhere", () => {
+  assert.deepEqual(
+    validateWireframeSyntax('screen S\n  chart "Trend" 600x220\n'),
+    [],
+  );
 });

--- a/services/aep-api/internal/platform/agentfold/dslgate.go
+++ b/services/aep-api/internal/platform/agentfold/dslgate.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentfold
+
+// dslgate.go — the wireframes `.dsl` syntax write-gate, an EXACT accept/reject
+// port of packages/excalidraw-dsl validateWireframeSyntax as consumed by
+// packages/agent-stream/src/wireframe-layout.ts checkWireframeLayout. The flow
+// dialect computes geometry from structure, so the gate polices STRUCTURE:
+// unknown keywords, misplaced `left`/`right`/table-`row` lines, and the
+// retired coordinate dialect. Like designgate.go, only the accept/reject
+// decision is parity-critical (a write the agent applied must fold here too);
+// message text is log-only.
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	dslScreenRe   = regexp.MustCompile(`(?i)^screen\s+[\w-]+(?:\s+"(?:[^"\\]|\\.)*")?(?:\s+\d+\s*x\s*\d+)?\s*$`)
+	dslFlowRe     = regexp.MustCompile(`(?i)^flow\b`)
+	dslTableRowRe = regexp.MustCompile(`(?i)^row\s+"`)
+	dslLayoutRow  = regexp.MustCompile(`(?i)^row\s*$`)
+	dslSplitRe    = regexp.MustCompile(`(?i)^split\s+\d+\s*/\s*\d+\s*$`)
+	dslColRe      = regexp.MustCompile(`(?i)^(left|right)\s*$`)
+	dslKindRe     = regexp.MustCompile(`(?i)^(rect|ellipse|button|text|heading|input|card|image|table|navbar|sidebar|tabs|list|select|search|textarea|checkbox|radio|toggle|badge|avatar|progress|divider|breadcrumb|chart|icon|link)\b`)
+	dslNavRe      = regexp.MustCompile(`\s*->\s*[\w-]+\s*$`)
+	dslQuotedRe   = regexp.MustCompile(`"(?:[^"\\]|\\.)*"`)
+	dslLegacyRe   = regexp.MustCompile(`(?:^|\s)\d+\s*,\s*\d+(?:\s|$)`)
+)
+
+// isWireframesDslPath mirrors wireframe-layout.ts: `.dsl` files except the
+// erd/domain domain-model grammar.
+func isWireframesDslPath(path string) bool {
+	if !strings.HasSuffix(path, ".dsl") {
+		return false
+	}
+	parts := strings.Split(path, "/")
+	base := strings.ToLower(parts[len(parts)-1])
+	return !(strings.HasPrefix(base, "erd") || strings.HasPrefix(base, "domain"))
+}
+
+type dslCtx struct {
+	level int
+	kind  string // root | row | split | col | card | table
+}
+
+// checkWireframeDslGuard mirrors checkWireframeLayout: a wireframes .dsl body
+// with syntax problems is rejected (INVALID_DSL) so a typo can't silently
+// vanish from the drawing — and so this fold's verdict matches the TS
+// bundle's, keeping the D14 manifest check green.
+func checkWireframeDslGuard(path, content string) (ErrCode, string) {
+	if !isWireframesDslPath(path) {
+		return "", ""
+	}
+	var (
+		stack   []dslCtx
+		screen  bool
+		inFlow  bool
+		nErrors int
+		first   string
+	)
+	report := func(msg string) {
+		nErrors++
+		if first == "" {
+			first = msg
+		}
+	}
+
+	lines := strings.Split(content, "\n")
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, " \t\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		level := (indent + 1) / 2
+		_ = i
+
+		if level == 0 {
+			switch {
+			case dslScreenRe.MatchString(trimmed):
+				screen = true
+				inFlow = false
+				stack = []dslCtx{{level: 0, kind: "root"}}
+			case dslFlowRe.MatchString(trimmed):
+				screen = false
+				inFlow = true
+			default:
+				screen = false
+				inFlow = false
+				report("unknown top-level line — expected `screen <Name>`")
+			}
+			continue
+		}
+		if inFlow {
+			continue // flow edges (and stray lines) are tolerated, as in TS
+		}
+		if !screen {
+			continue
+		}
+
+		for len(stack) > 1 && stack[len(stack)-1].level >= level {
+			stack = stack[:len(stack)-1]
+		}
+		parent := stack[len(stack)-1]
+		inStack := parent.kind == "root" || parent.kind == "col"
+
+		switch {
+		case dslTableRowRe.MatchString(trimmed):
+			if parent.kind != "table" {
+				report("a quoted `row \"…\"` is table data and must nest under a `table`")
+			}
+		case dslLayoutRow.MatchString(trimmed):
+			if !inStack {
+				report("a layout `row` can only sit in a screen or split-column stack")
+			} else {
+				stack = append(stack, dslCtx{level: level, kind: "row"})
+			}
+		case dslSplitRe.MatchString(trimmed):
+			if !inStack {
+				report("`split` can only sit in a screen stack")
+			} else {
+				stack = append(stack, dslCtx{level: level, kind: "split"})
+			}
+		case dslColRe.MatchString(trimmed):
+			word := strings.ToLower(strings.TrimSpace(trimmed))
+			switch {
+			case parent.kind == "split":
+				stack = append(stack, dslCtx{level: level, kind: "col"})
+			case word == "right" && parent.kind == "row":
+				// right-packing marker — no ctx change
+			default:
+				report("`" + word + "` only makes sense under a `split` or inside a `row`")
+			}
+		default:
+			m := dslKindRe.FindString(trimmed)
+			if m == "" {
+				report("unknown element — not a DSL keyword or element kind")
+				continue
+			}
+			kind := strings.ToLower(m)
+			after := strings.TrimSpace(trimmed[len(m):])
+			// Strip the trailing `-> Screen`, then the quoted label, then test
+			// for the retired coordinate dialect — same order as the TS parser.
+			after = dslNavRe.ReplaceAllString(after, "")
+			if loc := dslQuotedRe.FindStringIndex(after); loc != nil {
+				after = strings.TrimSpace(after[:loc[0]] + " " + after[loc[1]:])
+			}
+			if dslLegacyRe.MatchString(" " + after + " ") {
+				report("absolute x,y coordinates are retired — layout is computed from structure")
+				continue
+			}
+			if kind == "navbar" || kind == "sidebar" {
+				continue
+			}
+			if parent.kind != "row" && parent.kind != "card" && !inStack {
+				report("an element cannot nest under a `" + parent.kind + "` here")
+				continue
+			}
+			if kind == "card" {
+				stack = append(stack, dslCtx{level: level, kind: "card"})
+			} else if kind == "table" {
+				stack = append(stack, dslCtx{level: level, kind: "table"})
+			}
+		}
+	}
+
+	if nErrors > 0 {
+		return ErrInvalidDSL, path + " has DSL syntax problems (first: " + first + ") — the file is unchanged; fix every line and re-emit the whole file."
+	}
+	return "", ""
+}

--- a/services/aep-api/internal/platform/agentfold/dslgate_test.go
+++ b/services/aep-api/internal/platform/agentfold/dslgate_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentfold
+
+// Accept/reject parity with the TS gate
+// (packages/agent-stream/test/wireframe-layout-gate.test.ts): a verdict
+// mismatch fails healthy turns on the manifest check, so every case here
+// mirrors a TS-side case.
+
+import "testing"
+
+const dslPath = "specs/design/components/shop-webapp/wireframes.dsl"
+
+const dslClean = `screen Dashboard "Admin overview"
+  navbar "Hub"
+  sidebar "Home | Reports"
+  row
+    heading "Good morning"
+    right
+    button "New audit" primary
+  row
+    card "Open items | 47 | across 5 projects"
+    card "Overdue | 12 | needs escalation"
+  table "A | B"
+    row "1 | 2"
+  split 60/40
+    left
+      text "a"
+    right
+      card "Discussion"
+        text "hello"
+        badge "Open" info
+`
+
+const dslLegacy = `screen Dashboard "Admin overview"
+  navbar "Hub"
+  heading "Overview" 280,84
+`
+
+const dslTypo = `screen Dashboard
+  navbar "Hub"
+  crd "Open items | 47 | across 5 projects"
+`
+
+func TestDslGateAcceptsCleanFlowDialect(t *testing.T) {
+	if code, msg := checkWireframeDslGuard(dslPath, dslClean); code != "" {
+		t.Fatalf("clean flow dialect rejected: %s %s", code, msg)
+	}
+}
+
+func TestDslGateRejectsLegacyCoordinates(t *testing.T) {
+	code, _ := checkWireframeDslGuard(dslPath, dslLegacy)
+	if code != ErrInvalidDSL {
+		t.Fatalf("legacy dialect not rejected, got %q", code)
+	}
+}
+
+func TestDslGateRejectsUnknownKind(t *testing.T) {
+	code, _ := checkWireframeDslGuard(dslPath, dslTypo)
+	if code != ErrInvalidDSL {
+		t.Fatalf("typo kind not rejected, got %q", code)
+	}
+}
+
+func TestDslGateRejectsMisplacedStructure(t *testing.T) {
+	for name, body := range map[string]string{
+		"stray right":       "screen S\n  right\n",
+		"table row outside": "screen S\n  row \"a | b\"\n",
+		"row under table":   "screen S\n  table \"A | B\"\n    row\n",
+	} {
+		if code, _ := checkWireframeDslGuard(dslPath, body); code != ErrInvalidDSL {
+			t.Fatalf("%s not rejected", name)
+		}
+	}
+}
+
+func TestDslGateSkipsOtherPaths(t *testing.T) {
+	if code, _ := checkWireframeDslGuard("specs/requirements/requirements.md", dslLegacy); code != "" {
+		t.Fatalf("markdown gated")
+	}
+	if code, _ := checkWireframeDslGuard("specs/design/components/api/erd.dsl", dslLegacy); code != "" {
+		t.Fatalf("domain-model dsl gated")
+	}
+}

--- a/services/aep-api/internal/platform/agentfold/fold.go
+++ b/services/aep-api/internal/platform/agentfold/fold.go
@@ -90,7 +90,7 @@ const (
 	ErrInvalidYAML     ErrCode = "INVALID_YAML"
 	ErrInvalidJSON     ErrCode = "INVALID_JSON"
 	ErrSchemaViolation ErrCode = "SCHEMA_VIOLATION"
-	ErrLayoutViolation ErrCode = "LAYOUT_VIOLATION"
+	ErrInvalidDSL      ErrCode = "INVALID_DSL"
 	ErrProtectedPath   ErrCode = "PROTECTED_PATH"
 )
 
@@ -280,14 +280,17 @@ func (f *Fold) RemoveFile(ctx context.Context, path string) (OpResult, error) {
 	return opOk(path, op, StatusApplied), nil
 }
 
-// commit applies content to path gated by the YAML reparse guard and the
-// component design.json schema gate; a rejection leaves the fold
-// byte-for-byte unchanged.
+// commit applies content to path gated by the YAML reparse guard, the
+// component design.json schema gate, and the wireframes .dsl syntax gate;
+// a rejection leaves the fold byte-for-byte unchanged.
 func (f *Fold) commit(path string, op Op, content string, rejectMsg func(yamlErr string) string) OpResult {
 	if yamlErr := checkYAMLGuard(path, content); yamlErr != "" {
 		return opErr(path, op, ErrInvalidYAML, rejectMsg(yamlErr))
 	}
 	if code, msg := checkComponentDesignGuard(path, content); code != "" {
+		return opErr(path, op, code, msg)
+	}
+	if code, msg := checkWireframeDslGuard(path, content); code != "" {
 		return opErr(path, op, code, msg)
 	}
 	c := content

--- a/services/aep-api/skills/embedded/excalidraw-wireframes/SKILL.md
+++ b/services/aep-api/skills/embedded/excalidraw-wireframes/SKILL.md
@@ -15,10 +15,10 @@ deterministically. NEVER write a `.excalidraw` file by hand.
 
 Wireframes are **low-fidelity but product-flavored**: they validate layout,
 hierarchy, and flow, not pixel-perfect visuals. The compiler applies the look
-for you — the Oxygen UI palette (light surfaces, neutral borders, WSO2 brand
-orange on primary actions and active navigation) plus a sketchy hand-drawn
-style. You decide *structure and content*; add a semantic `variant` only where
-color should carry status meaning (see "Color" below).
+(Oxygen UI palette, hand-drawn style) AND computes every position — **you
+write structure and content, never coordinates**. Elements stack top-to-bottom
+by default; `row` puts things side by side; `split` makes two columns. The
+compiler guarantees nothing overlaps and nothing leaves the screen.
 
 Produce **one canonical set of screens** — the agreed design, not a gallery of
 alternatives. One screen per distinct user task, per role (for a store: a
@@ -41,8 +41,8 @@ You have up to three sources in context; read them in this order of priority:
 3. **This component's `specs/design/components/<name>/design.json`** — a thin
    per-component summary; use it mainly to **scope**, not for screen content:
    its `type` (draw wireframes only for `web-application`), its one-line
-   `description`, and its `dependencies` (e.g. a Thunder/auth dependency means
-   there's a signed-in vs. guest distinction → likely role-specific screens).
+   `description`, and its `dependencies` (e.g. an auth dependency means there's
+   a signed-in vs. guest distinction → likely role-specific screens).
 
 **Cover every task.** Walk the design and requirements and make sure each
 distinct user-facing task — for each role they name — has a wireframe screen
@@ -63,12 +63,9 @@ itself. What carries the quality:
   after its name) so anyone can tell at a glance what the view does and who
   uses it — not just infer it from the widgets.
 - **A clear visual hierarchy.** A page has a title, then primary content, then
-  secondary detail. Use `heading` for section titles (it renders prominently);
-  size and position should make the most important thing obvious. One dominant
-  action per screen (the primary button).
-- **A consistent grid and rhythm.** Align elements to shared edges; stack with
-  even 16–24px gaps; give related things the same width. Sloppy alignment is
-  the single biggest thing that makes a wireframe look amateur.
+  secondary detail. Use `heading` for section titles; put the most important
+  thing first (it renders highest). One dominant action per screen (the one
+  `primary` button).
 - **The right primitive for each thing.** A status is a `badge`, not text. A
   section switch is `tabs`. A person is an `avatar`. Picking the primitive that
   matches the real UI element is most of what makes screens feel real.
@@ -108,19 +105,14 @@ Rules of thumb:
 - Name the screen for its role and put the role in the description:
   `screen ReviewQueue "Manager reviews and approves pending requests"`.
 - **A role screen is the SAME app — keep the identical `navbar` and `sidebar`
-  every other screen uses**, with the same items in the same order, and lay its
-  content out in the same content area (with a sidebar, `x ≥ 264`). The role
+  every other screen uses**, with the same items in the same order. The role
   changes what's *inside* the screen — which buttons, columns, rows — not the
-  shell. Do NOT give a scoped/secondary role its own smaller sidebar (e.g.
-  `"My Engagements | Reports"`) or start its content at `x≈40` as if there were
-  no rail; that renders the content on top of the sidebar. If a role genuinely
-  has fewer sections, still show the full sidebar (its extra items just aren't
-  where that role acts) — a per-role mini-sidebar reads as a different app.
+  shell. Never give a scoped role its own smaller sidebar; that reads as a
+  different app.
 - Reflect the real difference in **actions and data** — a role that can't
   approve/assign/delete simply doesn't have that button or column. Don't reskin
   one layout and call it two. The role difference should be legible from the
-  screen itself (which buttons and columns are present), not spelled out in a
-  caption.
+  screen itself, not spelled out in a caption.
 - A screen that is genuinely identical for everyone (a shared login, a generic
   detail page) stays single — don't fork it just to have a matching set.
 
@@ -129,249 +121,152 @@ Rules of thumb:
 Most webapp screens are one of three shapes. Follow these anatomies — they're
 what makes a wireframe read like a designed product instead of a pile of boxes.
 (Every `navbar` includes a notification bell + account avatar at its top-right:
-the compiler draws this account cluster as part of the `navbar` itself — the
-same way a real app header always shows the signed-in user — so it's identical
-on every screen. This is by design, not a stray extra; don't add an `avatar` or
-bell of your own to the navbar, and don't try to remove them.)
+the compiler draws this account cluster as part of the `navbar` itself — don't
+add your own.)
 
 **Dashboard / landing** (top → bottom):
 
-1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS") at
-   `y≈76`, then a human `heading` ("Good morning — here's where things stand")
-   just below it at `y≈104`, with `search` (and a filter `select`) on the
-   heading's line, right side. The eyebrow is the TOP row — keep it at `y≥72` so
-   it clears the navbar. Don't anchor the heading at `y≈80` and stack the
-   eyebrow above it at a smaller `y` (that slides the eyebrow under the bar);
-   the eyebrow comes first, the heading sits below it.
-2. A row of stat-tile `card`s — `card "Open items | 47 | across 5 active
-   projects"` — 3–4 tiles, same size, same `y`. Every number gets its label and
-   a caption that explains it.
-3. A grid of rich entity cards (one per project/order/record/…): compose them by
-   LAYERING elements inside a plain `card`'s bounds — a small muted `text`
-   eyebrow ("PROJECT · ACTIVE"), a `text` title, a `progress "47/60"`, a meta
-   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge` at the
-   card's top-right (`success`/`warning` variant: "On track"/"At risk").
+1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS"), then
+   a `row` with a human `heading` ("Good morning — here's where things stand")
+   and, after `right`, a `search` and a filter `select`.
+2. A `row` of 3–4 stat-tile `card`s — `card "Open items | 47 | across 5 active
+   projects"`. Every number gets its label and a caption that explains it. The
+   row makes them equal-width automatically.
+3. A `row` of rich entity cards (one per project/order/record): a `card` whose
+   title is the entity, with nested children — a `progress "47/60"`, a meta
+   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge`
+   (`success`/`warning`: "On track"/"At risk") that docks to the card's corner
+   automatically.
+4. A `row` with a section `heading` ("Needs your attention") and, after
+   `right`, the page's primary CTA. Then a `table` whose LAST column is the
+   action — put "Review →" / "Follow up →" in each `row`'s final cell.
 
-   Every layered element must sit FULLY INSIDE the card — the compiler draws
-   each element exactly where you place it, so an element whose coordinates spill
-   past the card's edge will straddle the border. For a card at `x,y` sized
-   `w×h`, keep inner content at `x+16 … x+w-16`. A top-right `badge` of width
-   `bw` therefore goes at `x + w - 16 - bw` (NOT at `x + w`, which pushes it
-   over the right border). Give the eyebrow/title room too: don't let a long
-   title `text` run under the badge — end the title before `x + w - 16 - bw`, or
-   shorten it.
-4. A "Needs your attention" `table` whose LAST column is the action — put
-   "Review →" / "Follow up →" in each `row`'s final cell.
-
-**List / queue**: `heading`, then a row of filter `badge`s with counts
-("All (146)", "Open (23)", "Resolved (98)", …) or `tabs`, then a full-width
+**List / queue**: `heading`, then a `row` of filter `badge`s with counts
+("All (146)", "Open (23)", "Resolved (98)") or `tabs`, then a full-width
 `table` with real `row`s — status as a word in a status column, owner, due
 date, and a trailing action cell.
 
-**Detail / record** (the screen for ONE item): `breadcrumb`, `heading` with
-status `badge`s beside it, a short description `text` — then TWO columns with a
-**vertical `divider` between them** (`divider "" 760,180 1x420` — a
-taller-than-wide divider renders as a vertical rule):
+**Detail / record** (the screen for ONE item): `breadcrumb`, then a `row` with
+the `heading` and its status `badge`s, a short description `text` — then a
+`split 60/40`:
 
-- **Left (main, ~60%)**: the item's content — e.g. a bordered panel `card` with
-  detail `text` lines, an items/records `table` with rows, an "Upload new" /
-  primary action.
-- **Right rail (~35%)**: the collaboration side — a "Discussion" `card` with a
-  few comment `text` lines (author + time + message), a comment `textarea` +
-  "Post" `button`, and an "Activity" list of timestamped `text` rows ("2 days
-  ago — J. Alvarez uploaded report-final.pdf"). Budget the rail's height so both
-  sections fit without overlap: the Discussion `card` takes about the TOP HALF
-  (e.g. `card "Discussion" 784,176 416x280`, ending ~`y456`, with its comment
-  lines and the `textarea`+`Post` composer inside it), then `heading "Activity"
-  784,476` and its rows go BELOW the card. Do NOT stretch the Discussion card to
-  the full rail height (~420) — that leaves nowhere for Activity, so it ends up
-  on top of the composer. Keep each comment `text` SHORT (a phrase, not a
-  sentence) so it fits the ~400px rail width.
-
-Always put the `divider` between the two columns — the rule is what makes it
-read as two distinct areas instead of floating content.
-
-**Keep the columns from overlapping** — this is the one mistake to avoid here.
-The left column's widest element (usually the `table`) must END before the
-divider, and the right rail must START after it. With a sidebar app on a
-1280-wide screen, a layout that always fits: left content at `x=280` with
-`width ≤ 440` (so it ends by ~720), `divider "" 760,180 1x420`, right rail at
-`x=784` with `width ≤ 440`. Do NOT reuse a single-column full-width `table`
-(`940` wide) on a two-column screen — a 940-wide table starting at 280 runs to
-1220 and buries the divider and the entire right rail underneath it. Narrow the
-left table to the left column, or drop to a single column if the content truly
-needs the full width (in which case there's no right rail and no divider).
+- **`left` (main)**: the item's content — a bordered panel `card` with detail
+  `text` lines, an items/records `table` with rows, an "Upload new" / primary
+  action.
+- **`right` (rail)**: the collaboration side — a "Discussion" `card` with
+  nested comment `text` lines (author + time + message), a `textarea` + "Post"
+  `button`, then an "Activity" `heading` and timestamped `text` rows ("2 days
+  ago — J. Alvarez uploaded report-final.pdf").
 
 A record's conversation and history belong in this right rail, beside the
-record — not on a separate screen. That's where users expect to pick up the
-discussion and see what changed.
+record — not on a separate screen. The divider between the columns is drawn
+automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
 
 ## The DSL
 
+Line-oriented, nested by 2-space indentation. **No coordinates anywhere** —
+position comes from structure:
+
 ```
-screen <Name> ["what this view is for"] [WxH]   // desktop 1280x800 default; quoted description optional
-  navbar "App | Nav1 | Nav2"         // full-width top bar; pipe-separated items; no coordinates
-  sidebar "Item1 | Item2 | Item3"    // left rail below the navbar; no coordinates
-  <kind> "<label>" <x>,<y> [WxH] [variant] [-> Screen]   // -> Screen: this element navigates there
-  button "Add to cart" <x>,<y> [WxH] primary -> Cart     // e.g. a button that opens the Cart screen
-  table "Col1 | Col2" <x>,<y> [WxH]
-    row "cell | cell"                // optional; realistic table data, one per body row
+screen <Name> ["what this view is for"]   // one per view; description renders as a subtitle
+  navbar "App | Nav1 | Nav2"     // top bar; pipe-separated; bell+avatar added automatically
+  sidebar "Item1 | Item2"        // left rail; same items on every screen of the app
+  <kind> "<label>" [WxH] [variant] [-> Screen]   // a block: stacks below the previous one
+  row                            // children go side by side (equal shares, 16px gaps)
+    <kind> "<label>" …
+    right                        // everything after this packs to the right edge
+    <kind> "<label>" …
+  split 60/40                    // two columns + automatic vertical divider
+    left
+      <blocks…>                  // each column is its own stack (rows allowed)
+    right
+      <blocks…>
+  card "Title"                   // a card with nested children lays them out inside
+    <elements…>                  //   …a badge child docks to the card's top-right
+  table "Col1 | Col2" [-> Screen]
+    row "cell | cell"            // table data — quoted `row` lines belong to the table
 ```
 
-Give every screen a **description** — a short quoted phrase after the name
-saying what the view is for and who uses it. It renders as a subtitle under the
-title and is the fastest way to make a wireframe self-explanatory:
-`screen ReviewQueue "Managers approve or reject pending requests"`.
+**The six rules of layout** (everything else is automatic):
+
+1. Blocks **stack** top-to-bottom in the order you write them.
+2. `row` puts children **side by side** — flexible things (cards, inputs,
+   selects, charts, tables) share the width equally; small things (badges,
+   buttons) keep their natural size. A row can never overflow.
+3. `right` inside a row **right-aligns** what follows — header CTAs, the
+   search+filter pair, footer Cancel/Save (primary rightmost).
+4. `split N/M` + `left`/`right` makes **two columns** with the divider drawn
+   for you.
+5. Children indented under a `card` render **inside** it; the card grows to
+   fit; a `badge` child docks to its top-right corner.
+6. `WxH` is optional and rarely needed (a taller `chart "…" 600x260`); widths
+   are clamped to fit. The screen grows downward if content is long.
 
 **Navigation** is attached to the control that triggers it: put `-> ScreenName`
-at the end of the button (or link) that leads there, and the compiler draws a
-`→ Screen N · ScreenName` marker beside it. This is how you show the flow
-between screens — usually on buttons like "View", "Open", "Continue",
-"Checkout". Leave a little empty space to the right of a navigating button so
-the marker has room. The target must be a `screen` name that exists.
+at the end of the button (or link, or table) that leads there, and the compiler
+draws a `→ Screen N · ScreenName` marker beside it. The target must be a
+`screen` name that exists. When two buttons sit in a row, put the `->` on the
+primary/forward one.
+
+Syntax is validated at write time: an unknown keyword, a misplaced
+`left`/`right`/table-`row`, or old-style x,y coordinates rejects the write with
+line numbers (`INVALID_DSL`) — fix every listed line and re-emit the file.
 
 ### Element kinds
 
-Chrome & structure
+Chrome & structure: `navbar`, `sidebar`, `tabs` (`"A | B | C"`, first active),
+`breadcrumb` (`"Projects / Acme / Settings"`), `divider` (a horizontal rule;
+column dividers come from `split` automatically).
 
-| Kind | Use for | Default size |
-|---|---|---|
-| `navbar` | app top bar (first line of every screen); `\|`-separated items | full width × 56 |
-| `sidebar` | section navigation rail; `\|`-separated items | 240 × full height |
-| `tabs` | in-page section switcher; `\|`-separated, first shown active | 480×40 |
-| `breadcrumb` | trail like `"Projects / Acme / Settings"` | auto |
-| `divider` | a rule between sections — horizontal, or **vertical** when taller than wide (`1x420`, e.g. between two columns) | width×1 |
+Content & data:
 
-Content & data
+| Kind | Use for |
+|---|---|
+| `heading` | page / section titles (renders large with an underline rule) |
+| `text` | body copy, values, helper text |
+| `link` | inline navigation text (renders blue) |
+| `card` | stat tile — `"Open items \| 47 \| across 5 audits"` (label, BIG value, caption); one-part label = a panel; nested children = a container |
+| `table` | data grids; label = `\|`-separated headers; nested `row "…"` lines for data |
+| `list` | stacked rows (feed, comments, nav); `\|`-separated items |
+| `image` | logos, photos, media slots (renders a crossed box) |
+| `chart` | data viz placeholder (renders axes + bars) |
+| `progress` | progress bar; label `"60%"`/`"3/4"` sets the fill |
+| `badge` | status pills — `"Open"`, `"Overdue"` (color via variant) |
+| `avatar` | a person — label `"Jane Doe"` renders initials `JD` |
+| `icon` | a small glyph slot; label is 1–2 chars |
 
-| Kind | Use for | Default size |
-|---|---|---|
-| `heading` | page / section titles (renders large with an underline rule) | auto |
-| `text` | body copy, values, helper text | auto |
-| `link` | inline navigation text (renders blue) | auto |
-| `card` | stat tile — `"Open items \| 47 \| across 5 projects"` (label, BIG value, caption); a one-part label is a plain panel/container | 300×160 |
-| `table` | data grids; label = `\|`-separated headers; add `row` lines for data | 640×240 |
-| `list` | stacked rows (feed, comments, nav); `\|`-separated items | 320 × n·40 |
-| `image` | logos, photos, media slots (renders a crossed box) | 240×140 |
-| `chart` | data viz placeholder (renders axes + bars) | 320×180 |
-| `progress` | progress bar; label as `"60%"`/`"3/4"`/`"0.6"` sets the fill | 240×10 |
-| `badge` | status pills — `"Open"`, `"Overdue"`, `"Live"` (color via variant) | auto |
-| `avatar` | a person — label `"Jane Doe"` renders initials `JD` | 40×40 |
-| `icon` | a small glyph slot; label is 1–2 chars | 24×24 |
-
-Inputs & controls
-
-| Kind | Use for | Default size |
-|---|---|---|
-| `input` | text field; label is the placeholder | 320×36 |
-| `textarea` | multi-line field | 320×96 |
-| `select` | dropdown (renders a ▾) | 320×36 |
-| `search` | search box (renders a ⌕) | 320×36 |
-| `button` | actions; the bottom-most button gets the flow marker | 140×40 |
-| `checkbox` / `radio` | options; add `active` variant to show it selected | auto |
-| `toggle` | on/off switch; add `active` variant for on | 44×24 |
-
-Generic (use only when nothing above fits)
-
-| Kind | Use for | Default size |
-|---|---|---|
-| `rect` / `ellipse` | a container or shape with no better primitive | 160×32 |
+Inputs & controls: `input` (label = placeholder), `textarea`, `select`
+(renders ▾), `search` (renders ⌕), `button`, `checkbox` / `radio` / `toggle`
+(add `active` to show selected/on). Generic `rect` / `ellipse` only when
+nothing above fits.
 
 ### Color
 
-The compiler already applies the Oxygen theme: white/neutral surfaces, the WSO2
-brand orange on the active navbar/sidebar item, and orange section-heading
-rules. You don't set any of that — it's automatic.
+The compiler applies the Oxygen theme automatically: white/neutral surfaces,
+brand orange on the active navbar/sidebar item and section-heading rules. You
+add color only through a trailing **variant**, to carry *status meaning*:
 
-You add color only through a trailing **variant** on an element, to carry
-*status meaning*: `primary`, `secondary`, `danger`, `success`, `warning`,
-`info`, `ai`, `active`, `muted`.
-
-- `primary` on the ONE main action per screen (`button "Create" ... primary`)
-  — fills brand orange. Every other button stays a plain outline.
+- `primary` on the ONE main action per screen — fills brand orange. Every
+  other button stays a plain outline.
 - `danger` / `success` / `warning` / `info` on a `badge` or destructive
-  `button` to signal status or severity (`badge "Overdue" ... danger`).
-- `ai` (purple) reserved for an automated / AI-driven step, if the product has
-  one.
+  `button` (`badge "Overdue" danger`).
+- `ai` (purple) for an automated / AI-driven step, if the product has one.
 - `active` marks a `checkbox` / `radio` / `toggle` as selected / on.
+- `muted` for de-emphasized text (an eyebrow label).
 
 Keep status variants purposeful — a screen dense with red/green/amber badges
-stops communicating. Let the theme carry the "product" feel; use variants for
-the handful of things that genuinely signal state.
+stops communicating.
 
-### Layout rules
+### Consistency rules
 
-The platform **validates layout at write time**: an element outside the frame,
-under the navbar/sidebar, or partially overlapping another is rejected with a
-`LAYOUT_VIOLATION` error listing the exact coordinates — fix them and retry.
-(Fully nesting one element inside another — a badge inside a card — is
-layering and always allowed.)
-
-- **Everything stays inside the screen.** The frame is 1280×800. Every element's
-  right edge (`x + width`) must be ≤ **1240** (a 40px right margin) and its
-  bottom (`y + height`) ≤ **760**; nothing extends past the frame. For anything
-  right-aligned — a header filter `select`, a top-right button, a footer action
-  — compute its `x` from the edge (`x = 1240 − width`), never by eyeballing a
-  large number. Elements without an explicit `WxH` get a DEFAULT size (a
-  `chart` is 320 wide, a `select` 320) — placing one near the right edge
-  without a size makes it overflow, so always give near-edge elements an
-  explicit `WxH`. Check `x + width ≤ 1240` for every element on the right or
-  bottom edge before finishing.
-- **Header search + filter: use these exact slots** (this pair is the most
-  common collision — don't re-derive it):
-  - With a sidebar: `search "…" 820,104 240x36` then `select "…" 1076,104 164x36`
-    (search ends 1060, filter ends 1240 — 16px gap).
-  - Without a sidebar: `search "…" 780,104 280x36` then `select "…" 1076,104 164x36`.
-- **Filter chips / badge rows: give every `badge` an explicit width and place
-  the next chip from it.** A `badge` with no `WxH` auto-sizes to its label, so
-  its real width is a guess — and guessed chips collide. Width a chip at
-  roughly `10 × characters + 30` and start the next chip at the previous
-  chip's `x + width + 12`: `badge "All (18)" 280,150 110x24`,
-  `badge "Overdue (2)" 402,150 140x24`, `badge "Changes requested (3)" 554,150 250x24`.
-- **Nothing sits under the navbar.** The `navbar` fills the top band of every
-  screen (frame-relative `y` 0–56). So the FIRST content element — including any
-  muted eyebrow/label above the heading — starts at `y ≥ 72`. The most common
-  overlap is an eyebrow crammed above an `y≈80` heading at `y≈52`, which slips
-  under the bar: put the eyebrow at `y≈76` and the heading at `y≈104` instead.
-- **The left margin depends on whether the screen has a sidebar.** Then:
-  - **With a `sidebar`** (a 240px left rail): content starts at `x ≥ 264` and
-    full-width elements (tables/charts) are ~940 wide.
-  - **Without a sidebar**: content starts at `x ≈ 40` — a plain page margin —
-    and uses the FULL width (full-width elements ~1200 wide). Do **not** indent
-    to `x=280` when there is no sidebar; that leaves a dead empty strip on the
-    left where the missing rail would be. Either add a sidebar to fill it or
-    start at `x≈40`.
-- **One primary navigation, not two.** Pick where the section links live and
-  put them in exactly one place:
-  - **Sidebar app** (content-heavy tools, admin consoles, dashboards): the
-    `sidebar` holds the section links, and the `navbar` carries ONLY the app /
-    brand name — e.g. `navbar "Acme"`. The compiler adds the
-    notification bell + account avatar to the right of the navbar automatically,
-    so a brand-only bar is complete. **Do not repeat the sidebar's links in the
-    navbar** — that's the duplicated top+left nav that reads as a bug.
-  - **Top-nav app** (simple public flows — storefront, checkout, marketing):
-    the `navbar` holds the links (`navbar "Shop | Cart | Account"`) and there is
-    **no `sidebar`**.
-  Choose one model per app and keep it consistent across every screen —
-  **including role-specific and scoped screens**. The `sidebar` is identical
-  (same items, same order) on all of them; a screen never gets its own shorter
-  sidebar. With a sidebar, EVERY screen's content starts at `x ≥ 264` — content
-  at `x≈40` on a screen that has a sidebar lands on top of the rail.
-- Stack vertically with 16–24px gaps; align related elements to the same `x`;
-  give a row of cards/inputs the same `y` and width. Keep everything inside the
-  screen and never overlapping.
-- **Right-align a screen's action buttons.** A form or dialog's footer buttons
-  (Cancel / Save, Back / Continue) sit at the **bottom-right** of that form —
-  the primary action rightmost — not at the left. Compute their `x` from the
-  right edge of the content, not the left. A single page-level CTA ("New", "Add
-  …") goes top-right. When two buttons sit side by side, put the `-> Screen`
-  nav marker only on the **primary/forward** one (a marker on the left button
-  would collide with the button to its right); a Cancel/Back button rarely
-  needs a marker.
+- **One primary navigation, not two.** A content-heavy tool (admin console,
+  dashboard app) uses the `sidebar` for section links and a brand-only
+  `navbar` (`navbar "Acme"`). A simple public flow (storefront, checkout) uses
+  a link-carrying `navbar` and **no sidebar**. Never both on one screen.
 - Repeat the SAME `navbar` (and `sidebar`) verbatim on every screen of one app
   — consistent chrome is what makes screens read as one product.
-- Comments start with `//`. `-> Screen` targets must match a `screen` name
-  exactly; every screen should be reachable from some control.
+- Comments start with `//`. Every screen should be reachable from some
+  control's `-> Screen`.
 
 Read `references/wireframes-dsl-example.md` for a complete worked example
 before writing your first wireframe.
@@ -380,5 +275,6 @@ before writing your first wireframe.
 
 The DSL is line-oriented, so `editFile` works naturally: anchor on the
 `screen <Name>` line plus the element line you're changing. Add a screen by
-appending a new `screen` block and its `flow` edges. Add table data by
-inserting `row` lines directly under the `table`.
+appending a new `screen` block. Add table data by inserting `row` lines under
+the `table`. Insert a new element by adding its line where it should appear in
+the stack — everything below it moves down automatically.

--- a/services/aep-api/skills/embedded/excalidraw-wireframes/references/wireframes-dsl-example.md
+++ b/services/aep-api/skills/embedded/excalidraw-wireframes/references/wireframes-dsl-example.md
@@ -1,68 +1,81 @@
 # Worked example — risk register webapp wireframes
 
 A complete `wireframes.dsl` for a three-screen desktop flow. Note the rhythm:
-every screen repeats the same `navbar` + `sidebar` (consistent chrome); content
-sits right of the sidebar (`x ≥ 280`) and below the navbar (`y ≥ 80`); rows of
-cards share a `y` and width; the primary action is the one colored `button`
-(`primary`), and status is carried by `badge`s, not prose.
+every screen repeats the same `navbar` + `sidebar` (consistent chrome); blocks
+stack in reading order; `row` groups things side by side; the primary action is
+the one `primary` button per screen; status is carried by `badge`s, not prose.
+No coordinates anywhere — the compiler computes every position.
 
 ```
-// Risk register — three screens, desktop 1280x800
+// Risk register — three screens, desktop
 
 screen RiskDashboard "Managers monitor open risk and act on what's overdue"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  heading "Risk Overview" 280,80
-  card "Open risks: 24" 280,130 300x110
-  card "Overdue actions: 6" 600,130 300x110
-  card "High severity: 3" 920,130 300x110
-  heading "Recent activity" 280,272
-  tabs "All | Mine | Watching" 280,312 480x36
-  table "Risk | Owner | Severity | Status | Updated" 280,360 940x220
+  row
+    heading "Risk Overview"
+    right
+    button "New risk" primary -> NewRisk
+  row
+    card "Open risks | 24 | across 6 registers"
+    card "Overdue actions | 6 | need follow-up"
+    card "High severity | 3 | review this week"
+  heading "Recent activity"
+  tabs "All | Mine | Watching"
+  table "Risk | Owner | Severity | Status | Updated" -> RiskDetail
     row "Unpatched edge servers | Platform team | High | Open | 2h ago"
     row "Stale access keys | Security | Medium | In review | 1d ago"
     row "Vendor SOC2 lapse | Compliance | High | Overdue | 3d ago"
-  button "New risk" 1080,80 140x40 primary -> NewRisk
 
 screen NewRisk "An owner logs a new risk into a register"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / New risk" 280,80
-  heading "New Risk" 280,108
-  text "Title" 280,158
-  input "e.g. Unpatched edge servers" 280,180 640x36
-  text "Description" 280,232
-  textarea "What is the risk and why does it matter?" 280,254 640x96
-  text "Register" 280,372
-  select "Infrastructure" 280,394 300x36
-  text "Owner" 620,372
-  select "Platform team" 620,394 300x36
-  text "Impact" 280,450
-  select "High" 280,472 300x36
-  text "Likelihood" 620,450
-  select "Likely" 620,472 300x36
-  checkbox "Notify owner on create" 280,532 300x20 active
-  button "Cancel" 600,584 140x40
-  button "Create risk" 760,584 160x40 primary -> RiskDashboard
+  breadcrumb "Risks / New risk"
+  heading "New Risk"
+  input "Title — e.g. Unpatched edge servers"
+  textarea "What is the risk and why does it matter?"
+  row
+    select "Register: Infrastructure"
+    select "Owner: Platform team"
+  row
+    select "Impact: High"
+    select "Likelihood: Likely"
+  checkbox "Notify owner on create" active
+  row
+    right
+    button "Cancel"
+    button "Create risk" primary -> RiskDashboard
 
 screen RiskDetail "The owner tracks remediation for one risk"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / Unpatched edge servers" 280,80
-  heading "Unpatched edge servers" 280,108
-  badge "High" 640,114 70x26 danger
-  badge "Open" 720,114 70x26 info
-  text "Owner: Platform team — Updated 2h ago" 280,152
-  avatar "Priya Rao" 280,184 40x40
-  text "Priya Rao, Platform team" 332,196
-  heading "Remediation" 280,248
-  progress "60%" 280,288 640x12 info
-  text "6 of 10 actions complete" 280,308
-  table "Action | Assignee | Due | Status" 280,344 940x180
-    row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
-    row "Rotate edge certs | M. Diaz | Mon | In progress"
-    row "Close inbound 8443 | Platform | Tue | To do"
-  button "Update status" 1060,576 160x40 primary
+  breadcrumb "Risks / Unpatched edge servers"
+  row
+    heading "Unpatched edge servers"
+    badge "High" danger
+    badge "Open" info
+  text "Owner: Platform team — Updated 2h ago"
+  split 60/40
+    left
+      heading "Remediation"
+      progress "60%" info
+      text "6 of 10 actions complete"
+      table "Action | Assignee | Due | Status"
+        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+        row "Rotate edge certs | M. Diaz | Mon | In progress"
+        row "Close inbound 8443 | Platform | Tue | To do"
+      row
+        right
+        button "Update status" primary
+    right
+      card "Discussion"
+        text "K. Smith · 2d: when does the cert rotation land?"
+        text "M. Diaz · 1d: Monday, after the freeze."
+        textarea "Add a comment…"
+        button "Post" primary
+      heading "Activity"
+      text "2h ago — A. Chen closed CVE-2026-1"
+      text "1d ago — M. Diaz started cert rotation"
 ```
 
 Checklist before finishing a wireframe file:
@@ -72,15 +85,15 @@ Checklist before finishing a wireframe file:
   screen per role, named and described for it.
 - Every screen has a one-line description saying what it's for.
 - Chrome (`navbar`, `sidebar`) is identical across screens of the same app.
-- Content stays inside the screen, right of the sidebar, below the navbar;
-  rows of cards/inputs share a `y` and width; nothing overlaps.
-- Labels are content-bearing ("Open risks: 24", "Platform team", "Overdue"),
-  never placeholders like "text" or "label".
+- Labels are content-bearing ("Open risks | 24 | across 6 registers",
+  "Platform team", "Overdue"), never placeholders like "text" or "label".
 - The right primitive does each job — `badge` for status, `tabs` for section
   switching, `avatar` for people, `progress` for completion, `table` + `row`
   for real data.
 - Color is rare and meaningful: one `primary` action per screen, plus the odd
-  status `badge`. If more than ~3 things are colored, pull some back to gray.
-- Navigation is on the control that triggers it: the button/link that leads to
-  another screen ends with `-> ScreenName`, and every `-> ScreenName` target
-  matches a real `screen`. Leave room to the right of a navigating button.
+  status `badge`.
+- Navigation is on the control that triggers it: the button/link/table that
+  leads to another screen ends with `-> ScreenName`, and every target matches
+  a real `screen`.
+- NO coordinates and no manual sizes unless an element truly needs one — the
+  layout comes from stacking, `row`, and `split`.

--- a/services/agents/src/agents/main/prompt.ts
+++ b/services/agents/src/agents/main/prompt.ts
@@ -44,6 +44,10 @@ Reacting to tool results (each result tells you the next move):
   schema problem, listed in the message); re-emit the WHOLE corrected file with removeFile + addFile.
   skillsApplied (the skills that component's build needs) is a per-component key inside its design.json,
   not project-level frontmatter.
+- INVALID_DSL — a wireframes .dsl write was rejected (bad lines listed with line numbers: an unknown
+  keyword, a misplaced left/right/table-row, or retired x,y coordinates). Fix EVERY listed line and
+  re-emit the WHOLE corrected file with removeFile + addFile — layout comes from structure, never
+  from coordinates.
 
 Keep prose outside tool calls to a single short sentence. When the instruction is fully applied, stop.`;
 

--- a/services/agents/src/collab/streaming-add.test.ts
+++ b/services/agents/src/collab/streaming-add.test.ts
@@ -127,7 +127,7 @@ test("streams a .cell addFile incrementally, line-by-line, converging to full co
 
 const DSL_PATH = "specs/design/components/shop-webapp/wireframes.dsl";
 const DSL =
-  'screen Catalog "Shoppers browse products"\n  navbar "Shop"\n  heading "Browse" 40,84\n  button "View cart" 1050,84 150x40 primary -> Cart\n\nscreen Cart "Review and check out"\n  heading "Your cart" 40,84\n';
+  'screen Catalog "Shoppers browse products"\n  navbar "Shop"\n  heading "Browse"\n  button "View cart" primary -> Cart\n\nscreen Cart "Review and check out"\n  heading "Your cart"\n';
 
 test("streams a wireframes .dsl addFile incrementally, line-by-line, converging to full content", async () => {
   const peer = new FakePeer();

--- a/skills/excalidraw-wireframes/SKILL.md
+++ b/skills/excalidraw-wireframes/SKILL.md
@@ -15,10 +15,10 @@ deterministically. NEVER write a `.excalidraw` file by hand.
 
 Wireframes are **low-fidelity but product-flavored**: they validate layout,
 hierarchy, and flow, not pixel-perfect visuals. The compiler applies the look
-for you — the Oxygen UI palette (light surfaces, neutral borders, WSO2 brand
-orange on primary actions and active navigation) plus a sketchy hand-drawn
-style. You decide *structure and content*; add a semantic `variant` only where
-color should carry status meaning (see "Color" below).
+(Oxygen UI palette, hand-drawn style) AND computes every position — **you
+write structure and content, never coordinates**. Elements stack top-to-bottom
+by default; `row` puts things side by side; `split` makes two columns. The
+compiler guarantees nothing overlaps and nothing leaves the screen.
 
 Produce **one canonical set of screens** — the agreed design, not a gallery of
 alternatives. One screen per distinct user task, per role (for a store: a
@@ -41,8 +41,8 @@ You have up to three sources in context; read them in this order of priority:
 3. **This component's `specs/design/components/<name>/design.json`** — a thin
    per-component summary; use it mainly to **scope**, not for screen content:
    its `type` (draw wireframes only for `web-application`), its one-line
-   `description`, and its `dependencies` (e.g. a Thunder/auth dependency means
-   there's a signed-in vs. guest distinction → likely role-specific screens).
+   `description`, and its `dependencies` (e.g. an auth dependency means there's
+   a signed-in vs. guest distinction → likely role-specific screens).
 
 **Cover every task.** Walk the design and requirements and make sure each
 distinct user-facing task — for each role they name — has a wireframe screen
@@ -63,12 +63,9 @@ itself. What carries the quality:
   after its name) so anyone can tell at a glance what the view does and who
   uses it — not just infer it from the widgets.
 - **A clear visual hierarchy.** A page has a title, then primary content, then
-  secondary detail. Use `heading` for section titles (it renders prominently);
-  size and position should make the most important thing obvious. One dominant
-  action per screen (the primary button).
-- **A consistent grid and rhythm.** Align elements to shared edges; stack with
-  even 16–24px gaps; give related things the same width. Sloppy alignment is
-  the single biggest thing that makes a wireframe look amateur.
+  secondary detail. Use `heading` for section titles; put the most important
+  thing first (it renders highest). One dominant action per screen (the one
+  `primary` button).
 - **The right primitive for each thing.** A status is a `badge`, not text. A
   section switch is `tabs`. A person is an `avatar`. Picking the primitive that
   matches the real UI element is most of what makes screens feel real.
@@ -108,19 +105,14 @@ Rules of thumb:
 - Name the screen for its role and put the role in the description:
   `screen ReviewQueue "Manager reviews and approves pending requests"`.
 - **A role screen is the SAME app — keep the identical `navbar` and `sidebar`
-  every other screen uses**, with the same items in the same order, and lay its
-  content out in the same content area (with a sidebar, `x ≥ 264`). The role
+  every other screen uses**, with the same items in the same order. The role
   changes what's *inside* the screen — which buttons, columns, rows — not the
-  shell. Do NOT give a scoped/secondary role its own smaller sidebar (e.g.
-  `"My Engagements | Reports"`) or start its content at `x≈40` as if there were
-  no rail; that renders the content on top of the sidebar. If a role genuinely
-  has fewer sections, still show the full sidebar (its extra items just aren't
-  where that role acts) — a per-role mini-sidebar reads as a different app.
+  shell. Never give a scoped role its own smaller sidebar; that reads as a
+  different app.
 - Reflect the real difference in **actions and data** — a role that can't
   approve/assign/delete simply doesn't have that button or column. Don't reskin
   one layout and call it two. The role difference should be legible from the
-  screen itself (which buttons and columns are present), not spelled out in a
-  caption.
+  screen itself, not spelled out in a caption.
 - A screen that is genuinely identical for everyone (a shared login, a generic
   detail page) stays single — don't fork it just to have a matching set.
 
@@ -129,249 +121,152 @@ Rules of thumb:
 Most webapp screens are one of three shapes. Follow these anatomies — they're
 what makes a wireframe read like a designed product instead of a pile of boxes.
 (Every `navbar` includes a notification bell + account avatar at its top-right:
-the compiler draws this account cluster as part of the `navbar` itself — the
-same way a real app header always shows the signed-in user — so it's identical
-on every screen. This is by design, not a stray extra; don't add an `avatar` or
-bell of your own to the navbar, and don't try to remove them.)
+the compiler draws this account cluster as part of the `navbar` itself — don't
+add your own.)
 
 **Dashboard / landing** (top → bottom):
 
-1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS") at
-   `y≈76`, then a human `heading` ("Good morning — here's where things stand")
-   just below it at `y≈104`, with `search` (and a filter `select`) on the
-   heading's line, right side. The eyebrow is the TOP row — keep it at `y≥72` so
-   it clears the navbar. Don't anchor the heading at `y≈80` and stack the
-   eyebrow above it at a smaller `y` (that slides the eyebrow under the bar);
-   the eyebrow comes first, the heading sits below it.
-2. A row of stat-tile `card`s — `card "Open items | 47 | across 5 active
-   projects"` — 3–4 tiles, same size, same `y`. Every number gets its label and
-   a caption that explains it.
-3. A grid of rich entity cards (one per project/order/record/…): compose them by
-   LAYERING elements inside a plain `card`'s bounds — a small muted `text`
-   eyebrow ("PROJECT · ACTIVE"), a `text` title, a `progress "47/60"`, a meta
-   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge` at the
-   card's top-right (`success`/`warning` variant: "On track"/"At risk").
+1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS"), then
+   a `row` with a human `heading` ("Good morning — here's where things stand")
+   and, after `right`, a `search` and a filter `select`.
+2. A `row` of 3–4 stat-tile `card`s — `card "Open items | 47 | across 5 active
+   projects"`. Every number gets its label and a caption that explains it. The
+   row makes them equal-width automatically.
+3. A `row` of rich entity cards (one per project/order/record): a `card` whose
+   title is the entity, with nested children — a `progress "47/60"`, a meta
+   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge`
+   (`success`/`warning`: "On track"/"At risk") that docks to the card's corner
+   automatically.
+4. A `row` with a section `heading` ("Needs your attention") and, after
+   `right`, the page's primary CTA. Then a `table` whose LAST column is the
+   action — put "Review →" / "Follow up →" in each `row`'s final cell.
 
-   Every layered element must sit FULLY INSIDE the card — the compiler draws
-   each element exactly where you place it, so an element whose coordinates spill
-   past the card's edge will straddle the border. For a card at `x,y` sized
-   `w×h`, keep inner content at `x+16 … x+w-16`. A top-right `badge` of width
-   `bw` therefore goes at `x + w - 16 - bw` (NOT at `x + w`, which pushes it
-   over the right border). Give the eyebrow/title room too: don't let a long
-   title `text` run under the badge — end the title before `x + w - 16 - bw`, or
-   shorten it.
-4. A "Needs your attention" `table` whose LAST column is the action — put
-   "Review →" / "Follow up →" in each `row`'s final cell.
-
-**List / queue**: `heading`, then a row of filter `badge`s with counts
-("All (146)", "Open (23)", "Resolved (98)", …) or `tabs`, then a full-width
+**List / queue**: `heading`, then a `row` of filter `badge`s with counts
+("All (146)", "Open (23)", "Resolved (98)") or `tabs`, then a full-width
 `table` with real `row`s — status as a word in a status column, owner, due
 date, and a trailing action cell.
 
-**Detail / record** (the screen for ONE item): `breadcrumb`, `heading` with
-status `badge`s beside it, a short description `text` — then TWO columns with a
-**vertical `divider` between them** (`divider "" 760,180 1x420` — a
-taller-than-wide divider renders as a vertical rule):
+**Detail / record** (the screen for ONE item): `breadcrumb`, then a `row` with
+the `heading` and its status `badge`s, a short description `text` — then a
+`split 60/40`:
 
-- **Left (main, ~60%)**: the item's content — e.g. a bordered panel `card` with
-  detail `text` lines, an items/records `table` with rows, an "Upload new" /
-  primary action.
-- **Right rail (~35%)**: the collaboration side — a "Discussion" `card` with a
-  few comment `text` lines (author + time + message), a comment `textarea` +
-  "Post" `button`, and an "Activity" list of timestamped `text` rows ("2 days
-  ago — J. Alvarez uploaded report-final.pdf"). Budget the rail's height so both
-  sections fit without overlap: the Discussion `card` takes about the TOP HALF
-  (e.g. `card "Discussion" 784,176 416x280`, ending ~`y456`, with its comment
-  lines and the `textarea`+`Post` composer inside it), then `heading "Activity"
-  784,476` and its rows go BELOW the card. Do NOT stretch the Discussion card to
-  the full rail height (~420) — that leaves nowhere for Activity, so it ends up
-  on top of the composer. Keep each comment `text` SHORT (a phrase, not a
-  sentence) so it fits the ~400px rail width.
-
-Always put the `divider` between the two columns — the rule is what makes it
-read as two distinct areas instead of floating content.
-
-**Keep the columns from overlapping** — this is the one mistake to avoid here.
-The left column's widest element (usually the `table`) must END before the
-divider, and the right rail must START after it. With a sidebar app on a
-1280-wide screen, a layout that always fits: left content at `x=280` with
-`width ≤ 440` (so it ends by ~720), `divider "" 760,180 1x420`, right rail at
-`x=784` with `width ≤ 440`. Do NOT reuse a single-column full-width `table`
-(`940` wide) on a two-column screen — a 940-wide table starting at 280 runs to
-1220 and buries the divider and the entire right rail underneath it. Narrow the
-left table to the left column, or drop to a single column if the content truly
-needs the full width (in which case there's no right rail and no divider).
+- **`left` (main)**: the item's content — a bordered panel `card` with detail
+  `text` lines, an items/records `table` with rows, an "Upload new" / primary
+  action.
+- **`right` (rail)**: the collaboration side — a "Discussion" `card` with
+  nested comment `text` lines (author + time + message), a `textarea` + "Post"
+  `button`, then an "Activity" `heading` and timestamped `text` rows ("2 days
+  ago — J. Alvarez uploaded report-final.pdf").
 
 A record's conversation and history belong in this right rail, beside the
-record — not on a separate screen. That's where users expect to pick up the
-discussion and see what changed.
+record — not on a separate screen. The divider between the columns is drawn
+automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
 
 ## The DSL
 
+Line-oriented, nested by 2-space indentation. **No coordinates anywhere** —
+position comes from structure:
+
 ```
-screen <Name> ["what this view is for"] [WxH]   // desktop 1280x800 default; quoted description optional
-  navbar "App | Nav1 | Nav2"         // full-width top bar; pipe-separated items; no coordinates
-  sidebar "Item1 | Item2 | Item3"    // left rail below the navbar; no coordinates
-  <kind> "<label>" <x>,<y> [WxH] [variant] [-> Screen]   // -> Screen: this element navigates there
-  button "Add to cart" <x>,<y> [WxH] primary -> Cart     // e.g. a button that opens the Cart screen
-  table "Col1 | Col2" <x>,<y> [WxH]
-    row "cell | cell"                // optional; realistic table data, one per body row
+screen <Name> ["what this view is for"]   // one per view; description renders as a subtitle
+  navbar "App | Nav1 | Nav2"     // top bar; pipe-separated; bell+avatar added automatically
+  sidebar "Item1 | Item2"        // left rail; same items on every screen of the app
+  <kind> "<label>" [WxH] [variant] [-> Screen]   // a block: stacks below the previous one
+  row                            // children go side by side (equal shares, 16px gaps)
+    <kind> "<label>" …
+    right                        // everything after this packs to the right edge
+    <kind> "<label>" …
+  split 60/40                    // two columns + automatic vertical divider
+    left
+      <blocks…>                  // each column is its own stack (rows allowed)
+    right
+      <blocks…>
+  card "Title"                   // a card with nested children lays them out inside
+    <elements…>                  //   …a badge child docks to the card's top-right
+  table "Col1 | Col2" [-> Screen]
+    row "cell | cell"            // table data — quoted `row` lines belong to the table
 ```
 
-Give every screen a **description** — a short quoted phrase after the name
-saying what the view is for and who uses it. It renders as a subtitle under the
-title and is the fastest way to make a wireframe self-explanatory:
-`screen ReviewQueue "Managers approve or reject pending requests"`.
+**The six rules of layout** (everything else is automatic):
+
+1. Blocks **stack** top-to-bottom in the order you write them.
+2. `row` puts children **side by side** — flexible things (cards, inputs,
+   selects, charts, tables) share the width equally; small things (badges,
+   buttons) keep their natural size. A row can never overflow.
+3. `right` inside a row **right-aligns** what follows — header CTAs, the
+   search+filter pair, footer Cancel/Save (primary rightmost).
+4. `split N/M` + `left`/`right` makes **two columns** with the divider drawn
+   for you.
+5. Children indented under a `card` render **inside** it; the card grows to
+   fit; a `badge` child docks to its top-right corner.
+6. `WxH` is optional and rarely needed (a taller `chart "…" 600x260`); widths
+   are clamped to fit. The screen grows downward if content is long.
 
 **Navigation** is attached to the control that triggers it: put `-> ScreenName`
-at the end of the button (or link) that leads there, and the compiler draws a
-`→ Screen N · ScreenName` marker beside it. This is how you show the flow
-between screens — usually on buttons like "View", "Open", "Continue",
-"Checkout". Leave a little empty space to the right of a navigating button so
-the marker has room. The target must be a `screen` name that exists.
+at the end of the button (or link, or table) that leads there, and the compiler
+draws a `→ Screen N · ScreenName` marker beside it. The target must be a
+`screen` name that exists. When two buttons sit in a row, put the `->` on the
+primary/forward one.
+
+Syntax is validated at write time: an unknown keyword, a misplaced
+`left`/`right`/table-`row`, or old-style x,y coordinates rejects the write with
+line numbers (`INVALID_DSL`) — fix every listed line and re-emit the file.
 
 ### Element kinds
 
-Chrome & structure
+Chrome & structure: `navbar`, `sidebar`, `tabs` (`"A | B | C"`, first active),
+`breadcrumb` (`"Projects / Acme / Settings"`), `divider` (a horizontal rule;
+column dividers come from `split` automatically).
 
-| Kind | Use for | Default size |
-|---|---|---|
-| `navbar` | app top bar (first line of every screen); `\|`-separated items | full width × 56 |
-| `sidebar` | section navigation rail; `\|`-separated items | 240 × full height |
-| `tabs` | in-page section switcher; `\|`-separated, first shown active | 480×40 |
-| `breadcrumb` | trail like `"Projects / Acme / Settings"` | auto |
-| `divider` | a rule between sections — horizontal, or **vertical** when taller than wide (`1x420`, e.g. between two columns) | width×1 |
+Content & data:
 
-Content & data
+| Kind | Use for |
+|---|---|
+| `heading` | page / section titles (renders large with an underline rule) |
+| `text` | body copy, values, helper text |
+| `link` | inline navigation text (renders blue) |
+| `card` | stat tile — `"Open items \| 47 \| across 5 audits"` (label, BIG value, caption); one-part label = a panel; nested children = a container |
+| `table` | data grids; label = `\|`-separated headers; nested `row "…"` lines for data |
+| `list` | stacked rows (feed, comments, nav); `\|`-separated items |
+| `image` | logos, photos, media slots (renders a crossed box) |
+| `chart` | data viz placeholder (renders axes + bars) |
+| `progress` | progress bar; label `"60%"`/`"3/4"` sets the fill |
+| `badge` | status pills — `"Open"`, `"Overdue"` (color via variant) |
+| `avatar` | a person — label `"Jane Doe"` renders initials `JD` |
+| `icon` | a small glyph slot; label is 1–2 chars |
 
-| Kind | Use for | Default size |
-|---|---|---|
-| `heading` | page / section titles (renders large with an underline rule) | auto |
-| `text` | body copy, values, helper text | auto |
-| `link` | inline navigation text (renders blue) | auto |
-| `card` | stat tile — `"Open items \| 47 \| across 5 projects"` (label, BIG value, caption); a one-part label is a plain panel/container | 300×160 |
-| `table` | data grids; label = `\|`-separated headers; add `row` lines for data | 640×240 |
-| `list` | stacked rows (feed, comments, nav); `\|`-separated items | 320 × n·40 |
-| `image` | logos, photos, media slots (renders a crossed box) | 240×140 |
-| `chart` | data viz placeholder (renders axes + bars) | 320×180 |
-| `progress` | progress bar; label as `"60%"`/`"3/4"`/`"0.6"` sets the fill | 240×10 |
-| `badge` | status pills — `"Open"`, `"Overdue"`, `"Live"` (color via variant) | auto |
-| `avatar` | a person — label `"Jane Doe"` renders initials `JD` | 40×40 |
-| `icon` | a small glyph slot; label is 1–2 chars | 24×24 |
-
-Inputs & controls
-
-| Kind | Use for | Default size |
-|---|---|---|
-| `input` | text field; label is the placeholder | 320×36 |
-| `textarea` | multi-line field | 320×96 |
-| `select` | dropdown (renders a ▾) | 320×36 |
-| `search` | search box (renders a ⌕) | 320×36 |
-| `button` | actions; the bottom-most button gets the flow marker | 140×40 |
-| `checkbox` / `radio` | options; add `active` variant to show it selected | auto |
-| `toggle` | on/off switch; add `active` variant for on | 44×24 |
-
-Generic (use only when nothing above fits)
-
-| Kind | Use for | Default size |
-|---|---|---|
-| `rect` / `ellipse` | a container or shape with no better primitive | 160×32 |
+Inputs & controls: `input` (label = placeholder), `textarea`, `select`
+(renders ▾), `search` (renders ⌕), `button`, `checkbox` / `radio` / `toggle`
+(add `active` to show selected/on). Generic `rect` / `ellipse` only when
+nothing above fits.
 
 ### Color
 
-The compiler already applies the Oxygen theme: white/neutral surfaces, the WSO2
-brand orange on the active navbar/sidebar item, and orange section-heading
-rules. You don't set any of that — it's automatic.
+The compiler applies the Oxygen theme automatically: white/neutral surfaces,
+brand orange on the active navbar/sidebar item and section-heading rules. You
+add color only through a trailing **variant**, to carry *status meaning*:
 
-You add color only through a trailing **variant** on an element, to carry
-*status meaning*: `primary`, `secondary`, `danger`, `success`, `warning`,
-`info`, `ai`, `active`, `muted`.
-
-- `primary` on the ONE main action per screen (`button "Create" ... primary`)
-  — fills brand orange. Every other button stays a plain outline.
+- `primary` on the ONE main action per screen — fills brand orange. Every
+  other button stays a plain outline.
 - `danger` / `success` / `warning` / `info` on a `badge` or destructive
-  `button` to signal status or severity (`badge "Overdue" ... danger`).
-- `ai` (purple) reserved for an automated / AI-driven step, if the product has
-  one.
+  `button` (`badge "Overdue" danger`).
+- `ai` (purple) for an automated / AI-driven step, if the product has one.
 - `active` marks a `checkbox` / `radio` / `toggle` as selected / on.
+- `muted` for de-emphasized text (an eyebrow label).
 
 Keep status variants purposeful — a screen dense with red/green/amber badges
-stops communicating. Let the theme carry the "product" feel; use variants for
-the handful of things that genuinely signal state.
+stops communicating.
 
-### Layout rules
+### Consistency rules
 
-The platform **validates layout at write time**: an element outside the frame,
-under the navbar/sidebar, or partially overlapping another is rejected with a
-`LAYOUT_VIOLATION` error listing the exact coordinates — fix them and retry.
-(Fully nesting one element inside another — a badge inside a card — is
-layering and always allowed.)
-
-- **Everything stays inside the screen.** The frame is 1280×800. Every element's
-  right edge (`x + width`) must be ≤ **1240** (a 40px right margin) and its
-  bottom (`y + height`) ≤ **760**; nothing extends past the frame. For anything
-  right-aligned — a header filter `select`, a top-right button, a footer action
-  — compute its `x` from the edge (`x = 1240 − width`), never by eyeballing a
-  large number. Elements without an explicit `WxH` get a DEFAULT size (a
-  `chart` is 320 wide, a `select` 320) — placing one near the right edge
-  without a size makes it overflow, so always give near-edge elements an
-  explicit `WxH`. Check `x + width ≤ 1240` for every element on the right or
-  bottom edge before finishing.
-- **Header search + filter: use these exact slots** (this pair is the most
-  common collision — don't re-derive it):
-  - With a sidebar: `search "…" 820,104 240x36` then `select "…" 1076,104 164x36`
-    (search ends 1060, filter ends 1240 — 16px gap).
-  - Without a sidebar: `search "…" 780,104 280x36` then `select "…" 1076,104 164x36`.
-- **Filter chips / badge rows: give every `badge` an explicit width and place
-  the next chip from it.** A `badge` with no `WxH` auto-sizes to its label, so
-  its real width is a guess — and guessed chips collide. Width a chip at
-  roughly `10 × characters + 30` and start the next chip at the previous
-  chip's `x + width + 12`: `badge "All (18)" 280,150 110x24`,
-  `badge "Overdue (2)" 402,150 140x24`, `badge "Changes requested (3)" 554,150 250x24`.
-- **Nothing sits under the navbar.** The `navbar` fills the top band of every
-  screen (frame-relative `y` 0–56). So the FIRST content element — including any
-  muted eyebrow/label above the heading — starts at `y ≥ 72`. The most common
-  overlap is an eyebrow crammed above an `y≈80` heading at `y≈52`, which slips
-  under the bar: put the eyebrow at `y≈76` and the heading at `y≈104` instead.
-- **The left margin depends on whether the screen has a sidebar.** Then:
-  - **With a `sidebar`** (a 240px left rail): content starts at `x ≥ 264` and
-    full-width elements (tables/charts) are ~940 wide.
-  - **Without a sidebar**: content starts at `x ≈ 40` — a plain page margin —
-    and uses the FULL width (full-width elements ~1200 wide). Do **not** indent
-    to `x=280` when there is no sidebar; that leaves a dead empty strip on the
-    left where the missing rail would be. Either add a sidebar to fill it or
-    start at `x≈40`.
-- **One primary navigation, not two.** Pick where the section links live and
-  put them in exactly one place:
-  - **Sidebar app** (content-heavy tools, admin consoles, dashboards): the
-    `sidebar` holds the section links, and the `navbar` carries ONLY the app /
-    brand name — e.g. `navbar "Acme"`. The compiler adds the
-    notification bell + account avatar to the right of the navbar automatically,
-    so a brand-only bar is complete. **Do not repeat the sidebar's links in the
-    navbar** — that's the duplicated top+left nav that reads as a bug.
-  - **Top-nav app** (simple public flows — storefront, checkout, marketing):
-    the `navbar` holds the links (`navbar "Shop | Cart | Account"`) and there is
-    **no `sidebar`**.
-  Choose one model per app and keep it consistent across every screen —
-  **including role-specific and scoped screens**. The `sidebar` is identical
-  (same items, same order) on all of them; a screen never gets its own shorter
-  sidebar. With a sidebar, EVERY screen's content starts at `x ≥ 264` — content
-  at `x≈40` on a screen that has a sidebar lands on top of the rail.
-- Stack vertically with 16–24px gaps; align related elements to the same `x`;
-  give a row of cards/inputs the same `y` and width. Keep everything inside the
-  screen and never overlapping.
-- **Right-align a screen's action buttons.** A form or dialog's footer buttons
-  (Cancel / Save, Back / Continue) sit at the **bottom-right** of that form —
-  the primary action rightmost — not at the left. Compute their `x` from the
-  right edge of the content, not the left. A single page-level CTA ("New", "Add
-  …") goes top-right. When two buttons sit side by side, put the `-> Screen`
-  nav marker only on the **primary/forward** one (a marker on the left button
-  would collide with the button to its right); a Cancel/Back button rarely
-  needs a marker.
+- **One primary navigation, not two.** A content-heavy tool (admin console,
+  dashboard app) uses the `sidebar` for section links and a brand-only
+  `navbar` (`navbar "Acme"`). A simple public flow (storefront, checkout) uses
+  a link-carrying `navbar` and **no sidebar**. Never both on one screen.
 - Repeat the SAME `navbar` (and `sidebar`) verbatim on every screen of one app
   — consistent chrome is what makes screens read as one product.
-- Comments start with `//`. `-> Screen` targets must match a `screen` name
-  exactly; every screen should be reachable from some control.
+- Comments start with `//`. Every screen should be reachable from some
+  control's `-> Screen`.
 
 Read `references/wireframes-dsl-example.md` for a complete worked example
 before writing your first wireframe.
@@ -380,5 +275,6 @@ before writing your first wireframe.
 
 The DSL is line-oriented, so `editFile` works naturally: anchor on the
 `screen <Name>` line plus the element line you're changing. Add a screen by
-appending a new `screen` block and its `flow` edges. Add table data by
-inserting `row` lines directly under the `table`.
+appending a new `screen` block. Add table data by inserting `row` lines under
+the `table`. Insert a new element by adding its line where it should appear in
+the stack — everything below it moves down automatically.

--- a/skills/excalidraw-wireframes/references/wireframes-dsl-example.md
+++ b/skills/excalidraw-wireframes/references/wireframes-dsl-example.md
@@ -1,68 +1,81 @@
 # Worked example — risk register webapp wireframes
 
 A complete `wireframes.dsl` for a three-screen desktop flow. Note the rhythm:
-every screen repeats the same `navbar` + `sidebar` (consistent chrome); content
-sits right of the sidebar (`x ≥ 280`) and below the navbar (`y ≥ 80`); rows of
-cards share a `y` and width; the primary action is the one colored `button`
-(`primary`), and status is carried by `badge`s, not prose.
+every screen repeats the same `navbar` + `sidebar` (consistent chrome); blocks
+stack in reading order; `row` groups things side by side; the primary action is
+the one `primary` button per screen; status is carried by `badge`s, not prose.
+No coordinates anywhere — the compiler computes every position.
 
 ```
-// Risk register — three screens, desktop 1280x800
+// Risk register — three screens, desktop
 
 screen RiskDashboard "Managers monitor open risk and act on what's overdue"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  heading "Risk Overview" 280,80
-  card "Open risks: 24" 280,130 300x110
-  card "Overdue actions: 6" 600,130 300x110
-  card "High severity: 3" 920,130 300x110
-  heading "Recent activity" 280,272
-  tabs "All | Mine | Watching" 280,312 480x36
-  table "Risk | Owner | Severity | Status | Updated" 280,360 940x220
+  row
+    heading "Risk Overview"
+    right
+    button "New risk" primary -> NewRisk
+  row
+    card "Open risks | 24 | across 6 registers"
+    card "Overdue actions | 6 | need follow-up"
+    card "High severity | 3 | review this week"
+  heading "Recent activity"
+  tabs "All | Mine | Watching"
+  table "Risk | Owner | Severity | Status | Updated" -> RiskDetail
     row "Unpatched edge servers | Platform team | High | Open | 2h ago"
     row "Stale access keys | Security | Medium | In review | 1d ago"
     row "Vendor SOC2 lapse | Compliance | High | Overdue | 3d ago"
-  button "New risk" 1080,80 140x40 primary -> NewRisk
 
 screen NewRisk "An owner logs a new risk into a register"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / New risk" 280,80
-  heading "New Risk" 280,108
-  text "Title" 280,158
-  input "e.g. Unpatched edge servers" 280,180 640x36
-  text "Description" 280,232
-  textarea "What is the risk and why does it matter?" 280,254 640x96
-  text "Register" 280,372
-  select "Infrastructure" 280,394 300x36
-  text "Owner" 620,372
-  select "Platform team" 620,394 300x36
-  text "Impact" 280,450
-  select "High" 280,472 300x36
-  text "Likelihood" 620,450
-  select "Likely" 620,472 300x36
-  checkbox "Notify owner on create" 280,532 300x20 active
-  button "Cancel" 600,584 140x40
-  button "Create risk" 760,584 160x40 primary -> RiskDashboard
+  breadcrumb "Risks / New risk"
+  heading "New Risk"
+  input "Title — e.g. Unpatched edge servers"
+  textarea "What is the risk and why does it matter?"
+  row
+    select "Register: Infrastructure"
+    select "Owner: Platform team"
+  row
+    select "Impact: High"
+    select "Likelihood: Likely"
+  checkbox "Notify owner on create" active
+  row
+    right
+    button "Cancel"
+    button "Create risk" primary -> RiskDashboard
 
 screen RiskDetail "The owner tracks remediation for one risk"
   navbar "RiskHub"
   sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / Unpatched edge servers" 280,80
-  heading "Unpatched edge servers" 280,108
-  badge "High" 640,114 70x26 danger
-  badge "Open" 720,114 70x26 info
-  text "Owner: Platform team — Updated 2h ago" 280,152
-  avatar "Priya Rao" 280,184 40x40
-  text "Priya Rao, Platform team" 332,196
-  heading "Remediation" 280,248
-  progress "60%" 280,288 640x12 info
-  text "6 of 10 actions complete" 280,308
-  table "Action | Assignee | Due | Status" 280,344 940x180
-    row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
-    row "Rotate edge certs | M. Diaz | Mon | In progress"
-    row "Close inbound 8443 | Platform | Tue | To do"
-  button "Update status" 1060,576 160x40 primary
+  breadcrumb "Risks / Unpatched edge servers"
+  row
+    heading "Unpatched edge servers"
+    badge "High" danger
+    badge "Open" info
+  text "Owner: Platform team — Updated 2h ago"
+  split 60/40
+    left
+      heading "Remediation"
+      progress "60%" info
+      text "6 of 10 actions complete"
+      table "Action | Assignee | Due | Status"
+        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+        row "Rotate edge certs | M. Diaz | Mon | In progress"
+        row "Close inbound 8443 | Platform | Tue | To do"
+      row
+        right
+        button "Update status" primary
+    right
+      card "Discussion"
+        text "K. Smith · 2d: when does the cert rotation land?"
+        text "M. Diaz · 1d: Monday, after the freeze."
+        textarea "Add a comment…"
+        button "Post" primary
+      heading "Activity"
+      text "2h ago — A. Chen closed CVE-2026-1"
+      text "1d ago — M. Diaz started cert rotation"
 ```
 
 Checklist before finishing a wireframe file:
@@ -72,15 +85,15 @@ Checklist before finishing a wireframe file:
   screen per role, named and described for it.
 - Every screen has a one-line description saying what it's for.
 - Chrome (`navbar`, `sidebar`) is identical across screens of the same app.
-- Content stays inside the screen, right of the sidebar, below the navbar;
-  rows of cards/inputs share a `y` and width; nothing overlaps.
-- Labels are content-bearing ("Open risks: 24", "Platform team", "Overdue"),
-  never placeholders like "text" or "label".
+- Labels are content-bearing ("Open risks | 24 | across 6 registers",
+  "Platform team", "Overdue"), never placeholders like "text" or "label".
 - The right primitive does each job — `badge` for status, `tabs` for section
   switching, `avatar` for people, `progress` for completion, `table` + `row`
   for real data.
 - Color is rare and meaningful: one `primary` action per screen, plus the odd
-  status `badge`. If more than ~3 things are colored, pull some back to gray.
-- Navigation is on the control that triggers it: the button/link that leads to
-  another screen ends with `-> ScreenName`, and every `-> ScreenName` target
-  matches a real `screen`. Leave room to the right of a navigating button.
+  status `badge`.
+- Navigation is on the control that triggers it: the button/link/table that
+  leads to another screen ends with `-> ScreenName`, and every target matches
+  a real `screen`.
+- NO coordinates and no manual sizes unless an element truly needs one — the
+  layout comes from stacking, `row`, and `split`.


### PR DESCRIPTION
## What

Replaces the wireframes coordinate DSL with a **flow dialect**: the agent writes structure and content; the compiler computes every pixel. Overlap and out-of-frame become **inexpressible** instead of validated — removing the gate-driven redraw loop (#215's follow-up) at the root.

## Why

The coordinate dialect made the agent be the layout engine: every element line carried an absolute `x,y` (+ often `WxH`), so overlap-freedom was a global arithmetic constraint over all element pairs — including widths the model could only guess (auto-sized badges, default-sized charts). Every gate rejection traced in real turns was a width-guess or edge-arithmetic slip, and even with precomputed slot guidance a generation took 1–5 rejected redraws. The machine should do the arithmetic.

## The dialect

Six constructs (line-oriented, indent-nested; kinds/labels/variants/`-> Screen`/table `row "…"` all carry over; **no `x,y` anywhere**):

1. **Vertical stack** (default) — blocks land below each other, consistent gaps.
2. **`row`** — children side by side; flexible kinds share the remaining width equally, small kinds keep intrinsic size, and everything shrinks to fit: a row cannot overflow.
3. **`right`** — packs the rest of a row against the content edge (header CTAs, search+filter, footer buttons).
4. **`split N/M`** + `left`/`right` — two independent column stacks with the vertical divider drawn automatically.
5. **Card nesting** — children indented under a `card` render inside it; the card auto-grows; a `badge` child docks top-right.
6. **`WxH` optional** — clamped to the column; the frame auto-grows downward.

## How

- **Compiler** (`@aep/excalidraw-dsl`): indent-tree parser + a pure layout pass resolving every box; the renderer is untouched (it already consumed resolved boxes, and stable element ids keep streaming `updateScene` diffs clean). The old coordinate dialect errors with a "regenerate the wireframes" message.
- **Write-gate**: `LAYOUT_VIOLATION` (arithmetic) retires; the same `FileBundle.commit()` seam now gates **syntax strictly** — an unknown keyword, a misplaced `left`/`right`/table-`row`, or retired coordinates aborts with `INVALID_DSL` + line numbers, because the tolerant compile path (needed for streamed prefixes) would otherwise silently drop a typo'd line. **Ported to the Go fold** (`agentfold/dslgate.go`): the Go fold re-executes tool-calls for D14 parity, so a TS-only gate would diverge on rejected-then-retried writes and fail healthy turns at the manifest check.
- **Skill**: full rewrite — every coordinate rule deleted (edge formulas, header slots, chip-width arithmetic, two-column coordinates); teaches the six constructs and keeps the content/anatomy guidance. Worked example, console mock fixture, and all test fixtures re-dialected.

## Verification

- `@aep/excalidraw-dsl` **45/45**, including an **invariant property test**: #215's overlap validator is retained as the oracle asserting flow output never overlaps and never leaves the frame.
- `@aep/agent-stream` 69/69 · `@aep/agents` 144/144 · console spec suite 41/41 + tsc clean · Go fold suite (incl. TS↔Go gate verdict parity cases) + `go build`/`go vet` clean.
- e2e on the local compose stack: generation draws the screens **once**, top-to-bottom, streaming live — zero layout retries (previously 1–5 redraws with rollbacks); old coordinate files report "regenerate to view".

Design record: `docs/superpowers/specs/2026-07-12-wireframe-flow-dsl-design.md` (repo-untracked scratch spec; happy to move it into `packages/excalidraw-dsl/design/` if wanted).

Follow-up to #215 · Refs #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
