### PR TITLE
feat(aepctl): guard `aep init` on a provisioned build registry

### DIFF
--- a/apps/console/src/features/spec/collab/SpecMdEditor.browser.test.tsx
+++ b/apps/console/src/features/spec/collab/SpecMdEditor.browser.test.tsx
@@ -27,7 +27,7 @@
 // helper against a shared Y.Doc whose XmlFragment backs the editor, so the
 // editor grows exactly as it does in production — no server, no cluster.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -44,6 +45,8 @@ var (
 	initConsoleURL           string
 	initAPIURL               string
 	initWorkspacesAccessMode string
+	initBuildPlaneNamespace  string
+	initRegistryService      string
 )
 
 var initCmd = &cobra.Command{
@@ -71,6 +74,8 @@ func init() {
 	initCmd.Flags().StringVar(&initAPIURL, "api-url", "http://api.openchoreo.localhost:8080", "Public URL of the AEP API")
 	initCmd.Flags().StringVar(&initWorkspacesAccessMode, "workspaces-access-mode", "", "PVC access mode for the shared workspaces volume (e.g. ReadWriteOnce for local k3d, ReadWriteMany for production)")
 	_ = viper.BindPFlag("platform.workspaces.access_mode", initCmd.Flags().Lookup("workspaces-access-mode"))
+	initCmd.Flags().StringVar(&initBuildPlaneNamespace, "build-plane-namespace", "openchoreo-workflow-plane", "Namespace of the OpenChoreo build/workflow plane (must already exist, incl. its image registry)")
+	initCmd.Flags().StringVar(&initRegistryService, "registry-service", "registry", "Name of the build-plane image registry Service (the coding-agent build pushes/pulls here)")
 	initCmd.Flags().String("oc-api-url", "", "In-cluster URL of the OpenChoreo platform API (overrides config file)")
 	_ = viper.BindPFlag("oc.api_url", initCmd.Flags().Lookup("oc-api-url"))
 	initCmd.Flags().String("server", "", "AEP server gRPC URL (overrides config file)")
@@ -88,6 +93,16 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 	k8sClient, err := k8s.NewClient("")
 	if err != nil {
 		return fmt.Errorf("connect to cluster: %w", err)
+	}
+
+	// 0. Prerequisite guard — verify the OpenChoreo build plane + image registry
+	// exist BEFORE installing anything. The coding-agent build/deploy chain
+	// pushes built images to, and pulls them from, this registry; without it,
+	// builds fail deep in the pipeline with an opaque publish/pull error. aepctl
+	// does not provision it (that is the OpenChoreo cluster's responsibility) —
+	// so fail fast here with an actionable message rather than half-installing.
+	if err := checkBuildRegistry(ctx, k8sClient, initBuildPlaneNamespace, initRegistryService); err != nil {
+		return err
 	}
 
 	// 1. Wait for OpenBao pod.
@@ -224,6 +239,32 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 	}
 
 	_, _ = fmt.Fprintln(os.Stdout, "\nAEP is ready. Open the console to get started.")
+	return nil
+}
+
+// checkBuildRegistry fails fast (before any install) when the OpenChoreo build
+// plane or its image registry Service is absent. The coding-agent build →
+// publish → deploy chain depends on this registry; aepctl assumes a
+// pre-provisioned OpenChoreo cluster and does not create it.
+func checkBuildRegistry(ctx context.Context, client *kubernetes.Clientset, namespace, service string) error {
+	if _, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("OpenChoreo build plane namespace %q not found.\n"+
+				"AEP requires a pre-provisioned OpenChoreo build/workflow plane (with its image registry) — "+
+				"the coding-agent build pipeline pushes and pulls images there.\n"+
+				"Provision it first, or pass --build-plane-namespace if yours differs.", namespace)
+		}
+		return fmt.Errorf("check build plane namespace %q: %w", namespace, err)
+	}
+	if _, err := client.CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("build image registry Service %q not found in namespace %q.\n"+
+				"The coding-agent build pipeline needs an in-cluster image registry (publish + deploy-time pull). "+
+				"Provision the OpenChoreo build plane's registry before running `aep init`, "+
+				"or pass --registry-service if yours is named differently.", service, namespace)
+		}
+		return fmt.Errorf("check registry Service %q/%q: %w", namespace, service, err)
+	}
 	return nil
 }
 

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -267,8 +267,8 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 func checkOCVersion(ctx context.Context, client *kubernetes.Clientset, namespace, minVersion string) error {
 	if _, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("OpenChoreo namespace %q not found.\n"+
-				"AEP requires OpenChoreo >= %s. Provision it first, or pass --oc-namespace if yours differs.",
+			return fmt.Errorf("OpenChoreo namespace %q not found: "+
+				"AEP requires OpenChoreo >= %s; provision it first, or pass --oc-namespace if yours differs",
 				namespace, minVersion)
 		}
 		return fmt.Errorf("check OpenChoreo namespace %q: %w", namespace, err)
@@ -293,15 +293,15 @@ func checkOCVersion(ctx context.Context, client *kubernetes.Clientset, namespace
 			return fmt.Errorf("parse OpenChoreo version %q: %w", ver, err)
 		}
 		if !ok {
-			return fmt.Errorf("OpenChoreo version %s is below the minimum required version %s.\n"+
-				"Upgrade OpenChoreo to %s or later before running `aep init`.",
+			return fmt.Errorf("OpenChoreo version %s is below the minimum required version %s: "+
+				"upgrade OpenChoreo to %s or later before running `aep init`",
 				ver, minVersion, minVersion)
 		}
 		return nil
 	}
 
-	return fmt.Errorf("could not determine the OpenChoreo version from deployments in namespace %q.\n"+
-		"Ensure OpenChoreo >= %s is installed, or pass --skip-oc-version-check to bypass this check.",
+	return fmt.Errorf("could not determine OpenChoreo version from deployments in namespace %q: "+
+		"ensure OpenChoreo >= %s is installed, or pass --skip-oc-version-check to bypass this check",
 		namespace, minVersion)
 }
 
@@ -350,19 +350,19 @@ func splitVersion(v string) ([3]int, error) {
 func checkBuildRegistry(ctx context.Context, client *kubernetes.Clientset, namespace, service string) error {
 	if _, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("OpenChoreo build plane namespace %q not found.\n"+
-				"AEP requires a pre-provisioned OpenChoreo build/workflow plane (with its image registry) — "+
-				"the coding-agent build pipeline pushes and pulls images there.\n"+
-				"Provision it first, or pass --build-plane-namespace if yours differs.", namespace)
+			return fmt.Errorf("OpenChoreo build plane namespace %q not found: "+
+				"AEP requires a pre-provisioned OpenChoreo build/workflow plane with its image registry "+
+				"(the coding-agent build pipeline pushes and pulls images there); "+
+				"provision it first, or pass --build-plane-namespace if yours differs", namespace)
 		}
 		return fmt.Errorf("check build plane namespace %q: %w", namespace, err)
 	}
 	if _, err := client.CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("build image registry Service %q not found in namespace %q.\n"+
-				"The coding-agent build pipeline needs an in-cluster image registry (publish + deploy-time pull). "+
-				"Provision the OpenChoreo build plane's registry before running `aep init`, "+
-				"or pass --registry-service if yours is named differently.", service, namespace)
+			return fmt.Errorf("build image registry Service %q not found in namespace %q: "+
+				"the coding-agent build pipeline needs an in-cluster image registry (publish + deploy-time pull); "+
+				"provision the OpenChoreo build plane's registry before running `aep init`, "+
+				"or pass --registry-service if yours is named differently", service, namespace)
 		}
 		return fmt.Errorf("check registry Service %q/%q: %w", namespace, service, err)
 	}

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,8 @@ import (
 	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
 )
 
