### PR TITLE
feat(aepctl): local source-driven dev mode (aep dev)

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -26,13 +26,18 @@ FROM node:22-alpine AS builder
 RUN corepack enable
 WORKDIR /repo
 
-# Workspace manifests first for install-layer caching (same shape as
-# services/agents/Dockerfile).
+# Workspace manifests + package manifests first, so the install layer (and the
+# workspace-dep builds below) stay cached when only app source changes. The app
+# source itself is COPY'd LAST — see the note before `COPY apps/console`.
+# The pnpm content-addressable store is a BuildKit cache mount, so a cache miss
+# on install relinks from the store instead of re-downloading (needs BuildKit;
+# `aep dev reload` and CI's buildx both set it).
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
 COPY packages ./packages
-COPY apps/console ./apps/console
+COPY apps/console/package.json ./apps/console/
 
-RUN pnpm install --frozen-lockfile --filter @aep/console...
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store --filter @aep/console...
 
 # Workspace deps whose exports resolve to ./dist must be compiled first
 # (@aep/excalidraw-dsl — the wireframe DSL + layout gate, built FIRST because
@@ -43,14 +48,19 @@ RUN pnpm install --frozen-lockfile --filter @aep/console...
 # types: dist/index.d.ts so consumers read its pre-built declarations instead
 # of re-typechecking its source). The @aep/ui-cell-diagram-view package
 # resolves to its src/ (types: src/index.ts) so tsc reads it directly — no
-# pre-build.
+# pre-build. These depend only on packages/, so an app-source edit doesn't
+# rerun them.
 RUN pnpm --filter @aep/excalidraw-dsl build
 RUN pnpm --filter @aep/agent-stream build
 RUN pnpm --filter @aep/collab-doc build
 RUN pnpm --filter @aep/design-projection build
 RUN pnpm --filter @aep/ui-cell-diagram-react build
-RUN pnpm --filter @aep/console gen
-RUN pnpm --filter @aep/console build
+
+# App source LAST: a console-only change invalidates only this COPY and the
+# gen+build below (install + the workspace-dep builds above stay cached).
+COPY apps/console ./apps/console
+RUN --mount=type=cache,id=vite-console,target=/repo/apps/console/node_modules/.vite \
+    pnpm --filter @aep/console gen && pnpm --filter @aep/console build
 
 # Stage 1: serve with nginx.
 FROM nginx:1.28-alpine

--- a/apps/console/src/features/spec/collab/SpecMdEditor.browser.test.tsx
+++ b/apps/console/src/features/spec/collab/SpecMdEditor.browser.test.tsx
@@ -27,7 +27,7 @@
 // helper against a shared Y.Doc whose XmlFragment backs the editor, so the
 // editor grows exactly as it does in production — no server, no cluster.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";

--- a/services/aep-api/Dockerfile
+++ b/services/aep-api/Dockerfile
@@ -18,9 +18,12 @@ FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/aep-api ./cmd/aep-api
+# Cache the Go module + build caches (BuildKit) so incremental rebuilds — the
+# `aep dev reload aep-api` inner loop — reuse compiled packages.
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o bin/aep-api ./cmd/aep-api
 
 FROM alpine:3.21
 

--- a/services/aep-mcp-server/Dockerfile
+++ b/services/aep-mcp-server/Dockerfile
@@ -24,8 +24,9 @@ WORKDIR /workspace
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY services/aep-mcp-server/package.json services/aep-mcp-server/package.json
 
-RUN corepack enable && corepack prepare pnpm@10.12.1 --activate && \
-    pnpm install --filter @aep/aep-mcp-server... --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    corepack enable && corepack prepare pnpm@10.12.1 --activate && \
+    pnpm install --filter @aep/aep-mcp-server... --frozen-lockfile --store-dir=/pnpm/store
 
 COPY services/aep-mcp-server/tsconfig.json services/aep-mcp-server/tsconfig.json
 COPY services/aep-mcp-server/src services/aep-mcp-server/src

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -26,18 +26,23 @@ FROM node:22-bookworm-slim
 RUN corepack enable
 WORKDIR /repo
 
-# Workspace manifests first for install-layer caching. tsconfig.base.json is the
-# shared base @aep/agent-stream's tsconfig extends — needed for the tsc build below.
+# Workspace + package manifests first so the install layer (and the
+# workspace-dep builds below) stay cached when only agents source changes; the
+# service source is COPY'd LAST. tsconfig.base.json is the shared base
+# @aep/agent-stream's tsconfig extends — needed for the tsc build below. The
+# pnpm store is a BuildKit cache mount (needs BuildKit; `aep dev reload` and
+# CI's buildx both set it).
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
-# The agents package plus the workspace packages it depends on.
+# The workspace packages @aep/agents depends on, plus the agents manifest only.
 COPY packages ./packages
-COPY services/agents ./services/agents
+COPY services/agents/package.json ./services/agents/
 
 # Install @aep/agents + its workspace deps. This also installs the workspace ROOT
 # project's devDependencies (pnpm always installs the root's deps) — so `typescript`
 # is present to compile @aep/agent-stream in the next step. (@types/node and tsx
 # ride in via @aep/agents' own dependencies.)
-RUN pnpm install --frozen-lockfile --filter @aep/agents...
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store --filter @aep/agents...
 
 # @aep/agents runs from TypeScript source via tsx (no build of its own), but it
 # imports @aep/agent-stream and @aep/collab-doc as packages whose `exports`
@@ -45,8 +50,14 @@ RUN pnpm install --frozen-lockfile --filter @aep/agents...
 # @aep/excalidraw-dsl builds FIRST: @aep/agent-stream imports it (the layout
 # write-gate), so its dist must exist for agent-stream's tsc to resolve it.
 # Without this step the container crashes at boot with "Cannot find module
-# .../@aep/agent-stream/dist" (or the collab-doc analog).
+# .../@aep/agent-stream/dist" (or the collab-doc analog). These depend only on
+# packages/, so an agents-source edit doesn't rerun them.
 RUN pnpm --filter @aep/excalidraw-dsl build && pnpm --filter @aep/agent-stream build && pnpm --filter @aep/collab-doc build
