### PR TITLE
feat(dependencies): GET /dependencies/platform-resource-types

### DIFF
--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1304,6 +1304,25 @@ components:
         - name
         - createdAt
       type: object
+    PlatformResourceTypeDTO:
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        outputs:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        parameters:
+          additionalProperties: {}
+          type: object
+      required:
+        - name
+      type: object
     PreflightItem:
       additionalProperties: false
       properties:
@@ -2558,6 +2577,31 @@ paths:
       security:
         - userJWT: []
       summary: Delete an external-resource catalog entry (409 if in use)
+      tags:
+        - Dependencies
+  /dependencies/platform-resource-types:
+    get:
+      operationId: list-platform-resource-types
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/PlatformResourceTypeDTO"
+                type:
+                  - array
+                  - "null"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - userJWT: []
+      summary: List the platform-provisioned resource types available on the cluster
       tags:
         - Dependencies
   /organizations:

--- a/services/aep-api/internal/api/huma_register.go
+++ b/services/aep-api/internal/api/huma_register.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/feature/artifacts"
 	"github.com/wso2/aep/aep-api/internal/feature/build"
 	"github.com/wso2/aep/aep-api/internal/feature/component"
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies"
 	"github.com/wso2/aep/aep-api/internal/feature/execution"
 	"github.com/wso2/aep/aep-api/internal/feature/files"
 	"github.com/wso2/aep/aep-api/internal/feature/genai"
@@ -55,7 +56,8 @@ type HumaDeps struct {
 	ConfigSvc         component.ConfigService
 	CollabRepo        gitrepo.RepoService
 	IssueSvc          gitrepo.IssueService
-	ProvisioningSvc   *provisioning.Service
+	ProvisioningSvc     *provisioning.Service
+	ResourceTypeCatalog dependencies.ResourceTypeLister
 	TaskReads         *task.Reads
 	TaskCommands      *task.Commands
 	TaskPlan          *task.PlanService
@@ -93,6 +95,7 @@ func RegisterAllHuma(api huma.API, d HumaDeps) {
 	requirements.RegisterCollab(api, d.CollabRepo)
 	gitrepo.RegisterIssue(api, d.IssueSvc)
 	provisioning.RegisterResources(api, d.ProvisioningSvc)
+	dependencies.RegisterResourceTypes(api, d.ResourceTypeCatalog)
 	task.RegisterTask(api, d.TaskReads, d.TaskCommands, d.TaskPlan)
 	execution.RegisterTaskStream(api, d.TaskStream)
 	orgconfig.RegisterConfig(api, d.OrgConfigSvc)

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -857,6 +857,7 @@ func Build(cfg config.Config, db *gorm.DB) (*App, error) {
 	params.MCPOrgEndpoints = orgEndpointCatalog
 	resourceTypeCatalog := resources.NewResourceTypeCatalog(resourceClient)
 	params.MCPResourceTypes = resourceTypeCatalog
+	params.HumaDeps.ResourceTypeCatalog = resourceTypeCatalog
 	// Endpoint spec discovery: the read-only remote-git reader an agent uses to
 	// read a provider's OpenAPI file from its own repo (Contents + Code Search,
 	// no clone). It resolves the org's credential (token + owner) from

--- a/services/aep-api/internal/feature/dependencies/resource_types_huma.go
+++ b/services/aep-api/internal/feature/dependencies/resource_types_huma.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dependencies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies/resources"
+	"github.com/wso2/aep/aep-api/internal/platform/humakit"
+)
+
+// This endpoint is the HTTP transport of the same discovery data the
+// list_platform_resource_types MCP tool serves, backed by the package's existing
+// ResourceTypeLister port (see ports.go; *resources.ResourceTypeCatalog
+// satisfies it). The catalog is cluster-global, so the endpoint only requires an
+// authenticated caller.
+
+// listResourceTypesInput carries no parameters beyond the org-scoped auth gate;
+// the catalog is cluster-wide, so there is nothing to filter by. Embedding
+// OrgScopedInput enforces a valid Thunder JWT (the IDOR fence).
+type listResourceTypesInput struct {
+	humakit.OrgScopedInput
+}
+
+// platformResourceTypeDTO is the HTTP view of one installed resource type: its
+// resourceType name, human description, provisioning parameter schema, and the
+// output names a consumer binds as env vars. Mirrors resources.PlatformResourceType
+// minus the AEP-internal Markers.
+type platformResourceTypeDTO struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+	Outputs     []string       `json:"outputs,omitempty"`
+}
+
+type platformResourceTypesOutput struct{ Body []platformResourceTypeDTO }
+
+// RegisterResourceTypes registers the platform-resource-type discovery endpoint
+// on the public API. A nil lister registers the route but answers 503 (so
+// code-first spec generation still emits the surface with the feature unwired).
+func RegisterResourceTypes(api huma.API, lister ResourceTypeLister) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-platform-resource-types",
+		Method:      http.MethodGet,
+		Path:        "/dependencies/platform-resource-types",
+		Summary:     "List the platform-provisioned resource types available on the cluster",
+		Tags:        []string{"Dependencies"},
+		Security:    humakit.SecurityUserJWT,
+	}, func(ctx context.Context, _ *listResourceTypesInput) (*platformResourceTypesOutput, error) {
+		if lister == nil {
+			return nil, huma.Error503ServiceUnavailable("resource-type catalog is not configured")
+		}
+		types, err := lister.List(ctx)
+		if err != nil {
+			// The catalog reads cluster ClusterResourceTypes over OpenChoreo; a
+			// failure is an upstream (data-plane) fault, not the caller's.
+			return nil, huma.Error502BadGateway("failed to list platform resource types", err)
+		}
+		return &platformResourceTypesOutput{Body: toPlatformResourceTypeDTOs(types)}, nil
+	})
+}
+
+func toPlatformResourceTypeDTOs(in []resources.PlatformResourceType) []platformResourceTypeDTO {
+	out := make([]platformResourceTypeDTO, 0, len(in))
+	for _, t := range in {
+		out = append(out, platformResourceTypeDTO{
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.Parameters,
+			Outputs:     t.Outputs,
+		})
+	}
+	return out
+}