+const minOCVersion = "1.1.1"
+
 var (
 	initPlatformChart        string
 	initPlatformVersion      string
@@ -47,6 +50,8 @@ var (
 	initWorkspacesAccessMode string
 	initBuildPlaneNamespace  string
 	initRegistryService      string
+	initOCNamespace          string
+	initSkipOCVersionCheck   bool
 )
 
 var initCmd = &cobra.Command{
@@ -76,6 +81,8 @@ func init() {
 	_ = viper.BindPFlag("platform.workspaces.access_mode", initCmd.Flags().Lookup("workspaces-access-mode"))
 	initCmd.Flags().StringVar(&initBuildPlaneNamespace, "build-plane-namespace", "openchoreo-workflow-plane", "Namespace of the OpenChoreo build/workflow plane (must already exist, incl. its image registry)")
 	initCmd.Flags().StringVar(&initRegistryService, "registry-service", "registry", "Name of the build-plane image registry Service (the coding-agent build pushes/pulls here)")
+	initCmd.Flags().StringVar(&initOCNamespace, "oc-namespace", "openchoreo-system", "Namespace where OpenChoreo control-plane is installed")
+	initCmd.Flags().BoolVar(&initSkipOCVersionCheck, "skip-oc-version-check", false, "Skip the OpenChoreo minimum version check (not recommended)")
 	initCmd.Flags().String("oc-api-url", "", "In-cluster URL of the OpenChoreo platform API (overrides config file)")
 	_ = viper.BindPFlag("oc.api_url", initCmd.Flags().Lookup("oc-api-url"))
 	initCmd.Flags().String("server", "", "AEP server gRPC URL (overrides config file)")
@@ -95,7 +102,17 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("connect to cluster: %w", err)
 	}
 
-	// 0. Prerequisite guard — verify the OpenChoreo build plane + image registry
+	// 0a. Prerequisite guard — verify the OpenChoreo version meets the minimum
+	// requirement. Features used by the coding-agent build/deploy chain (e.g.
+	// the workflow plane APIs) are only available from 1.1.1 onward; older
+	// clusters produce cryptic failures deep in the pipeline.
+	if !initSkipOCVersionCheck {
+		if err := checkOCVersion(ctx, k8sClient, initOCNamespace, minOCVersion); err != nil {
+			return err
+		}
+	}
+
+	// 0b. Prerequisite guard — verify the OpenChoreo build plane + image registry
 	// exist BEFORE installing anything. The coding-agent build/deploy chain
 	// pushes built images to, and pulls them from, this registry; without it,
 	// builds fail deep in the pipeline with an opaque publish/pull error. aepctl
@@ -240,6 +257,90 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 
 	_, _ = fmt.Fprintln(os.Stdout, "\nAEP is ready. Open the console to get started.")
 	return nil
+}
+
+// checkOCVersion fails fast when the installed OpenChoreo version is below the
+// required minimum. It reads the app.kubernetes.io/version label from any
+// Deployment in the OC namespace that carries app.kubernetes.io/part-of=openchoreo.
+// A missing namespace or no versioned Deployment is treated as an unrecognised
+// installation and also fails.
+func checkOCVersion(ctx context.Context, client *kubernetes.Clientset, namespace, minVersion string) error {
+	if _, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("OpenChoreo namespace %q not found.\n"+
+				"AEP requires OpenChoreo >= %s. Provision it first, or pass --oc-namespace if yours differs.",
+				namespace, minVersion)
+		}
+		return fmt.Errorf("check OpenChoreo namespace %q: %w", namespace, err)
+	}
+
+	deps, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/part-of=openchoreo",
+	})
+	if err != nil {
+		return fmt.Errorf("list OpenChoreo deployments in %q: %w", namespace, err)
+	}
+
+	for _, d := range deps.Items {
+		ver, ok := d.Labels["app.kubernetes.io/version"]
+		if !ok || ver == "" {
+			continue
+		}
+		// Strip a leading "v" if present (e.g. "v1.2.0" → "1.2.0").
+		ver = strings.TrimPrefix(ver, "v")
+		ok, err := versionAtLeast(ver, minVersion)
+		if err != nil {
+			return fmt.Errorf("parse OpenChoreo version %q: %w", ver, err)
+		}
+		if !ok {
+			return fmt.Errorf("OpenChoreo version %s is below the minimum required version %s.\n"+
+				"Upgrade OpenChoreo to %s or later before running `aep init`.",
+				ver, minVersion, minVersion)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("could not determine the OpenChoreo version from deployments in namespace %q.\n"+
+		"Ensure OpenChoreo >= %s is installed, or pass --skip-oc-version-check to bypass this check.",
+		namespace, minVersion)
+}
+
+// versionAtLeast reports whether version >= minimum, comparing major.minor.patch
+// numerically. Both strings must be of the form "X.Y.Z".
+func versionAtLeast(version, minimum string) (bool, error) {
+	vParts, err := splitVersion(version)
+	if err != nil {
+		return false, fmt.Errorf("version %q: %w", version, err)
+	}
+	mParts, err := splitVersion(minimum)
+	if err != nil {
+		return false, fmt.Errorf("minimum %q: %w", minimum, err)
+	}
+	for i := 0; i < 3; i++ {
+		if vParts[i] > mParts[i] {
+			return true, nil
+		}
+		if vParts[i] < mParts[i] {
+			return false, nil
+		}
+	}
+	return true, nil // equal
+}
+
+func splitVersion(v string) ([3]int, error) {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return [3]int{}, fmt.Errorf("expected major.minor.patch, got %q", v)
+	}
+	var out [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return [3]int{}, fmt.Errorf("non-numeric segment %q", p)
+		}
+		out[i] = n
+	}
+	return out, nil
 }
 
 // checkBuildRegistry fails fast (before any install) when the OpenChoreo build