+
+# Service source LAST: an agents-only change invalidates only this COPY (install
+# + the workspace-dep builds above stay cached). @aep/agents runs via tsx, so
+# there is no build step of its own.
+COPY services/agents ./services/agents
 
 WORKDIR /repo/services/agents
 

--- a/tools/aepctl/cmd/dev.go
+++ b/tools/aepctl/cmd/dev.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/wso2/aep/aepctl/internal/dev"
+)
+
+// devCmd is the parent for the local source-driven inner loop. After editing a
+// service's code, `aep dev reload <service>` builds the image from the local
+// checkout, imports it into the k3d cluster, and redeploys the running service.
+//
+// Dev mode is opt-in: enable it once with `aep dev enable --project-path <dir>`.
+// Commands that mutate the cluster (reload/restart/logs) refuse unless enabled.
+var devCmd = &cobra.Command{
+	Use:   "dev",
+	Short: "Local source-driven dev mode (build, import, redeploy services)",
+	Long: `Dev mode rebuilds AEP platform services from a local source checkout and
+redeploys them into the running k3d cluster.
+
+Enable it once, pointing at your AEP repo:
+
+  aep dev enable --project-path ~/src/aep
+
+Then, after editing a service's code:
+
+  aep dev reload aep-api      # build image + import to cluster + redeploy
+  aep dev restart aep-api     # rollout restart only (no rebuild)
+  aep dev status              # show dev mode + per-service images
+  aep dev logs aep-api -f     # tail the service logs
+
+Reloaded images are local-only (imported into k3d, never pushed) and are
+persisted to ~/.aep/dev-values.yaml so a later 'aep init'/upgrade keeps them.`,
+}
+
+func init() {
+	rootCmd.AddCommand(devCmd)
+}
+
+// devService maps a service name to how it is built (dockerfile + context,
+// relative to the project root — matching .github/workflows/build-images.yml)
+// and how it is deployed (Deployment + container name in the platform namespace,
+// and the top-level values key used for the dev-values.yaml image override).
+type devService struct {
+	Name       string
+	Dockerfile string
+	Context    string
+	Deployment string
+	Container  string
+	ValuesKey  string
+	// DevServerCmd, when non-empty, is the local dev server for this service
+	// (run from the project root by `aep dev serve`). Only edge/leaf services
+	// like the console frontend can run locally — backends are called by other
+	// services via cluster DNS, so they stay in-cluster (empty here).
+	DevServerCmd  []string
+	DevServerPort int
+	// DevServerPrepare are commands run in order before the dev server (from the
+	// project root) to bring the local checkout to the state the dev server
+	// needs — the same prerequisites the Dockerfile handles: (1) install the
+	// service's dependency closure (the local node_modules may lag the
+	// lockfile), and (2) build the workspace deps whose exports resolve to ./dist
+	// (Vite can't resolve them otherwise).
+	DevServerPrepare [][]string
+}
+
+// devServices is the set of platform runtime Deployments dev mode can rebuild.
+// collab's chart is not on every branch yet (it lands with the collab work);
+// reload verifies the Deployment exists first and errors clearly if it does not.
+var devServices = []devService{
+	{Name: "aep-api", Dockerfile: "services/aep-api/Dockerfile", Context: "services/aep-api", Deployment: "aep-api", Container: "aep-api", ValuesKey: "aepApi"},
+	{Name: "agents", Dockerfile: "services/agents/Dockerfile", Context: ".", Deployment: "aep-agents", Container: "aep-agents", ValuesKey: "aepAgents"},
+	{Name: "aep-mcp-server", Dockerfile: "services/aep-mcp-server/Dockerfile", Context: ".", Deployment: "aep-mcp-server", Container: "aep-mcp-server", ValuesKey: "aepMcpServer"},
+	{
+		Name: "console", Dockerfile: "apps/console/Dockerfile", Context: ".",
+		Deployment: "aep-console", Container: "aep-console", ValuesKey: "console",
+		DevServerCmd:  []string{"pnpm", "--filter", "@aep/console", "dev"},
+		DevServerPort: 8090,
+		DevServerPrepare: [][]string{
+			{"pnpm", "install", "--frozen-lockfile", "--filter", "@aep/console..."},
+			{"pnpm", "--filter", "@aep/console^...", "build"},
+		},
+	},
+	{Name: "collab", Dockerfile: "services/collab/Dockerfile", Context: ".", Deployment: "collab-server", Container: "collab-server", ValuesKey: "collab"},
+}
+
+func lookupDevService(name string) (devService, bool) {
+	for _, s := range devServices {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return devService{}, false
+}
+
+func devServiceNames() []string {
+	names := make([]string, len(devServices))
+	for i, s := range devServices {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// resolveDevServices turns a command argument into the services to act on:
+// "all" expands to every registered service; any other value must name one.
+func resolveDevServices(arg string) ([]devService, error) {
+	if arg == "all" {
+		return devServices, nil
+	}
+	s, ok := lookupDevService(arg)
+	if !ok {
+		return nil, fmt.Errorf("unknown service %q — valid: %s, all",
+			arg, strings.Join(devServiceNames(), ", "))
+	}
+	return []devService{s}, nil
+}
+
+// devImageTag is the deterministic local tag for a service's dev image, e.g.
+// aep-dev/aep-api:dev. The stable tag keeps ~/.aep/dev-values.yaml stable across
+// reloads; each reload overwrites the tag's content in the k3d node.
+func devImageTag(s devService) string {
+	return fmt.Sprintf("%s/%s:dev", viper.GetString("dev.image_prefix"), s.Name)
+}
+
+// devProjectRoot returns the configured local source directory, validating that
+// it exists and looks like the AEP repo root.
+func devProjectRoot() (string, error) {
+	root := viper.GetString("dev.project_path")
+	if root == "" {
+		return "", fmt.Errorf("no project path set — run `aep dev enable --project-path <dir>` or `aep dev set-path <dir>`")
+	}
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("project path %q is not a directory", root)
+	}
+	// A light sanity check: the AEP repo root has an AGENTS.md and a Go/pnpm
+	// workspace marker. Catches pointing at the wrong directory before a build.
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); err != nil {
+		return "", fmt.Errorf("project path %q does not look like the AEP repo root (no AGENTS.md)", root)
+	}
+	return root, nil
+}
+
+// requireDevMode is the guard for cluster-mutating dev subcommands: dev mode
+// must be enabled and the project path valid. Returns the validated root.
+func requireDevMode() (string, error) {
+	if !viper.GetBool("dev.enabled") {
+		return "", fmt.Errorf("dev mode is disabled — enable it with `aep dev enable --project-path <dir>`")
+	}
+	return devProjectRoot()
+}
+
+// requireK3d verifies the k3d binary is available and the configured cluster
+// exists — the prerequisite for importing locally-built images.
+func requireK3d(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("k3d"); err != nil {
+		return "", fmt.Errorf("k3d is required for dev mode but was not found in PATH\nInstall it from https://k3d.io and try again")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		return "", fmt.Errorf("docker is required for dev mode but was not found in PATH")
+	}
+	cluster := viper.GetString("dev.k3d_cluster")
+	exists, err := dev.K3dClusterExists(ctx, cluster)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", fmt.Errorf("k3d cluster %q not found — set dev.k3d_cluster in ~/.aep/config.yaml or create it", cluster)
+	}
+	return cluster, nil
+}
+
+// saveConfig writes the current viper config to ~/.aep/config.yaml (same pattern
+// as `aep connect`). Shared by the dev enable/disable/set-path subcommands.
+func saveConfig() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	cfgDir := filepath.Join(home, ".aep")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		return "", fmt.Errorf("create config dir: %w", err)
+	}
+	cfgFile := filepath.Join(cfgDir, "config.yaml")
+	if err := viper.WriteConfigAs(cfgFile); err != nil {
+		return "", fmt.Errorf("write config: %w", err)
+	}
+	return cfgFile, nil
+}

