### PR TITLE
fix(auth): long-lived SPA token + working logout against Thunder

### DIFF
--- a/deployments/single-cluster/resource-types/thunder-app/operator/internal/thunder/client.go
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/internal/thunder/client.go
@@ -417,12 +417,20 @@ var (
 	allowedUserTypes = []string{"Person"}
 )
 
-// tokenClaimConfig returns the oauth2 `token` block (per-token userAttributes).
-// A fresh map per call so each app payload owns its copy.
+// tokenValiditySeconds is the access/id token lifetime (24h). Thunder's default
+// is short; a SPA whose token expires quickly is forced back through a full
+// sign-in redirect (or a silent renew) far too often, so pin a long-lived token
+// — the same 86400 the seeded Console app uses. The SPA still refreshes via the
+// refresh_token grant; this just keeps a returning user signed in across a
+// refresh/new tab without a round-trip.
+const tokenValiditySeconds = 86400
+
+// tokenClaimConfig returns the oauth2 `token` block (per-token validity +
+// userAttributes). A fresh map per call so each app payload owns its copy.
 func tokenClaimConfig() map[string]any {
 	return map[string]any{
-		"accessToken": map[string]any{"userAttributes": identityUserAttributes},
-		"idToken":     map[string]any{"userAttributes": identityUserAttributes},
+		"accessToken": map[string]any{"validityPeriod": tokenValiditySeconds, "userAttributes": identityUserAttributes},
+		"idToken":     map[string]any{"validityPeriod": tokenValiditySeconds, "userAttributes": identityUserAttributes},
 	}
 }
 

--- a/deployments/single-cluster/resource-types/thunder-app/operator/internal/thunder/client_test.go
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/internal/thunder/client_test.go
@@ -304,6 +304,12 @@ func assertIdentityClaimContract(t *testing.T, body map[string]any) {
 		if !anySliceHas(sub["userAttributes"], "groups") {
 			t.Errorf("token.%s.userAttributes = %v, want to include %q (drives role-based UI)", kind, sub["userAttributes"], "groups")
 		}
+		// A long-lived token keeps a returning SPA user signed in across a
+		// refresh/new tab; dropping validityPeriod reverts to Thunder's short
+		// default and reintroduces the every-visit re-login.
+		if sub["validityPeriod"] == nil {
+			t.Errorf("token.%s.validityPeriod missing — SPA session would expire on Thunder's short default", kind)
+		}
 	}
 	sc, _ := cfg["scopeClaims"].(map[string]any)
 	if !anySliceHas(sc["group"], "groups") {

--- a/services/aep-api/skills/embedded/thunder-authentication/SKILL.md
+++ b/services/aep-api/skills/embedded/thunder-authentication/SKILL.md
@@ -65,6 +65,10 @@ instead of deriving it from YOUR dependency name) produces a
   token by posting the refresh token to that endpoint — no hidden iframe, no
   third-party-cookie dependency. This is what `automaticSilentRenew` and
   `signinSilent()` use to keep a signed-in user signed in.
+- Thunder does NOT advertise an `end_session_endpoint` (its discovery doc lists
+  only issuer, authorize, and token). So RP-initiated logout via
+  `signoutRedirect()` rejects — sign-out drops the local session
+  (`removeUser()`) and reloads instead.
 - The signed-in user's identity claims ride in the ID TOKEN, surfaced by
   `oidc-client-ts` as `user.profile`: `groups` (their role/group memberships)
   and `ouId`/`ouName`/`ouHandle` (their organization), beside standard
@@ -212,8 +216,19 @@ export const userManager = new UserManager({
 });
 
 export async function signIn()         { await userManager.signinRedirect(); }
-export async function signOut()        { await userManager.signoutRedirect(); }
 export async function handleCallback() { return userManager.signinRedirectCallback(); }
+
+// Sign the user out. Thunder advertises no end_session_endpoint, so
+// signoutRedirect() rejects; fall back to dropping the LOCAL session and
+// reloading — the load-time guard then starts a fresh sign-in.
+export async function signOut() {
+  try {
+    await userManager.signoutRedirect();
+  } catch {
+    await userManager.removeUser();
+    window.location.assign("/");
+  }
+}
 
 // Return the current user, renewing a persisted-but-expired session SILENTLY
 // via the refresh token (no redirect). Returns null only when there is no
@@ -297,3 +312,4 @@ export async function listTodos() {
 | After login, "invalid redirect URI" | `redirect_uri` doesn't match the `<origin>/callback` URL the platform registered (e.g. an invented redirect-URI key) | Compute `window.location.origin + '/callback'`. |
 | Sign-in loops endlessly even at the right path | `oidc-client-ts` written without a persistent `WebStorageStateStore` (in-memory default) | Use `WebStorageStateStore({ store: localStorage })` as shown; without persistent web storage the state and PKCE verifier don't survive the redirect. |
 | User is sent to the login screen on every visit / new tab | Session kept in `sessionStorage` (per-tab, wiped on close), or the load path calls `signIn()` on an expired token instead of renewing it | Store the session in `localStorage` and enable `automaticSilentRenew`; on load renew via `signinSilent()` (refresh token) and only `signIn()` when there is no session to renew. |
+| Logout button does nothing | `signOut()` calls only `signoutRedirect()`, which rejects because Thunder has no `end_session_endpoint` — and the click handler swallows the rejection | Wrap `signoutRedirect()` in a try/catch that falls back to `removeUser()` + `window.location.assign('/')` (shown in the `signOut` above); local sign-out always works. |

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -65,6 +65,10 @@ instead of deriving it from YOUR dependency name) produces a
   token by posting the refresh token to that endpoint — no hidden iframe, no
   third-party-cookie dependency. This is what `automaticSilentRenew` and
   `signinSilent()` use to keep a signed-in user signed in.
