### PR TITLE
feat(helm): deploy durable Temporal for the devflow on aepctl installs

### DIFF
--- a/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
+++ b/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
@@ -155,6 +155,19 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
               value: "postgresql://{{ .Values.postgres.user }}:$(POSTGRES_PASSWORD)@postgres.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.postgres.database }}"
+            {{- if .Values.temporal.enabled }}
+            # Temporal (devflow workflows). Points the in-process worker at the
+            # in-cluster temporal-frontend Service. Plain host:port — CoreDNS
+            # answers gRPC's SRV probe, so the compose `passthrough:///` scheme
+            # is not needed. Disabled (temporal.enabled=false) omits these so
+            # devflow is off: no worker starts and /devflows answers 503.
+            - name: TEMPORAL_HOSTPORT
+              value: {{ printf "temporal-frontend.%s.svc.cluster.local:7233" .Release.Namespace | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.temporal.namespace | quote }}
+            - name: TEMPORAL_TASKQUEUE
+              value: {{ .Values.temporal.taskQueue | quote }}
+            {{- end }}
           volumeMounts:
             - name: task-signing-key
               mountPath: /app/keys

--- a/deployments/helm-charts/platform/templates/temporal/deployment.yaml
+++ b/deployments/helm-charts/platform/templates/temporal/deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.temporal.enabled }}
+# Temporal server that drives the aep-api devflow workflows
+# (services/aep-api/internal/feature/devflow). aep-api runs the Temporal WORKER
+# in-process and dials this frontend via TEMPORAL_HOSTPORT (see the aep-api
+# Deployment). Unlike the setup.sh path (an in-memory `temporal server
+# start-dev`), this uses the temporalio/auto-setup image backed by the chart's
+# existing postgres StatefulSet, so workflow state is durable and survives a
+# Temporal pod restart. auto-setup creates the schema, creates the temporal +
+# temporal_visibility databases (SKIP_DB_CREATE=false), and registers the
+# `default` namespace on startup — all idempotently.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: temporal-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: temporal-frontend
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-aep
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: temporal-frontend
+  template:
+    metadata:
+      labels:
+        app: temporal-frontend
+        app.kubernetes.io/part-of: wso2-aep
+    spec:
+      containers:
+        - name: temporal
+          image: "{{ .Values.temporal.image }}"
+          imagePullPolicy: {{ .Values.temporal.imagePullPolicy }}
+          ports:
+            - containerPort: 7233
+              name: grpc
+          env:
+            # PostgreSQL persistence, reusing the chart's postgres StatefulSet.
+            # DB=postgres12 selects the pgx (PG 12+) driver — it is the driver
+            # name, not the server version (the chart runs postgres 16).
+            - name: DB
+              value: "postgres12"
+            - name: DB_PORT
+              value: "5432"
+            - name: POSTGRES_SEEDS
+              value: "postgres.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            # POSTGRES_PWD reuses the same secret aep-api/postgres already use.
+            # auto-setup issues CREATE DATABASE, which needs a role with
+            # `createdb`; the official postgres image creates POSTGRES_USER as a
+            # superuser, so this works as-is. If a hardened postgres without
+            # createdb is ever substituted, pre-create the two databases and set
+            # SKIP_DB_CREATE=true.
+            - name: POSTGRES_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secrets
+                  key: POSTGRES_PASSWORD
+            - name: DBNAME
+              value: {{ .Values.temporal.db.name | quote }}
+            - name: VISIBILITY_DBNAME
+              value: {{ .Values.temporal.db.visibilityName | quote }}
+            # SQL-backed visibility (no Elasticsearch).
+            - name: ENABLE_ES
+              value: "false"
+            - name: SKIP_DB_CREATE
+              value: "false"
+            # Namespace aep-api connects to (TEMPORAL_NAMESPACE). Must match the
+            # namespace value wired into the aep-api Deployment.
+            - name: DEFAULT_NAMESPACE
+              value: {{ .Values.temporal.namespace | quote }}
+          readinessProbe:
+            tcpSocket:
+              port: 7233
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources: {{ toYaml .Values.temporal.resources | nindent 12 }}
+{{- end }}

--- a/deployments/helm-charts/platform/templates/temporal/service.yaml
+++ b/deployments/helm-charts/platform/templates/temporal/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.temporal.enabled }}
+# ClusterIP for the Temporal frontend. aep-api reaches it in-cluster at
+# temporal-frontend.<namespace>.svc.cluster.local:7233 (plain DNS — the
+# docker-compose `passthrough:///` scheme is a docker embedded-DNS workaround
+# not needed here).
+apiVersion: v1
+kind: Service
+metadata:
+  name: temporal-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: temporal-frontend
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: wso2-aep
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7233
+      targetPort: 7233
+      name: grpc
+  selector:
+    app: temporal-frontend
+{{- end }}

--- a/deployments/helm-charts/platform/values.yaml
+++ b/deployments/helm-charts/platform/values.yaml
@@ -174,3 +174,30 @@ postgres:
     limits:
       cpu: "500m"
       memory: "512Mi"
+
+# Temporal workflow engine that drives the devflow workflows. aep-api runs the
+# worker in-process and dials the frontend below. Backed by the postgres
+# StatefulSet above (dedicated temporal / temporal_visibility databases), so
+# workflow state is durable across Temporal pod restarts. enabled=false turns
+# the whole feature off (no server deployed, no TEMPORAL_* env on aep-api, and
+# /devflows answers 503).
+temporal:
+  enabled: true
+  # Temporal namespace aep-api connects to; auto-setup registers it on startup.
+  namespace: "default"
+  # Task queue the in-process worker polls (matches the aep-api code default).
+  taskQueue: "aep-devflow"
+  # temporalio/auto-setup pinned to the server version used by
+  # deployments/scripts/setup-temporal.sh (admin-tools 1.29.7).
+  image: "temporalio/auto-setup:1.29.7"
+  imagePullPolicy: IfNotPresent
+  db:
+    name: "temporal"
+    visibilityName: "temporal_visibility"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"


### PR DESCRIPTION
Adds a durable Temporal to the `platform` chart so the Temporal-backed devflow works on **aepctl/Helm** installs. Previously `aep-api` had no `TEMPORAL_HOSTPORT`, so the worker never started and a Build answered `503 temporal_unavailable`.

Follows #137 (now merged), which introduced the Helm charts + aepctl.

## Change
- **`templates/temporal/{deployment,service}.yaml`** — `temporalio/auto-setup` backed by the chart's existing `postgres` StatefulSet (dedicated `temporal` + `temporal_visibility` databases). Workflow state is durable across Temporal pod restarts; auto-setup creates the schema/databases and registers the `default` namespace on startup.
- **`templates/aep-api/deployment.yaml`** — wire `TEMPORAL_HOSTPORT`/`NAMESPACE`/`TASKQUEUE` at the in-cluster service DNS.
- **`values.yaml`** — a `temporal` block, gated by `temporal.enabled` (default `true`).

## Verified (live k3d OpenChoreo cluster, aepctl install)
- auto-setup provisioned both databases on the existing Postgres.
- `aep-api` worker connected via the self-healing dial retry and polls the `aep-devflow` task queue.
- A Build from the console starts the `DevFlowWorkflow` instead of returning `temporal_unavailable`.