--- a/tools/aepctl/cmd/dev_enable.go
+++ b/tools/aepctl/cmd/dev_enable.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var devEnableProjectPath string
+
+var devEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable dev mode (optionally set the source directory)",
+	Long: `Turns dev mode on and persists it to ~/.aep/config.yaml. Optionally set the
+local AEP source directory that images are built from:
+
+  aep dev enable --project-path ~/src/aep`,
+	RunE: runDevEnable,
+}
+
+var devDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable dev mode",
+	RunE:  runDevDisable,
+}
+
+var devSetPathCmd = &cobra.Command{
+	Use:   "set-path <dir>",
+	Short: "Set the local AEP source directory used by dev mode",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDevSetPath,
+}
+
+func init() {
+	devCmd.AddCommand(devEnableCmd, devDisableCmd, devSetPathCmd)
+	devEnableCmd.Flags().StringVar(&devEnableProjectPath, "project-path", "", "Path to the local AEP source repo (built by `aep dev reload`)")
+}
+
+func runDevEnable(cmd *cobra.Command, args []string) error {
+	if devEnableProjectPath != "" {
+		if err := setProjectPath(devEnableProjectPath); err != nil {
+			return err
+		}
+	}
+	viper.Set("dev.enabled", true)
+	cfgFile, err := saveConfig()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stdout, "Dev mode: enabled")
+	if p := viper.GetString("dev.project_path"); p != "" {
+		fmt.Fprintf(os.Stdout, "Project:  %s\n", p)
+	} else {
+		fmt.Fprintln(os.Stdout, "Project:  (not set) — run `aep dev set-path <dir>` before reloading")
+	}
+	fmt.Fprintf(os.Stdout, "Config:   %s\n", cfgFile)
+	return nil
+}
+
+func runDevDisable(cmd *cobra.Command, args []string) error {
+	viper.Set("dev.enabled", false)
+	cfgFile, err := saveConfig()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, "Dev mode: disabled")
+	fmt.Fprintf(os.Stdout, "Config:   %s\n", cfgFile)
+	return nil
+}
+
+func runDevSetPath(cmd *cobra.Command, args []string) error {
+	if err := setProjectPath(args[0]); err != nil {
+		return err
+	}
+	cfgFile, err := saveConfig()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "Project: %s\n", viper.GetString("dev.project_path"))
+	fmt.Fprintf(os.Stdout, "Config:  %s\n", cfgFile)
+	return nil
+}
+
+// setProjectPath resolves path to an absolute path, validates it looks like the
+// AEP repo root, and stores it in viper (persisted by the caller via saveConfig).
+func setProjectPath(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	viper.Set("dev.project_path", abs)
+	if _, err := devProjectRoot(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/aepctl/cmd/dev_logs.go
+++ b/tools/aepctl/cmd/dev_logs.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+
+	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
+)
+
+var (
+	devLogsFollow bool
+	devLogsTail   int64
+)
+
+var devLogsCmd = &cobra.Command{
+	Use:   "logs <service>",
+	Short: "Tail the logs of a dev-mode service",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDevLogs,
+}
+
+func init() {
+	devCmd.AddCommand(devLogsCmd)
+	devLogsCmd.Flags().BoolVarP(&devLogsFollow, "follow", "f", false, "Stream new log output")
+	devLogsCmd.Flags().Int64Var(&devLogsTail, "tail", 200, "Number of recent lines to show")
+}
+
+func runDevLogs(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if !viper.GetBool("dev.enabled") {
+		return fmt.Errorf("dev mode is disabled — enable it with `aep dev enable`")
+	}
+	s, ok := lookupDevService(args[0])
+	if !ok {
+		return fmt.Errorf("unknown service %q", args[0])
+	}
+	client, err := k8s.NewClient("")
+	if err != nil {
+		return fmt.Errorf("connect to cluster: %w", err)
+	}
+	ns := viper.GetString("dev.namespace")
+
+	pod, err := k8s.FindRunningPod(ctx, client, ns, s.Deployment)
+	if err != nil {
+		return fmt.Errorf("find running pod for %s: %w", s.Name, err)
+	}
+
+	opts := &corev1.PodLogOptions{
+		Container: s.Container,
+		Follow:    devLogsFollow,
+	}
+	if devLogsTail >= 0 {
+		opts.TailLines = &devLogsTail
+	}
+	stream, err := client.CoreV1().Pods(ns).GetLogs(pod, opts).Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("stream logs for %s: %w", pod, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = io.Copy(os.Stdout, stream)
+	return err
+}

--- a/tools/aepctl/cmd/dev_reload.go
+++ b/tools/aepctl/cmd/dev_reload.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/wso2/aep/aepctl/internal/dev"
+	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
+)
+
+var devReloadCmd = &cobra.Command{
+	Use:   "reload <service|all>",
+	Short: "Build a service from local source, import it, and redeploy it",
+	Long: `Rebuilds one service (or all) from the local AEP source, imports the image
+into the k3d cluster, records the image override in ~/.aep/dev-values.yaml, and
+rolls the running Deployment to the new image.
+
+  aep dev reload aep-api
+  aep dev reload all
+
+Valid services: ` + fmt.Sprint(devServiceNames()),
+	Args: cobra.ExactArgs(1),
+	RunE: runDevReload,
+}
+
+func init() {
+	devCmd.AddCommand(devReloadCmd)
+}
+
+func runDevReload(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	root, err := requireDevMode()
+	if err != nil {
+		return err
+	}
+	services, err := resolveDevServices(args[0])
+	if err != nil {
+		return err
+	}
+	cluster, err := requireK3d(ctx)
+	if err != nil {
+		return err
+	}
+	client, err := k8s.NewClient("")
+	if err != nil {
+		return fmt.Errorf("connect to cluster: %w", err)
+	}
+	valuesPath, err := dev.ValuesPath()
+	if err != nil {
+		return err
+	}
+	ns := viper.GetString("dev.namespace")
+
+	for _, s := range services {
+		if err := reloadService(ctx, client, root, cluster, ns, valuesPath, s); err != nil {
+			return fmt.Errorf("reload %s: %w", s.Name, err)
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "\n✅ Reloaded %d service(s). Images are local-only and recorded in %s.\n",
+		len(services), valuesPath)
+	return nil
+}
+
+func reloadService(ctx context.Context, client *kubernetes.Clientset, root, cluster, ns, valuesPath string, s devService) error {
+	fmt.Fprintf(os.Stdout, "\n=== %s ===\n", s.Name)
+
+	// Fail fast if the Deployment isn't present (e.g. `collab` before its chart
+	// lands) — before spending minutes on a build.
+	if _, err := client.AppsV1().Deployments(ns).Get(ctx, s.Deployment, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("deployment %s/%s not found — is this service installed in the cluster?", ns, s.Deployment)
+		}
+		return fmt.Errorf("get deployment %s/%s: %w", ns, s.Deployment, err)
+	}
+
+	tag := devImageTag(s)
+	if err := dev.BuildImage(ctx, root, s.Dockerfile, s.Context, tag, os.Stdout); err != nil {
+		return err
+	}
+	if err := dev.ImportImage(ctx, tag, cluster, os.Stdout); err != nil {
+		return err
+	}
+	if err := dev.MergeImageOverride(valuesPath, s.ValuesKey, imageRepo(tag), "dev", "Never"); err != nil {
+		return err
+	}
+	if err := setImageAndRoll(ctx, client, ns, s, tag); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "→ waiting for rollout of deployment/%s...\n", s.Deployment)
+	if err := waitForRolloutComplete(ctx, client, ns, s.Deployment, 5*time.Minute); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "✅ %s running %s\n", s.Name, tag)
+	return nil
+}
+
+// imageRepo strips the ":dev" tag suffix, returning just the repository — the
+// form Helm values want (image.repository + image.tag are separate keys).
+func imageRepo(tag string) string {
+	return tag[:len(tag)-len(":dev")]
+}
+
+// setImageAndRoll patches the Deployment's container image + pull policy and
+// stamps a reload annotation. The annotation forces a new ReplicaSet even though
+// the ":dev" tag is unchanged (only its content in the node changed).
+func setImageAndRoll(ctx context.Context, client *kubernetes.Clientset, ns string, s devService, tag string) error {
+	patch := map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"aepctl.wso2.com/reloadedAt": time.Now().UTC().Format(time.RFC3339Nano),
+					},
+				},
+				"spec": map[string]any{
+					"containers": []map[string]any{
+						{"name": s.Container, "image": tag, "imagePullPolicy": "Never"},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	if _, err := client.AppsV1().Deployments(ns).Patch(ctx, s.Deployment, types.StrategicMergePatchType, b, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("patch deployment %s/%s: %w", ns, s.Deployment, err)
+	}
+	return nil
+}
+
+// waitForRolloutComplete blocks until the Deployment has rolled all replicas to
+// the latest revision, or the timeout elapses.
+func waitForRolloutComplete(ctx context.Context, client *kubernetes.Clientset, ns, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		d, err := client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get deployment %s/%s: %w", ns, name, err)
+		}
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		st := d.Status
+		rolled := st.ObservedGeneration >= d.Generation &&
+			st.UpdatedReplicas == desired &&
+			st.AvailableReplicas == desired &&
+			st.Replicas == desired
+		if rolled {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for rollout of %s/%s (updated=%d available=%d desired=%d)",
+				timeout, ns, name, st.UpdatedReplicas, st.AvailableReplicas, desired)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/tools/aepctl/cmd/dev_restart.go
+++ b/tools/aepctl/cmd/dev_restart.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
+)
+
+var devRestartCmd = &cobra.Command{
+	Use:   "restart <service|all>",
+	Short: "Rollout-restart a service without rebuilding its image",
+	Long: `Triggers a rolling restart of one service (or all) using the currently
+deployed image — no rebuild. Useful after a ConfigMap/Secret change.
+
+  aep dev restart aep-api
+  aep dev restart all`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDevRestart,
+}
+
+func init() {
+	devCmd.AddCommand(devRestartCmd)
+}
+
+func runDevRestart(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if !viper.GetBool("dev.enabled") {
+		return fmt.Errorf("dev mode is disabled — enable it with `aep dev enable`")
+	}
+	services, err := resolveDevServices(args[0])
+	if err != nil {
+		return err
+	}
+	client, err := k8s.NewClient("")
+	if err != nil {
+		return fmt.Errorf("connect to cluster: %w", err)
+	}
+	ns := viper.GetString("dev.namespace")
+
+	for _, s := range services {
+		if err := k8s.RolloutRestart(ctx, client, ns, s.Deployment); err != nil {
+			return fmt.Errorf("restart %s: %w", s.Name, err)
+		}
+		fmt.Fprintf(os.Stdout, "→ restarting deployment/%s...\n", s.Deployment)
+		if err := waitForRolloutComplete(ctx, client, ns, s.Deployment, 5*time.Minute); err != nil {
+			return fmt.Errorf("restart %s: %w", s.Name, err)
+		}
+		fmt.Fprintf(os.Stdout, "✅ %s restarted\n", s.Name)
+	}
+	return nil
+}