+- Thunder does NOT advertise an `end_session_endpoint` (its discovery doc lists
+  only issuer, authorize, and token). So RP-initiated logout via
+  `signoutRedirect()` rejects — sign-out drops the local session
+  (`removeUser()`) and reloads instead.
 - The signed-in user's identity claims ride in the ID TOKEN, surfaced by
   `oidc-client-ts` as `user.profile`: `groups` (their role/group memberships)
   and `ouId`/`ouName`/`ouHandle` (their organization), beside standard
@@ -212,8 +216,19 @@ export const userManager = new UserManager({
 });
 
 export async function signIn()         { await userManager.signinRedirect(); }
-export async function signOut()        { await userManager.signoutRedirect(); }
 export async function handleCallback() { return userManager.signinRedirectCallback(); }
+
+// Sign the user out. Thunder advertises no end_session_endpoint, so
+// signoutRedirect() rejects; fall back to dropping the LOCAL session and
+// reloading — the load-time guard then starts a fresh sign-in.
+export async function signOut() {
+  try {
+    await userManager.signoutRedirect();
+  } catch {
+    await userManager.removeUser();
+    window.location.assign("/");
+  }
+}
 
 // Return the current user, renewing a persisted-but-expired session SILENTLY
 // via the refresh token (no redirect). Returns null only when there is no
@@ -297,3 +312,4 @@ export async function listTodos() {
 | After login, "invalid redirect URI" | `redirect_uri` doesn't match the `<origin>/callback` URL the platform registered (e.g. an invented redirect-URI key) | Compute `window.location.origin + '/callback'`. |
 | Sign-in loops endlessly even at the right path | `oidc-client-ts` written without a persistent `WebStorageStateStore` (in-memory default) | Use `WebStorageStateStore({ store: localStorage })` as shown; without persistent web storage the state and PKCE verifier don't survive the redirect. |
 | User is sent to the login screen on every visit / new tab | Session kept in `sessionStorage` (per-tab, wiped on close), or the load path calls `signIn()` on an expired token instead of renewing it | Store the session in `localStorage` and enable `automaticSilentRenew`; on load renew via `signinSilent()` (refresh token) and only `signIn()` when there is no session to renew. |
+| Logout button does nothing | `signOut()` calls only `signoutRedirect()`, which rejects because Thunder has no `end_session_endpoint` — and the click handler swallows the rejection | Wrap `signoutRedirect()` in a try/catch that falls back to `removeUser()` + `window.location.assign('/')` (shown in the `signOut` above); local sign-out always works. |


### PR DESCRIPTION
Two generic auth-UX defects seen in freshly generated apps (audit-evidence-hub-13). Both root causes verified against the cluster and the generated source; neither was fixable by app-code alone.

## 1. Re-login on every page refresh — `thunder-app` operator
The operator provisioned the SPA's OAuth client with **no token `validityPeriod`**, so tokens took Thunder's short default TTL and expired almost immediately — every refresh fell through to a full sign-in redirect. (The generated `auth.ts` was already correct: `localStorage` + `automaticSilentRenew`.)

**Fix:** pin `validityPeriod: 86400` (24h) on both access + id tokens (`token.accessToken`/`idToken.validityPeriod`, camelCase Thunder API), matching the seeded AEP Console app. Refresh-token renewal still applies; this just stops the constant round-trips. A test now asserts `validityPeriod` is present (mirrors the existing `refresh_token` guard).

## 2. Logout button did nothing — `thunder-authentication` skill
Thunder advertises **no `end_session_endpoint`** (discovery doc lists only issuer/authorize/token), so `oidc-client-ts` `signoutRedirect()` rejects and the click is a silent no-op.

**Fix:** the skill's `signOut()` now falls back to a local `removeUser()` + reload when `signoutRedirect()` rejects — mirroring the AEP Console's own `AuthGuard` (the proven pattern). Added the platform fact + a pitfall row.

## Verification
- Operator: `go build` / `go vet` / `go test ./internal/thunder/` all pass in `golang:1.26` (host toolchain is broken locally); new `validityPeriod` assertion green.
- Rebuilt + k3d-imported the operator and rebuilt `aep-api` (embeds the skill) into the local `openchoreo` cluster — both healthy. Re-vendored `skills/embedded/` (CI `vendor-skills-check` enforces parity).

## Not in this PR
- The employee-service directory refresh (BUG 1, `?username=` discovery contract) is a demo-repo + cluster change, already applied to the running org (demo PR #3/#4, merged).
- Existing generated apps won't retroactively improve — a fresh generation picks all this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte