### PR TITLE
feat(deployments): intelligent run-after-pull update script

### DIFF
--- a/deployments/.gitignore
+++ b/deployments/.gitignore
@@ -6,3 +6,4 @@ github-app-private-key.pem
 data/
 .webhook-relay.pid
 .webhook-relay.log
+.aep-last-run

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -65,6 +65,7 @@ Key wiring:
 | `scripts/setup-openchoreo.sh` | Control Plane + Data Plane + Workflow Plane + Thunder |
 | `scripts/setup-aep.sh` | ClusterWorkflows + ClusterComponentTypes + Environment + AuthzRoleBindings + `.env` |
 | `scripts/start.sh` | Refresh DNS, seed kubeconfig, `docker compose up` |
+| `scripts/update.sh` | Run-after-pull driver: diff vs last run → run only the changed steps → `start.sh` (see `docs/developer-guide/run-after-pull.md`) |
 | `scripts/stop.sh` | `docker compose down` (cluster stays) |
 | `manifests/docker-build-workflow.yaml` | `dockerfile-builder` ClusterWorkflow (Argo CWTs) |
 | `manifests/aep-coding-agent.yaml` | Coding-agent one-shot pod template (mirrors v2 exactly) |

--- a/deployments/scripts/update.sh
+++ b/deployments/scripts/update.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Intelligent "run-after-pull" driver. Diffs the checkout against the last
+# successful run (deployments/.aep-last-run marker) and runs ONLY the setup
+# steps whose inputs changed, then hands off to start.sh. It never modifies the
+# other scripts — it only invokes them. See docs/developer-guide/run-after-pull.md
+# for the manual equivalent and the change → step mapping.
+#
+# Usage (from the repo root):
+#   bash deployments/scripts/update.sh            # detect → plan → confirm → run
+#   bash deployments/scripts/update.sh --dry-run  # print the plan only (no side effects)
+#   bash deployments/scripts/update.sh --yes      # run without the confirm prompt
+#   bash deployments/scripts/update.sh --full     # run every step regardless of the diff
+#   bash deployments/scripts/update.sh --from <sha>   # diff against <sha> instead of the marker
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEPLOY_DIR="$SCRIPT_DIR/.."
+
+# shellcheck source=env.sh
+source "$SCRIPT_DIR/env.sh"
+# shellcheck source=utils.sh
+source "$SCRIPT_DIR/utils.sh"
+
+MARKER="$DEPLOY_DIR/.aep-last-run"
+
+# ── Flags ────────────────────────────────────────────────────────────────────
+ASSUME_YES=0
+DRY_RUN=0
+FULL=0
+FROM_OVERRIDE=""
+
+usage() {
+    sed -n '18,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes)      ASSUME_YES=1 ;;
+        -n|--dry-run)  DRY_RUN=1 ;;
+        -f|--full)     FULL=1 ;;
+        --from)        FROM_OVERRIDE="$2"; shift ;;
+        -h|--help)     usage 0 ;;
+        *)             echo "❌ Unknown argument: $1"; echo; usage 1 ;;
+    esac
+    shift
+done
+
+echo "=== AEP update — run only what the pull changed ==="
+
+# ── Change detection (pure git; no side effects) ─────────────────────────────
+NEW="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+
+# The set of paths (repo-root-relative) to base the decision on:
+#   committed range  marker..HEAD   +   uncommitted tracked changes vs HEAD
+#   +  untracked files.  So both a pull AND local edits are accounted for.
+CHANGED=""
+MODE="incremental"
+
+resolve_sha() { git -C "$ROOT_DIR" rev-parse --verify --quiet "$1^{commit}" >/dev/null 2>&1; }
+
+if [ "$FULL" = "1" ]; then
+    MODE="full (--full)"
+elif [ -n "$FROM_OVERRIDE" ]; then
+    if resolve_sha "$FROM_OVERRIDE"; then
+        OLD="$FROM_OVERRIDE"
+    else
+        echo "❌ --from '$FROM_OVERRIDE' is not a resolvable commit."; exit 1
+    fi
+elif [ -f "$MARKER" ]; then
+    OLD="$(cat "$MARKER")"
+    if ! resolve_sha "$OLD"; then
+        echo "⚠️  Marker sha ($OLD) not found in history — falling back to a full run."
+        MODE="full (unresolvable marker)"
+    fi
+else
+    echo "ℹ️  No marker ($MARKER) — first intelligent run; planning a full run."
+    MODE="full (no marker)"
+fi
+
+if [[ "$MODE" == full* ]]; then
+    # Full run: force every gated step on. start.sh always runs regardless.
+    NEED_INSTALL=1; NEED_GEN=1; NEED_VRUN=1; NEED_AEP=1
+    T_INSTALL="(full run)"; T_GEN="(full run)"; T_VRUN="(full run)"; T_AEP="(full run)"
+else
+    # Assemble the changed-path set. grep/diff exit non-zero on "no match"; keep
+    # set -e happy with `|| true`.
+    committed=""
+    if [ "$OLD" != "$NEW" ]; then
+        committed="$(git -C "$ROOT_DIR" diff --name-only "$OLD" "$NEW" 2>/dev/null || true)"
+    fi
+    working="$(git -C "$ROOT_DIR" diff --name-only HEAD 2>/dev/null || true)"
+    untracked="$(git -C "$ROOT_DIR" ls-files --others --exclude-standard 2>/dev/null || true)"
+    CHANGED="$(printf '%s\n%s\n%s\n' "$committed" "$working" "$untracked" | grep -v '^$' | sort -u || true)"
+
+    # first_match REGEX → prints the first changed path matching REGEX (or empty).
+    first_match() { grep -E -m1 "$1" <<<"$CHANGED" || true; }
+
+    RE_INSTALL='^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|go\.work|go\.work\.sum)$|^(apps|packages|services|runners)/[^/]+/package\.json$|^packages/ui/[^/]+/package\.json$|^(services/aep-api|tools/aepctl|deployments/single-cluster/resource-types/thunder-app/operator)/go\.(mod|sum)$'
+    RE_GEN='^packages/contracts/api/v1/openapi\.yaml$|^packages/contracts/schemas/.*\.schema\.json$|^skills/'
+    RE_AEP='^deployments/scripts/(setup-aep|env|utils|build-validation-runner)\.sh$|^deployments/manifests/|^deployments/single-cluster/resource-types/'
+
+    T_INSTALL="$(first_match "$RE_INSTALL")"; [ -n "$T_INSTALL" ] && NEED_INSTALL=1 || NEED_INSTALL=0
+    T_GEN="$(first_match "$RE_GEN")";         [ -n "$T_GEN" ]     && NEED_GEN=1     || NEED_GEN=0
+    T_AEP="$(first_match "$RE_AEP")";         [ -n "$T_AEP" ]     && NEED_AEP=1     || NEED_AEP=0
+
+    # Validation runner: any runners/remote-worker/ change EXCEPT plugin/ (that is
+    # a live hostPath overlay — skill edits are picked up on the next dispatch).
+    T_VRUN="$(grep -E '^runners/remote-worker/' <<<"$CHANGED" | grep -vE '^runners/remote-worker/plugin/' | head -1 || true)"
+    [ -n "$T_VRUN" ] && NEED_VRUN=1 || NEED_VRUN=0
+fi
+
+# start.sh always runs — its `docker compose up --build` rebuilds every service
+# image from source, and it also refreshes DNS, kubeconfig, OpenBao, secrets.
+NEED_START=1
+
+# ── Print the plan ───────────────────────────────────────────────────────────
+echo ""
+if [[ "$MODE" == full* ]]; then
+    echo "Plan ($MODE):"
+else
+    echo "Plan — changes since ${OLD:0:12} → ${NEW:0:12}:"
+fi
+plan_row() { printf "  %-38s ← %s\n" "$1" "$2"; }
+[ "$NEED_INSTALL" = "1" ] && plan_row "make install" "${T_INSTALL:-?}"
+[ "$NEED_GEN"     = "1" ] && plan_row "make gen" "${T_GEN:-?}"
+[ "$NEED_VRUN"    = "1" ] && plan_row "make build-validation-runner FORCE=1" "${T_VRUN:-?}"
+[ "$NEED_AEP"     = "1" ] && plan_row "deployments/scripts/setup-aep.sh" "${T_AEP:-?}"
+[ "$NEED_START"   = "1" ] && plan_row "deployments/scripts/start.sh" "always"
+
+if [ "$NEED_AEP" = "1" ] && [[ "$MODE" != full* ]]; then
+    echo ""
+    echo "  ⚠️  setup-aep.sh re-applies cluster config and SIGHUP-restarts k3s (brief disruption)."
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo ""
+    echo "🅳 dry-run — no steps executed, marker unchanged."
+    exit 0
+fi
+
+# ── Confirm ──────────────────────────────────────────────────────────────────
+if [ "$ASSUME_YES" != "1" ]; then
+    echo ""
+    read -r -p "Proceed? [y/N] " reply || reply=""
+    case "$reply" in
+        y|Y) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+fi
+
+# ── Preflight (side effects allowed past this point) ─────────────────────────
+echo ""
+echo "🔍 Preflight..."
+if ! docker info &>/dev/null; then
+    echo "❌ Docker is not running. Start Docker / Colima first."; exit 1
+fi
+if ! command -v k3d &>/dev/null; then
+    echo "❌ k3d not installed."; exit 1
+fi
+
+# Cluster must exist. If it exists but is stopped (e.g. after a reboot), start it.
+CLUSTER_STATE="$(k3d cluster list "$CLUSTER_NAME" --no-headers 2>/dev/null | awk '{print $2}')"
+if [ -z "$CLUSTER_STATE" ]; then
+    echo "❌ k3d cluster '$CLUSTER_NAME' does not exist."
+    echo "   This is a first-time bring-up — run: bash deployments/scripts/setup.sh"
+    exit 1
+fi
+SERVERS_RUNNING="${CLUSTER_STATE%%/*}"   # "1/1" → 1, "0/1" → 0
+if [ "${SERVERS_RUNNING:-0}" -lt 1 ]; then
+    echo "⏻ k3d cluster '$CLUSTER_NAME' is stopped → starting..."
+    k3d cluster start "$CLUSTER_NAME"
+    wait_for_cluster || { echo "❌ Cluster failed to become ready."; exit 1; }
+else
+    echo "✅ k3d cluster '$CLUSTER_NAME' is running"
+fi
+
+# ── Execute the selected steps in order ──────────────────────────────────────
+if [ "$NEED_INSTALL" = "1" ]; then
+    echo ""; echo "📦 make install"
+    make -C "$ROOT_DIR" install
+fi
+if [ "$NEED_GEN" = "1" ]; then
+    echo ""; echo "🧬 make gen"
+    make -C "$ROOT_DIR" gen
+fi
+if [ "$NEED_VRUN" = "1" ]; then
+    echo ""; echo "🐳 make build-validation-runner FORCE=1"
+    make -C "$ROOT_DIR" build-validation-runner FORCE=1
+fi
+if [ "$NEED_AEP" = "1" ]; then
+    echo ""; echo "⚙️  setup-aep.sh"
+    bash "$SCRIPT_DIR/setup-aep.sh"
+fi
+
+echo ""; echo "🚀 start.sh"
+bash "$SCRIPT_DIR/start.sh"
+
+# ── Record the marker (success only; `set -e` aborts before here on failure) ──
+echo "$NEW" > "$MARKER"
+echo ""
+echo "✅ update complete — marker set to ${NEW:0:12}"

