### PR TITLE
feat(console): cost visibility — per-phase actuals only, USD-first with expand-for-tokens (#245)

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -83,6 +83,13 @@ Features currently being built. One line each; **must be emptied on ship**
 (the line moves to the inventory below). If a line sits here for weeks,
 that's a stalled feature — investigate, don't ignore.
 
+- Cost visibility — actual USD spend for every unit of agentic work, per
+  phase (per task/build on the Builds page, drafting-cycle chip on the Spec
+  view; USD-only primary, token detail on expand, no overview surface);
+  actuals only — estimates and the model comparator are out of scope
+  (single-model platform); tokens stored, USD derived at read (ADR-0011) —
+  [#245](https://github.com/wso2/labs-agentic-engineer/issues/245)
+  (BE handshake: [#249](https://github.com/wso2/labs-agentic-engineer/issues/249))
 - Deployments page — two-column board (Development / Production): one card
   per component × binding with status chip, release, endpoint URL,
   deployed-at; unbound components show greyed "Not deployed" cards in dev;

--- a/apps/console/design/decisions/ADR-0011-usage-stored-as-tokens-usd-derived.md
+++ b/apps/console/design/decisions/ADR-0011-usage-stored-as-tokens-usd-derived.md
@@ -1,0 +1,41 @@
+# ADR-0011: Usage is persisted as tokens + model id; USD is always derived at read time
+
+**Status:** Accepted (2026-07-17, amended 2026-07-21) · **Issue:** [#245](https://github.com/wso2/labs-agentic-engineer/issues/245)
+
+## Context
+
+Agent work runs through two runtimes with different cost reporting: the coding
+runner's Claude Agent SDK returns per-run token usage *and* a ready-made
+`total_cost_usd`; the spec/design agent (Vercel AI SDK) returns token counts
+only. Cost surfaces in the console must reconcile across both, and Anthropic
+per-token prices change over time.
+
+## Decision
+
+Every usage record persists **raw token counts (input, output, cache read,
+cache write) plus the model id** — never a dollar amount. `aep-api` derives
+USD at read time from configured per-token-class rates (checked-in defaults,
+overridable via deployment config/env). The rates never leave the server —
+clients only see the derived `costUsd` (the platform runs a single model, so
+there is no client-side pricing use case). Provider-computed cost figures
+(e.g. the SDK's `total_cost_usd`) may be logged as a cross-check but are
+never displayed or persisted as truth.
+
+## Consequences
+
+- One formula prices every surface (turns, tasks, builds, per-phase rollups)
+  — figures always reconcile.
+- A rate fix retroactively corrects all displayed history; nothing stale is
+  frozen in the database.
+- Displayed USD for old records shifts when configured rates change — cost
+  views are a *current-prices* lens, not an invoice. Anything invoice-like
+  would need a separate snapshotting decision.
+- Tokens stay the stored truth, so re-pricing (e.g. if the platform ever runs
+  multiple models again) needs no data migration.
+
+## Rejected
+
+- **Display provider cost where available** — two irreconcilable sources
+  (SDK dollars vs catalog math) across the two runtimes.
+- **Persist computed USD at capture time** — stale rates freeze wrong numbers
+  forever; a mispriced catalog entry becomes permanent history.

--- a/apps/console/src/features/builds/components/BuildsPage.tsx
+++ b/apps/console/src/features/builds/components/BuildsPage.tsx
@@ -32,6 +32,7 @@ import {
 } from "@wso2/oxygen-ui";
 import type { components } from "../../../generated/aep-api";
 import { TasksList } from "../../tasks/components/TasksList";
+import { UsageChip } from "../../usage/components/UsageChip";
 import { useBuilds } from "../api/queries";
 
 type BuildSummary = components["schemas"]["BuildSummary"];
@@ -153,6 +154,15 @@ function BuildSummaryCard({ build }: { build: BuildSummary }) {
         >
           <Typography variant="h6">{build.tag}</Typography>
           <Chip size="small" label={chip.label} color={chip.color} />
+          {/* Actual build cost (#245): the run's aggregate coding-execution
+              usage — accrues on the existing poll while the build runs.
+              Absent for runs that predate usage capture. */}
+          {build.usage && (
+            <UsageChip
+              usage={build.usage}
+              context={`Agent spend — build ${build.tag}`}
+            />
+          )}
           <Box sx={{ flexGrow: 1 }} />
           {planning ? (
             // Subtle "planning" signal for the selected tag: the run has started

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -85,6 +85,12 @@ vi.mock("../../projects/api/queries", () => ({
   useBuildPreflight: () => ({ refetch: mockPreflightRefetch }),
 }));
 
+// Cost visibility (#245): stubbed like the other data hooks — no spend — so
+// the chip renders nothing and Build routing stays the subject.
+vi.mock("../../usage/api/queries", () => ({
+  useProjectUsage: () => ({ data: undefined, isPending: true, isError: false }),
+}));
+
 vi.mock("../api/queries", () => ({
   useSpecFiles: () => ({
     data: [{ path: "specs/design/overview.md", sha: "abc", group: "designs" }],

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -44,6 +44,9 @@ import {
   useProjectTags,
 } from "../../projects/api/queries";
 import { useSpecFileContent, useSpecFiles } from "../api/queries";
+import { useProjectUsage } from "../../usage/api/queries";
+import { totalTokens } from "../../usage/lib/format";
+import { UsageChip } from "../../usage/components/UsageChip";
 import { toSpecEntry } from "../api/mapping";
 import { useCollabSpec } from "../collab/useCollabSpec";
 import { CollabTextArea } from "../collab/CollabTextArea";
@@ -99,6 +102,9 @@ export function SpecView({ projectName }: { projectName: string }) {
   // Rooms are org-scoped (`spec-<org>-<project>`); without an org claim fall
   // back to the collab mock BFF's default org so mock mode keeps working.
   const collab = useCollabSpec(projectName, user, orgHandle ?? "acme");
+  // Cost visibility (#245): the header's draft-cycle spend chip — spec/design
+  // turn usage since the last published tag, mirroring the version chips.
+  const usageQ = useProjectUsage(projectName);
   const [selection, setSelection] = useState<SpecSelection | null>(null);
   const [addArtifactOpen, setAddArtifactOpen] = useState(false);
   // Build (#162): commit-then-build. buildPhase drives the button label /
@@ -451,6 +457,15 @@ export function SpecView({ projectName }: { projectName: string }) {
             <Chip size="small" color="warning" label="draft changes" />
           )}
           {chip && <Chip size="small" color={chip.color} label={chip.label} />}
+          {/* Draft-cycle spend (#245): what this version-in-progress has cost
+              in spec/design turns. Hidden until any spend exists. */}
+          {usageQ.data && totalTokens(usageQ.data.draftCycle) > 0 && (
+            <UsageChip
+              usage={usageQ.data.draftCycle}
+              label="spec"
+              context="Spec & design agent spend — current draft cycle"
+            />
+          )}
 
           <Divider orientation="vertical" flexItem />
 
@@ -458,6 +473,7 @@ export function SpecView({ projectName }: { projectName: string }) {
               next pipeline step — Generate design until a design exists, then
               Build. A dead disabled Build hid what to do next. */}
           {hasDesignFiles ? (
+            <>
             <Tooltip
               title={
                 agentBusy
@@ -484,7 +500,9 @@ export function SpecView({ projectName }: { projectName: string }) {
                 </Button>
               </span>
             </Tooltip>
+            </>
           ) : (
+            <>
             <Tooltip
               title={
                 agentBusy
@@ -506,6 +524,7 @@ export function SpecView({ projectName }: { projectName: string }) {
                 </Button>
               </span>
             </Tooltip>
+            </>
           )}
         </Box>
 

--- a/apps/console/src/features/tasks/components/TasksList.tsx
+++ b/apps/console/src/features/tasks/components/TasksList.tsx
@@ -30,6 +30,8 @@ import {
 import { GitHub } from "@wso2/oxygen-ui-icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAllTasks } from "../api/queries";
+import { UsageBreakdown } from "../../usage/components/UsageBreakdown";
+import { formatTokens, formatUsd, totalTokens } from "../../usage/lib/format";
 import { TaskStatusChip } from "./TaskStatusChip";
 
 // The flat task list (#173): one row per task, status chip inline — the user
@@ -132,6 +134,33 @@ export function TasksList({
                     </Typography>
                   }
                   primary={t.title}
+                  // Per-task cost (#245): deliberately quiet — a small caption
+                  // under the title, never a column of highlighted figures.
+                  // USD only (tokens live in the hover breakdown); absent
+                  // until an execution has run.
+                  secondary={
+                    t.usage && totalTokens(t.usage) > 0 ? (
+                      <Tooltip
+                        title={
+                          <UsageBreakdown
+                            usage={t.usage}
+                            context="This task's agent spend"
+                          />
+                        }
+                      >
+                        <Typography
+                          component="span"
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontVariantNumeric: "tabular-nums" }}
+                        >
+                          {t.usage.costUsd !== null
+                            ? formatUsd(t.usage.costUsd)
+                            : `${formatTokens(totalTokens(t.usage))} tok`}
+                        </Typography>
+                      </Tooltip>
+                    ) : undefined
+                  }
                 />
               </ListingTable.Cell>
               <ListingTable.Cell sx={{ maxWidth: 160 }}>

--- a/apps/console/src/features/usage/api/keys.ts
+++ b/apps/console/src/features/usage/api/keys.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const usageKeys = {
+  project: (projectName: string) =>
+    ["projects", "detail", projectName, "usage"] as const,
+};

--- a/apps/console/src/features/usage/api/queries.ts
+++ b/apps/console/src/features/usage/api/queries.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { client } from "../../../api/client";
+import { usageKeys } from "./keys";
+
+function firstError(error: unknown, fallback: string): Error {
+  const e = error as { detail?: string; title?: string } | undefined;
+  return new Error(e?.detail ?? e?.title ?? fallback);
+}
+
+// Per-project usage rollups (#245). Actuals accrue as executions/turns land;
+// 30s staleness is plenty — the surfaces that need faster movement (a running
+// build) get it from their own polling reads carrying usage inline.
+export function useProjectUsage(projectName: string) {
+  return useQuery({
+    queryKey: usageKeys.project(projectName),
+    queryFn: async () => {
+      const { data, error } = await client.GET("/projects/{projectName}/usage", {
+        params: { path: { projectName } },
+      });
+      if (error || data === undefined) {
+        throw firstError(error, "Failed to load project usage");
+      }
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/console/src/features/usage/components/UsageBreakdown.tsx
+++ b/apps/console/src/features/usage/components/UsageBreakdown.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Box, Stack, Typography } from "@wso2/oxygen-ui";
+import { formatTokens, type Usage } from "../lib/format";
+
+// The detailed token view behind every folded cost figure (#245): the
+// input/output/cache split that explains why agentic token counts look large.
+// Rendered in the UsageChip's expand popover and the task caption's tooltip.
+// `context` names WHAT the figure covers ("Agent spend — build v1") so no
+// number ever floats without a scope.
+export function UsageBreakdown({
+  usage,
+  context,
+}: {
+  usage: Usage;
+  // `| undefined` keeps pass-through from optional props legal under
+  // exactOptionalPropertyTypes.
+  context?: string | undefined;
+}) {
+  const rows: [string, number][] = [
+    ["Input", usage.inputTokens],
+    ["Output", usage.outputTokens],
+    ["Cache read", usage.cacheReadTokens],
+    ["Cache write", usage.cacheCreationTokens],
+  ];
+  return (
+    <Stack spacing={0.25} sx={{ py: 0.25 }}>
+      {context && (
+        <Typography variant="caption" sx={{ fontWeight: 600, mb: 0.25 }}>
+          {context}
+        </Typography>
+      )}
+      {rows.map(([label, tokens]) => (
+        <Box
+          key={label}
+          sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
+        >
+          <Typography variant="caption">{label}</Typography>
+          <Typography
+            variant="caption"
+            sx={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            {formatTokens(tokens)} tok
+          </Typography>
+        </Box>
+      ))}
+      {usage.model && (
+        <Typography variant="caption" color="inherit" sx={{ opacity: 0.7 }}>
+          {usage.model}
+        </Typography>
+      )}
+      {usage.costUsd === null && (
+        <Typography variant="caption" sx={{ opacity: 0.7 }}>
+          No configured rate for this model — tokens only.
+        </Typography>
+      )}
+    </Stack>
+  );
+}

--- a/apps/console/src/features/usage/components/UsageChip.tsx
+++ b/apps/console/src/features/usage/components/UsageChip.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import { Box, Chip, Popover, Tooltip } from "@wso2/oxygen-ui";
+import { Coins } from "@wso2/oxygen-ui-icons-react";
+import { formatTokens, formatUsd, totalTokens, type Usage } from "../lib/format";
+import { UsageBreakdown } from "./UsageBreakdown";
+
+// The folded cost figure (#245): USD is the ONLY primary value — the token
+// detail is a technical view that lives behind an explicit expand (click),
+// never in the chip label. costUsd null (no configured rate) degrades to
+// tokens-only, the one exception. Renders nothing at zero.
+export function UsageChip({
+  usage,
+  label,
+  context,
+}: {
+  usage: Usage;
+  label?: string;
+  /** Names what the figure covers in the expanded breakdown, e.g. "Agent spend — build v1". */
+  context?: string;
+}) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const tokens = totalTokens(usage);
+  if (tokens === 0) return null;
+
+  const figures =
+    usage.costUsd !== null
+      ? formatUsd(usage.costUsd)
+      : `${formatTokens(tokens)} tok`;
+
+  return (
+    <>
+      <Tooltip title={context ? `${context} — click for token detail` : "Click for token detail"}>
+        <Chip
+          size="small"
+          variant="outlined"
+          icon={<Coins size={14} />}
+          label={label ? `${label} ${figures}` : figures}
+          onClick={(e) => {
+            e.stopPropagation();
+            setAnchorEl(e.currentTarget);
+          }}
+        />
+      </Tooltip>
+      <Popover
+        open={anchorEl !== null}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, minWidth: 220 }}>
+          <UsageBreakdown usage={usage} context={context} />
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/apps/console/src/features/usage/lib/format.ts
+++ b/apps/console/src/features/usage/lib/format.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+
+export type Usage = components["schemas"]["Usage"];
+
+// "12.3K" / "3.1M" — cost chips live in dense headers, so token counts are
+// always abbreviated; the exact split lives in the breakdown tooltip.
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${m >= 10 ? m.toFixed(0) : m.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000;
+    return `${k >= 10 ? k.toFixed(0) : k.toFixed(1)}K`;
+  }
+  return String(n);
+}
+
+// USD is the product's one primary value (tokens are hover detail), so the
+// formatting works hard on readability: "<$0.01" for dust, whole dollars when
+// the cents are zero ("$34", not "$34.00"), cents kept when they carry
+// information ("$6.40").
+export function formatUsd(n: number): string {
+  if (n > 0 && n < 0.01) return "<$0.01";
+  return `$${n.toFixed(2).replace(/\.00$/, "")}`;
+}
+
+// All four token kinds folded together — the fallback figure when no rate is
+// configured; the breakdown explains why it can dwarf input+output (cache
+// traffic).
+export function totalTokens(u: Usage): number {
+  return (
+    u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheCreationTokens
+  );
+}

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -1,4 +1,5 @@
 import type { components } from "../../generated/aep-api";
+import { buildUsageByScenario, taskUsage } from "./usage";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 type ComponentList = components["schemas"]["ComponentList"];
@@ -414,12 +415,15 @@ function task(
   derivedStatus: string,
   component?: string,
 ): TaskView {
+  const usage = taskUsage[issueNumber];
   return {
     issueNumber,
     title,
     derivedStatus,
     issueUrl: `${BOARD_URL}/${issueNumber}`,
     ...(component !== undefined && { component }),
+    // Pending tasks (no execution yet) carry no usage — exercises the "—" cell (#245).
+    ...(usage !== undefined && { usage }),
     attention: null,
     dependsOn: null,
     executions: {},
@@ -477,6 +481,8 @@ const runningV1Build: BuildList = {
       status: "in_progress",
       tasks: { total: 4, done: 0, failed: 1, active: 3 },
       startedAt: "2026-07-10T09:12:00Z",
+      // Mid-build the aggregate is the cost so far — it accrues on the poll (#245).
+      usage: buildUsageByScenario.running,
     },
   ],
 };
@@ -488,6 +494,7 @@ const completedV1Build: BuildList = {
       tasks: { total: 4, done: 4, failed: 0, active: 0 },
       startedAt: "2026-07-10T09:12:00Z",
       completedAt: "2026-07-10T10:03:00Z",
+      usage: buildUsageByScenario.completed,
     },
   ],
 };

--- a/apps/console/src/mocks/fixtures/usage.ts
+++ b/apps/console/src/mocks/fixtures/usage.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../generated/aep-api";
+import type { ProjectScenario } from "./project";
+
+type Usage = components["schemas"]["Usage"];
+type ProjectUsage = components["schemas"]["ProjectUsage"];
+
+const FABLE = "claude-fable-5";
+
+// The single active model's rates ($/MTok), mirroring aep-api's checked-in
+// defaults (deployment-config-overridable there). Cache reads are ~0.1x
+// input, cache writes 1.25x, so mock USD figures look like production ones.
+const RATES = {
+  inputPerMTok: 10,
+  outputPerMTok: 50,
+  cacheReadPerMTok: 1,
+  cacheWritePerMTok: 12.5,
+};
+
+// Rate-derived USD, exactly the read-time math aep-api does (ADR-0011).
+function priceUsd(u: Omit<Usage, "costUsd" | "model">): number {
+  const usd =
+    (u.inputTokens * RATES.inputPerMTok +
+      u.outputTokens * RATES.outputPerMTok +
+      u.cacheReadTokens * RATES.cacheReadPerMTok +
+      u.cacheCreationTokens * RATES.cacheWritePerMTok) /
+    1_000_000;
+  return Math.round(usd * 100) / 100;
+}
+
+// Fixture builder: tokens in, priced Usage out. Pass costUsd: null to
+// exercise the no-configured-rate state (tokens render without USD).
+export function usage(
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens: number,
+  cacheCreationTokens: number,
+  model = FABLE,
+): Usage {
+  const tokens = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens };
+  return { ...tokens, model, costUsd: priceUsd(tokens) };
+}
+
+export const zeroUsage: Usage = usage(0, 0, 0, 0);
+
+function sum(items: Usage[], model = FABLE): Usage {
+  const totals = items.reduce(
+    (acc, u) => ({
+      inputTokens: acc.inputTokens + u.inputTokens,
+      outputTokens: acc.outputTokens + u.outputTokens,
+      cacheReadTokens: acc.cacheReadTokens + u.cacheReadTokens,
+      cacheCreationTokens: acc.cacheCreationTokens + u.cacheCreationTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  );
+  return { ...totals, model, costUsd: priceUsd(totals) };
+}
+
+// Per-task actuals for the building/deployed scenarios — one coding run each,
+// cache-heavy the way real agentic runs are. Keyed by issue number.
+export const taskUsage: Record<number, Usage> = {
+  9: usage(140_000, 88_000, 1_900_000, 260_000), // storefront shell (merged)
+  10: usage(95_000, 41_000, 1_150_000, 180_000), // catalog CRUD (in progress, accruing)
+  11: usage(210_000, 120_000, 2_600_000, 340_000), // orders payment (failed — burnt before failing)
+  // 12 (pending) has no execution yet — exercises the absent-usage cell.
+};
+
+const specTurnsAll = usage(180_000, 96_000, 1_400_000, 240_000);
+const specDraftCycle = usage(52_000, 27_000, 410_000, 68_000);
+const buildingBuildUsage = sum([taskUsage[9]!, taskUsage[10]!, taskUsage[11]!]);
+const doneBuildUsage = sum(Object.values(taskUsage));
+const validationUsage = usage(48_000, 22_000, 520_000, 70_000);
+
+const noUsageRollup: ProjectUsage = {
+  spec: zeroUsage,
+  build: zeroUsage,
+  validation: zeroUsage,
+  draftCycle: zeroUsage,
+};
+
+// Per-scenario per-phase actuals for get-project-usage, consistent with the
+// tallies in fixtures/project.ts (building = v1 mid-build; deployed = v1 done
+// + drifted spec so the draft cycle has fresh spend).
+export const projectUsage: Record<
+  Exclude<ProjectScenario, "error">,
+  ProjectUsage
+> = {
+  fresh: noUsageRollup,
+  spec: {
+    spec: specTurnsAll,
+    build: zeroUsage,
+    validation: zeroUsage,
+    draftCycle: specTurnsAll, // nothing published yet — the whole spend is the cycle
+  },
+  "spec-failed": {
+    spec: specDraftCycle,
+    build: zeroUsage,
+    validation: zeroUsage,
+    draftCycle: specDraftCycle,
+  },
+  building: {
+    spec: specTurnsAll,
+    build: buildingBuildUsage,
+    validation: zeroUsage,
+    draftCycle: zeroUsage, // v1 just published; no new spec turns since
+  },
+  deploying: {
+    spec: specTurnsAll,
+    build: doneBuildUsage,
+    validation: validationUsage,
+    draftCycle: zeroUsage,
+  },
+  deployed: {
+    spec: sum([specTurnsAll, specDraftCycle]),
+    build: doneBuildUsage,
+    validation: validationUsage,
+    draftCycle: specDraftCycle, // specs/ drifted past v1 — the v1+ cycle
+  },
+  "deploy-failed": {
+    spec: specTurnsAll,
+    build: doneBuildUsage,
+    validation: validationUsage,
+    draftCycle: zeroUsage,
+  },
+  "repo-error": noUsageRollup,
+};
+
+// Build totals shared with fixtures/project.ts so the builds list agrees with
+// the rollup above.
+export const buildUsageByScenario = {
+  running: buildingBuildUsage,
+  completed: doneBuildUsage,
+} as const;

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -24,6 +24,7 @@ import {
   streamFrames,
   taskDetailOf,
 } from "../fixtures/task-log";
+import { projectUsage } from "../fixtures/usage";
 
 function scenario(): ProjectScenario {
   return (
@@ -79,6 +80,10 @@ export const projectHandlers = [
   // Builds page (#185): the per-tag build history.
   http.get("*/api/v1/projects/:projectName/builds", () =>
     respond((s) => projectBuilds[s]),
+  ),
+  // Cost visibility (#245): per-phase actual usage.
+  http.get("*/api/v1/projects/:projectName/usage", () =>
+    respond((s) => projectUsage[s]),
   ),
   // Task page (#173): one task with its execution history…
   http.get("*/api/v1/projects/:projectName/tasks/:issueNumber", ({ params }) => {

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1758,6 +1758,37 @@ paths:
       summary: Attach to a turn's event stream (SSE replay + live tail)
       tags:
       - GenAI
+  /projects/{projectName}/usage:
+    get:
+      description: Per-phase actual usage for a project (#245) — spec, build, validation, plus the current
+        drafting cycle. USD derived at read time from the configured model rates (ADR-0011).
+      operationId: get-project-usage
+      parameters:
+      - description: Project name (DNS-label slug)
+        in: path
+        name: projectName
+        required: true
+        schema:
+          description: Project name (DNS-label slug)
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectUsage'
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Error
+      security:
+      - userJWT: []
+      summary: Get per-phase project usage
+      tags:
+      - Projects
   /rca-agent/reports:
     get:
       operationId: list-rca-agent-reports
@@ -2394,6 +2425,10 @@ components:
           type: string
         tasks:
           $ref: '#/components/schemas/BuildTally'
+        usage:
+          $ref: '#/components/schemas/Usage'
+          description: Aggregate actual usage of the run's coding executions (#245); absent for runs
+            that predate usage capture.
       required:
       - tag
       - status
@@ -3476,6 +3511,28 @@ components:
       - build
       - deploy
       type: object
+    ProjectUsage:
+      additionalProperties: false
+      description: Per-phase actual usage for a project (#245). All figures derive from persisted per-run token records (ADR-0011); costUsd is computed at read time from the configured model rates.
+      properties:
+        build:
+          $ref: "#/components/schemas/Usage"
+          description: All coding/build executions.
+        draftCycle:
+          $ref: "#/components/schemas/Usage"
+          description: Spec/design agent turns since the last published spec tag — the Spec view chip.
+        spec:
+          $ref: "#/components/schemas/Usage"
+          description: All spec/design agent turns (project lifetime).
+        validation:
+          $ref: "#/components/schemas/Usage"
+          description: All validation executions.
+      required:
+        - spec
+        - build
+        - validation
+        - draftCycle
+      type: object
     ProvisionBody:
       additionalProperties: false
       properties:
@@ -3909,6 +3966,9 @@ components:
           type: string
         title:
           type: string
+        usage:
+          $ref: "#/components/schemas/Usage"
+          description: Aggregate actual usage across the task's executions (#245); absent for tasks that predate usage capture.
       required:
       - issueNumber
       - title
@@ -4089,6 +4149,39 @@ components:
           type: string
       required:
       - skillMd
+      type: object
+    Usage:
+      additionalProperties: false
+      description: Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+      properties:
+        cacheCreationTokens:
+          format: int64
+          type: integer
+        cacheReadTokens:
+          format: int64
+          type: integer
+        costUsd:
+          description: Catalog-derived USD; null when pricing is unavailable for the model.
+          format: double
+          type: number
+          nullable: true
+          x-go-type: '*float64'
+        inputTokens:
+          format: int64
+          type: integer
+        model:
+          description: Model id the work ran on; "" on mixed-model aggregates.
+          type: string
+        outputTokens:
+          format: int64
+          type: integer
+      required:
+        - inputTokens
+        - outputTokens
+        - cacheReadTokens
+        - cacheCreationTokens
+        - model
+        - costUsd
       type: object
     Warning:
       additionalProperties: false

--- a/services/aep-api/internal/edge/method_origin_test.go
+++ b/services/aep-api/internal/edge/method_origin_test.go
@@ -84,6 +84,7 @@ var opOwner = map[string]string{
 	"GetProject":                    embedProjects,
 	"GetProjectBuild":               embedDelivery,
 	"GetProjectStatus":              embedProjects,
+	"GetProjectUsage":               embedProjects,
 	"GetRcaAgentReport":             embedOps,
 	"GetSkill":                      embedSpec,
 	"GetSpecCollabSession":          embedSpec,

--- a/services/aep-api/internal/gen/models_gen.go
+++ b/services/aep-api/internal/gen/models_gen.go
@@ -362,6 +362,9 @@ type BuildSummary struct {
 	Status    BuildSummaryStatus `json:"status"`
 	Tag       string             `json:"tag"`
 	Tasks     BuildTally         `json:"tasks"`
+
+	// Usage Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	Usage Usage `json:"usage,omitempty"`
 }
 
 // BuildSummaryStatus defines model for BuildSummary.Status.
@@ -813,6 +816,21 @@ type ProjectStatus struct {
 	SpecStatus string `json:"specStatus"`
 }
 
+// ProjectUsage Per-phase actual usage for a project (#245). All figures derive from persisted per-run token records (ADR-0011); costUsd is computed at read time from the configured model rates.
+type ProjectUsage struct {
+	// Build Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	Build Usage `json:"build"`
+
+	// DraftCycle Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	DraftCycle Usage `json:"draftCycle"`
+
+	// Spec Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	Spec Usage `json:"spec"`
+
+	// Validation Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	Validation Usage `json:"validation"`
+}
+
 // PromoteFromIssueRequest defines model for PromoteFromIssueRequest.
 type PromoteFromIssueRequest struct {
 	// ComponentName Component this issue is about
@@ -1029,6 +1047,9 @@ type TaskView struct {
 	PrURL     string `json:"prUrl,omitempty"`
 	Rationale string `json:"rationale,omitempty"`
 	Title     string `json:"title"`
+
+	// Usage Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+	Usage Usage `json:"usage,omitempty"`
 }
 
 // TimelineEvent A unified-timeline entry: today's ProgressEvent (phase | tool_use | git_commit | git_push | gh_action | build_step | log | result) plus its attribution — which execution attempt it came from. This is the per-row shape the console renders; the FE groups rows by executionId/kind.
@@ -1118,6 +1139,20 @@ type UpdateConfigBody struct {
 type UpdateSkillInput struct {
 	References map[string]string `json:"references,omitempty"`
 	SkillMd    string            `json:"skillMd"`
+}
+
+// Usage Actual token usage for one unit of agent work or an aggregate (#245). Tokens + model are the persisted truth; costUsd is derived at read time from the configured model rates (ADR-0011) and null when no rate is configured for the model.
+type Usage struct {
+	CacheCreationTokens int64 `json:"cacheCreationTokens"`
+	CacheReadTokens     int64 `json:"cacheReadTokens"`
+
+	// CostUsd Catalog-derived USD; null when pricing is unavailable for the model.
+	CostUsd     *float64 `json:"costUsd"`
+	InputTokens int64    `json:"inputTokens"`
+
+	// Model Model id the work ran on; "" on mixed-model aggregates.
+	Model        string `json:"model"`
+	OutputTokens int64  `json:"outputTokens"`
 }
 
 // Warning defines model for Warning.

--- a/services/aep-api/internal/gen/server_gen.go
+++ b/services/aep-api/internal/gen/server_gen.go
@@ -176,6 +176,9 @@ type ServerInterface interface {
 	// Attach to a turn's event stream (SSE replay + live tail)
 	// (GET /projects/{projectName}/turns/{turnId}/stream)
 	StreamTurn(w http.ResponseWriter, r *http.Request, projectName string, turnID string, params StreamTurnParams)
+	// Get per-phase project usage
+	// (GET /projects/{projectName}/usage)
+	GetProjectUsage(w http.ResponseWriter, r *http.Request, projectName string)
 	// List RCA-agent alert reports across the caller's org, newest first
 	// (GET /rca-agent/reports)
 	ListRcaAgentReports(w http.ResponseWriter, r *http.Request, params ListRcaAgentReportsParams)
@@ -2181,6 +2184,38 @@ func (siw *ServerInterfaceWrapper) StreamTurn(w http.ResponseWriter, r *http.Req
 	handler.ServeHTTP(w, r)
 }
 
+// GetProjectUsage operation middleware
+func (siw *ServerInterfaceWrapper) GetProjectUsage(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectName" -------------
+	var projectName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectName", r.PathValue("projectName"), &projectName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, UserJWTScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProjectUsage(w, r, projectName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRcaAgentReports operation middleware
 func (siw *ServerInterfaceWrapper) ListRcaAgentReports(w http.ResponseWriter, r *http.Request) {
 
@@ -2651,6 +2686,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/active", wrapper.GetActiveTurn)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/{turnId}", wrapper.GetTurn)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/{turnId}/stream", wrapper.StreamTurn)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/usage", wrapper.GetProjectUsage)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/rca-agent/reports", wrapper.ListRcaAgentReports)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/rca-agent/reports", wrapper.CreateRcaAgentReport)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/rca-agent/reports/{reportId}", wrapper.GetRcaAgentReport)
@@ -4740,6 +4776,45 @@ func (response StreamTurndefaultJSONResponse) VisitStreamTurnResponse(w http.Res
 	return err
 }
 
+type GetProjectUsageRequestObject struct {
+	ProjectName string `json:"projectName"`
+}
+
+type GetProjectUsageResponseObject interface {
+	VisitGetProjectUsageResponse(w http.ResponseWriter) error
+}
+
+type GetProjectUsage200JSONResponse ProjectUsage
+
+func (response GetProjectUsage200JSONResponse) VisitGetProjectUsageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProjectUsagedefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response GetProjectUsagedefaultJSONResponse) VisitGetProjectUsageResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response.Body); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListRcaAgentReportsRequestObject struct {
 	Params ListRcaAgentReportsParams
 }
@@ -5319,6 +5394,9 @@ type StrictServerInterface interface {
 	// Attach to a turn's event stream (SSE replay + live tail)
 	// (GET /projects/{projectName}/turns/{turnId}/stream)
 	StreamTurn(ctx context.Context, request StreamTurnRequestObject) (StreamTurnResponseObject, error)
+	// Get per-phase project usage
+	// (GET /projects/{projectName}/usage)
+	GetProjectUsage(ctx context.Context, request GetProjectUsageRequestObject) (GetProjectUsageResponseObject, error)
 	// List RCA-agent alert reports across the caller's org, newest first
 	// (GET /rca-agent/reports)
 	ListRcaAgentReports(ctx context.Context, request ListRcaAgentReportsRequestObject) (ListRcaAgentReportsResponseObject, error)
@@ -6781,6 +6859,32 @@ func (sh *strictHandler) StreamTurn(w http.ResponseWriter, r *http.Request, proj
 	}
 }
 
+// GetProjectUsage operation middleware
+func (sh *strictHandler) GetProjectUsage(w http.ResponseWriter, r *http.Request, projectName string) {
+	var request GetProjectUsageRequestObject
+
+	request.ProjectName = projectName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProjectUsage(ctx, request.(GetProjectUsageRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProjectUsage")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProjectUsageResponseObject); ok {
+		if err := validResponse.VisitGetProjectUsageResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListRcaAgentReports operation middleware
 func (sh *strictHandler) ListRcaAgentReports(w http.ResponseWriter, r *http.Request, params ListRcaAgentReportsParams) {
 	var request ListRcaAgentReportsRequestObject
@@ -7088,212 +7192,220 @@ func (sh *strictHandler) UpdateSkill(w http.ResponseWriter, r *http.Request, nam
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H3bchtHluCvnEBvhMAxQMhqTe80Ff1Ak5LNtmwxRNreXUthJaoOgDSzMsuZWaDQsiLmaWIj9m1ivrC/",
-	"ZCNPZl0AVAFV4MUCRw8dbRFZeTuXPPfzoRepJFUSpTW9ow89E80wYfSfx1GExrzG3zI01v2BxTG3XEkm",
-	"zrVKUVuOpnc0YcLgoJdW/uQmlSZLUJ/kk3/PEnQ/2EWKvaOesZrLae/joBh5rtWvGNmzuH6URmYxPqZ9",
-	"TJROmO0d9WJmcWh5gr3B+ie8fialpxeo5zzCxi2lWs153Gbz+cgzYzL8PkvGqJc2yKX9y9Nyc1xanKJe",
-	"+/IHLTZOv/lu8lGXzFw1DDGW2czU/pSlcbeb/Tjoafwt4xrj3tHP7prrgDhoQIE1ABSbqwK5uq23xQ7U",
-	"2E3uNn2cpmJxouRE8Gg7asZoIs1T93vvqPdKIky4QLieKYMwZgYvZgykAqHkFDUkzEYzNPDN8+PTw94q",
-	"Zofx9ViaaY3SNv2cMjur+WHlQmnUoFhnadatd2E6XgZzHw/ddRh4+vivMFbxAv757/8FdoYwyYSAKMwM",
-	"Bu0zkMrOuJzCNTPgvuUYr19RVN0Mt5jQf/wPjZPeUe9Po5LhjAK3GS3D82NxSqY1W6zdUDl/433sxrVi",
-	"FGix/bZPafyr1C0rMyHYWGDvyOoMV08w6CVoDJvWs5Frzbss+5Mb3mbVj83XYzLRnacnCW9EbsKh1kd4",
-	"wQV+h5a1ublrpiWX0w734z9odT/LeJUfMD9OHX59lXERn8k0s2cWk453yFLHrbHKpcdKCWTSv4XhLB4Z",
-	"l7jWtTsSFCNAsvpnL8YUZYwyWqxPclr81vj5FZe0OZRZ4u4E31vUkomhIzo+7Q3Kv5gUI0f7gln3bgw1",
-	"GpXpKPD4ofFMvnKHVU6oWYIW9QZ+9aEOe92aJ0racEfrD12KUdNrOmci64CiJ3TgH91Hu2BSAOQSQML1",
-	"NmLVS266vmaCGztM/bM7HLtJDGg0qZIGiZEriYDS6gWkqMGNsOBuCeaoDVcSLJsOQOI1GgsTro2tefNo",
-	"3tY3R2e5yJKE6UXnqwtrNd+Rmj53x+lIeALnWI8WQk1r/+6kH2NZkm5/st0UmzZsum5WTTvednErLfip",
-	"VZaJE5VJ20pWXT/rBuica5wIPp11fVuKk7Y6crEKceAWR5aIsSGeXcd4V05YGTwI+2k8725yBneTd4Rw",
-	"+eLs9OyH3XrG0HG7E8ZFpjuwTtrrC/9VK4xk03oiqz/GhQ2CVAc+SR8OjfsS2HSqccosgpIQVJYLUkKg",
-	"/6cv/+3pQSEBWzaFMXI5HQlmbOCeTMbArQHLzBVEjo7MAIyiD9TcvXp4DYREpFQ4Bu2GOr7MaqTlUjdb",
-	"3jGPBUJf4jxn2wcD0Jl0YsAAHEgwHoDJoggxRqdw5U+2+7A36IWxTpahwU7TKkavPcqD3vvhVA3XuaDb",
-	"ece7viwvBsZZdIUWY5holUCMms8x9pe9fhUssnyOLTXoWMm2Q8MFtBtM7HEXzug/DBur3Ho4VR0PCW/w",
-	"OvAv3AvtsM8hVVAASxyMPUI8gze9Nz3gE6hgyeFWjT1ftKJ5eyi/3UBwAUU7cA2NzNQdLfAFiNEyLmCi",
-	"NLCAz+FwfUxSuwBlZ6ivucGSHmOcT4S6fuRoKVI6xhhQa6UL+ouUNEogREyCmalr+Omb/w3chvkP6yTe",
-	"kv5yAjKWaUug4/KXVKupRkP2CZWkTuGLS+h2p6MOEhRtzBFTKy1J6St3N7802npW0KAA/uqXW9CANtTx",
-	"vVs2jy3jw9fcfpONgcaApEGgJgRNYiQO9oLLKwPM48fQ7xO0ugariBX7j/uOM1sVOLe5Ggo1BWM1suTg",
-	"GWhMBYvQeD4tYrDcChz+qrh0eNGCM9wuppCIaQVuh5QfVqzfDJ8gcne3h3kFQU2gTp1wAGBrOsMjkysN",
-	"OpOHcEyf0hMHMxZevjlCjlzwW4Z6QXT6Jr+2N73AuFQUZdrADDXWWZPCXW4wUTYQRy1N/ov75vDSfUj3",
-	"fK9cKtMTFrkp0PAYafSLMCmLpwhcVtlYE7/SHU3ht4+4rEFnyrncVuZ2yYRYV/7cvGvPUvXIjbjv5+to",
-	"jPnvJm6cCI7SXmCk0b7KbJrZr1Tc9daiyiTbedfS6No9KUe6F2gcY9l5U5gwXq/ea6WSBq9IZlA3unau",
-	"Tb0daeV8Yfp8fGXSQdhU86F/ZII7ur2DU8sNHiu3ifzYK4L7DMEd6JGBMG4AGo0Sc8egFv7l1CwS6MX5",
-	"d+5RGL7JHj/+c6T0lP4Dw7/DBP5v754FtuaODcEyCJlBQ8KZ0vSzQYz9C9L/05dfPj3YLsrK6kUvH67+",
-	"2iv21S6MIrOKuEy92db9fIqpUIsGs27VeVljsK2AoO53blLBFo2IijJOFZc2oOsyRM+zseAR/PD6ZS5T",
-	"BbXQPVIQ06YTlPYQzlWaCUaamtJwjWPv34mYm8mAkmLxDNjYoLSQSctF+LpBqm6LgF1clf4Pq0csgApX",
-	"3GnmEo6fnz8yEKPhUwlzFbFxJpj2fq03vWscDytHe9MDpZ1M4pHyTQ/65AD0d+SmOPzVKPnIlLb3y0WK",
-	"B4fwKkV5MlMaFdELTvh7jOGkOorM7Ab65UWP/uUgCD0sTZFpcNLUjBs4Pj+rvcis1o9dRwcbMd5bs7fi",
-	"/aogtS6KbfHmd/fTo5z/yHR73eg5jW+jEvF4Jwy8FY94dZHBysWVZ+7i8y5A2cpLcBPzaskmuxrvm62l",
-	"xZyOao7Pz7r7HrfGkVTortE31EJgWQHV8rxhlvoTOgr7Fhenl686+50nLBPW+5p2eSOucFF/5FUprcnm",
-	"7SbYeKgfOV4/sFOdOzbf8UxTbs9DuM0NeemU21k2fqmmvOHwK45YP75WG0tUjNWhKbMNXtcWAjutG+Yc",
-	"rExV3iCP0xuen0w2uvbov15fmSYn7uq15N5np/iYKdMxKgqZMVYlNZdQd9i68wmR3PB8LOXfNuDv6hmY",
-	"tDOtUh613PAgn3x952s+k2Xbh9JT78c/rJJAZcyQJ6nShCY+Wing3WGkktG1UU9GDFP3vyFL+cipploy",
-	"McqhMCoWoK2ERfxTGKj8BsQmxKtJ7+jnzY/X1+VHlYU/vl2FV4nEGz1Zp+fVWUrEaLWXly+/27yHVd+q",
-	"cHhcPbbf5NuOUC3XvGPQFry9A1SbuPq84Z2o4en54AbeTmGH3V/hqE24Z2Mc5moU31IkZHXi2k2TFEix",
-	"oG09ystKEH0KVvnIRuWtiGEPZIdM1SHEGGcpfosLSNgVGiDZkysJPMYkVdbpUClqUCnK3KQu2BjFEGWk",
-	"YowPBqQcRkoGlxQwgdrCjMlYoK7x6I2DUaPm7Q97qY/JcKsuC6zrGuY2p3I34zrttBk2gaZ2jSvM1b9z",
-	"nqLgEu/EErBJ505SW2/vyQzqRwa45JYzAeFq3F5JX76eMeuQaQHXTAYP+CGcozbcWIyBmTVUKydgMoYr",
-	"Hl0ZUJOJ9yCQB9hjXW72kXidfw99j3Z/+p9PDg5z13xAVIzhmtuZyiww8CeCK8QUrIrZ4pGBMc7YnCtd",
-	"q0Y7Cqg3er3GVBlulfZBccW2yiMFD5Wb4hkEqdbkjqZ85+7bQbCQTZnk/wikZcDbBQzqOeohmf2LU37Z",
-	"1sbVjJivI3Y8RWndMbTdjXtQQKnfmvYTBIeHA83rk+Mhm5bErmmhcIZ1b41gxvBJMK6s37bjI0MKxhqA",
-	"f07yfyXumgagNEglfeyaQZubHR2LcUhEO6kD8FLsZF1UJNmq6g10+a934mGKOZtKZXhNiMeLTAh3v1CM",
-	"gS/A0U7MPfZEPtQR+gnTV7G6lge1IZ/cpBSz3nA8gtTz9xHqtP52+Jb0hYbD556JldP7r/JpLxvYcPh5",
-	"Q+oD4Xmt/lf6OXd1qebTD0rnaph0sIrCVQg2k+HFFReiiDDr8DY0Mm2NE9QoI9wUI9tkJK2GzLqdfdfW",
-	"iFiOrztrEfDe7YybciY6JEXU7yiPrt0pSEWR6+WGkoZGFjeY/jsHY/i5BsXGGs4s1GKXKDj/ZacwOCcA",
-	"PDLemc8luQ3cs66VEO4pzn3H9X77Mq+swyZLg/7qIsXbnIufnnGvr11A5D4csH6xOkCt+92ld9b6ffuX",
-	"o3iaugcVzb0DsfahPVFMG4RyCAUhgs4kuG2Vco5gFvO4siP/9valolAO96SEFxlYFGFqmYwQIicuaM6q",
-	"AYlF4AD0NZNOOAp/4Up651/KjBm5E8IcdcwjSzhl8pAHL1Yc5KGN0Hd/LHdPGw8/JRjNmOQRE2JBAtTK",
-	"7ZaRjy3DGcplSI9av8yzmuCkUj6s7NLdceEmu54hnU2jEwOlWjnOIVxWItZyZ6hVXv9yS+RKePVDoaaQ",
-	"OvLtT9EHlsIoBDkNi6AnDyzg9qBlaFO5QK0b8SWXV7nAy4xRESd5vLKt89drEPNCLjMUOCPEmEVXMMaJ",
-	"0gjMjcf33FhzEKIYN1xWrUC/PXSywrIqkZIhgW2D83J7uGSFtS0RYTOzTro7nTs627b5hev8blwrmTSJ",
-	"zBsEE4HMYHcP7seN13Pnbq0KJG7Pr3XKTaSkxGj3gJqOMkLjLuaod97DTtb41Uvyc5Rf1O00eG8/KZPh",
-	"c62V7iikvBDM+qg+QDlHoVL3hNlMSx8qg3PUC/eaDp+8f19kZNVJSXHNe/Mdi2Zc4tCJFg5Jw0puMPSN",
-	"pT8ZkU396/eeuVeud1RhRb8U4WA1qrBlXNRpoxxF7LXxEPboBa4KS6dtkKzXzlXvhp/SVOtJvUspscs7",
-	"+SZLmFw9fBi9fOLcXEF5y9wJE7TbrUw98u6tfAeNWBE2v0uGeXmZqxe4jgU0uubZVV4HzUUONZmgjN3z",
-	"RR9AHw+nh3T2Q8etD2ofysZb/mnGrLuza63klGxrPuvbTb39WfRb3nKF7zHK3Go7eI93iiSJ78iG0xBJ",
-	"kjvyap7IPKp4/adMbno59V0FOrd9ZYh4gpuxpjJDPZi9mPo6JADv4nrJo5M6pOaGUIsWCnpeiqJT8m/h",
-	"RWqxwDbLfYMsVW+AKTKty23X3foLLrCSCt3tthsTqBvMMYOeqbXf1NeuyBfwXzVtnvL/u+284+4GPcP/",
-	"gbvo9uEgTduvdzJ3hoITG7uxuG1RIzxGabldnMyYnHatl+M/fd4YVJyP2L58I4fj0lgmhNe124bIdwiF",
-	"EczYPKy60+lXY2hYmq6Fv1St0zg/23obBgUBmDxMNzMxtuXey9E7FYW1xLXWwQT1SH5nEQXLoRbdaGnG",
-	"zEl9WsKqG+TeI44GvTQbC25mqP0W20QPBDCuaVR1kw3WTt8awstXfneQTbxrcreaMymzfMwFt4tuMpjg",
-	"EYZc9/a2jdpaMx2ptf5VDyAtFqh7Vpby5ne0FjW5PytFYW5Bjl0541KNk/BR7QEdQp/JidpBo/LmRMo7",
-	"EdzYkUGmo9khkNoaAu2ZRjg5Pj+7PH559n+en+aBMNdcI/Rn3FilecQEmBlLMeTqeTsgOGROonTo/fSQ",
-	"Mm3Q5z7GCqSy8KY34e/f9CpBCJFSOuaSTKHfnZznnwb72MG6mvdVUzTMy1uId+lUfu7CMltPAc3+2h9e",
-	"v9yOCWEX+TwDf2b/cb5scd5GFGnJK+qM9AlaFjPLgE0s6hA6ksc+xX9zdwcJMmmAyWqkU6H/GpZgJVSK",
-	"CfLveGs1xoQR3hEwyrQA8tL6NOR1eIdF658jqWJsSEyTXUCZtbHNyRwsGb0iYe26+1+OWbwHkfYKFy+Z",
-	"sU+bQsDPKbPmxoG0N5ANN6QklaadwojY6mUvz1W5gJsKbMugu7Pn/CWX2Mb1vEoLhk/lZUPisEkxumxd",
-	"BeZVJcLqzt0G1cXIjnV7zoO1qe/cRHZnIYabKozWprAtI7Ebc/jDD2enrdF2qtRU4Igm/7h65fTXQWFQ",
-	"2Wi9Og9YnluvLhcp7pLCs5MFaHA7ESg71tNrG2m4XG/rBoLpjjUNdzUPtiPXG9dM3JrH9GnXVNQVxO+Q",
-	"H1db2nD5MupxqQjs25XVNUR3/nHx1aR8pGxDSWmNqaqNrDgRSmI1P3sp7JiiYnxw8nJUiVT0E3DK1J9z",
-	"w5XEuAzK7cSfb5RhHOB5589wjjetqv29tyeZNqqm2pD/eyX2/L2lcJrieoPKSLW20uBv3OIxaXzfl4Lq",
-	"doiCy5zCcXH68gTSGTNIgXdMWz5hkfVRXKahWGfbAlNTLOmnXfxE5SMn0F00VK9703vTG0Cs2cQOoKh6",
-	"W4OYM2ZOaaZ6LWnGzMVy3u7yj5d5xZn1X+nO1ncm1dCRzoAIaBgJ5QPY6F+hTI/PLhhQxsIAmI5m3GJk",
-	"M40DivAyA1gKAaold1IIvmtyvl5goGQPWW4qG2hMYNh82an3DQ+gciYWLwbe6dw0Z5PZM8+W3oQRDjIF",
-	"Phj/j5tgw6oThgC4dPRyzyVqVHGoghNLO1pB13C8QSCWggIaiDhRFl9olXRK0NoSzdUU80rFILxJghtg",
-	"Y5XZFtEM2xLMzvNHYpcqM2WgWA1on1d+BavK5wj6IVXmCH6OkUJk3KC3B9Xokd0k3S0SzkoJlHxDTtYs",
-	"hSToqzlqnVfhCtVC8uyeSp5FY2rtx0FvOfmmI4c/lpT7EfJpyLDpdlKWFYGL189HZfpNngLTz0NGCUvM",
-	"vqTg7KStllk7q7EraGeoQ+SwyYT1UTHvqfjcGFGWlt3+j6j5ZAEv+HuwM41mpkQ8IJtughrFAs5fDxPU",
-	"U4wrYO+WHvTppgM131ukKJQoR6782oqvywhxLq8wzjNCCZeBB7vpUEmxGCVMZkwM828hUTGGKkEMZlnC",
-	"KvOa+ktuCLFZzV1aeUVnjnTQ/5xL0GG71bqSa8JzsPmyIrew1iPetWxlnqe4TDDPgIlQnpQKWl7hAvoG",
-	"EUZB1jejD5VyMR9HJGKMPlSW/3iwFlRekCMdwpOxg0WLeO8/MF+rDnwO48OQZ0tFXK3OZOSEXP8oTjJN",
-	"uOvQ0hebVNe10lfLHLBqnZ6VSjydksKWKK7CtN5ufTDuXGlaeZ/2SXe6YHOk8gLmFkSWpuy53bPqVmQM",
-	"1MPKmvAhUOS3uDgCCjyGj5Cw1ByC99E7JuDdlVqRlheSK3xpG0iYZFPUOSPROOXGosYYPGQPe9tseUs3",
-	"UHu/V1wIH966SxHIrX758FY1pf1ts8VgzK3H0zrV7nad/kpPz+I/KAfz5uXGipvKDzJYCTmoXnW5laXD",
-	"LYFrWyEywpy2tYZrIw/vGSk6RV/WXtrS7RS72HY5O7D3RjvhN5ffvayaCZWeAoHSGw5gzKIrJ83R+8ks",
-	"E2qaNdQPpq9aPyFL0O7q+gprlVp785UtZOSzV24re6ZA413iPwtHbD5H48Z/oAE7xLNQKY0hl6EPHSZj",
-	"jGOnruTG/4NC3o/5ZOJU1kJHVHoaqrpApNLFIbzGSMmICyTDFNNoIMQGX3xz7HUdRhLjMGFcWsYlxnk1",
-	"78M3stcyK72tUbhyMzsQQdS6N00On47oHGDWFZvztQZhh7UnL0xi3TDCfdc2L/sQjoMJbUQmNeAm76zh",
-	"QW2s0iFUJa/Y7vR4JmP6OebaLuBvhSEO+vPvD54Vf/ZzRhRBbNxvXxw8o4TMMNXfIJN5GGLsRz8LyZzg",
-	"lcO/ueFU7mWBtWExub131dVGNhjfjZAmLEsDu8n606AMIFCS55zjdVnodZxZq2Q1B6aqwruzra/opjUj",
-	"SOgWlMx1xtQJsJXcaMum9dP6U6/PeywXfstUjiloFs/C7WiUsaNmt8DXKFG7p55Gn1we16/TmOz60m9w",
-	"7msuf++rLfulLZuuNggpoLZdMA8nG1TSX/0d5pbUeuy3TNsTH7tCwYy7pCKuhYiv8M7UTwTVgWR55NLp",
-	"1RUVOTPu0FSAiEHEZEyxPyUbffIF/Yr6oE2W9MctB945+ZJldqY0/we2SrNcGt0ABJuZ78z0/vNQL9l0",
-	"B37vqWwd0t/7/hKrnSdC2tv8zwerZh2f2s2NGzVtaveSYnRazw0udYZ+qsAXPA+MQyhhYAbXrGb+Cq1a",
-	"NjUNWemVQzjGukS0B+tN+G4pAJk2VA8tc9UywXEFYa2TLAJD2t2WPxYqusL4qxpQfE/hvEHWLcIMeG4K",
-	"orIH3MA142T4VfIZpBpLXFhqNOVGKvnLTPm8xhtsuCl+t030tXl1w+taOlO9fpTnW35Doc6L9jW1lxI1",
-	"W+ylWGmjYtxpyTX09GsofSKYqT+vg+iGXI9OEdEbrZuiDHncWO8zDPs46LlrYI2KrNK8KWko1VsrcDjs",
-	"f2QgzYTI67UNqNXMnExExfNWtHvLTf0F1B4ZeNNL9Z++f9MDH65fsNJqhQ6VojT13mjm4Y03KcK1hq7L",
-	"cCvNsAVsqrRUQmWVNAJiDCp8agljm3jhBVVReT5vk1G5rs9dXDyHiWZJUX5zpQXVIbxzq76DmLtPE0oc",
-	"CNUT2UIoFh/BO/fNO4iY1jz8Rk243e4cnUDf91OBLDWorYHxwnsgDgbwrjjhO2r6ukRgtR/G7it3if6D",
-	"S55Q7BRdQPEBS+nCB3kEPRU3yKc+i78w+NvBgFSLd7FyU3kzprXCKQdLbLjvf6IkCeu4dCSUCccMbbrq",
-	"lIUVrrcWR1FdCUJvMKf65A+CkmKRwyTskeBUi9jF0TrzrzzsbNNHS1ecN0za+lEAfrUFRh5KSN9Xdx32",
-	"EdoC1VaSct8O50xT1JqbZAX3LxcpXvp5a355Xlmq5ueXfvWaX05pQ2vCidteE0HuEBP9UEWTvRVFPgsI",
-	"nwWEnT20f5g0sMSnO4b1QCb5hGNM7hs3i2+veFQUKj4P5QzDQ+sjAH8Hq5T4JaP/nHL7S6SShNvwjzQz",
-	"M/efs18YZffA775g3y/GYgq/U1W430MkzAGkwnEWa4BZq/mYDhqKOfJoVkLZ/Y4JFYqDiGofa5UcwqUP",
-	"QfOiCeqhVteVjMncOx/MWN5l/+I5TLXKUurKaVZkhNEVlzWNj8eayWjWxMQS1uDNWekHuc55GhKxKkCv",
-	"MyudxTlPX78eYuwEyTEKJacGrNosPXwbfFHLa7i/+lWYLSbvB9oLEIXfQaXG1970IpgvzEzXy+V0ZHx+",
-	"F/ga6bXbIAtqx+IK6yytsWN+paLQOnfKg27XDS/EA38sLZltOq7ib21HNhUAqZbU6RIV7wire/Vhpeqv",
-	"zLaxqy1dEH3jb6BwSlYReBXZatlYpuWJkhPBo65czNushzbTEp4+/qsvMgXun79UOoYuaSq+8SSNeWSA",
-	"x8+qteDNLwk3xuG5T76txFxmBoeRY4Ghb2z1K/eiXSt95TlTQ8Nwd8yzJmaxXNZj9QC9AgRLm9zeiIUm",
-	"brrzXU3fvj9iTYl6pZKhiZRTvwgi/T/9219C5PjTgyN/+xTG96vicrUiP9lPQ+tFrVTiS3JSdcwUUfsw",
-	"cUMqHMbU2N6JBjPmRIVYRV6586+RKYysVrl3qd4CyqWxOovqo09/MFjUcoMRTL0DxDG0mGv0vUtrO87q",
-	"KdoN3gA/INiGmds4uElqIyQzgye1uQE/0ftY7mkUOU49Eer6EF4lvjqrziQwP4ZHwdWSaVmtQ1tFqWGY",
-	"DVdQbeimLrwp5aitmFe93SYE3NkVYQtSWu8UEVhpSeBey1ZCjJi1LJr5HHq+PV49rNK0+53yZV7JgvUI",
-	"PsFoEQkkDyH0q7zsyeMn8M//+M/qtg9qa1cnvDFMJVJyjtpUPFS3Eey86VWVyhd0asp0YXZ28xrmTRXr",
-	"TIPpZb32c168uZaAm5l05wioJQpuhWprQCunqC1zty0GykcQ+ETT3eIT76Tn5XoQIC3TfIKd2xbce3eC",
-	"TW0JfvJFdTq/tjF2l2/btysYtKky+lPoj/86kzuEYPra5vVNh7eWj75Ji97dZOqiPXwrpK9cDZkj22D/",
-	"pvu982jrKixvr0jE6jXsiCUN0Nr46jQiSLOStwE12gaPUTeiW+0xskPBy82FLWsbLxqMMs3t4sKhg99U",
-	"ZlD//adL2h8yjfpF/rq5vw7WhKxMxqgBZTyk0JW//3QJ/dcXT/71LwP4+0/fXgznqMm05KRawjoiepq5",
-	"fCVn1qa+JAYPlbaCua13/PwcvnrxAo7PzyqRPUe9Lw8fHz4ORknJUt476v358PHhn3sV0WLkNYhRqHhD",
-	"4A8SeWHKdO97Ly+x43vcH0eRV7Oq5Ql+Xk9/dGNVUARISTk7hX7b9vKUUujmmSHzXRM96vb+15BUJ3rv",
-	"PZXWpV7eeO013Fld4ysCEVh1haEbRqg1AHnFTB/DR132vH2WxOjaQx2HAKA8E6XpYLsuunqat1QiguqX",
-	"EyY8efx4pYpspZ366NcgRpa72lyqw11+jjIVtYXwd0XC/9a7HihD89Z24Os21SyX/1ASNiFuQdI/v3U3",
-	"U1iDCrAgVYZbw6l+aABnVagTR4hDsUI/L+Ogd5KNyqIntWT2NeY93e8UPCv9RPcPLF+jXevKR/0OLU51",
-	"kVY54VMqrG8zg4bs1WZAQayUj2OqsHqlpxBu/q1/P7wRexk8VQUhaP5oCo38NoFD669UQAoNbj/jRTNe",
-	"0L21xYwU9TDY3QfArEp41IgSJe2OptwO01BCdxRKug0NGpP7RVNlakibgkor1XdDfOkdoVF9zO49I1RD",
-	"HO3+oRUdBI7TdEg50FUMgIAB0H/l3ophrPkcZWc8iouOM80YVHal+XqpmfRGIazYtJJiceSDFbyoDQLZ",
-	"HENLKgq6rgTLUzous1T4dMhiRdMVxR8MONQ5IHdFKkjjDuI7yTa/ZUhxX0G0yWSYf0WsCcD2etS97npF",
-	"sa5WpzNXPB2qYH8eUq8l1OF4dys11TYd2j9aKY9BQJpyCwWt9CNmIhbjQZECovS0BanwOB3lbtOiFng9",
-	"kbxWllk8i9Ol4tl3+WpW1tlrwPmbI6icnZ4XaSU6OKzzLOZ+0RBJyQgPWkIvDr2sFo2ib97t6ixOt/G0",
-	"V2enJz5CUlP2pFUwwfzhL1aCWEUZJW5PqFBSG1ZV1GZvUr92W/o+la+armF7ykTmqIFJqFz5I1NUgt6E",
-	"d9X4vVFRhTGviGgaUfAlN3a17Y25Ke9oGaq/3mxnu7Fx36Dq7reS6boGmTzHuQLb0woo20F39MHR8kdP",
-	"ugK9TWuF1dDfV+98G9fJx0Ox3ZBcTowk2BIDHwm/LIvazVylcertjONpTSyrytOEP20aJyg4Cm9EBB9j",
-	"B/2nj/8KfAKcwkoOOqDHWslVEvI2c4C60sH3wwWaihY/YE5QAKha8LRAAwIWsDnjdPg83j8SmbHeON6M",
-	"B1UDwGaAv1oaeYdP81qF8z0FnFq5sMpDXPm7B0NeDWszyeWDtgl+KfstQ0jZlMtgy/FVjdpJd8XgRumu",
-	"ef6t3oATZnDIpUFpOIXMmWzsR0NCVikliatT4FW1KHG7vfvGKJs8Hruvv/Vs37H3PMmSSq9s4mcUOIU+",
-	"di1kAAXE9Rq7jy1vayYQPCFPRdMBb7yJtdTvuxTDqxWU95TM05IqcwovCJWM5LUK+AmF25wXFdjuxEhe",
-	"XSMv3drKuPnlbQO47rZPQvXBTxnCfo/AoKyVVwPkKgdfrme4Xb4uUWAjTw/DPG/qn35/MaQYeN8JuV66",
-	"roaytBeyty3030HW3gztQaNT8uHB8vF9MII98KLuzABGFJtuRh+WYzA/jkLwkdni5C6+2VukWhOTXjwf",
-	"RjNlkFyMxfkg9K2p2eda+GrbrW5e6baxfzUqau8s2zhbxNo/dxT7v3Rp/RxhydlUtS58jfL4bKuoc5np",
-	"zzh8Pzh8+5LkcmJPKxHyya0uvtlMfxxFmAZR8unjv97qykUOWd26PiOJm6JTYsgLCI4736HGYRoVlm+b",
-	"90WF4z59Rz9bSxby6iWlmfz7f7m7MBCjZdEM42cQ8mTmnPk8bTc2VL6oYSYbXtSiyUs9u6H2Lg9CErt9",
-	"Oqa76aQJPr7ttf3se/g8Xmo+naIuRUHIG6h0Ewjpq1Gat5XbJP8FVM5HflYrGrCqvKL9Q6vQ64p4ok+C",
-	"LzvLDWPNrlFDWkGBXZDtg2XTj5sQLUz2VUDoByKk0XHAsmn9rvwPbXdTnezeETxkhe6n7rzELqFIONwB",
-	"kavK8noGrPeCpqh9eem12pnLRSZJREEWYlIsmz4y+e86k3k6L9Wd/gdKX9rIMiEWh71Bs2/mK7/Nz5y6",
-	"AZEfgKEfxjmMu2FwpWveJiffSbW53mcsWo++D3/aZ0xabqBY5MEUf2yJR6MPS4muHzebEsvWtQ/keT9Z",
-	"6p3ccq/LqcHtd7t9sT+ECvbWnF5tpXx7FLAuJqwz2D1/oj+TQW3S+YN4DtZFiyWSaDKwB8vEA9Pe9g6v",
-	"v7wLvN7XwInSWraC3XfB70cf6P/9n4Samq1GtZdu0GdSuR9SaTDMVLC8y74LUHc23rRZ8P41YoeJ+ynF",
-	"eYOO8KR0i0TtE6JMK3WmyDL/TMoPRqkJMN1PoiifuyhHzZI0ysoJmW2um/AZtf8w1L59l+tatbx7L1ex",
-	"71Tlb7AVYe323izlQn2IMQ2Re1S+aRiQYkMutR/wSk8vUM95hG3rPkmTJeTduycKbr1iC1IOM0VLZHbb",
-	"JNy0yNb9KT2lSkM8qrSpWITzhgrBeV2KMHfDTQds6LDtHde+T/3SI+hSHMj+aZhh++DJFKxyuqZWxgxz",
-	"9K6HxOZ8uFvjHkWmXjPjOM+HrGY0PsQ3n4LffDiDStEXRoA+odR7W8SU3okE0G7prWc5X82SXSXv2+Ig",
-	"bRa6J+mlQNFcdLnLQM+yeeeWGM9Pt7BWfl3AIN0ExT4zCxkd3BMvKsvSNunTxeqLonPMZw70yXGg07vh",
-	"N6dbucvaTp7LOddKUvGWvHDUEcQ4R6HSpEM6K5YTbUhqbbXcvZaPWaWXffXDljzpkYFCZuFymncT7CsK",
-	"vTeQMHOFsZOzqHneXfAuoRbJ1gCZ08q4z7aR/Tf7lfB8GD7ceAk/b9EsXhSobmEWfxXGfiaQB2QXd0A9",
-	"Pj9rJpHbzH1qs+rlrGqW49QhCZiE4/OzIb5PFfW8Chq4r8I9VvGiaJxVfHq5SLGodeiuNgZMUrugNwgP",
-	"9ymc6ZGBcGEUf7wDB1iS4ZdtkJsfxiWrzkMyP769j6pSKzaxh1lLilEHyyoQHpncgKZLxOku17WrNjea",
-	"M5HhhurPJ0oIjNaqC/7oP3swj9l6Ibt+KYcf3GXBvLp17smUdMHmAZDNtqTH92NL+uRTwogKqjX/lvU0",
-	"T0ZUoqpQ2UL/is6UW/RLbXxXXtCIB0N8r6RYgKCEDmZnBnzfmZCsjRP+PvRRdM+3Gfl87VFbc4afYVPt",
-	"tF1X/0MeRQf679Cyh/oeUooYUQAwC988Pz6t0JDH++3EM3KnWTQ/asfu5/0mojt6Euhm/qB09LC2cch5",
-	"LwoVLZhXk6g3GEoEpSFRGgNSJmqOMaTMlwHlGkKnL0pezNvR0pYw/rTVpGNqHMKEWNB+F8Bg7OstTuBa",
-	"c4uO2Qm0aKDv1EaBoe0uWAUJ40u9IlpT5gdHLM15Ua+RxW6uB1SXhguklyU8LP4Zgb7VjAuHLNdcxBHT",
-	"8REkbAEmZRKSTFieCgSDUzJbDYAf4qFTFSzjEoxgZuYNvnUH9f9qXc6mdoP3bFFxmyjq0e1hnSYWAyvf",
-	"rt2eLioVv1nwO/ND/jjiaGMVTNjQoNugxThvcEIboJCQCRcWNYwXvYZqqjSy12nRb3FxrXQMvtYsUAF+",
-	"uk2gXoOjsYoXA9BMXmEM4wXE3FguIzu0qBMaLlgKfRoM18inM0vdxrOxwIMBRCxNMXZAffKvh/AaHdMc",
-	"jjkz6JtOZ8Z7YUymJyxC0Cjo7B6gMMZJeD/obQCJ16AkHjZcwG8bz34vQiah2ZmcqAcqZY4CogTkDHDy",
-	"MQKFEUZjqioEHEhvW1E1GvYJEejbuyxkS4f9g6TFsPZmafHTr2JbRcG2GLjhDXFPUOiNmrd22+Sdukgx",
-	"8t0eL8Lgh1Nq5nOT001NTgO897rZTt5Mc7m/aUB7yOdWunBkkYB2rfSVSRnFdG7qeNpEYVsjtwLq7nnY",
-	"1j1UHt7zQJ2SUV+cvjzZtYySH729x8Qlm35GptqSoGy6z2EqqzWxdsEgc7UZhS5pxIN52n+a8WgGdKhq",
-	"E428e4ZKfR/TVt1JLLO44UFvu5TMEgcw9+/eoBcJZTDuDXpMiEp3/o1GIktyQ1gqFUzKXEIgVwQJdj69",
-	"t4IswTUx//PBsxCf4XdogAmRDzSHLS/Dl9LbYCe64z3+IbquO8yPHK8fboBB+U7xJBVU0dhLSh6OfcHn",
-	"mOsh//x//xfwPUYZtUKCf/7Hf0KMms8xLxN4MIC8yaxYgIlU6m0fSmID/A/hcobAMD2a+8b6+dJOFMb3",
-	"kcjiYEfhFLHEIJ0xg6AmJLPpTA5yy0pc1CrOA1b8ph6ZEON3WC7xDKZoh1Qk0FguBEU9oXGLjBehF89h",
-	"hdd6Hrmd0Y4+kK72PU2wscCXm/HhMN0lRbVsZeSAEQ5as9fKVXXY6/alJkonzPqeSH95et8tktwmTtEy",
-	"LvZUdnXEShRY1tTMhIDnOeHDjBur9OLG5DESatpIIhdUatxN/FJNPxPKJ0soFt/bEc6piTWBrBuleDA/",
-	"nze4di4unoei89WtPzKA0nKNQK8TiWn0RniGP6g8UgOKumGQST7h7jHiCQouERjlnpKUwax1ooc5hFcS",
-	"4V3MLDt6B3+/ePU9TBzSUY1aOiL0Gazsmtoja55wSVb98QLeuVt8d+RL0P5e7gV+B1r5d4iVxIOBr2Zr",
-	"LEvcK/mOx0fwJnv8+M+Rwd/oP/DdM3h3BFeI6ZC5k74jHyv1HEhZhMBjgXDNuNv6MRi0VmDsaddfminJ",
-	"NxCtu0MJKGPjydufFn4+ffX987fv6LLIFuJbzpGoaoIZhbqfcyXJyeH/ZYBptw1MUuUQ4ig0sqTO2llq",
-	"UFtD9zAqb2G8AB77dn0YZ6mhSzEDMCoAUuMQE26tz7rS+Vru9TdsgiQxaKSVYxR87LgGigVIFbY9NDzG",
-	"4Eoy0C+WPotHV1zGB76UMHW0JoDk8c3urtS1dPig+djvNr+QSEmjBMJUK7fn8SLHGsg7uPMYP/UuEERH",
-	"LCehCu30Q/LQF1Xx7os1ojkAZuDi4vnNOX+qVaIsDp16MKRfNqZdu7FupRdaJZ+aD6UVi7cKwpGLRpXM",
-	"UuPLG7D7luz7TrKM3VEKaHRy8jxZf6nyXGEiTEdtk0xKFMU1oQGV2aGaDMdMfuKBM5eZdlwDWDycqWjZ",
-	"g8Olr3qgYi6nnk9XscFpH+uJxm0ozCnMIxZZPsdNOscxjdjrzk53KrlnWm6zOje1S8wbCTlQ7IVbpOJI",
-	"rGwd+k8eP/UdZqUTUrp1+vF4+MH931m8Wft9UN3FiOZ5YexCePL4CUTeiZtja0NPC7qqDnttudSnRjaf",
-	"vMLrAPHIrLtpOmP9qNSCNum1n/H/XvF/bcuvkRzvpXmajY0SmcWg6HEZ43voX3NpfMTYS2bskDS+4dnp",
-	"QUN0lptug5H85osmXPIkS3pHwy/XxL1B7/1wqobur0NzxdNhboodpsqN0cG8X3MbTs1mmVXDUtvSaLIE",
-	"Q6d4r9cJZmzQiHlc1fQMu34G2h/Of2eATSxq4PYQ8vbz6N3spNKnGIWYaDmUWYKaR0WWjNMop1JpjKFP",
-	"qquf+cCbiuny6NqBqAfotujFGis7o89TjQalPWwK2Fi61hsG1G2xf6wgALsGajALng2cMx1u1KlbxIdQ",
-	"J1wy4TFiADweBgvBs4rW7tX1GjzfN/Z77JsMklgcWLAnhWD06TtsCZj1hddYLeOiSS7RERvS/Y40pkpv",
-	"ScB9HbFjN/h1GLuFH+d4zKZcej+FJ46W/rNicGOqUfP8W9nZd+y94wsVMx+5t6peyWDSyZ2TRDFsbDrU",
-	"fhE84Zuqvtx4E/dqp1+G/j4HCbw+OfZYD0ygthBwPzdxEqNmQqB+ZEDplb5aFUpapYdt0azL43t3GUu6",
-	"vFQne8OXd4Qx+1uHMVI6DpHm9agDfZIXJBOjUA1iyDI7Q2nd3jH2GUD6mTdrbMSgWq48+uD/Y4uSuIZf",
-	"G9nz65PjfPtNTZ3zVTvIm6uz3qditR3f9iISLqSH1aPaVuQxV1yIze/4hR9yl9npboULf669DifLbyq/",
-	"83B12zg9DbtTBk8rUMvy++bqtLJ32DdFOu8DWy9yBqLMWJV4UNdBuiSqEU+IBBs9L2f0+3bg+4xEpu2I",
-	"CmjGzNK5UXpLN/kquMDKV5chdqpybyqyWOhQdO7iAlPt9mW5B34+1YrX5R88HboL1mgMxkCsxB8aLNNj",
-	"RmcoXCZjLpkPYVgVrSuo97Nfq4zRU2PqUl5bC+P2MNJfe3P2yj6goz8DFZeqBcQmtDQLGTUj5cVCRvfF",
-	"8Rcy8jkQe8jw3eZ9Z90hl4HzQ9+byrxSoPT0kcl/cc8x8Akk3LgH+2ALjDIq8t/iXf4hDLxrWPl19vlx",
-	"ZnPGKcB0BWqQFVe4CSK+ZJNnjAItrsPklP6es/ONwjQNCgbhDfbmjvWN6ma9bYGaxTH3Zs/z6qvxsYaH",
-	"7xmSePCVL7zS4B9wjJtf+0Fzdt/DxoMbinz7oVk1Q31Dw6J9APxd9fXpqmZ8xrm1vj4tNAyaUs9zzMq0",
-	"6B31Rizlo/mXvY9vP/7/AAAA//8=",
+	"7L1bcxs3tjD6V1Yxp8rUF1K0PZ4538g1D4pkTzRxYpUlJ+ecOBWD3YskRmigA6ApcxxX7addp+q87dq/",
+	"cH7JKSygLyS7yW7qElPbD1MTi2jc1gXrvj72IpWkSqK0pnf0sWeiGSaM/vM4itCYN/hbhsa6P7A45pYr",
+	"ycS5Vilqy9H0jiZMGBz00sqf3KTSZAnqk3zyH1iC7ge7SLF31DNWczntfRoUI8+1+idG9iyuH6WRWYyP",
+	"aR8TpRNme0e9mFkcWp5gb7D+Ca+fSenpBeo5j7BxS6lWcx632Xw+8syYDH/IkjHqpQ1yaf/yrNwclxan",
+	"qNe+fKvFxuk3300+6pKZq4YhxjKbmdqfsjTudrOfBj2Nv2VcY9w7+tldcx0QBw0osAaAYnNVIFe39Uux",
+	"AzV2k7tNH6epWJwoORE82o6aMZpI89T93jvqvZYIEy4QrmfKIIyZwYsZA6lAKDlFDQmz0QwNfPvi+PSw",
+	"t4rZYXw9lmZao7RNP6fMzmp+WLlQGjUo1lmadetdmI6XwdzHQ3cdBp49/iuMVbyAf//Hf4OdIUwyISAK",
+	"M4NB+xyksjMup3DNDLhvOcbrVxRVN8MtJvQf/4fGSe+o99WoZDijwG1Gy/D8VJySac0WazdUzt94H7tx",
+	"rRgFWmy/7VMa/zp1y8pMCDYW2DuyOsPVEwx6CRrDpvVs5FrzLsv+5Ia3WfVT8/WYTHTn6UnCG5GbcKj1",
+	"EV5ygd+jZW1u7pppyeW0w/34D1rdzzJe5QfMj1OHX99kXMRnMs3smcWk4x2y1HFrrHLpsVICmfRvYTiL",
+	"R8YlrnXtjgTFCJCs/tmLMUUZo4wW65OcFr81fn7FJW0OZZa4O8EPFrVkYuiIjk97g/IvJsXI0b5g1r0b",
+	"Q41GZToKPH5oPJOv3GGVE2qWoEW9gV99rMNet+aJkjbc0fpDl2LU9JrOmcg6oOgJHfhH99EumBQAuQSQ",
+	"cL2NWPWKm66vmeDGDlP/7A7HbhIDGk2qpEFi5EoioLR6ASlqcCMsuFuCOWrDlQTLpgOQeI3GwoRrY2ve",
+	"PJq39c3RWS6yJGF60fnqwlrNd6SmL9xxOhKewDnWo4VQ09q/O+nHWJak259sN8WmDZuum1XTjrdd3EoL",
+	"fmqVZeJEZdK2klXXz7oBOucaJ4JPZ13fluKkrY5crEIcuMWRJWJsiGfXMd6VE1YGD8J+Gs+7m5zB3eQd",
+	"IVy+ODs9+2G3njF03O6EcZHpDqyT9vrSf9UKI9m0nsjqj3FhgyDVgU/Sh0PjvgQ2nWqcMougJASV5YKU",
+	"EOh/9eR/PzsoJGDLpjBGLqcjwYwN3JPJGLg1YJm5gsjRkRmAUfSBmrtXD6+BkIiUCseg3VDHl1mNtFzq",
+	"Zss75rFA6Euc52z7YAA6k04MGIADCcYDMFkUIcboFK78yXYf9ga9MNbJMjTYaVrF6LVHedD7MJyq4ToX",
+	"dDvveNeX5cXAOIuu0GIME60SiFHzOcb+stevgkWWz7GlBh0r2XZouIB2g4k97sIZ/YdhY5VbD6eq4yHh",
+	"DV4H/oV7oR32OaQKCmCJg7FHiOfwrveuB3wCFSw53Kqx54tWNG8P5V82EFxA0Q5cQyMzdUcLfAFitIwL",
+	"mCgNLOBzOFwfk9QuQNkZ6mtusKTHGOcToa4fOVqKlI4xBtRa6YL+IiWNEggRk2Bm6hp++vb/Bm7D/Id1",
+	"Em9JfzkBGcu0JdBx+Wuq1VSjIfuESlKn8MUldLvTUQcJijbmiKmVlqT0lbubXxttPStoUAB/9cstaEAb",
+	"6vjeLZvHlvHh79x+m42BxoCkQaAmBE1iJA72gssrA8zjx9DvE7S6BquIFfuP+44zWxU4t7kaCjUFYzWy",
+	"5OA5aEwFi9B4Pi1isNwKHP5TcenwogVnuF1MIRHTCtwOKT+sWL8ZPkHk7m4P8wqCmkCdOuEAwNZ0hkcm",
+	"Vxp0Jg/hmD6lJw5mLLx8c4QcueC3DPWC6PRdfm3veoFxqSjKtIEZaqyzJoW73GCibCCOWpr8X+6bw0v3",
+	"Id3zvXKpTE9Y5KZAw2Ok0S/DpCyeInBZZWNN/Ep3NIXfPuKyBp0p53JbmdslE4L4VpZbxTZ98pYGrdEF",
+	"m64/YtULaqQUv3pH083/NOHkRHCU9gIjjfZ1ZtPMfqPirrcWVSbZzumWRtfuSTlCv0Dj2NDOm8KE8Xpj",
+	"gFYqafChZAZ1oyPo2tRbnVbOF6bPx1cmHYRNNR/6Rya4o/I7OLXc4N9ym8iPvSLmzxDcgR4ZCOMGoNEo",
+	"MXfsbOHfWc0igV74f++ekOG77PHjP0VKT+k/MPw7TOD/9v55YILu2BDsiJAZNCTKKU0/G8TYvzf9r548",
+	"eXawXfCV1YtePlz9tVessV0YRWYVcZl6I6/7+RRToRYNRuCqq7PGvFsBQd3v3KSCLRoRFWWcKi5tQNdl",
+	"iJ5nY8EjePvmVS6BBSXSPWkQ06YTlPYQzlWaCUZ6ndJwjWPvDYqYm8mAkmLxHNjYoLSQSctF+LpBBm+L",
+	"gF0cm/4Pq0csgApX3OnxEo5fnD8yEKPhUwlzFbFxJpj2XrB3vWscDytHe9cDpZ0E45HyXQ/65C70d+Sm",
+	"OPynUfKRKS31l4sUDw7hdYryZKY0KqIXnPAPGMNJdRQZ5Q30y4se/a+DICKxNEWmwcleM27g+Pys9iKz",
+	"Wq93HR1sxHhv+96K96ti17rgtsX3392rj3L+I9PtNakXNL6NAsXjnTDwVvzn1UUGKxdXnrmLh7wAZSuf",
+	"wk2MsSWb7Grqb7atFnM6qjk+P+vuqdwadVKhu0ZPUguBZQVUy/OGWepP6CjsO1ycXr7u7KWesExY75na",
+	"5Y24wkX9kVeltCYLuZtg46F+5Hj9wE517th8xzNNuT0PwTk35KVTbmfZ+JWa8obDr7ht/fha3S1RMVaH",
+	"psw2+GhbCOy0bphzsDJVeYM8Tm94fjLw6Nqj//P6yjS5fFevJfdVO8XHTJmOUVGAjbEqqbmEusPWnU+I",
+	"5IbnYyn/rgF/V8/ApJ1plfKo5YYH+eTrO1/zsCxbSpSeeq//YZUEKmOGPEmVJjTxsU0B7w4jlYyujXo6",
+	"Ypi6/w1ZykdONdWSiVEOhVGxAG0lLOKfwkDlNyA2IV5Pekc/b368/l5+VFn40y+r8CqReKPf6/S8OkuJ",
+	"GK328urV95v3sOqJFQ6Pq8f2m/ylI1TLNe8YtAVv7wDVJq4+b3gnanh6PriBt1OQYvdXOGoTHNoYtbka",
+	"87cUN1mduHbTJAVS5Ghb//OyEkSfglU+DlJ5m2PYA1ktU3UIMcZZit/hAhJ2hQZI9uRKAo8xSZV1OlSK",
+	"GlSKMjfACzZGMUQZqRjjgwEph5GSwYEFTKC2MGMyFqhr/H/jYNSoefvDXuojONyqywLruoa5zQXdzRRP",
+	"O22GTaCpXaMQc/XvnKcouMQ7sQRs0rmT1NbbezKD+pEBLrnlTEC4GrdX0pevZ8w6ZFrANZPBX34I56gN",
+	"NxZjYGYN1coJmIzhikdXBtRk4v0N5C/2WJebfSRe599D36PdV//n04PD3JEfEBVjuOZ2pjILDPyJ4Aox",
+	"BatitnhkYIwzNudK16rRjgLqjV5vMFWGW6V9CF2xrfJIwZ/lpngOQao1uVsq37n7dhAsZFMm+b8CaRnw",
+	"dgGDeo56SE6C4pRP2tq4mhHzTcSOpyitO4a2u3EPCj/1W9N+guAecaB5c3I8ZNOS2DUtFM6w7tsRzBg+",
+	"CcaV9dt2fGRIoVsD8M9J/q/EXdMAlAappI90M2hzs6NjMQ6JaCd1AF6KtKyLoSRbVb2BLv/1TvxRMWdT",
+	"qQyvCQh5mQnh7heKMfA1ONqJuceeyAdGQj9h+ipW1/KgNkCUm5Qi3BuOR5B68SFCndbfDt+S7NBw+Nwz",
+	"sXJ6/1U+7WUDGw4/b0iUIDyv1f9Kr+iuDth8+kHpig2TDlZRuArBZjK8uOJCFPFoHd6GRqatcYIaZYSb",
+	"ImqbjKTVAFu3s+/bGhHL8XVnLcLju51xU4ZFhxSK+h3lsbg7hbQocr3cUNLQyOIG03/n0A0/16DYWMOZ",
+	"hVrsEjPnv+wUNOcEgEfGu/65JLeBe9a1EsI9xbmnud7LX2ahddhkadBfXaR4m3Px0zPu9bULiNyHA9Yv",
+	"VgeodS+99M5av2//chRPU/cQpLl3INY+tCeKaYNQDqGQRdCZBLetUs4RzGIehXbk396+VBT44Z6U8CID",
+	"iyJMLZMRQuTEBc1ZNXyxCDOAvmbSCUfhL1xJ7/xLmTEjd0KYo455ZAmnTB4g4cWKgzwQEvruj+XuaePh",
+	"pwSjGZM8YkIsSIBaud0yTrJl8EO5DOlR65d5VhPKVMqHlV26Oy7cZNczpLNpdGKgVCvHOYTLSnxb7gy1",
+	"yutfbolcCa9+KNQUUke+/Sn6MFQYhZCoYREi5YEF3B60DIQqF6h1I77i8ioXeJkxKuIkj1e2df5mDWJe",
+	"yGWGwmyEGLPoCsY4URqBufH4gRtrDkLM44bLqhXotwdaVlhWJa4ypLttcF5uD66ssLYlImxm1kl3p3NH",
+	"Z9s2v3Cd341rJZMmkXmDYCKQGezuwf208Xru3K1VgcTt+bVOuYmUlBjtHlDTUUZo3MUc9c572Mkav3pJ",
+	"fo7yi7qdBu/tZ2UyfKG10h2FlJeCWR8DCCjnKFTqnjCbaelDZXCOeuFe0+HTDx+K/K06KSmueW++Z9GM",
+	"Sxw60cIhaVjJDYa+sfQnI7Kpf/0+MPfK9Y4qrOjXIhysRhW2jIs6bZSjiL02HoIkvcBVYem0DZL12rnq",
+	"3fBTmmo9BXgpgXZ5J99mCZOrhw+jl0+cmysoy5k7YYJ2u5WpR969le+gESvC5nfJRy8vc/UC17GARtc8",
+	"u8rroLnIoSYTlLF7vugD6OPh9JDOfui49UHtQ9l4yz/NmHV3dq2VnJJtzeeIu6m3P4t+y1uu8ANGmVtt",
+	"B+/xTpEk8R3ZcBoiSXJHXs0Tmccgr/+UyU0vp76rsOi2rwwRT3Az1tRxqAezF1PfhHThXVwveXRSh0Te",
+	"EGrRQkHPC1d0ShUuvEgtFthmuW+QpeoNMEVedrntult/yQVWEqe73XZjunWDOWbQM7X2m/pKF/kC/qum",
+	"zVO1gG4777i7Qc/wf+Euun04SNP2653MnaHgxMZuLG5b1AiPUVpuFyczJqddq+v4T180BhXnI7Yv38jh",
+	"uDSWCeF17bYh8h1CYQQzNg+r7nT61RgalqZr4S9V6zTOz7behkFBACYP081MjG2593L0TkVhLXGtdTBB",
+	"PZLfWUTBcqhFN1qaMXNSn5aw6ga594ijQS/NxoKbGWq/xTbRAwGMaxpV3WSDtdO3hvDyld8dZBPvmtyt",
+	"Qk3KLB9zwe2imwwmeIQhM769baO2Mk1Haq1/1QNIiwXqnpWlLPsdrUVN7s9KCZlbkGNXzrhUESV8VHtA",
+	"h9BncqJ20Ki8OZHyTgQ3dmSQ6Wh2CKS2hkB7phFOjs/PLo9fnf0/L07zQJhrrhH6M26s0jxiAsyMpRgy",
+	"+7wdEBwyJ1E69H56SJk26DMlYwVSWXjXm/AP73qVIIRIKR1zSabQ70/O80+DfexgXc37pika5tUtxLt0",
+	"KlZ3YZmtp4Bmf+3bN6+2Y0LYRT7PwJ/Zf5wvW5y3EUVa8oo6I32ClsXMMmATizqEjuSxT/Hf3N1Bgkwa",
+	"YLIa6VTov4YlWAmVYoL8O95ajTFhhHcEjDItgLy0Pml5Hd5h0frnSKoYGxLTZBdQZm1sczIHS0avSFi7",
+	"7v6XYxbvQaS9wsUrZuyzphDwc8qsuXEg7Q1kww0pSaVppzAitnrZy3NVLuCmAtsy6O7sOX/FJbZxPa/S",
+	"guFTedmQZmxSjC5b14x5XYmwunO3QXUxsmPdnvNgbeo7N5HdWYjhpnqktSlsy0jsxhy+fXt22hptp0pN",
+	"BY5o8k+rV05/HRQGlY3Wq/OA5bn16nKR4i4pPDtZgAa3E4GyY/W9tpGGy9W5biCY7lgBcVfzYDtyvXGF",
+	"xa15TJ93BUZdQfwO+XG1hRCXL6Mel4rAvl1ZXUN05x8XX03KR8o2FKDWmKrayIoToSRW87OXwo4pKsYH",
+	"Jy9HlUhFPwGnTP05N1xJjMug3E78+UYZxgGed/4M53jTqjbgB3uSaaNqahP5v1dizz9YCqcprjeojFSZ",
+	"Kw3+xi0ek8b3fSmobocouMwpHBenr04gnTGDFHjHtOUTFlkfxWUaSnu2LUc1xZJ+2sVPVD5yAt1FQ627",
+	"d713vQHEmk3sAIoauTWIOWPmlGaq15JmzFws5+0u/3iZ16dZ/5XubH1nUg0d6QyIgIaRUD6Ajf4Vivr4",
+	"7IIBZSwMgOloxi1GNtM4oAgvM4ClEKBacieF4Psm5+sFBkr2kOWmsoHGBIbNl5163/AAKmdi8WLgnc5N",
+	"czaZPfNs6U0Y4SBT4IPx/7gJNqw6YQiAS0cv91yiRhWHKjixtKMVdA3HGwRiKShgAxG/Nd3Dbc9RDwPl",
+	"RjZjAqg0UsitKFJevnr67M8Hh3AsBEz4NNNoQlVFb+xKi1ybFPVQZxKsukIZKlEZ6B+fvhk+fvzkycFz",
+	"iJSxb03s0CnK+QcLNbycSuBnDPWo/GIxJCpGAfoG3CQUcxr0CMIni0hg60/a4FkxeDngtXt9qRWoV6Zb",
+	"2nsDGiTK4kutkk55eluC+ppCn6kmiLdMcQNsrDLbIqhlW57heS4r7FJsqIwXrKHwF5VfwapSKoF+yJg6",
+	"gp9jpEgpN+iXg2oQ0W4KzxZBd4UW8w05laOUlaGv5qh1XrotFI3Jk7wq6TaNGdafBr3lHKyOTOJYUgpQ",
+	"SKsqCLSsLgMXb16MyiysPBOqn0cOE5aYfcnE2sloUSZvrYYwoZ2hDgHkJhPWB0d9oIqFY0RZGvj7P6Lm",
+	"kwW85B/AzjSamRLxgEz7CWoUCzh/M0xQTzGugL1bltjnmxXWfG+RooiyHLnyayu+LhMFuLzCOE8MJlwG",
+	"HsznQyXFYpQwmTExzL+llyUUi2IwyxJWmdfUX3JDpNVqCtuKMDVzpIP+51yRCtutFiNd06GC6Z8VKaa1",
+	"gRFda53m6arLBPMcmAg1bakK6hUuoG8QYRQkATP6WKka9GlEkuboY2X5TwdruQUFOdIhPBk7WLQI+/8D",
+	"0/bqwOcwPgx5vlT51+pMRk468Y/iJNOEuw4tfYVSdV0rhLdMBayWa1opyNQpN3CJ4ipM65etD8ad684r",
+	"79M+qdAXbI5UZcLcgsjSlES5e3LlurxfWRM+Bor8DhdHQPHn8AkSlppD8KEajgl4r7VWJKyHHBtf4QgS",
+	"JtkUdc5INE6dIuBkdg/Zw942k+7SDdTe7xUXwkc571ILdGt4RnirmrI/t5nkMObW42mdhn+7sR9KT8/i",
+	"PygV9+ZV54qbyg8yWIk8qV51uZWlwy2Ba1s9OsKctgWqawNQ7xkpOgXh1l7a0u0Uu9h2OTuw90Zz8beX",
+	"37+qWouVngKB0tuPYMyiKyfN0fvJLBNqmjUUnaavWj8hS9Du6gENa5XGm+YrW8jIJzHdVhJVgca7hAEX",
+	"/vh8jsaNv6UBO4Q1UUWVIZeheSEmY4xjp67kPqCDQt6P+WTiVNZCR1R6Gor7QKTSxSG8wUjJiAsk8w/T",
+	"aCCEiF98e+x1HUYS4zBhXFrGJcZ5CfjDd7LXsjhBW99A5WZ2IIKodUOjHD4d0TnArCs252sNwg5rT15Y",
+	"RrthhPuubXr+IRwHS+qIbFfAc8NhUGuNVTpELOVl/p0ez2RMP8dc2wX8rbDHQn/+w8Hz4s9+zogCyY37",
+	"7euD55SXG6b6G2Qyj0aN/ejnIacXvHL4Nzecqv4ssDY6Kjf7r3pcyQbjW1jShGWFaDdZfxqUAQTK9Z1z",
+	"vC7r/Y4za5WspkJVVXh3tvUV3bRmBAndgpK5zpg6AbaSIm/ZtH5af+r1eY/lwm+ZqnIFzeJ5uB2NMnbU",
+	"7Bb4O0rU7qmn0SeXx/XrNOY8v/IbnPvS2z/4ott+acumq11lCqhtF8zDyQaVLGh/h7lBvR77LdP2xIcw",
+	"UUzrLhmpa5kCK7wz9RNBdSBZHrl0enVFRc6MOzTVoWIQMRlTCFjJRp9+Tb+iPmiTLP9py4F3zsFlmZ0p",
+	"zf+FrbJtl0Y3AMFm5nszvf905Es23YHfeypbh/QPvinJaruSkP04/9PBqlnHZ/hz40ZNm3oEpRid1nOD",
+	"S52hnyrwBc8D4xBRGpjBNauZv0Krlk1NQ3GCyiEcY10i2oP1zo23FIdOG6qHlrlqmee6grDWSRaBIe1u",
+	"yx8LFV1h/E0NKH6gqO4g6xbRJjw3BVH1C27gmnEy/Cr5HFKNJS4sdSdzI5X8daZ8eusNNtwUxt0mCN+8",
+	"vuF1LZ2pXj/K026/pYj3RfvS6kv5ui32Uqy0UTHutOQaevo1lD4RzNSf10F0Q8pPp8D4jdZNUUa+biz7",
+	"GoZ9GvTcNbBGRVZp3pQ7luqthVgc9j8ykGZC5GX7BuQVnpOJqHjeih6Buam/gNojA+96qf7qh3c98Fkb",
+	"BSutFmpRKUpTH5TAPLzxJrXY1tB1GW6lGbaATZWWSqiskkZAjEGFTy1hbBMvvKBiOi/mbRJr1/W5i4sX",
+	"MNEsKaqwrvQtO4T3btX3EHP3aUL5I6GIJlsIxeIjeO++eQ8R05qH36hzu9udoxPo+7Y6kKUGtTUwXngP",
+	"xMEA3hcnfE+dgpcIrPbD2H3lLtF/cMkTCqGjCyg+YCld+CBPpKAaF/nUZ/HXBn87GJBq8T5WbipvxrRW",
+	"OOVgiQ33/U+UK2Mdl46EMuGYobdbnbKwwvXWwmmqK0FoKOdUn/xBUFIscpiEPRKcahG7OFpn/pVHH276",
+	"aOmK8y5bWz8KwK92QskjSun76q7DPkJ3qNqCYu7b4ZxpCl50k6zg/uUixUs/b80vLypL1fz8yq9e88sp",
+	"bWhNOHHbayLIHULjH6posreiyBcB4YuA0FpAuFEPwT9Odlji6h2DgCCTfMIxJmePm8V38DwqqlufhxqY",
+	"4Vn2YYW/g1VK/JrRf065/TVSScJt+EeamZn7z9mvjFLC4Hdf5fFXYzGF36mU4O8hbuYAUuH4kDXArNV8",
+	"TAcNFUB5NCtxwv2OCVUXhIiFmMJDuPQBa16QQT3U6rqSZpv78oPRyzv4X76AqVZZSo1fzYpEMbrisqa3",
+	"9lgzGc2aWF7CGnw/Ky1H1/lUQ/ZeBeh1RqizOH8B1q+HngGC5BiFklMDVm2WNb4LnqvlNdxf/SrMFpP3",
+	"A6UGiMLvoFLjC7Z6gc1X86br5XI6Mj4pEHxh/dptkL21Y0WOdQaIc6xnjZUyVOu8LI/UXjfTEKn/WNo9",
+	"2zT1xd/ajmyqGlOtw9QllcIRVveS1UrVX5ltY4VbuiD6xt9A4cKsIvAqstWysUzLEyUngkdduZi3cA9t",
+	"piU8e/xXX5kM3D9/rTSlXdJrfLdSGvPIAI+fVxsImF8TbozDc5+xXYnQzAwOI8cCQ2vi6lfu/btW+spz",
+	"poae9O6YZ03MYrkWzOoBegUIlja5vXsPTdx057sayn1TzZq+BkolQxMpp6wRRPpf/e+/hHSDZwdH/vYp",
+	"6O+fisvVNg5kbQ39OrVSia/jSiVVU0TtcwsMKXwYu1eDBIkZc4JFrCKvCvrXyBQmWavcu1RvL+XSWJ1F",
+	"9bGqbw0WBQBhBFPvLnEMLeYafcPb2qbGeop2g+/ADwiWZOY2Dm6S2njKzOBJbULJT/Q+lnsaRY5TT4S6",
+	"PoTXiS/pqzMJzI/hUXDMZFpWixdXUWoYZsMVVBu6qQvfSzlqK+ZVb7cJAXd2XNiClNbbiwRWWhK418mV",
+	"ECNmLYtmvvAC3x7dHlZp2v1OSVavZcF6BJ9gtIgEkj8R+lVe9vTxU/j3f/5XddsHtQXPE94Y1BIpOUdt",
+	"Kv6s2wiN3vSqSuWrgDWlRzE7u3nh+6Yyh6bBULNeMDyv+F1LwM1MunO81BIFt0K1NaCVU9TWRtwWMeXj",
+	"DXx28m7RjHfSKHU9ZJCWaT7Bzr0u7r2lxaZeFrskdB37NC6fgFUmcymJTn+j0HP/pJL4oTQwWYnjyDO9",
+	"Lt3nBr4OmVdMY641hUQvqzM7W8rmyu2aXZK5KplhPuYjE6LMHnYb4qb6aR5kQVPUsDcWzfAktAzzR2gp",
+	"ZtOXb5DF3b7yp6+JP/ZxbcP8Tt5enD6vHC7VPAr+30yyOeOE+uunK3mGynzcZAOZFLVzlsLlJ0KxPGDe",
+	"kUKns9Emaso+E/B47ItWORTSTJLpkAI4lPSpOcOANzli1etzvrBEh22tiQzl5yuzrYN0UIse+UFLYNYR",
+	"4k++JFpnsTfG7opm+2YzgzY1on9S+soJem8yuUPktO9MUd8yfmvx/5s0WN9NubV5qnWr16dyNeRFaPMM",
+	"bbrfO0+SqMLy9kr8rF7DjljSAK2N4l8jgjRbWzagRtuYT+old6sdonYoV7y5LHFt21yDUaa5XVw4dPCb",
+	"ygzqf/x0SftDplG/zFmo++tgTdvJZIwaUMZDijj7x0+X0H9z8fTPfxnAP3767mI4R002XqdeEtYR0dPM",
+	"JTueWZv6gkY81EkMVvLe8Ytz+OblSzg+P6sE5B31nhw+PnwcfAmSpbx31PvT4ePDP/UqMv7Iq/KjkPFM",
+	"4A+qceGBcIJ2Ly+QdkLjj6PI2zuqxWV+Xs9admNV0MjJWnB2Cn2n5Q59cJPSUx/eFP4deFQIeeq5s7qj",
+	"I/M9bz3q9v6vIdkwSPD2VFqXMX3jtddwZ3WNbwhEXurzlutQKQbyesdeRKMeqV4qI3229lDHIW4vTyBr",
+	"Otiui66e5hcq8EPdJwgTnj5+vFIDnKWpCAlto38Gfa7c1eZCS+7yc5Sp2A8If1dU7e+8x5ASq29tB77q",
+	"Xs1y+Q8lYRPiFiT98y/uZgqzbAEWpLqeazjVD+07rQpVPglxKMTv52Uc9L7tUVmyqpbM/o72JC/+dIfg",
+	"WekGvX9g+TvatZ6q1K3W4lQX2dATPqW2KDYzaMhxZAYUe05pdKYKq9d6CuHmf/Hvh/cmLYOnqqkHExya",
+	"wjR2m8Ch9Vfq14X25F/wohkv6N7aYkaKehgcYANgViU8akSJknZHU26HaSiAPgoFOYcGjcnDGVJlakib",
+	"YsErtdNDWPgdoVF9qP09I1RD+Pv+oRUdBI7TlFRsqGIABAyA/mv3VgxjzecoO+NRXPQLa8agsqdYBY22",
+	"CWHFppUUiyNvCvGiNghkcwwNBSlXopLjQln0zFLZ6iGLFU1X1Gwx4FDngPyGqSCNO4jvJNv8liGFawbR",
+	"JpNh/hWxJgDb61H3uusVxbpaW9Rc8XSogiNoSJ3yUIfj3a3UVNsybv9opTwGAWnKLRS00o+YiViMB4XZ",
+	"TelpC1LhcTrK4xeKTg71RPJGWWbxLE6XWh/c5atZWWevAedvjqBydnpeZIPpEDmSFx/oF+3slIzwoCX0",
+	"4tCJcNEo+ua9Cs/idBtPe312euIDmzUlPVsFE8wf/mIliFWUUb2FCZW5a8Oqis4aTerXbkvfp/JV0/Nx",
+	"T5nIHMlRUrnyR6ao478J76pht6Oihm5ez9Y0ouArbuxq0zJzU97RMsNmvVXadmPjvkHV3W8lQX0NMnlp",
+	"ggpsTyugbAfd0UdHy5886Qr0Nq0VVkN/X73zbVwnHw/FdkNNCGIkwZYY+Ej4ZVnUbuYqjVNvZxzPakLQ",
+	"VZ7d/3nTOEHBUXgjIvhgV+g/e/xX4BPgFN910AE91gpmk5C3mQPUFX6/Hy7QVHL+AXOCAkDVctUFGhCw",
+	"oHTWhjSdSGTGeuN4Mx5UDQCbAf56aeQdPs1r/Sn2FHBq5cIqD3Hl7x4MeRG7zSSXD9om+KXstwwhZVMu",
+	"gy3HFyNrJ90Vgxulu+b5t3oDTpjBIZcGpeEUu2qysR8NCVmllCSuTjEX1ZLy7fbu21pt8njsvv7Ws33P",
+	"PvAkS/JChmoCxM8oghF9EGlI3AuI6zV2nxLS1kwgeEKeiqYD3ngTa4ENdymGV+vf7ymZpyVV5hReECoZ",
+	"yWsVcIr1wPOicOKdGMmra+QVl1sZN5/cNoDrbvskFA39nCHs91jWG68HcpWDL5ch3S5flyiwkaeHYZ43",
+	"9U9/uBhSMorvY18vXVdDWdoL2dsW+p8ga2+G9qDRKfnwYPn4PhjBHnhRd2YAI4poNaOPy8HQn0Yh+Mhs",
+	"cXIX3+wtUq2JSS9fDKOZMkguxuJ8ELqO1exzLY687VY3r3Tb2L8aFbV3lm2cLWLtnztKwlm6tH6OsORs",
+	"qloX/o7y+GyrqHOZ6S84fD84fPuS5HKGXSsR8umtLr7ZTH8cRZgGUfLZ47/e6spFMmfduj41kJuiz21I",
+	"0AmOO99fzGEa9YNom4BJ9R4/f0c/W8va8+ol5Xv9x3+7uzAQo2XRDOPnEBLW5pz58gpubChYU8NMNryo",
+	"RVOdenZDzbkehCR2+3RMd9NJE3x822v72ffwebzUfDrFau+pvBFSN4GQvhqleVPQTfJfQOV85Be1ogGr",
+	"yivaP7QKnQqJJ/pqFGVf0GGs2TVqSCsosAuyfbRs+mkTooXJvgkI/UCENDoOWDat35X/oe1uqpPdO4KH",
+	"9Oz91J2X2CUUmb87IHJVWV5PRfde0BS1rwq/VvJ2uTYsiSjIQkyKZdNHJv9dZzLPq6dy8f9C6SuSWSbE",
+	"4rA3aPbNfOO3+YVTNyDyAzD0wziHcTcMrvQ83eTkO6m2Rv2CRevR9+FP+4xJy+1vizyY4o8t8Wj0cSnR",
+	"9dNmU2LZePyBPO8nS53vW+51OTW4/W63L/aHUMHemtOrjfBvjwLWxYR1BrvnT/QXMqhNOn8Qz8G6aLFE",
+	"Ek0G9mCZeGDa297h9ZO7wOt9DZworWUr2H0X/H70kf7f/0moqdlqVHvlBn0hlfshlQbDTAXLu+y7AHVn",
+	"402bBe9fI3aYuJ9SnDfoCE9Kt0jUPiHKtFJniizzL6T8YJSaANP9JIryuYty1CxJo6yckNnmuglfUPsP",
+	"Q+3bd7mula2893IV+05V/gZbEdZu781SLtTHGNMQuUflm4YBKTbkUvsBr/X0AvWcR9i27pM0WULevXui",
+	"4NYrtiDlMFO0RGa3TcJNi2zdn9JTqjTEo0p3mUU4byjVndelCHM33HTAhg7b3nHt+9QvPYIuxYHsn4YZ",
+	"tg+eTMEqp2tqZcwwR+96SGzOh7s17lFk6jUzjvN8yGpG40N88yn4zYczqBR9YQToE0p9sEVM6Z1IAO2W",
+	"3nqW89Us2VXyvi0O0mahe5JeChTNRZe7DPQse+5uifH8fAtr5dcFDNJNUOwzs5DRwT3xorIsbZM+Xay+",
+	"KFo4feFAnx0HOr0bfnO6lbus7eSFnHOtJBVvyQtHHUGMcxQqTTqks2I50Yak1lbL3Wv5mFV62Vc/bMmT",
+	"HhkoZBYup3kT0L6vXW4gYeYKYydnUc/Lu+BdQi2SrQEyp5VxX2wj+2/2K+H5MHy48RJ+3qJZvChQ3cIs",
+	"/jqM/UIgD8gu7oB6fH7WTCK3mfvUZtXLWdUsx6lVGTAJx+dnQ/yQKmo+FzRwX4V7rOJF0cGu+PRykZYt",
+	"RtzVxoBJahf0BuHhPoUzPTIQLozij3fgAEsy/LINcvPDuGTVeUjmx1/uo6rUik3sYdaSYtRKtgqERyY3",
+	"oOkScbrLde2qzY3mTGS4ofrziRICo7Xqgj/6zx7MY7ZeyK5fyuEHd1kwr26dezIlXbB5AGSzLenx/diS",
+	"PvuUMKKCas2/ZT3NkxGVqCpUttC/ojPlFo2LG9+VlzTiwRDfaykWICihg9mZAd93JiRr44R/CA1N3fNt",
+	"Rj5fe9TWnOFn2FQ7bdfV/5BH0YH+e7Tsob6HlCJGFADMwrcvjk8rNOTxfjvxjNxpFs2P2rH7eb+J6I6e",
+	"BLqZPygdPaxtHHLei0JFC+bVJOoNhhJBaUiUxoCUiZpjDCnzZUC5htDpi5IX877QtCWMP2816ZgahzAh",
+	"FrTfBTAY+3qLE7jW3KJjdgKp8aZTGwWG/tdgFSSML/WKaE2ZHx2xNOdFvUEWu7keUF0aLpBelvCw+GcE",
+	"+lYzLhyyXHMRR0zHR5CwBZiUSUgyYXkqEAxOyWw1AH6Ih05VsIxLMIKZmTf41h3U/6t1OZvaDd6zRcVt",
+	"oqhHt4d1mlgMrHy7dnu6qFT8ZsHvzA/544ijjVUwYUODboMW47zBCW2AQkImXFjUMF70Gqqp0shep0W/",
+	"w8W10jH4WrNABfjpNoF6DY7GKl4MQDN5hTGMFxBzY7mM7NCiTmi4YCn0aTBcI5/OLLX9z8YCDwYQsTT1",
+	"vYqf/vkQ3qBjmsMxZwZ99/fMeC+MyfSERQgaBZ3dAxTGOAnvB70NIPEalMTDhgv4bePZ70XIJDQ7kxP1",
+	"QKXMUUCUgJwBTj5GoDDCaExVhYAD6W0rqkbDPiMC/eUuC9nSYf8gaTGsvVla/Pyr2FZRsC0GbnhD3BMU",
+	"eqPmrd02eacuUox8t8eLMPjhlJr50uR0U5PTAO+9braTN9Nc7m8a0B7yuZUuHFkkoF0rfWVSRjGdmzqe",
+	"NlHY1sitgLp7HrZ1D5WH9zxQp2TUF6evTnYto+RHb+8xccmmX5CptiQom+5zmMpqTaxdMMhcbUahSxrx",
+	"YJ72n2Y8mgEdqtpEI++eoVLfx7RVdxLLLG540NsuJbPEAcz9uzfoRUIZjHuDHhOi0p1/o5HIktwQlkoF",
+	"kzKXEMgVQYKdT++tIEtwTcz/dPA8xGf4HRpgQuQDzWHLy/Cl9DbYie54j3+IrusO8yPH64cbYFC+UzxJ",
+	"BVU09pKSh2Nf8Dnmesi//7//F/ADRhm1QoJ//+d/QYyazzEvE3gwgLzJrFiAiVTqbR9KYgP8D+FyhsAw",
+	"PZr7xvr50k4Uxg+RyOJgR+EUscQgnTGDoCYks+lMDnLLSlzUKs4DVvymHpkQ43dYLvEcpmiHVCTQWC4E",
+	"RT2hcYuMF6EXz2GF13oeuZ3Rjj6SrvYDTbCxwJeb8eEw3SVFtWxl5IARDlqz18pVddjr9qUmSifM+p5I",
+	"f3l23y2S3CZO0TIu9lR2dcRKFFjW1MyEgBc54cOMG6v04sbkMRJq2kgiF1Rq3E38Sk2/EMpnSygWP9gR",
+	"zqmJNYGsG6V4ML+YN7h2Li5ehKLz1a0/MoDSco1ArxOJafRGeIY/qDxSA4q6YZBJPuHuMeIJCi4RGOWe",
+	"kpTBrHWihzmE1xLhfcwsO3oP/7h4/QNMHNJRjVo6IvQZrOya2iNrnnBJVv3xAt67W3x/5EvQ/l7uBX4H",
+	"Wvl3iJXEg4GvZmssS9wr+Z7HR/Aue/z4T5HB3+g/8P1zeH8EV4jpkLmTvicfK/UcSFmEwGOBcM242/ox",
+	"GLRWYOxp11+aKck3EK27QwkoY+PJ258Wfj59/cOLX97TZZEtxLecI1HVBDMKdT/nSpKTw//LANNuG5ik",
+	"yiHEUWhkSZ21s9SgtobuYVTewngBPPbt+jDOUkOXYgZgVACkxiEm3FqfdaXztdzrb9gESWLQSCvHKPjY",
+	"cQ0UC5AqbHtoeIzBlWSgXyx9Fo+uuIwPfClh6mhNAMnjm91dqWvp8EHzsd9tfiGRkkYJhKlWbs/jRY41",
+	"kHdw5zF+7l0giI5YTkIV2umH5KGvq+Ld12tEcwDMwMXFi5tz/lSrRFkcOvVgSL9sTLt2Y91KL7VKPjcf",
+	"SisWbxWEIxeNKpmlxpc3YPct2fedZBm7oxTQ6OTkebr+UuW5wkSYjtommZQoimtCAyqzQzUZjpn8zANn",
+	"LjPtuAaweDhT0bIHh0tf9UDFXE49n65ig9M+1hON21CYU5hHLLJ8jpt0jmMasdedne5Ucs+03GZ1bmqX",
+	"mDcScqDYC7dIxZFY2Tr0nz5+5jvMSiekdOv04/Hwo/u/s3iz9vuguosRzfPC2IXw9PFTiLwTN8fWhp4W",
+	"dFUd9tpyqc+NbD57hdcB4pFZd9N0xvpRqQVt0mu/4P+94v/alt8gOd5L8zQbGyUyi0HR4zLGD9C/5tL4",
+	"iLFXzNghaXzDs9ODhugsN90GI/nNF0245EmW9I6GT9bEvUHvw3Cqhu6vQ3PF02Fuih2myo3RwbxfcxtO",
+	"zWaZVcNS29JosgRDp3iv1wlmbNCIeVzV9Ay7fg7aH85/Z4BNLGrg9hDy9vPo3eyk0qcYhZhoOZRZgppH",
+	"RZaM0yinUmmMoU+qq5/5wJuK6fLo2oGoB+i26MUaKzujz1ONBqU9bArYWLrWGwbUbbF/rCAAuwZqMAue",
+	"DZwzHW7UqVvEh1AnXDLhMWIAPB4GC8Hzitbu1fUaPN839nvsmwySWBxYsCeFYPTpO2wJmPW111gt46Kj",
+	"XJIZNsXGXkTnqIfeqcAimzEBNJzCQsrecf2vnj77s7ccOOQd+GK6AyhdCgNIRRZsJZnWZBrSbGKdaBUt",
+	"IoGH8PbitHCYMEdizOvWJTfzpRIzh/uJilGAZhRif3z6Zvj48ZMnB+vdjMqYkrd0zC+SfWNIib+gPe3K",
+	"VWBpjpJZAHdDPICO2JB4zUhjqvSWZPQ3ETt2g9+EsVuwKOfpbMql99n5h6KlL7kY3Jh21zz/1qf9e/bB",
+	"vZEVkze5eqse+mDezB319HqwselQB0nwhG+qgHTjTdyrz2oZ+vscMPPm5NhjPTCB2kLA/dzcTzyWCYH6",
+	"kQGlV3rMVYhplR62RXYvj+/dZVz18lKdbG9P7ghj9rcmaaR0HLIu6lEH+iQ7SyZGoTLKkGV2htK6vWPs",
+	"s+H0c2/i24hBtVx59NH/xxaDyRp+bWTPb06O8+03NTjPV+3woq/Oep8v+HZ824uo0JAqWY9qW5HHXHEh",
+	"Nr/jF37IXVZqcCtc+HPtdWhlflP5nYer28bpadidMnhagdr33zdXp5V98EpT1P8+sPUifybKjFWJB3Ud",
+	"pEuiGvGESLDRC3lGv28Hvs/OZdqOqJhszCydG6X3+pDfjgusfHUZ4ggr96Yii4U9gc5dXGCq3b4s98DP",
+	"p1rxQP6Lp0N3wRqNwRiIlfhDg2V6zOgMhftwzCXz4TyronUF9X72a5XxqmpMHftr68LcHkb6a2/O5NoH",
+	"dPRnoEJrtYDYhJZmIaNmpLxYyOi+OP5CRj4faA8Zvtu87zI95DJwfuh7s7FXCpSePjL5L+45Bj6BhBv3",
+	"YB9sgVFGDS9avMtvw8C7hpVfZ58fZzZnnIKtV6AGWXGFmyDiy5d5xijQ4jpMTunvOTvfKEzToGDG2mAl",
+	"61jrq27W2xaoWRxz7wI4r74an2p4+J4hiQdf+cIrDf4Bx7j5tR80Z7o+bDy4oci3H5pVM9Q3NO/aB8Df",
+	"VY+rrmrGF5xb63HVQsOgKfU8x6xMi95Rb8RSPpo/6X365dP/HwAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -11,7 +11,7 @@ their write-authority + the read projection.**
 flowchart LR
   API(["/api/v1"]) --> HTTP
   subgraph projects
-    HTTP["httpapi — projectcrud · componentread · componentbuild · componentconfig"]
+    HTTP["httpapi — projectcrud · componentread · componentbuild · componentconfig · projectusage"]
     ROOT["root — Service · ComponentService · ConfigService · TraitSyncService + shared HTTP vocab (httperrors.go)"]
     HTTP --> ROOT
   end
@@ -34,6 +34,7 @@ services (`Service`, `ComponentService`, `ConfigService`, `TraitSyncService`) li
 | `componentread` | list-components / get-component | `ComponentService` |
 | `componentbuild` | trigger-build / list-builds / build-logs / list-deployments / component-openapi | `ComponentService` |
 | `componentconfig` | get / update component env-config | `ConfigService` |
+| `projectusage` | get-project-usage (per-phase agent usage, #245) | none — all-zero placeholder until #249 lands capture + aggregation |
 
 The shared HTTP vocabulary — `RequireSlug`, `RequireComponentSlugs`, `MapProjectError`, `MapComponentError`
 and the private `errFromStatus` — lives in the ROOT (`httperrors.go`), because a slice may not import a

--- a/services/aep-api/internal/projects/httpapi/aggregate.go
+++ b/services/aep-api/internal/projects/httpapi/aggregate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/projects/componentconfig"
 	"github.com/wso2/aep/aep-api/internal/projects/componentread"
 	"github.com/wso2/aep/aep-api/internal/projects/projectcrud"
+	"github.com/wso2/aep/aep-api/internal/projects/projectusage"
 )
 
 // Every slice names its type Handler, so embedding them directly would be
@@ -31,6 +32,7 @@ type (
 	componentreadHandler   = componentread.Handler
 	componentbuildHandler  = componentbuild.Handler
 	componentconfigHandler = componentconfig.Handler
+	projectusageHandler    = projectusage.Handler
 )
 
 // Handlers is the projects domain's slice handlers, embedded so Go promotes each
@@ -40,6 +42,7 @@ type Handlers struct {
 	*componentreadHandler
 	*componentbuildHandler
 	*componentconfigHandler
+	*projectusageHandler
 }
 
 // New assembles the domain: pure wiring, constructor injection only.
@@ -53,5 +56,6 @@ func New(d projects.Deps) (*Handlers, error) {
 		componentreadHandler:   componentread.New(d.ComponentSvc),
 		componentbuildHandler:  componentbuild.New(d.ComponentSvc),
 		componentconfigHandler: componentconfig.New(d.ConfigSvc),
+		projectusageHandler:    projectusage.New(),
 	}, nil
 }

--- a/services/aep-api/internal/projects/projectusage/doc.go
+++ b/services/aep-api/internal/projects/projectusage/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package projectusage serves the per-phase agent-usage read for the console's
+// cost-visibility surfaces (#245).
+//
+// Triggers: get-project-usage.
+// Ports:    none yet — the op answers all-zero usage until the #249 capture
+// and aggregation backend lands (zero spend IS the truth today: nothing is
+// captured, and the console hides zero-usage chips).
+package projectusage

--- a/services/aep-api/internal/projects/projectusage/handler.go
+++ b/services/aep-api/internal/projects/projectusage/handler.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projectusage
+
+import (
+	"context"
+
+	"github.com/wso2/aep/aep-api/internal/gen"
+)
+
+// Handler serves get-project-usage. PLACEHOLDER until the #249 backend
+// (capture, persistence, per-phase aggregation, USD derivation per ADR-0011)
+// lands: no usage capture exists yet, so all-zero rollups are the truth —
+// the console hides zero-usage chips.
+type Handler struct{}
+
+// New returns the slice's handler.
+func New() *Handler { return &Handler{} }
+
+func (h *Handler) GetProjectUsage(_ context.Context, _ gen.GetProjectUsageRequestObject) (gen.GetProjectUsageResponseObject, error) {
+	zero := gen.Usage{} // zero tokens, "" model, null costUsd — nothing captured yet
+	return gen.GetProjectUsage200JSONResponse(gen.ProjectUsage{
+		Spec:       zero,
+		Build:      zero,
+		Validation: zero,
+		DraftCycle: zero,
+	}), nil
+}


### PR DESCRIPTION
Frontend for cost visibility ([#245](https://github.com/wso2/labs-agentic-engineer/issues/245)), reworked per the 2026-07-21 requirement change: **actuals only** — the console shows what each unit of agentic work actually cost, per phase, and nothing predictive.

## What changed vs. the original build round

- **Estimates dropped entirely** (were phase 2): no `EstimateChip`, no `GET /projects/{p}/estimates`.
- **Model comparator dropped**: the platform runs a single model for all agent work, so cross-model re-pricing is noise. `GET /models/pricing` leaves the contract; rates become aep-api deployment config (#249).
- **Expand → token detail**: USD stays the only primary value; clicking a cost figure now expands the detailed token version (input / output / cache read / cache write + model) in the slot the comparator occupied.
- **`ProjectUsage` simplified** to per-phase actuals `{spec, build, validation, draftCycle}` — the per-version rollups and lifetime total had no surface left.

## Surfaces

- **Spec view** — drafting-cycle spend chip (`spec $3.13`) beside the version chips; hidden at zero.
- **Builds page** — the selected build's USD chip, accruing on the existing poll while it runs; per-task cost as a quiet caption under each task title (never a column).
- **Zero states** — fresh projects and models without a configured rate degrade honestly (no chip / tokens-only).

## Scope of this PR (frontend-only split, per #245)

- `packages/contracts/api/v1/openapi.yaml` — the contract diff (source of truth, #76)
- `apps/console` — UI, typed MSW mocks covering all decided scenarios, tests; ADR-0011 amended, PRD in-flight line updated
- `services/aep-api` — **mechanical only**: `make gen-api` regen (CI freshness gate) + a placeholder `projectusage` slice answering all-zero rollups, which is the truth until capture exists. The real backend (capture, persistence, aggregation, USD derivation) is [#249](https://github.com/wso2/labs-agentic-engineer/issues/249) and ships as a separate PR.

## Verification

- `@aep/console`: typecheck, eslint, 158 unit tests green; UI exercised in mock mode (`VITE_API_MODE=mock`) across building / deployed / fresh scenarios.
- `aep-api`: build, vet, edge + projects + arch tests, deadcode gate green.

Screenshots (drag-and-drop from `.screenshots-245/`): USD chip + task captions · expanded token detail · spec draft-cycle chip · fresh zero state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