### PR DESCRIPTION
## Summary
Adds two **prerequisite guards** to \`aep init\` that fail fast before any install step.

**PR 2 of 3** (aepctl/Helm work): PR 1 = SRE agent + observability plane (#233); PR 2 = this; PR 3 = collab + streaming + build/deploy fixes.

## Why
The coding-agent **build → publish → deploy** chain depends on:
1. **OpenChoreo >= 1.1.1** — workflow-plane APIs used by the build pipeline are only stable from this version; older clusters produce cryptic, late-stage failures.
2. **An in-cluster image registry** — the build pipeline pushes built images to, and pulls them from, the OC build plane registry. Without it, failures only surface as opaque \`ImagePullBackOff\` deep in a build.

Both checks run **before any install step** and print actionable messages.

## What

### Guard 1 — OC version (\`checkOCVersion\`)
- Reads \`app.kubernetes.io/version\` from Deployments labeled \`app.kubernetes.io/part-of=openchoreo\` in \`--oc-namespace\` (default \`openchoreo-system\`).
- Fails if OC is absent, the namespace is missing, or the version is below \`1.1.1\`.
- Escape hatch: \`--skip-oc-version-check\` (e.g. non-standard OC installs).

### Guard 2 — Build registry (\`checkBuildRegistry\`)
- Verifies the build-plane namespace and the registry \`Service\` exist.
- Flags \`--build-plane-namespace\` (default \`openchoreo-workflow-plane\`) and \`--registry-service\` (default \`registry\`) for non-default setups.

### Lint fix
- Removed unused \`vi\` import from \`SpecMdEditor.browser.test.tsx\` (ESLint \`no-unused-vars\` error in CI).

## Verified
\`go build\`, \`gofmt\`, \`make license-check\` clean. Negative paths (missing namespace / missing Service / OC below 1.1.1) error and stop before any install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)