--- a/tools/aepctl/cmd/dev_serve.go
+++ b/tools/aepctl/cmd/dev_serve.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	devServeReal        bool
+	devServeAPIPort     int
+	devServeSkipPrepare bool
+)
+
+var devServeCmd = &cobra.Command{
+	Use:   "serve <service>",
+	Short: "Run a service's local dev server (HMR) instead of building an image",
+	Long: `Runs a service's local development server with hot-reload, as a fast
+alternative to the in-cluster build/redeploy of 'aep dev reload'.
+
+Only edge/leaf services (the console frontend) can run locally: nothing in the
+cluster calls into them. Backend services are reached by other services via
+cluster DNS and need in-cluster dependencies, so they have no local dev server —
+use 'aep dev reload <service>' for those.
+
+  aep dev serve console            # Vite dev server on :8090 with mock data
+  aep dev serve console --real     # proxy to the in-cluster aep-api (auto port-forward)
+
+Runs in the foreground; press Ctrl-C to stop.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDevServe,
+}
+
+func init() {
+	devCmd.AddCommand(devServeCmd)
+	devServeCmd.Flags().BoolVar(&devServeReal, "real", false, "Proxy to the in-cluster aep-api (auto kubectl port-forward) instead of mock data")
+	devServeCmd.Flags().IntVar(&devServeAPIPort, "api-port", 9090, "Local port for the aep-api port-forward (with --real)")
+	devServeCmd.Flags().BoolVar(&devServeSkipPrepare, "skip-prepare", false, "Skip building the service's workspace deps before starting (faster when already built)")
+}
+
+func runDevServe(cmd *cobra.Command, args []string) error {
+	root, err := requireDevMode()
+	if err != nil {
+		return err
+	}
+	s, ok := lookupDevService(args[0])
+	if !ok {
+		return fmt.Errorf("unknown service %q — valid: %s", args[0], devServiceNames())
+	}
+	if len(s.DevServerCmd) == 0 {
+		return fmt.Errorf("%s has no local dev server. Backend services run in-cluster "+
+			"because other services reach them by cluster DNS — use `aep dev reload %s`.", s.Name, s.Name)
+	}
+	if _, err := exec.LookPath(s.DevServerCmd[0]); err != nil {
+		return fmt.Errorf("%q is required to run the %s dev server but was not found in PATH", s.DevServerCmd[0], s.Name)
+	}
+
+	// Ctrl-C cancels the context, which stops the dev server (and the
+	// port-forward child, if any) cleanly.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Bring the local checkout to the state the dev server needs: install the
+	// dependency closure (node_modules may lag the lockfile) then build the
+	// workspace deps whose exports resolve to ./dist (Vite can't resolve them
+	// otherwise) — the same prerequisites the Dockerfile handles. Both are fast
+	// when already satisfied; --skip-prepare bypasses them once warm.
+	if len(s.DevServerPrepare) > 0 && !devServeSkipPrepare {
+		fmt.Fprintf(os.Stdout, "Preparing dependencies for %s...\n", s.Name)
+		for _, cmdArgs := range s.DevServerPrepare {
+			prep := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
+			prep.Dir = root
+			prep.Stdout = os.Stdout
+			prep.Stderr = os.Stderr
+			if err := prep.Run(); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("prepare %s (%s): %w", s.Name, cmdArgs[0], err)
+			}
+		}
+	}
+
+	env := os.Environ()
+	if devServeReal {
+		cleanup, err := startAPIPortForward(ctx)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		env = append(env, fmt.Sprintf("API_PROXY_TARGET=http://localhost:%d", devServeAPIPort))
+		fmt.Fprintf(os.Stdout, "Data source: in-cluster aep-api (via port-forward :%d)\n", devServeAPIPort)
+	} else {
+		env = append(env, "VITE_API_MODE=mock")
+		fmt.Fprintln(os.Stdout, "Data source: mock (VITE_API_MODE=mock) — no cluster. Use --real for live data.")
+	}
+
+	if s.DevServerPort > 0 {
+		fmt.Fprintf(os.Stdout, "Starting %s dev server → http://localhost:%d (Ctrl-C to stop)\n", s.Name, s.DevServerPort)
+	}
+
+	c := exec.CommandContext(ctx, s.DevServerCmd[0], s.DevServerCmd[1:]...)
+	c.Dir = root
+	c.Env = env
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		// A Ctrl-C (context canceled) is a clean stop, not an error.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("%s dev server: %w", s.Name, err)
+	}
+	return nil
+}
+
+// startAPIPortForward spawns `kubectl port-forward` for the in-cluster aep-api
+// and returns a cleanup func that stops it. Best-effort readiness wait so the
+// first proxied request from the dev server connects.
+func startAPIPortForward(ctx context.Context) (func(), error) {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return nil, fmt.Errorf("kubectl is required for --real but was not found in PATH")
+	}
+	ns := viper.GetString("dev.namespace")
+	pf := exec.CommandContext(ctx, "kubectl", "-n", ns, "port-forward",
+		"svc/aep-api", fmt.Sprintf("%d:9090", devServeAPIPort))
+	pf.Stdout = os.Stdout
+	pf.Stderr = os.Stderr
+	if err := pf.Start(); err != nil {
+		return nil, fmt.Errorf("start aep-api port-forward: %w", err)
+	}
+	// Give the tunnel a moment to establish before the dev server starts.
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+	}
+	cleanup := func() {
+		if pf.Process != nil {
+			_ = pf.Process.Kill()
+		}
+		_ = pf.Wait()
+	}
+	return cleanup, nil
+}

--- a/tools/aepctl/cmd/dev_status.go
+++ b/tools/aepctl/cmd/dev_status.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
+)
+
+var devStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show dev mode state and per-service deployment images",
+	RunE:  runDevStatus,
+}
+
+func init() {
+	devCmd.AddCommand(devStatusCmd)
+}
+
+func runDevStatus(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	enabled := viper.GetBool("dev.enabled")
+	fmt.Fprintf(os.Stdout, "Dev mode:  %s\n", enabledLabel(enabled))
+	fmt.Fprintf(os.Stdout, "Project:   %s\n", orNotSet(viper.GetString("dev.project_path")))
+	fmt.Fprintf(os.Stdout, "Cluster:   %s (k3d)\n", viper.GetString("dev.k3d_cluster"))
+	ns := viper.GetString("dev.namespace")
+	fmt.Fprintf(os.Stdout, "Namespace: %s\n\n", ns)
+
+	client, err := k8s.NewClient("")
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "(cluster unreachable: %v)\n", err)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "SERVICE\tDEPLOYMENT\tREADY\tIMAGE")
+	for _, s := range devServices {
+		d, err := client.AppsV1().Deployments(ns).Get(ctx, s.Deployment, metav1.GetOptions{})
+		if err != nil {
+			state := "error"
+			if apierrors.IsNotFound(err) {
+				state = "not installed"
+			}
+			fmt.Fprintf(w, "%s\t%s\t-\t(%s)\n", s.Name, s.Deployment, state)
+			continue
+		}
+		image := "-"
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == s.Container {
+				image = c.Image
+				break
+			}
+		}
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\n", s.Name, s.Deployment, d.Status.ReadyReplicas, desired, image)
+	}
+	return w.Flush()
+}
+
+func orNotSet(s string) string {
+	if s == "" {
+		return "(not set)"
+	}
+	return s
+}
+
+func enabledLabel(b bool) string {
+	if b {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/wso2/aep/aepctl/internal/adminpb"
+	"github.com/wso2/aep/aepctl/internal/dev"
 	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
 )
 
@@ -195,6 +196,17 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("localOrgProvisioning.enabled=%t", viper.GetBool("oc.local_org_provisioning.enabled")))
 	if ns := viper.GetString("oc.org_namespace"); ns != "" {
 		helmArgs = append(helmArgs, "--set", "localOrgProvisioning.orgNamespace="+ns)
+	}
+	// Dev mode: if enabled and a dev-values override exists (written by
+	// `aep dev reload`), pass it last so locally-built images survive this
+	// install/upgrade instead of reverting to the registry images.
+	if viper.GetBool("dev.enabled") {
+		if devValues, err := dev.ValuesPath(); err == nil {
+			if _, statErr := os.Stat(devValues); statErr == nil {
+				helmArgs = append(helmArgs, "-f", devValues)
+				_, _ = fmt.Fprintf(os.Stdout, "Dev mode: applying image overrides from %s\n", devValues)
+			}
+		}
 	}
 	var helmOut bytes.Buffer
 	helmCmd := exec.CommandContext(ctx, "helm", helmArgs...)

--- a/tools/aepctl/design/dev-mode.md
+++ b/tools/aepctl/design/dev-mode.md
@@ -1,0 +1,102 @@
+# Dev mode (`aep dev`) — final shape
+
+Dev mode is aepctl's local inner loop: after editing an AEP service's source, one
+command rebuilds its image, imports it into the local k3d cluster, and rolls the
+running Deployment to it. It is **opt-in** — off by default, and the
+cluster-mutating subcommands refuse until it is enabled.
+
+## Command surface
+
+All commands follow `aep dev <verb> [service]`:
+
+- `aep dev enable [--project-path DIR]` / `disable` / `set-path DIR` — toggle the
+  mode and point it at a local AEP checkout. Persisted to `~/.aep/config.yaml`
+  (`dev.enabled`, `dev.project_path`, plus `dev.k3d_cluster`, `dev.namespace`,
+  `dev.image_prefix`). The path is also editable directly in the config file.
+- `aep dev status` — always available; prints the mode, paths, and a per-service
+  table of the running Deployment image + ready replicas.
+- `aep dev reload <service|all>` — the core in-cluster verb (build → import →
+  persist → redeploy). Gated by `requireDevMode()`.
+- `aep dev serve <service>` — run the service's **local dev server** (HMR) instead
+  of building an image. Capability-gated (see below).
+- `aep dev restart <service|all>` — rollout restart only (no rebuild), for
+  ConfigMap/Secret changes.
+- `aep dev logs <service> [-f]` — tail the service pod logs.
+
+## In-cluster (`reload`) vs local dev server (`serve`)
+
+Two ways to see a code change run — the user picks by verb:
+
+- **`reload`** builds the image and redeploys it into the cluster. Works for every
+  service. It's the source of truth, but a full container build per edit.
+- **`serve`** runs the service's own dev server on your laptop with hot-reload —
+  seconds per edit, but not the deployed artifact.
+
+`serve` is **capability-gated**, not a universal mode: a service opts in via a
+non-empty `DevServerCmd` in the registry. Only the **console** frontend does today.
+This is deliberate — console is an edge/leaf (nothing in the cluster calls into it;
+it only makes outbound calls to aep-api), so it runs locally safely with just a
+proxy to the API. Backends (`aep-api`, `agents`, `aep-mcp-server`, `collab`) are
+mesh nodes reached by other services via cluster DNS and need many injected
+dependencies, so "run locally" doesn't work cleanly (that's mirrord/telepresence
+territory — out of scope). `aep dev serve aep-api` therefore returns a clear error
+pointing to `reload`, rather than half-working.
+
+`serve console` defaults to **mock data** (`VITE_API_MODE=mock`, no cluster) — ideal
+for pure UI work. `--real` auto-manages a `kubectl port-forward` to the in-cluster
+aep-api (torn down on Ctrl-C) for live data. It runs in the foreground until Ctrl-C.
+
+## Service registry
+
+`cmd/dev.go` holds the single source of truth mapping a service name to how it
+builds (dockerfile + context, relative to the project root — mirroring
+`.github/workflows/build-images.yml`) and how it deploys (Deployment + container
+name, and the top-level Helm values key). Registered services: `aep-api`,
+`agents`, `aep-mcp-server`, `console`, `collab`. `reload` checks the Deployment
+exists first, so a service whose chart isn't installed (e.g. `collab` on branches
+before its chart lands) fails fast with a clear message rather than after a build.
+
+## `reload` pipeline
+
+1. Guard — dev enabled, project path valid (contains `AGENTS.md`), `k3d`/`docker`
+   present, and `dev.k3d_cluster` exists.
+2. `docker build -f <root>/<dockerfile> -t <prefix>/<svc>:dev <root>/<context>`.
+3. `k3d image import <prefix>/<svc>:dev -c <cluster>`.
+4. Merge the image override into `~/.aep/dev-values.yaml`
+   (`<valuesKey>.image = {repository, tag: dev, pullPolicy: Never}`).
+5. Strategic-merge patch the Deployment's container image + `imagePullPolicy:
+   Never` and stamp an `aepctl.wso2.com/reloadedAt` annotation, then wait for the
+   rollout to complete.
+
+The `:dev` tag is **stable** (keeps `dev-values.yaml` stable); each import
+overwrites its content in the node, and the annotation forces a fresh ReplicaSet
+even though the tag is unchanged. `pullPolicy: Never` guarantees the imported
+local image is used and fails loudly (`ErrImageNeverPull`) if it is missing.
+
+### Build speed
+`reload` sets `DOCKER_BUILDKIT=1` (in `internal/dev/build.go`) so the service
+Dockerfiles' `--mount=type=cache` steps apply. The pnpm-workspace Dockerfiles
+(`apps/console`, `services/agents`, `services/aep-mcp-server`) copy manifests +
+`packages/` before `pnpm install` and the frequently-edited **app source last**,
+with the pnpm store on a cache mount — so a source-only edit skips reinstall and
+the workspace-dep builds, rerunning just `gen`/`build`. `services/aep-api` (Go)
+caches the module + build caches. CI's buildx honors the same mounts.
+
+## Persistence across reinstall
+
+`aep dev reload` records overrides in `~/.aep/dev-values.yaml`, and `aep init`
+appends `-f ~/.aep/dev-values.yaml` to the platform `helm` args when dev mode is
+enabled (last `-f` wins). So a re-`init`/upgrade keeps the locally-built images
+instead of reverting to the registry images.
+
+**Caveat:** the dev images live only in the k3d node. If the cluster is recreated
+(`k3d cluster delete/create`), they are gone and pods with a persisted dev
+override will `ErrImageNeverPull` — re-run `aep dev reload <svc>` (or `all`) to
+re-import.
+
+## Scope / assumptions
+
+- k3d-only (import uses `k3d image import`); non-k3d clusters error clearly.
+- Covers the platform runtime Deployments only — not `aep-server` (the CLI's own
+  server) or data-plane Jobs (remote-worker / coding-agent-runner).
+- No file-watch/auto-reload; reload is an explicit command.

--- a/tools/aepctl/internal/config/config.go
+++ b/tools/aepctl/internal/config/config.go
@@ -93,6 +93,23 @@ func Init() {
 	viper.SetDefault("webhook.delivery_url", "")
 	viper.SetDefault("webhook.local_smee.enabled", true)
 
+	// Dev mode — local source-driven inner loop (`aep dev ...`). All overridable
+	// via ~/.aep/config.yaml. Off by default: dev commands that mutate the cluster
+	// (reload/restart/logs) refuse unless dev.enabled is true.
+	//
+	// dev.project_path: absolute path to a local checkout of the AEP source repo;
+	//   `aep dev reload <svc>` builds images from it.
+	// dev.k3d_cluster: the k3d cluster name images are imported into
+	//   (matches deployments/k3d-local-config.yaml).
+	// dev.namespace: the platform release namespace holding the service Deployments.
+	// dev.image_prefix: repository prefix for locally-built dev images
+	//   (final tag: <prefix>/<service>:dev).
+	viper.SetDefault("dev.enabled", false)
+	viper.SetDefault("dev.project_path", "")
+	viper.SetDefault("dev.k3d_cluster", "openchoreo")
+	viper.SetDefault("dev.namespace", "wso2-aep")
+	viper.SetDefault("dev.image_prefix", "aep-dev")
+
 	// Thunder defaults — all overridable via ~/.aep/config.yaml or AEP_THUNDER_* env vars.
 	viper.SetDefault("thunder.namespace", "thunder")
 	viper.SetDefault("thunder.url", "http://thunder-service.thunder.svc.cluster.local:8090")

--- a/tools/aepctl/internal/dev/build.go
+++ b/tools/aepctl/internal/dev/build.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package dev holds the helpers for aepctl's local source-driven dev mode:
+// building a service image from a local checkout, importing it into the k3d
+// cluster, and persisting the image override so it survives helm upgrades.
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// BuildImage builds a service image from the local source tree.
+// dockerfile and buildContext are paths relative to projectRoot (matching the
+// CI image matrix). Build output is streamed to out.
+func BuildImage(ctx context.Context, projectRoot, dockerfile, buildContext, tag string, out io.Writer) error {
+	df := filepath.Join(projectRoot, dockerfile)
+	cxt := filepath.Join(projectRoot, buildContext)
+	fmt.Fprintf(out, "→ docker build -f %s -t %s %s\n", df, tag, cxt)
+	c := exec.CommandContext(ctx, "docker", "build", "-f", df, "-t", tag, cxt)
+	// BuildKit is required for the Dockerfiles' `--mount=type=cache` steps, which
+	// keep dev rebuilds fast (skip reinstall / reuse the pnpm + Vite caches).
+	c.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	c.Stdout = out
+	c.Stderr = out
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("docker build %s: %w", tag, err)
+	}
+	return nil
+}
+
+// ImportImage loads a locally-built image into the named k3d cluster's nodes so
+// pods can run it without a registry pull (pullPolicy: Never).
+func ImportImage(ctx context.Context, tag, cluster string, out io.Writer) error {
+	fmt.Fprintf(out, "→ k3d image import %s -c %s\n", tag, cluster)
+	c := exec.CommandContext(ctx, "k3d", "image", "import", tag, "-c", cluster)
+	c.Stdout = out
+	c.Stderr = out
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("k3d image import %s: %w", tag, err)
+	}
+	return nil
+}
+
+// K3dClusterExists reports whether a k3d cluster with the given name exists.
+func K3dClusterExists(ctx context.Context, cluster string) (bool, error) {
+	out, err := exec.CommandContext(ctx, "k3d", "cluster", "list", "-o", "json").Output()
+	if err != nil {
+		return false, fmt.Errorf("k3d cluster list: %w", err)
+	}
+	var clusters []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &clusters); err != nil {
+		return false, fmt.Errorf("parse k3d cluster list: %w", err)
+	}
+	for _, c := range clusters {
+		if c.Name == cluster {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/tools/aepctl/internal/dev/values.go
+++ b/tools/aepctl/internal/dev/values.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dev
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ValuesPath returns the path to the Helm values override file that persists
+// dev image overrides (~/.aep/dev-values.yaml). `aep init`/upgrade pass this via
+// `-f` when dev mode is enabled so reloaded images survive a reinstall.
+func ValuesPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".aep", "dev-values.yaml"), nil
+}
+
+// MergeImageOverride sets <valuesKey>.image = {repository, tag, pullPolicy} in
+// the dev-values file, preserving any other services' overrides already present.
+func MergeImageOverride(path, valuesKey, repository, tag, pullPolicy string) error {
+	root := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := yaml.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		if root == nil {
+			root = map[string]any{}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	svc, _ := root[valuesKey].(map[string]any)
+	if svc == nil {
+		svc = map[string]any{}
+	}
+	svc["image"] = map[string]any{
+		"repository": repository,
+		"tag":        tag,
+		"pullPolicy": pullPolicy,
+	}
+	root[valuesKey] = svc
+
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return fmt.Errorf("marshal dev values: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/tools/aepctl/internal/kubernetes/rollout.go
+++ b/tools/aepctl/internal/kubernetes/rollout.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// RolloutRestart triggers a rolling restart of a Deployment by stamping a
+// timestamp annotation on the pod template (the same mechanism as
+// `kubectl rollout restart`).
+func RolloutRestart(ctx context.Context, client *kubernetes.Clientset, namespace, name string) error {
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"aepctl.wso2.com/restartedAt":%q}}}}}`,
+		time.Now().UTC().Format(time.RFC3339))
+	_, err := client.AppsV1().Deployments(namespace).Patch(ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	return err
+}