--- a/services/aep-api/internal/feature/dependencies/resource_types_huma_test.go
+++ b/services/aep-api/internal/feature/dependencies/resource_types_huma_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dependencies
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/humatest"
+
+	"github.com/wso2/aep/aep-api/internal/feature/dependencies/resources"
+)
+
+// stubResourceTypeLister satisfies ResourceTypeLister for registration/spec and
+// mapping tests — no request reaches it in the spec test.
+type stubResourceTypeLister struct {
+	types []resources.PlatformResourceType
+	err   error
+}
+
+func (s stubResourceTypeLister) List(context.Context) ([]resources.PlatformResourceType, error) {
+	return s.types, s.err
+}
+
+// TestRegisterResourceTypes_Spec is a registration/spec check: RegisterResourceTypes
+// does not panic and the generated OpenAPI carries the discovery operation, its
+// path, the org-scoped security scheme, and the DTO schema. It sends no requests
+// — the tenant gate defaults to enforce, and (per bff-component-testing) spec
+// tests must not flip the request-scoped gate mode; behavioral status/auth
+// coverage of the shared chain lives in the componenttest harness.
+func TestRegisterResourceTypes_Spec(t *testing.T) {
+	t.Parallel()
+
+	_, api := humatest.New(t)
+	RegisterResourceTypes(api, stubResourceTypeLister{})
+
+	spec, err := api.OpenAPI().YAML()
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	for _, want := range []string{
+		"list-platform-resource-types",
+		"/dependencies/platform-resource-types",
+		"PlatformResourceTypeDTO",
+		"userJWT",
+	} {
+		if !strings.Contains(string(spec), want) {
+			t.Fatalf("spec missing %q", want)
+		}
+	}
+}
+
+// TestToPlatformResourceTypeDTOs verifies the domain→DTO projection: the
+// architect-facing fields (name, description, parameters, outputs) map through,
+// and a type with no parameters/outputs projects to empties without panicking.
+func TestToPlatformResourceTypeDTOs(t *testing.T) {
+	t.Parallel()
+
+	in := []resources.PlatformResourceType{
+		{
+			Name:        "postgres-cnpg",
+			Description: "Managed PostgreSQL",
+			Parameters:  map[string]any{"size": map[string]any{"type": "string"}},
+			Outputs:     []string{"host", "port", "database"},
+		},
+		{Name: "redis-cache"}, // minimal: no description/params/outputs
+	}
+
+	got := toPlatformResourceTypeDTOs(in)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "postgres-cnpg" || got[0].Description != "Managed PostgreSQL" {
+		t.Errorf("name/description not mapped: %+v", got[0])
+	}
+	if _, ok := got[0].Parameters["size"]; !ok {
+		t.Errorf("parameters not mapped: %+v", got[0].Parameters)
+	}
+	if len(got[0].Outputs) != 3 || got[0].Outputs[0] != "host" {
+		t.Errorf("outputs not mapped: %+v", got[0].Outputs)
+	}
+	if got[1].Name != "redis-cache" || got[1].Parameters != nil || got[1].Outputs != nil {
+		t.Errorf("minimal type not projected cleanly: %+v", got[1])
+	}
+}


### PR DESCRIPTION
## Why
The catalog of installed `ClusterResourceType`s (what a `platform-resource` dependency can request) was only reachable via the internal `list_platform_resource_types` MCP tool (design-agent-facing). This exposes the same discovery data over REST.

## What — `GET /dependencies/platform-resource-types`
- Handler in the **dependencies** feature (owns the catalog + the MCP tool), reusing its existing `ResourceTypeLister` port — HTTP is a second transport of the same data. Org-scoped `userJWT`, `Dependencies` tag, nil lister → 503.
- Returns `[{ name, description, parameters, outputs }]`. Read-only (AEP never authors these).
- Contract path + `PlatformResourceTypeDTO` added to the committed `openapi.yaml`; served surface verified via `openapigen`.

## Verification
`go build`, `go test` (dependencies + api), `openapigen` — green (run in `golang:1.26`).

## Note
Backend only. A console "Resources" settings section that consumes this endpoint was prototyped and set aside on branch `feat-resources-console-section` for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y49xNCMjuch9q9GYUfDTte