### PR TITLE
Spec views: the collab doc is the source; git is the collab-less base

### DIFF
--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -48,6 +48,7 @@ import { toSpecEntry } from "../api/mapping";
 import { useCollabSpec } from "../collab/useCollabSpec";
 import { CollabTextArea } from "../collab/CollabTextArea";
 import { SpecMdEditor } from "../collab/SpecMdEditor";
+import { useYTextString } from "../collab/useYTextString";
 import { AddArtifactDialog } from "./AddArtifactDialog";
 import { BuildDependencyDrawer } from "./BuildDependencyDrawer";
 import { SpecFileList } from "./SpecFileList";
@@ -206,9 +207,31 @@ export function SpecView({ projectName }: { projectName: string }) {
       ? collab.getFileText(selectedFile.path)
       : null;
   const usesCollab = Boolean((fragment && collab.provider) || ytext);
+  // The collab doc is the SOURCE for the structured views while collab is up
+  // (the design.md rule): rooms are seeded with every committed specs/ file
+  // (non-md as Y.Text) and the agents service mirrors each applied write, so
+  // the doc always holds the freshest complete, gate-validated content — the
+  // committed file between turns, a new file before its commit lands, an
+  // EDITED file while the committed copy is stale. The committed fetch below
+  // stays for the collab-less base path only.
+  const structuredLiveText = useYTextString(
+    selectedFile && (isOpenApiFile || isComponentDesignFile)
+      ? collab.getFileText(selectedFile.path)
+      : null,
+  );
+  const structuredLive =
+    typeof structuredLiveText === "string" && structuredLiveText.trim().length > 0
+      ? structuredLiveText
+      : null;
   const content = useSpecFileContent(
     projectName,
-    selectedFile && (!usesCollab || isOpenApiFile || isComponentDesignFile)
+    selectedFile &&
+      (isOpenApiFile || isComponentDesignFile
+        ? // Doc has it → no fetch (mirrors usesCollab for md). An agent in
+          // the room also suppresses it: the doc WILL deliver the file, and
+          // probing git for a not-yet-committed path just sprays 404s.
+          !structuredLive && !agentInRoom
+        : !usesCollab)
       ? selectedFile
       : null,
   );
@@ -564,7 +587,15 @@ export function SpecView({ projectName }: { projectName: string }) {
                 // is reachable (#86 phase 5); solo-and-unsaved otherwise
                 // (#86 decision 10).
                 isOpenApiFile || isComponentDesignFile ? (
-                  content.data ? (
+                  structuredLive ? (
+                    // Fresh from the live collab doc — ahead of (or newer
+                    // than) the committed copy.
+                    isOpenApiFile ? (
+                      <OpenApiView spec={structuredLive} />
+                    ) : (
+                      <DesignView design={structuredLive} />
+                    )
+                  ) : content.data ? (
                     isOpenApiFile ? (
                       <OpenApiView
                         key={content.data.sha}
@@ -576,6 +607,22 @@ export function SpecView({ projectName }: { projectName: string }) {
                         design={content.data.content}
                       />
                     )
+                  ) : agentBusy ? (
+                    // Mid-generation the committed fetch is suppressed (the
+                    // doc will deliver the file) — "about to appear",
+                    // not a failure.
+                    <Box
+                      sx={{
+                        height: "100%",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        Waiting for the agent to write {selectedFile.path.split("/").at(-1)}…
+                      </Typography>
+                    </Box>
                   ) : content.isError ? (
                     <Alert
                       severity="error"

--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -106,13 +106,37 @@ describe("WireframePanel streaming", () => {
     expect(Number(screen.getByTestId("excalidraw").dataset.elements)).toBe(good);
   });
 
-  it("prefers the committed scene once it resolves (no streaming chip)", () => {
+  it("prefers the LIVE doc over a committed scene (an edit-turn's committed copy is stale)", () => {
     const committed = JSON.stringify({ elements: [{ type: "rectangle" }] });
     mockDerived.mockReturnValue({ scene: committed, isPending: false, isError: false });
     const doc = new Y.Doc();
     const ytext = doc.getText(DSL_PATH);
-    ytext.insert(0, 'screen Old "stale live text"\n');
+    ytext.insert(0, 'screen Fresh "the agent just rewrote this"\n  heading "New"\n');
+    renderPanel(makeCollab(ytext));
+
+    expect(screen.getByText("Drawing…")).toBeInTheDocument();
+    // renders the compiled live DSL (many elements), not the 1-element committed scene
+    expect(Number(screen.getByTestId("excalidraw").dataset.elements)).toBeGreaterThan(1);
+  });
+
+  it("renders the seeded doc content WITHOUT the chip when no agent is around", () => {
+    // Rooms are seeded with committed files, so browsing between turns reads
+    // the doc — the "Drawing…" chip must mean "agent generating", not that.
+    mockDerived.mockReturnValue({ scene: null, isPending: false, isError: true });
+    const doc = new Y.Doc();
+    const ytext = doc.getText(DSL_PATH);
+    ytext.insert(0, 'screen Catalog "Seeded committed content"\n  heading "Browse"\n');
     renderPanel(makeCollab(ytext, false));
+
+    expect(screen.queryByText("Drawing…")).not.toBeInTheDocument();
+    expect(Number(screen.getByTestId("excalidraw").dataset.elements)).toBeGreaterThan(0);
+  });
+
+  it("renders the committed scene when the live doc is empty (collab-less base path)", () => {
+    const committed = JSON.stringify({ elements: [{ type: "rectangle" }] });
+    mockDerived.mockReturnValue({ scene: committed, isPending: false, isError: false });
+    const doc = new Y.Doc();
+    renderPanel(makeCollab(doc.getText(DSL_PATH), false));
 
     expect(screen.queryByText("Drawing…")).not.toBeInTheDocument();
     expect(screen.getByTestId("excalidraw").dataset.elements).toBe("1");

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -37,14 +37,14 @@ export function WireframePanel({
   collab: CollabSpec;
 }) {
   const sha = files.find((f) => f.path === dslPath)?.sha;
-  const { scene, isPending, isError } = useDerivedWireframe(projectName, dslPath, sha);
 
-  // The committed file is authoritative. While it is not yet resolved (the
-  // agent is still writing wireframes.dsl, or the fetch is pending/failing
-  // mid-turn), fall back to the live DSL streaming into the collab doc so the
-  // screens draw piece-by-piece as the agent writes them — same pattern as
-  // CellDiagramPanel. Both paths feed the SAME compiler, so the streamed and
-  // committed renders match.
+  // The collab doc is the SOURCE while collab is up — the design.md rule.
+  // Rooms are seeded with every committed specs/ file (non-md as Y.Text), and
+  // the agents service mirrors each applied write, so the doc is always the
+  // freshest truth: the committed content between turns, the growing DSL
+  // during a generation, the edited DSL during an edit turn. The committed
+  // fetch below runs ONLY when the doc has nothing (collab offline / room not
+  // yet synced). Both paths feed the SAME compiler, so the renders match.
   const liveSource = useYTextString(collab.getFileText(dslPath));
   // The writer flushes on line boundaries, so the live text is whole lines —
   // but a mid-stream compile can still fail (e.g. a screen header typed ahead
@@ -58,10 +58,29 @@ export function WireframePanel({
     return lastGoodLive.current;
   }, [dslPath, liveSource]);
 
-  const derivedReady = !isPending && !isError && scene != null;
-  const streaming = !derivedReady && liveScene != null;
+  const streaming = liveScene != null;
   const agentBusy = collab.peers.some((p) => p.kind === "agent");
+  // Committed fetch: the collab-less base path only (mirrors `usesCollab`
+  // disabling the content query for markdown) — passing "" disables it. An
+  // agent in the room also suppresses it: the doc WILL deliver the file, and
+  // probing git for a not-yet-committed path just sprays retrying 404s.
+  const { scene, isPending, isError } = useDerivedWireframe(
+    projectName,
+    streaming || agentBusy ? "" : dslPath,
+    sha,
+  );
 
+  if (!streaming && agentBusy) {
+    // The committed fetch is suppressed while an agent is in the room (the
+    // doc will deliver the file) — "drawing about to start", not a failure.
+    return (
+      <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Typography variant="body2" color="text.secondary">
+          Waiting for the agent to draw the wireframes…
+        </Typography>
+      </Box>
+    );
+  }
   if (!streaming && isPending) {
     return (
       <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
@@ -70,17 +89,6 @@ export function WireframePanel({
     );
   }
   if (!streaming && isError) {
-    // Mid-generation the committed file may not exist yet; with an agent in
-    // the room that is "drawing about to start", not a failure.
-    if (agentBusy) {
-      return (
-        <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <Typography variant="body2" color="text.secondary">
-            Waiting for the agent to draw the wireframes…
-          </Typography>
-        </Box>
-      );
-    }
     return <Alert severity="error">Failed to load {dslPath}.</Alert>;
   }
   if (!streaming && !scene) {
@@ -97,7 +105,10 @@ export function WireframePanel({
   // (fillHeight) sets `flex: 1` on its own root inside the flex column.
   return (
     <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-      {streaming && (
+      {streaming && agentBusy && (
+        // The chip means "actively being generated", not "rendered from the
+        // live doc" — the doc is ALWAYS the source while collab is up (rooms
+        // are seeded), so gate the chip on the agent actually being in the room.
         <Box
           sx={{
             px: 1.5,


### PR DESCRIPTION
> **Stacked on #218** — contains its flow-DSL commit until that merges (this fix's wireframe test fixtures are written in the flow dialect). Review only the top commit: `fix(console): the collab doc is the source for spec views`.

## What

Adopts `design.md`'s source model for the same-file spec views — **wireframes, `design.json` overview, OpenAPI**: the collab doc renders whenever it holds the file; the committed files API is only the collab-less base path.

## Why

Three defects, one root cause (committed-first priority):

1. **`design.json` / OpenAPI had no collab read at all** — mid-generation they showed *"Failed to load specs/design/components/…/design.json"* until a manual page reload.
2. **The wireframe panel read committed-first** — an *edit* turn rendered the stale committed file for the whole turn (the fetch succeeds, so the live branch never activated; only fresh files streamed, and only because the 404 happened to unlock the fallback).
3. **The always-on committed probe sprayed retrying 404s** through every generation (React Query retry × refetch-on-focus against a path that can't exist yet) — visible as red rows in every DevTools session.

The premise that fixes all three: **rooms are seeded with every committed `specs/` file** (non-md as Y.Text) and the agents service mirrors each applied write — so the doc always holds the freshest, gate-validated content: the committed file between turns, the growing file during generation, the edited file during an edit turn. Committed git content isn't more authoritative than the doc; it's just older.

## How

- `SpecView` (structured views) + `WireframePanel`: render from `collab.getFileText(path)` whenever it has content; the committed query is disabled while the doc has the file **and** while an agent is in the room (the doc *will* deliver — probing git for an uncommitted path is pure noise). Mid-turn error states become *"Waiting for the agent to write …"*.
- The wireframe "Drawing…" chip now means *agent actively generating* (gated on the agent peer), not *rendered from the doc* — the doc is always the source, so the old condition would show it permanently.
- The cell diagram deliberately keeps committed-first: its live (`design.cell`) and committed (`design.json`-derived) sources are **different files** with a cross-file authority rule, not a freshness rule.
- Degradation: collab down → doc empty → the committed fetch enables and views render exactly as pre-collab; mid-session socket loss keeps rendering the local replica.

## Verification

- Console spec suite 43/43 (new: live-doc-beats-stale-committed on edit turns; seeded-doc render **without** the chip when no agent is around; committed base path when the doc is empty) · tsc clean · lint clean.
- e2e on the local stack: fresh generation renders `design.json`/OpenAPI/wireframes live with **zero per-file GETs and zero 404s for the entire turn** (previously multiple retrying 404s); plain browsing renders from the seeded doc; the one legitimate GET remains when collab is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