--- a/docs/developer-guide/run-after-pull.md
+++ b/docs/developer-guide/run-after-pull.md
@@ -1,0 +1,129 @@
+# Developer guide — run the platform after a pull
+
+How to bring AEP back up after `git pull` brings in the latest changes.
+
+All commands are run **from the repo root**. Paths are relative — the
+`deployments/scripts/*.sh` scripts resolve their own directories, so invoking
+them by their full relative path works regardless of your shell's CWD (as long
+as it's the repo root).
+
+This assumes you have **already run the one-time `setup.sh`** at least once
+(the k3d cluster + OpenChoreo + Thunder + Temporal exist). If not, see
+[First-time setup](#first-time-setup) at the end.
+
+## One command
+
+`update.sh` automates the decision below: it diffs your checkout against the
+last successful run, runs **only** the steps whose inputs changed, then hands
+off to `start.sh`. It prints a plan and asks for confirmation first, and
+auto-starts the k3d cluster if it exists but is stopped.
+
+```bash
+bash deployments/scripts/update.sh              # detect → plan → confirm → run
+bash deployments/scripts/update.sh --dry-run    # preview the plan only (no side effects)
+bash deployments/scripts/update.sh --yes        # run without the confirm prompt
+bash deployments/scripts/update.sh --full       # run every step regardless of the diff
+```
+
+It records the last-run commit in `deployments/.aep-last-run` (git-ignored). On
+its very first run — before that marker exists — it plans a full run. The manual
+steps below are the reference for what it does and the fallback when you want to
+run a single step yourself.
+
+## Steps
+
+### 1. Make sure Docker and the k3d cluster are up
+
+The compose stack talks to an in-cluster OpenChoreo, so the cluster must be
+running. After a reboot the cluster is *stopped*, not gone:
+
+```bash
+docker info >/dev/null && echo "docker ok"   # start Docker Desktop / Colima if this fails
+k3d cluster list                             # is "openchoreo" running?
+k3d cluster start openchoreo                 # start it if stopped
+```
+
+### 2. Sync dependencies from the pull
+
+`pnpm-lock.yaml` / `go.work.sum` change often, so refresh workspace deps:
+
+```bash
+make install        # pnpm install + go work sync
+```
+
+### 3. Re-apply cluster config if deployment/manifests changed
+
+When the pull touches `deployments/manifests/`, `deployments/single-cluster/`,
+ClusterWorkflows, or ComponentTypes, re-run the idempotent AEP config step. It
+re-applies ClusterWorkflows / ComponentTypes / Environment / AuthzRoleBindings,
+and builds + imports the validation runner image if it is missing.
+
+```bash
+bash deployments/scripts/setup-aep.sh
+```
+
+### 4. Rebuild the validation runner image if its Dockerfile/toolchain changed
+
+The validation runner's skills are baked into `aep-validation-runner:dev`. If
+`runners/remote-worker/Dockerfile.validation` or the runner's TS/toolchain
+changed in the pull, force a rebuild. (Skill-only edits are picked up live via
+the plugin hostPath overlay and do **not** need this.)
+
+```bash
+make build-validation-runner FORCE=1
+```
+
+### 5. Start the stack
+
+`start.sh` runs `docker compose up --build`, so it recompiles `aep-api`,
+`agents`, `console`, etc. from your freshly-pulled source. It also refreshes
+DNS, seeds the git-service kubeconfig, ensures OpenBao is reachable, and repairs
+per-org secrets.
+
+```bash
+bash deployments/scripts/start.sh
+```
+
+### 6. Verify
+
+```
+Console:          http://localhost:8090   (login: admin / admin)
+API:              http://localhost:9090
+Agents:           http://localhost:4000
+Temporal Web UI:  http://localhost:8233
+SRE-handoff MCP:  http://localhost:3401/healthz  → {"status":"ok"}
+```
+
+`start.sh` prints these at the end and runs health checks (mcp-server,
+runner-image drift, RCA agent). Watch its output for `⚠️` lines.
+
+## Notes & gotchas
+
+- **`.env` is preserved** across `setup-aep.sh` re-runs. Your
+  `ANTHROPIC_API_KEY` / `GITHUB_APP_*` / `LOCAL_DEV_ADMIN_GITHUB_PAT` stay put —
+  no need to re-edit unless you're adding them for the first time. Edit at
+  `deployments/.env`.
+- **Builds stuck in `CreateContainerConfigError`** after a cluster restart =
+  OpenBao (inmem) lost its k8s auth. `start.sh` runs `repair-secrets.sh`
+  automatically; if dispatches still hang, re-seed OpenBao and re-run
+  `bash deployments/scripts/repair-secrets.sh`.
+- **`make gen` / `make build` are for local IDE / typecheck / CI**, not required
+  to run the stack — `start.sh`'s `--build` handles the deployed images. Run
+  `make typecheck` / `make test` separately to validate the pull before
+  starting.
+- **Observability plane** (Live Progress, alert→RCA handoff) is skipped by
+  default. To enable: `ENABLE_OBSERVABILITY=1 bash deployments/scripts/setup.sh`,
+  or run `bash deployments/scripts/setup-observability.sh` directly.
+- **Stop without destroying state:** `bash deployments/scripts/stop.sh` (compose
+  down; cluster stays). Full teardown: `k3d cluster delete openchoreo`.
+
+## First-time setup
+
+Cluster doesn't exist yet:
+
+```bash
+make install
+bash deployments/scripts/setup.sh   # k3d + prereqs + OpenChoreo + Thunder + Temporal + AEP infra
+$EDITOR deployments/.env            # set ANTHROPIC_API_KEY (+ optional GITHUB_APP_*)
+bash deployments/scripts/start.sh
+```


### PR DESCRIPTION
## What

Adds `deployments/scripts/update.sh` — a run-after-pull driver that diffs the
checkout against the last successful run and executes **only** the setup steps
whose inputs changed, then hands off to the existing `start.sh`. It changes no
other scripts; it only invokes them.

Run from the repo root:

```bash
bash deployments/scripts/update.sh              # detect → plan → confirm → run
bash deployments/scripts/update.sh --dry-run    # preview the plan only (no side effects)
bash deployments/scripts/update.sh --yes        # run without the confirm prompt
bash deployments/scripts/update.sh --full       # run every step regardless of the diff
```

## Why

Bringing AEP back up after a `git pull` meant manually deciding which of
`make install`, `make gen`, `make build-validation-runner FORCE=1`,
`setup-aep.sh`, and `start.sh` to run — a decision fully derivable from which
files the pull changed. This automates it.

## How it works

Change set = committed range `marker..HEAD` + uncommitted tracked changes +
untracked files, so both a pull and local edits count. Each step fires only when
a changed path matches its inputs:

| Step | Fires on |
|---|---|
| `make install` | dependency manifests (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, workspace `*/package.json`, `go.work`/`go.work.sum`, member `go.mod`/`go.sum`) |
| `make gen` | `packages/contracts/api/v1/openapi.yaml`, `packages/contracts/schemas/*.schema.json`, `skills/**` |
| `make build-validation-runner FORCE=1` | anything under `runners/remote-worker/` **except** `plugin/**` (live hostPath overlay — no rebuild) |
| `deployments/scripts/setup-aep.sh` | its own scripts + `deployments/manifests/**` + `deployments/single-cluster/resource-types/**` (gated tightly since it SIGHUP-restarts k3s) |
| `deployments/scripts/start.sh` | always (its `docker compose up --build` rebuilds every service image from source) |

Behaviour: prints a plan with the triggering file and asks to confirm (`--yes`
bypasses); auto-starts the k3d cluster if it exists but is stopped; refuses to
run a heavy full bring-up when the cluster is missing (points at `setup.sh`);
records the last-run commit in `deployments/.aep-last-run` (git-ignored) on
success only. First run — before the marker exists — plans a full run.

## Docs

- `docs/developer-guide/run-after-pull.md` — new "One command" section; the
  manual steps remain as the reference and single-step fallback.
- `deployments/README.md` — `update.sh` added to the files table.

## Verification

All via `--dry-run` (no bring-up triggered):

- `HEAD~5..HEAD` range → all four steps + `start.sh`, correct triggering files, k3s-restart warning shown.
- Range with only doc/script changes → **only** `start.sh` (no over-triggering).
- No marker → full run.
- plugin-only change → validation-runner skipped; `src/` change → it fires.
- unresolvable `--from` → errors, exit 1.
- confirm `n` / EOF → aborts cleanly, no marker written.
- header passes `addlicense -check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)