### PR DESCRIPTION
## What

Adds an opt-in **`aep dev`** command group to `aepctl` — a local inner loop for developers editing AEP service source, so a code change can be run in the k3d cluster (or via a hot-reloading dev server) with one learnable command. All commands follow `aep dev <verb> [service]`.

| Command | Purpose |
|---|---|
| `aep dev enable [--project-path DIR]` / `disable` / `set-path DIR` | Opt into dev mode + point at a local AEP checkout (persisted to `~/.aep/config.yaml`). |
| `aep dev status` | Show mode + per-service Deployment image / ready replicas. |
| `aep dev reload <svc\|all>` | **In-cluster:** `docker build` → `k3d image import` → record override in `~/.aep/dev-values.yaml` → set-image + rollout. |
| `aep dev serve <svc>` | **Local dev server (HMR).** Capability-gated. |
| `aep dev restart <svc\|all>` | Rollout-restart only (no rebuild). |
| `aep dev logs <svc> [-f]` | Tail the service pod logs. |

Services: `aep-api`, `agents`, `aep-mcp-server`, `console`, `collab` (collab guarded — errors clearly until its chart is present).

## Design notes

- **Opt-in:** off by default; `reload`/`restart`/`serve`/`logs` refuse unless `dev.enabled`.
- **Persistence:** `reload` writes image overrides to `~/.aep/dev-values.yaml`; `aep init` applies them with `-f` when dev mode is on, so local images survive a reinstall (uses `pullPolicy: Never`; recreate the cluster → re-run `reload`).
- **`serve` is capability-gated, not a global toggle.** Only edge/leaf services (console) declare a dev server; backends are reached by other services via cluster DNS and can't run locally, so `serve aep-api` returns an educational error pointing to `reload`. `serve console` defaults to mock data (`VITE_API_MODE=mock`); `--real` proxies to the in-cluster aep-api via an auto port-forward. A prepare step (`pnpm install` + build workspace deps) runs first so the dev server resolves the `@aep/*` `dist` packages.

## Faster in-cluster builds

Reorders the `console` + `agents` Dockerfiles so app source is copied **last** (a source-only edit skips reinstall and the workspace-dep builds), and adds BuildKit cache mounts (pnpm store; Go module + build cache for aep-api). `reload` sets `DOCKER_BUILDKIT=1`. CI's buildx already honors these; the default build command is unchanged so CI/prod behavior is identical.

## Testing

- `go build ./...`, `go vet ./...`, `make license-check` — clean.
- CLI: `aep dev --help`; `enable`/`status`/`reload`/`serve` gating verified (dev-disabled refuses; backend `serve` → educational error; unknown service → valid list).
- End-to-end on a live k3d cluster: `reload console`/`aep-api` swap the running image; caching confirmed (source edit reruns only `gen`+`build`, no reinstall/redownload); `serve console` HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)