### PR TITLE
Stream the OpenAPI view live as the agent writes openapi.yaml

### DIFF
--- a/packages/ui/openapi-view/src/OpenApiView.tsx
+++ b/packages/ui/openapi-view/src/OpenApiView.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -41,6 +41,7 @@ import { ChevronDown, ChevronRight, Search, X } from "@wso2/oxygen-ui-icons-reac
 import {
   parseOpenApi,
   type Method,
+  type ParsedOpenApi,
   type Operation,
   type Param,
   type Response,
@@ -473,7 +474,14 @@ export interface OpenApiViewProps {
 }
 
 export function OpenApiView({ spec }: OpenApiViewProps) {
-  const parsed = useMemo(() => parseOpenApi(spec), [spec]);
+  // A STREAMED spec grows line by line; YAML's line-boundary prefixes almost
+  // always parse, but the odd one doesn't (e.g. cut inside a quoted scalar).
+  // Hold the last GOOD parse so a bad intermediate never flashes the error
+  // alert over already-rendered endpoints — the next flush repairs it.
+  const attempt = useMemo(() => parseOpenApi(spec), [spec]);
+  const lastGood = useRef<ParsedOpenApi | null>(null);
+  if (!("kind" in attempt)) lastGood.current = attempt;
+  const parsed = "kind" in attempt ? (lastGood.current ?? attempt) : attempt;
   const [query, setQuery] = useState("");
 
   if ("kind" in parsed) {

--- a/services/agents/src/collab/streaming-add.test.ts
+++ b/services/agents/src/collab/streaming-add.test.ts
@@ -150,7 +150,33 @@ test("streams a wireframes .dsl addFile incrementally, line-by-line, converging 
   assert.deepEqual(writer.rollbackDangling(), []);
 });
 
+const OA_PATH = "specs/design/components/shop-api/openapi.yaml";
+const OA =
+  'openapi: 3.0.3\ninfo:\n  title: Shop API\n  version: 1.0.0\npaths:\n  /products:\n    get:\n      summary: List products\n      responses:\n        "200":\n          description: OK\n';
+
+test("streams an openapi.yaml addFile incrementally, line-by-line, converging to full content", async () => {
+  const peer = new FakePeer();
+  const writer = new StreamingDocWriter(peer, new FileBundle({}));
+
+  await feed(writer, addFileParts("c1", OA_PATH, OA));
+  writer.observe(toolResult("c1", true, OA_PATH));
+  await writer.drain();
+
+  assert.ok(peer.sets.length >= 2, `expected incremental writes, got ${peer.sets.length}`);
+  assert.ok(peer.sets.every((s) => s.path === OA_PATH), "all writes target openapi.yaml");
+  for (let i = 1; i < peer.sets.length; i++) {
+    assert.ok(
+      peer.sets[i]!.content.startsWith(peer.sets[i - 1]!.content),
+      `write ${i} must extend write ${i - 1}`,
+    );
+  }
+  assert.equal(peer.sets.at(-1)!.content, OA, "final write is the whole YAML body");
+  assert.deepEqual(peer.deletes, []);
+  assert.deepEqual(writer.rollbackDangling(), []);
+});
+
 test("rolls back a truncated .cell stream", async () => {
+
   const peer = new FakePeer();
   const writer = new StreamingDocWriter(peer, new FileBundle({}));
   const parts = addFileParts("c1", CELL_PATH, CELL);
@@ -169,11 +195,11 @@ test("path resolves before any content is written", async () => {
   assert.equal(peer.sets[0]!.path, MD_PATH);
 });
 
-test("skips non-markdown addFile (execute owns yaml/json — no preview)", async () => {
+test("skips non-streamable addFile (execute owns design.json — no preview)", async () => {
   const peer = new FakePeer();
   const writer = new StreamingDocWriter(peer, new FileBundle({}));
-  await feed(writer, addFileParts("c1", "specs/design/components/x/openapi.yaml", "openapi: 3.0.0\ninfo: {}\n"));
-  writer.observe(toolResult("c1", true, "specs/design/components/x/openapi.yaml"));
+  await feed(writer, addFileParts("c1", "specs/design/components/x/design.json", '{"name":"x"}\n'));
+  writer.observe(toolResult("c1", true, "specs/design/components/x/design.json"));
   await writer.drain();
   assert.deepEqual(peer.sets, []);
   assert.deepEqual(peer.deletes, []);

--- a/services/agents/src/collab/streaming-add.ts
+++ b/services/agents/src/collab/streaming-add.ts
@@ -36,14 +36,15 @@
  *    ProseMirror fragment (~30× the Yjs traffic + rewrites earlier text); line
  *    boundaries are clean.
  *
- * Scope (v1): room-mode, MARKDOWN, `.cell`, and `.dsl` addFile only. `.cell`
- * is the project-level architecture DSL and `.dsl` a component's wireframes;
- * streaming either line-by-line draws its diagram live as the model writes
- * it. Markdown and `.cell` have no content-gate; `.dsl` has the layout gate
- * (LAYOUT_VIOLATION) — when execute() rejects it, the tool-result handler
- * below rolls the optimistic preview back, same as any rejected op. Other /
- * already-existing paths are skipped (execute owns them). Non-finalized
- * streams (truncation / reject) are rolled back.
+ * Scope: room-mode addFile for MARKDOWN, `.cell`, `.dsl`, and `openapi.yaml`.
+ * `.cell` is the project-level architecture DSL, `.dsl` a component's
+ * wireframes, `openapi.yaml` a component's API contract; streaming any of
+ * them line-by-line renders its view live as the model writes. Markdown and
+ * `.cell` have no content-gate; `.dsl` (INVALID_DSL) and `openapi.yaml`
+ * (INVALID_YAML) are gated at execute() — when a write is rejected, the
+ * tool-result handler below rolls the optimistic preview back, same as any
+ * rejected op. Other / already-existing paths are skipped (execute owns
+ * them). Non-finalized streams (truncation / reject) are rolled back.
  */
 
 import { parsePartialJson } from "ai";
@@ -52,9 +53,19 @@ import type { FileBundle, StreamPart } from "@aep/agent-stream";
 import type { RoomPeer } from "./room-peer.js";
 import { ADD_FILE } from "../agents/main/tools/files.js";
 
-/** Paths safe to optimistically stream: markdown (Y.XmlFragment) or a DSL (Y.Text) — `.cell` architecture, `.dsl` wireframes. */
+/**
+ * Paths safe to optimistically stream: markdown (Y.XmlFragment) or Y.Text
+ * artifacts — `.cell` architecture DSL, `.dsl` wireframes, `openapi.yaml`.
+ * YAML is line-oriented like the DSLs, so line-boundary prefixes parse and
+ * the OpenAPI view accumulates endpoints as the model writes them.
+ */
 function isStreamablePath(path: string): boolean {
-  return isMarkdownPath(path) || path.endsWith(".cell") || path.endsWith(".dsl");
+  return (
+    isMarkdownPath(path) ||
+    path.endsWith('.cell') ||
+    path.endsWith('.dsl') ||
+    path.endsWith('openapi.yaml')
+  );
 }
 
 interface CallState {


### PR DESCRIPTION
> **Stacked on #222** — contains its collab-source commit until that merges (this feature renders through the doc-as-source Spec view). Review only the top commit: `feat(spec): stream the OpenAPI view live`.

## What

The last generated design artifact without live rendering gets it: a component's `openapi.yaml` now streams into the Spec view **endpoint-by-endpoint as the model writes it**, matching `design.md`, the cell diagram, and the wireframes.

## How

- **Agents** — `StreamingDocWriter`'s gate accepts `openapi.yaml` alongside `.md`/`.cell`/`.dsl`. YAML is line-oriented like the DSLs: line-boundary prefixes parse (indentation blocks close implicitly at EOF), so the streamed partial document renders meaningfully at every flush. The existing `INVALID_YAML` write-gate + streamed-preview rollback cover rejected writes, same as `INVALID_DSL`.
- **`@aep/ui-openapi-view`** — holds the last **good** parse across updates: a rare unparseable intermediate prefix (e.g. cut inside a quoted scalar) keeps showing the already-rendered endpoints instead of flashing the parse-error alert; the next flush repairs it.
- **Console** — zero changes: the collab-doc-as-source Spec view (#222) already renders `OpenApiView` from the live doc.

Deliberately out of scope: streaming `design.json` — JSON is prefix-hostile (no line-boundary prefix parses until the document closes), so live rendering would need partial-JSON repair machinery for seconds of benefit, and the architecture already streams via `design.cell`. Recorded in #226.

## Verification

- Agents 145/145 — new test: `openapi.yaml` streams line-flushed, monotonically converging to the full body; `design.json` remains unstreamed (test updated to pin that).
- 26/26 line-boundary prefixes of a realistic multi-endpoint spec parse with **zero throws** through `parseOpenApi`.
- e2e on the local stack: during generation the OpenAPI view shows "Waiting for the agent to write openapi.yaml…", then builds up live (info → paths → operations) with no per-file GETs, no 404s, and no error flashes; the committed render is byte-identical after the turn.

Closes #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
