### PR TITLE
feat(validation): publish validation runner image via release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           - name: remote-worker
             dockerfile: runners/remote-worker/Dockerfile
             context: runners/remote-worker
+          - name: remote-worker-validation
+            dockerfile: runners/remote-worker/Dockerfile.validation
+            context: runners/remote-worker
           - name: console
             dockerfile: apps/console/Dockerfile
             context: .
@@ -126,6 +129,7 @@ jobs:
           yq -i '.console.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
           yq -i '.console.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
           yq -i '.codingAgentDispatch.clusterGatewayProxy.image = "${{ env.IMAGE_PREFIX }}/cluster-gateway-proxy:${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.validationRunner.image = "${{ env.IMAGE_PREFIX }}/remote-worker-validation:${{ inputs.version }}"' /tmp/platform/values.yaml
 
           helm package /tmp/platform --destination /tmp/charts
 
@@ -170,6 +174,7 @@ jobs:
           - \`ghcr.io/wso2/aep/aep-api:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/agents:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/remote-worker:${{ inputs.version }}\`
+          - \`ghcr.io/wso2/aep/remote-worker-validation:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/console:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/cluster-gateway-proxy:${{ inputs.version }}\`"
 

--- a/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
+++ b/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
@@ -100,6 +100,13 @@ spec:
               value: "http://aep-api.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.aepApi.port }}"
             - name: AGENT_RUNNER_IMAGE
               value: {{ .Values.codingAgentRunner.image | quote }}
+            # Validation-task runner image. Empty ⇒ env unset ⇒ validation
+            # dispatch stays disabled (aep-api fails loudly if a validation
+            # task is dispatched without it).
+            {{- if .Values.validationRunner.image }}
+            - name: VALIDATION_RUNNER_IMAGE
+              value: {{ .Values.validationRunner.image | quote }}
+            {{- end }}
             # cluster-gateway-proxy: enables coding-agent live streaming +
             # JobWatcher (reads pod logs/job status). Local → in-cluster stub
             # Service; prod → the real managed proxy URL. Unset → no streaming,

--- a/deployments/helm-charts/platform/values.yaml
+++ b/deployments/helm-charts/platform/values.yaml
@@ -63,6 +63,13 @@ codingAgentRunner:
   # K8s Job in the org's data-plane remote-worker namespace.
   image: "docker.io/xlight05/aep-coding-agent-runner:v7"
 
+validationRunner:
+  # Docker image for the validation-task runner Job (Playwright + baked
+  # chromium). Empty disables validation dispatch (fails loudly at dispatch
+  # time). The release pipeline pins this to the released
+  # ghcr.io/wso2/aep/remote-worker-validation:<version>.
+  image: ""
+
 # Coding-agent dispatch + live-streaming wiring.
 #
 # The coding-agent runner writes NDJSON progress to its pod stdout; aep-api

--- a/deployments/scripts/build-validation-runner.sh
+++ b/deployments/scripts/build-validation-runner.sh
@@ -17,10 +17,14 @@
 
 # Builds the validation-task runner image (Debian + Playwright + baked chromium,
 # runners/remote-worker/Dockerfile.validation) and imports it into the local k3d
-# cluster. Unlike the coding runner (published to Docker Hub), this image is not
-# published, so every machine builds it locally once — self-contained, no shared
-# registry needed. Validation dispatch (proxy path only) reads it via the compose
-# VALIDATION_RUNNER_IMAGE env, which defaults to the same tag built here.
+# cluster. This is the LOCAL/DEV path: every machine builds the :dev tag once —
+# self-contained, no shared registry needed. Validation dispatch (proxy path
+# only) reads it via the compose VALIDATION_RUNNER_IMAGE env, which defaults to
+# the same tag built here.
+#
+# For released platforms the image is published to GHCR as
+# ghcr.io/wso2/aep/remote-worker-validation:<version> by .github/workflows/release.yml
+# and wired into aep-api via the platform Helm chart's validationRunner.image.
 #
 # Idempotent: the (multi-minute, downloads chromium) build is skipped when the
 # image already exists. FORCE=1 rebuilds — use it after changing Dockerfile.validation

--- a/docs/design/validation.md
+++ b/docs/design/validation.md
@@ -131,10 +131,14 @@ a matching heal-log entry is a hard error (exit 2); newly added specs are not
 gated. The agent never hand-writes the report.
 
 **Image — `Dockerfile.validation`.** `node:22-bookworm-slim` (glibc, for chromium)
-with baked chromium + `playwright-cli` + `gh` + Go. `AEP_PLAYWRIGHT_VERSION` pins
-`tests/e2e/package.json` to the baked browser version. The alpine coding image
+with baked chromium + `playwright-cli` + `gh` + Go, plus the plugin skills baked
+in at build time (`COPY . .`, same convention as the coding runner). `AEP_PLAYWRIGHT_VERSION`
+pins `tests/e2e/package.json` to the baked browser version. The alpine coding image
 cannot run chromium, so there is no fallback — an empty `VALIDATION_RUNNER_IMAGE`
-disables validation dispatch (fails loudly).
+disables validation dispatch (fails loudly). Released to GHCR as
+`ghcr.io/wso2/aep/remote-worker-validation:<version>` by `.github/workflows/release.yml`
+and wired into aep-api via the platform Helm chart's `validationRunner.image`; the
+local `aep-validation-runner:dev` tag (`build-validation-runner.sh`) is the dev path.
 
 **Runner plumbing (`src/`).** The only validation-specific change is the
 `AEP_TASK_KIND` switch (`implementation` | `validation`) that preloads


### PR DESCRIPTION
## What

Publishes the validation-task runner image through the existing release pipeline and wires it into the platform Helm chart, so a released platform can actually dispatch validation.

## Why

Follow-up to the #229 review question (thanks @kaje94) — the validation runner image was **not** pushed to any registry. It was local-only: `build-validation-runner.sh` builds `aep-validation-runner:dev` per machine and imports it into k3d. Because an empty `VALIDATION_RUNNER_IMAGE` disables validation dispatch (fails loudly), any platform deployed from released artifacts had validation unavailable.

## Changes

**`.github/workflows/release.yml`**
- New `remote-worker-validation` entry in the `build-push-images` matrix (`Dockerfile.validation`, `runners/remote-worker` context) → published to `ghcr.io/wso2/aep/remote-worker-validation:<version>` + `:latest`, multi-arch, alongside the existing images.
- Chart-packaging step pins `validationRunner.image` into the packaged platform chart (same `yq` pattern as the other images).
- Image listed in the platform release notes.

**Helm platform chart** (mirrors the `codingAgentRunner` pattern)
- `values.yaml`: new `validationRunner.image` (empty by default).
- `aep-api/deployment.yaml`: guarded `VALIDATION_RUNNER_IMAGE` env — rendered only when the value is set, so the default keeps validation in its fail-loud "disabled" state.

**Docs**: `build-validation-runner.sh` header + `docs/design/validation.md` note the GHCR release channel; the local `:dev` build stays the dev path.

## Notes

- **Name** `remote-worker-validation` pairs with the existing `remote-worker` release image (both build from `runners/remote-worker`).
- **Empty default is intentional.** aep-api defaults `VALIDATION_RUNNER_IMAGE` to `""` (no baked fallback, unlike the coding runner) — empty means "validation disabled." The release pipeline injects the concrete `:<version>` into the packaged chart, so released installs get a working value; a source-tree install stays cleanly disabled rather than pulling a not-yet-published `:latest`.

## Verification

- `release.yml` is valid YAML; the matrix lists `remote-worker-validation`.
- `helm lint` passes; `helm template` renders `VALIDATION_RUNNER_IMAGE` when `validationRunner.image` is set and omits it on defaults.
- End-to-end (post-merge, manual): dispatch the Release workflow (component=platform) and confirm the image lands in GHCR and the packaged chart carries the pinned value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
