### PR TITLE
fix(#239): activity feed follow-ups — agent attribution, Recent activity rename, overview cap

### DIFF
--- a/apps/console/src/components/SectionTitle.tsx
+++ b/apps/console/src/components/SectionTitle.tsx
@@ -22,7 +22,7 @@ import { Stack, Typography } from "@wso2/oxygen-ui";
 // One section-heading pattern for the whole console: a title-cased heading
 // with consistent spacing below, and an optional trailing slot for inline
 // chips/counts (e.g. the deployments board's env count + version). Used above
-// the overview's Agent Activity / Components, the builds Tasks list, and the
+// the overview's Recent activity / Components, the builds Tasks list, and the
 // deployments Development / Production boards so every section reads the same.
 export function SectionTitle({
   children,

--- a/apps/console/src/components/SectionTitle.tsx
+++ b/apps/console/src/components/SectionTitle.tsx
@@ -19,11 +19,12 @@
 import type { ReactNode } from "react";
 import { Stack, Typography } from "@wso2/oxygen-ui";
 
-// One section-heading pattern for the whole console: a title-cased heading
-// with consistent spacing below, and an optional trailing slot for inline
+// One section-heading pattern for the whole console: a heading with
+// consistent spacing below, and an optional trailing slot for inline
 // chips/counts (e.g. the deployments board's env count + version). Used above
-// the overview's Recent activity / Components, the builds Tasks list, and the
-// deployments Development / Production boards so every section reads the same.
+// the overview's Recent activity / Components sections, the builds Tasks list,
+// and the deployments Development / Production boards so every section reads
+// the same.
 export function SectionTitle({
   children,
   trailing,

--- a/apps/console/src/features/agent-chat/components/ActivityStep.tsx
+++ b/apps/console/src/features/agent-chat/components/ActivityStep.tsx
@@ -23,6 +23,7 @@ import {
   ChevronRight,
   X as XIcon,
 } from "@wso2/oxygen-ui-icons-react";
+import type { ReactNode } from "react";
 import type { ChatItem, ToolMessage } from "../toolGrouping";
 
 // One tool step on a turn's activity rail (task 3). A single call is a plain
@@ -79,13 +80,37 @@ function StatusGlyph({
   );
 }
 
+// Every step's first row is this tall (the small-chip height), with the status
+// glyph centered against it — not against the whole step, so a wrapped error
+// below never pulls the glyph off its line.
+const STEP_ROW_HEIGHT = 24;
+
+function GlyphCell({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        flexShrink: 0,
+        height: STEP_ROW_HEIGHT,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
 /** The label + optional file chip for a single tool op, plus its full error.
  *  The error wraps (never ellipsizes) — a DSL validation message is the fix
  *  instruction, so cutting it to one line hides the actionable part. */
 function StepLine({ msg, showFile }: { msg: ToolMessage; showFile: boolean }) {
   return (
     <Stack spacing={0.25} sx={{ minWidth: 0, flexGrow: 1 }}>
-      <Stack direction="row" spacing={1} sx={{ alignItems: "center", minWidth: 0 }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ alignItems: "center", minWidth: 0, minHeight: STEP_ROW_HEIGHT }}
+      >
         <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
           {opLabel(msg.op, msg.status)}
         </Typography>
@@ -133,9 +158,9 @@ export function ActivityStep({
         spacing={1}
         sx={{ alignItems: "flex-start", py: 0.25, minWidth: 0 }}
       >
-        <Box sx={{ display: "flex", flexShrink: 0, mt: "3px" }}>
+        <GlyphCell>
           <StatusGlyph status={only.status} ok={only.ok} />
-        </Box>
+        </GlyphCell>
         <StepLine msg={only} showFile />
       </Stack>
     );
@@ -181,9 +206,9 @@ export function ActivityStep({
               spacing={1}
               sx={{ alignItems: "flex-start", minWidth: 0 }}
             >
-              <Box sx={{ display: "flex", flexShrink: 0, mt: "3px" }}>
+              <GlyphCell>
                 <StatusGlyph status={t.status} ok={t.ok} />
-              </Box>
+              </GlyphCell>
               <StepLine msg={t} showFile={false} />
             </Stack>
           ))}

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -36,7 +36,7 @@ import { StatusChip } from "../../../components/StatusChip";
 import { useAllTasks } from "../../tasks/api/queries";
 import { useProject, useProjectComponents, useProjectStatus } from "../api/queries";
 import { phaseChip } from "../lib/phaseChip";
-import { AgentActivity } from "./AgentActivity";
+import { RecentActivity } from "./RecentActivity";
 import { ComponentsList } from "./ComponentsList";
 import { OverviewPipeline } from "./OverviewPipeline";
 
@@ -153,7 +153,7 @@ export function ProjectOverview({ projectName }: { projectName: string }) {
             done) beside the component cards (what they're building). */}
         <Grid container spacing={4}>
           <Grid size={{ xs: 12, md: 6 }}>
-            <AgentActivity projectName={projectName} />
+            <RecentActivity projectName={projectName} />
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>
             <SectionTitle>Components</SectionTitle>

--- a/apps/console/src/features/projects/components/RecentActivity.test.tsx
+++ b/apps/console/src/features/projects/components/RecentActivity.test.tsx
@@ -19,7 +19,7 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { AgentActivity } from "./AgentActivity";
+import { RecentActivity } from "./RecentActivity";
 
 vi.mock("../../../auth/SessionContext", () => ({
   useSession: () => ({ user: { email: "me@x.com", name: "Me" } }),
@@ -30,10 +30,20 @@ vi.mock("../../activity/hooks/useActivityFeed", () => ({
   useActivityFeed: () => ({ events: mockEvents, isPending: false, isError: false }),
 }));
 
-describe("AgentActivity", () => {
+function specEvent(id: number) {
+  return {
+    id: String(id),
+    type: "spec_updated",
+    actorKind: "agent",
+    actorName: `Agent ${id}`,
+    occurredAt: new Date().toISOString(),
+  };
+}
+
+describe("RecentActivity", () => {
   it("shows the empty state with no events", () => {
     mockEvents = [];
-    render(<AgentActivity projectName="p" />);
+    render(<RecentActivity projectName="p" />);
     expect(screen.getByText("No activity yet")).toBeInTheDocument();
   });
 
@@ -49,7 +59,15 @@ describe("AgentActivity", () => {
         occurredAt: new Date().toISOString(),
       },
     ];
-    render(<AgentActivity projectName="p" />);
+    render(<RecentActivity projectName="p" />);
     expect(screen.getByText(/deployed #10 Catalog/)).toBeInTheDocument();
+  });
+
+  it("caps the overview at the newest six events", () => {
+    mockEvents = Array.from({ length: 10 }, (_, i) => specEvent(i + 1));
+    render(<RecentActivity projectName="p" />);
+    expect(screen.getByText("Agent 1")).toBeInTheDocument();
+    expect(screen.getByText("Agent 6")).toBeInTheDocument();
+    expect(screen.queryByText("Agent 7")).not.toBeInTheDocument();
   });
 });

--- a/apps/console/src/features/projects/components/RecentActivity.tsx
+++ b/apps/console/src/features/projects/components/RecentActivity.tsx
@@ -46,18 +46,24 @@ function relativeTime(iso: string): string {
   return `${Math.round(hrs / 24)} d ago`;
 }
 
-// The overview's "agent activity" feed: a status-dotted timeline (dots joined
-// by a vertical rail) of what the platform's agents — and you — have done on
-// this project, sourced from the real activity feed (seeded read + SSE tail).
-// The Builds page owns the detail.
-export function AgentActivity({ projectName }: { projectName: string }) {
+// The overview shows only the newest few events — it's a glanceable summary,
+// not the history; the feed itself keeps everything.
+const OVERVIEW_EVENT_LIMIT = 6;
+
+// The overview's "recent activity" feed: a status-dotted timeline (dots joined
+// by a vertical rail) of what the platform's agents — and every collaborating
+// user — have done on this project, sourced from the real activity feed
+// (seeded read + SSE tail). The Builds page owns the detail.
+export function RecentActivity({ projectName }: { projectName: string }) {
   const { user } = useSession();
   const { events } = useActivityFeed(projectName);
-  const items = events.map((e) => activityLine(e, user.email));
+  const items = events
+    .slice(0, OVERVIEW_EVENT_LIMIT)
+    .map((e) => activityLine(e, user.email));
 
   return (
     <div>
-      <SectionTitle>Agent Activity</SectionTitle>
+      <SectionTitle>Recent activity</SectionTitle>
       {items.length === 0 ? (
         <EmptyState
           bordered

--- a/services/aep-api/design/agent-activity-feed.md
+++ b/services/aep-api/design/agent-activity-feed.md
@@ -1,8 +1,9 @@
-# Agent Activity feed — how activity reaches the console (issue #239)
+# Activity feed — how activity reaches the console (issue #239)
 
-How the project overview's **Agent Activity** panel gets its data: where events
+How the project overview's **Recent activity** panel gets its data: where events
 are produced, where the state lives, and how it travels to the console — before
-(shipped in #232) versus after (backend #254 + the console follow-up PR).
+(shipped in #232, when the panel was named "Agent Activity") versus after
+(backend #254 + console cutover #265).
 
 ## Before — client-side derivation (shipped in #232)
 
@@ -40,7 +41,7 @@ Consequences (why #239 exists):
 - With zero tasks (every project before a build), the panel is permanently
   empty.
 
-## After — activity event store + replay/tail SSE (#254 backend + console PR)
+## After — activity event store + replay/tail SSE (#254 backend + #265 console)
 
 Producers append **ActivityEvent rows** to a dedicated Postgres table at the
 moment something happens; the console reads one page and then tails an SSE
@@ -52,6 +53,7 @@ flowchart LR
   subgraph Producers["Producers (aep-api)"]
     BH["delivery/build handler<br/>build start → spec_published<br/>(actor = signed-in user)"]
     WF["delivery/devflow Temporal workflows<br/>plan_derived · task_started<br/>task_deployed · task_failed<br/>(actor = plan/build agent)"]
+    SP["spec turn + files/apply → spec_updated<br/>(actor = Spec agent for turns,<br/>signed-in user for manual edits)"]
   end
 
   subgraph AppRoot["app root (composition)"]
@@ -76,13 +78,14 @@ flowchart LR
     S["openActivityStream + parseSseStream<br/>features/activity/api/stream.ts"]
     H["useActivityFeed<br/>seed page + live events, dedup by id"]
     R["render.tsx — event → sentence + tone"]
-    AA2["AgentActivity.tsx (overview)"]
+    AA2["RecentActivity.tsx (overview,<br/>newest 6 events)"]
     Q --> H
     S --> H
     H --> R --> AA2
   end
 
   BH --> AD
+  SP --> AD
   WF -->|"RecordActivity activity<br/>(workflow.Now → deterministic time)"| AD
   AD --> SVC
   DB --> LIST
@@ -117,6 +120,38 @@ flowchart LR
 - **Best-effort recording.** `ActivityService.Record` swallows storage errors:
   the feed is observability, and must never fail a build or a workflow.
 
+### Spec-edit attribution (who "updated the spec")
+
+A `spec_updated` line can originate from three places, and only one of them
+knows the agent was the author:
+
+- **Committed genai turn** — the turn lands its own commit; the turn recorder
+  writes the line as **Spec agent** (a turn is the agent working, so no user
+  identity is involved).
+- **Room-scoped genai turn** — the agent writes into the shared collab doc and
+  commits nothing; the collab committer flushes the doc to git later via
+  `files/apply` **under a participating user's token**. At the git layer the
+  flush is indistinguishable from a manual edit, so the turn recorder writes the
+  agent line at turn end and marks the manifest's paths in `specAuthorship`
+  (app root, in-process). When an apply's commit contains a marked path, the
+  files recorder claims those marks and suppresses its user line — the work is
+  already on the feed as the agent.
+- **Manual apply** (spec editor save, collab flush of hand edits) — no marked
+  path matches, so the files recorder attributes the commit to the signed-in
+  user from the request context. Each collaborator's flush carries their own
+  token, so different users appear under their own names.
+
+Marks are **per path**, not per project: the committer holds agent-marked
+markdown until the session-end force flush, so a user's own edit can land in an
+interim commit between the turn and that flush; path scoping lets that interim
+commit record as the user while the agent's paths stay marked until they land.
+Known limits, accepted for the single-replica deployment: one flush is one
+commit and one feed line (concurrent edits by several users inside a debounce
+window collapse into the flushing user's line; a commit mixing agent and user
+edits is attributed to the agent), a restart between turn and flush mislabels
+that one flush as manual, and a user reverting the agent's doc edits leaves the
+mark to suppress at most one later commit of that same path in the session.
+
 ## Diff — previous vs with the new PRs
 
 | | Before (#232 only) | After (#254 + console PR) |
@@ -124,7 +159,7 @@ flowchart LR
 | Source of truth | none — derived from the task list on render | `activity_events` table (append-only) |
 | Event coverage | build-task statuses only | spec_published, plan_derived, task_started, task_deployed, task_failed (taxonomy extensible via `activityvocab`) |
 | Timestamps | hardcoded `PLACEHOLDER_TIMES` | real `occurredAt` (workflow-deterministic inside Temporal) |
-| Actor | implicit "Build agent" | user (email + display name from JWT) or agent, rendered viewer-relative ("You") |
+| Actor | implicit "Build agent" | user (email + display name from JWT) or agent — Spec agent for turn-authored spec edits (see *Spec-edit attribution*) — rendered viewer-relative ("You") |
 | Liveness | refetch-only | SSE live tail with replay-based reconnect |
 | Pagination | n/a | keyset cursor `(occurred_at, id)`, newest first |
 | Console data path | `agentActivity(tasks)` in `features/projects/lib/projectActivity.ts` | `features/activity/` (queries + stream + `useActivityFeed` + `render`) |
@@ -138,6 +173,8 @@ flowchart LR
   store, producers, read API, SSE stream, contract. After the upstream merge,
   the feature lives in the domain layout (projects domain + activityfeed
   slice + activityvocab leaf + app-root adapters).
-- **Console follow-up PR** (to cut from the local `aep-rewrite-latest` FE
-  commits) — `features/activity/` data layer and `AgentActivity` consuming the
-  real feed; deletes `PLACEHOLDER_TIMES`. Depends on #254's contract types.
+- **#265** (`feat/agent-activity-frontend`) — the console cutover:
+  `features/activity/` data layer and the overview panel consuming the real
+  feed; deletes `PLACEHOLDER_TIMES`. A follow-up renamed the panel to
+  **Recent activity** (users appear on the feed too), capped the overview at
+  the newest 6 events, and added the path-scoped spec-edit attribution above.

--- a/services/aep-api/internal/app/activity_adapters.go
+++ b/services/aep-api/internal/app/activity_adapters.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/wso2/aep/aep-api/internal/contracts/activityvocab"
@@ -75,13 +76,53 @@ func (r buildActivityRecorder) RecordSpecPublished(ctx context.Context, orgID, p
 	})
 }
 
+// specAuthorship bridges the async gap between a room-scoped genai turn
+// finishing and the collab committer later flushing that turn's doc edits to git
+// (issue #239). A room turn writes into the shared doc and commits nothing; the
+// committer flushes ~a debounce-window later via files/apply, under the user's
+// own token — so at the git layer the agent's work is indistinguishable from a
+// manual edit and would be mis-attributed to the user. The turn is the only
+// place agent authorship is still known, so it marks the project here; the next
+// apply that lands a commit claims the mark and suppresses its (wrong) user
+// line, because the turn already recorded the agent line.
+//
+// A boolean per (org, project) is precise for the common cases: agent-only edit
+// (mark set → claimed → no user line), user-only edit (no mark → user line),
+// and agent-then-user within one flush (attributed to the agent). The state is
+// in-process, matching the single aep-api replica of the deployment; a restart
+// between a turn and its flush at worst mislabels that one flush as manual.
+type specAuthorship struct{ pending sync.Map } // key: orgID + "\x00" + projectID
+
+func specKey(orgID, projectID string) string { return orgID + "\x00" + projectID }
+
+// markAgent records that an agent turn authored uncommitted spec edits for this
+// project.
+func (a *specAuthorship) markAgent(orgID, projectID string) {
+	a.pending.Store(specKey(orgID, projectID), struct{}{})
+}
+
+// claimAgent reports whether an agent authored the change now being committed,
+// consuming the mark so a later manual edit is not swept up by it.
+func (a *specAuthorship) claimAgent(orgID, projectID string) bool {
+	_, ok := a.pending.LoadAndDelete(specKey(orgID, projectID))
+	return ok
+}
+
 // filesActivityRecorder implements files.SpecUpdatedRecorder: an apply landed a
 // real commit, so the project's spec changed. This is the path the collab
-// session flush and the spec editor's save share, which is what puts ordinary
-// spec work on the feed. Deduped by commit sha.
-type filesActivityRecorder struct{ svc *projects.ActivityService }
+// session flush and the spec editor's save share. A flush that carries an agent
+// turn's doc edits is already on the feed as the agent (recorded at turn
+// finish), so it is suppressed here; a genuine manual edit falls through and is
+// attributed to the signed-in user. Deduped by commit sha.
+type filesActivityRecorder struct {
+	svc        *projects.ActivityService
+	authorship *specAuthorship
+}
 
 func (r filesActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectName, commitSHA string) {
+	if r.authorship.claimAgent(orgID, projectName) {
+		return // agent-authored — the turn already recorded the agent line.
+	}
 	email, name := userIdentityFromContext(ctx)
 	r.svc.Record(ctx, projects.ActivityInput{
 		OrgID:      orgID,
@@ -96,14 +137,18 @@ func (r filesActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, pro
 }
 
 // turnActivityRecorder implements spec.TurnActivityRecorder: a genai turn
-// committed straight to main. The turn runs detached, so the request context is
-// long gone — the actor comes from the turn's captured commit author rather
-// than from ctx, falling back to the agent when the turn carries no identity.
-// Deduped by turn id.
-type turnActivityRecorder struct{ svc *projects.ActivityService }
+// authored spec changes. A turn is the agent working, so the actor is always the
+// agent (the console renders "Spec agent updated the spec"). It also marks the
+// project as agent-authored so the committer's later flush of the same edits is
+// suppressed rather than double-recorded as a manual edit. Deduped by turn id.
+type turnActivityRecorder struct {
+	svc        *projects.ActivityService
+	authorship *specAuthorship
+}
 
-func (r turnActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title, actorEmail, actorName string) {
-	in := projects.ActivityInput{
+func (r turnActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string) {
+	r.authorship.markAgent(orgID, projectID)
+	r.svc.Record(ctx, projects.ActivityInput{
 		OrgID:      orgID,
 		ProjectID:  projectID,
 		Type:       activityvocab.TypeSpecUpdated,
@@ -113,11 +158,7 @@ func (r turnActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, proj
 		Title:      title,
 		DedupKey:   "turn:" + turnID + ":committed",
 		OccurredAt: time.Now().UTC(),
-	}
-	if actorEmail != "" {
-		in.ActorKind, in.ActorID, in.ActorName = activityvocab.ActorUser, actorEmail, actorName
-	}
-	r.svc.Record(ctx, in)
+	})
 }
 
 // userIdentityFromContext returns (email, displayName) for the signed-in user,

--- a/services/aep-api/internal/app/activity_adapters.go
+++ b/services/aep-api/internal/app/activity_adapters.go
@@ -79,39 +79,84 @@ func (r buildActivityRecorder) RecordSpecPublished(ctx context.Context, orgID, p
 // specAuthorship bridges the async gap between a room-scoped genai turn
 // finishing and the collab committer later flushing that turn's doc edits to git
 // (issue #239). A room turn writes into the shared doc and commits nothing; the
-// committer flushes ~a debounce-window later via files/apply, under the user's
-// own token — so at the git layer the agent's work is indistinguishable from a
-// manual edit and would be mis-attributed to the user. The turn is the only
-// place agent authorship is still known, so it marks the project here; the next
-// apply that lands a commit claims the mark and suppresses its (wrong) user
-// line, because the turn already recorded the agent line.
+// committer flushes via files/apply, under the user's own token — so at the git
+// layer the agent's work is indistinguishable from a manual edit and would be
+// mis-attributed to the user. The turn is the only place agent authorship is
+// still known, so it marks the exact paths its manifest touched; an apply whose
+// commit contains a marked path is carrying agent text, claims those marks, and
+// suppresses its (wrong) user line, because the turn already recorded the agent
+// line.
 //
-// A boolean per (org, project) is precise for the common cases: agent-only edit
-// (mark set → claimed → no user line), user-only edit (no mark → user line),
-// and agent-then-user within one flush (attributed to the agent). The state is
-// in-process, matching the single aep-api replica of the deployment; a restart
-// between a turn and its flush at worst mislabels that one flush as manual.
-type specAuthorship struct{ pending sync.Map } // key: orgID + "\x00" + projectID
+// Marks are per path, not per project, because the committer holds agent-marked
+// markdown until the session-end force flush: a user's own edit can land in an
+// interim commit between the turn and that flush, and a project-wide mark would
+// suppress the user's line and then label the eventual agent commit as the
+// user — both halves inverted. Path scoping keeps the two flushes independent:
+// the user's disjoint commit records as the user, the agent's paths stay marked
+// until they actually land. A commit that mixes a marked path with user edits is
+// one commit and one feed line, attributed to the agent (the agent line exists;
+// a second line would double-report the commit). The state is in-process,
+// matching the single aep-api replica of the deployment; a restart between a
+// turn and its flush at worst mislabels that one flush as manual.
+type specAuthorship struct {
+	mu sync.Mutex
+	// pending maps orgID+"\x00"+projectID to the agent-edited paths whose
+	// commit has not yet landed.
+	pending map[string]map[string]struct{}
+}
 
 func specKey(orgID, projectID string) string { return orgID + "\x00" + projectID }
 
-// markAgent records that an agent turn authored uncommitted spec edits for this
-// project.
-func (a *specAuthorship) markAgent(orgID, projectID string) {
-	a.pending.Store(specKey(orgID, projectID), struct{}{})
+// markAgent records the paths an agent turn edited that are still awaiting the
+// committer's flush. No paths, no mark — a committed (non-room) turn lands its
+// own commit and needs no suppression.
+func (a *specAuthorship) markAgent(orgID, projectID string, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending == nil {
+		a.pending = make(map[string]map[string]struct{})
+	}
+	key := specKey(orgID, projectID)
+	set := a.pending[key]
+	if set == nil {
+		set = make(map[string]struct{})
+		a.pending[key] = set
+	}
+	for _, p := range paths {
+		set[p] = struct{}{}
+	}
 }
 
-// claimAgent reports whether an agent authored the change now being committed,
-// consuming the mark so a later manual edit is not swept up by it.
-func (a *specAuthorship) claimAgent(orgID, projectID string) bool {
-	_, ok := a.pending.LoadAndDelete(specKey(orgID, projectID))
-	return ok
+// claimAgent reports whether the commit now landing (touching paths) carries
+// agent-authored edits, consuming the matched marks so a later commit to the
+// same path records normally.
+func (a *specAuthorship) claimAgent(orgID, projectID string, paths []string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	set := a.pending[specKey(orgID, projectID)]
+	if len(set) == 0 {
+		return false
+	}
+	claimed := false
+	for _, p := range paths {
+		if _, ok := set[p]; ok {
+			delete(set, p)
+			claimed = true
+		}
+	}
+	if len(set) == 0 {
+		delete(a.pending, specKey(orgID, projectID))
+	}
+	return claimed
 }
 
 // filesActivityRecorder implements files.SpecUpdatedRecorder: an apply landed a
 // real commit, so the project's spec changed. This is the path the collab
-// session flush and the spec editor's save share. A flush that carries an agent
-// turn's doc edits is already on the feed as the agent (recorded at turn
+// session flush and the spec editor's save share. A commit that contains an
+// agent turn's doc edits is already on the feed as the agent (recorded at turn
 // finish), so it is suppressed here; a genuine manual edit falls through and is
 // attributed to the signed-in user. Deduped by commit sha.
 type filesActivityRecorder struct {
@@ -119,8 +164,8 @@ type filesActivityRecorder struct {
 	authorship *specAuthorship
 }
 
-func (r filesActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectName, commitSHA string) {
-	if r.authorship.claimAgent(orgID, projectName) {
+func (r filesActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectName, commitSHA string, paths []string) {
+	if r.authorship.claimAgent(orgID, projectName, paths) {
 		return // agent-authored — the turn already recorded the agent line.
 	}
 	email, name := userIdentityFromContext(ctx)
@@ -138,16 +183,17 @@ func (r filesActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, pro
 
 // turnActivityRecorder implements spec.TurnActivityRecorder: a genai turn
 // authored spec changes. A turn is the agent working, so the actor is always the
-// agent (the console renders "Spec agent updated the spec"). It also marks the
-// project as agent-authored so the committer's later flush of the same edits is
-// suppressed rather than double-recorded as a manual edit. Deduped by turn id.
+// agent (the console renders "Spec agent updated the spec"). A room turn also
+// marks its edited paths as agent-authored so the committer's later flush of
+// those edits is suppressed rather than double-recorded as a manual edit (a
+// committed turn passes no paths — its commit is its own). Deduped by turn id.
 type turnActivityRecorder struct {
 	svc        *projects.ActivityService
 	authorship *specAuthorship
 }
 
-func (r turnActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string) {
-	r.authorship.markAgent(orgID, projectID)
+func (r turnActivityRecorder) RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string, editedPaths []string) {
+	r.authorship.markAgent(orgID, projectID, editedPaths)
 	r.svc.Record(ctx, projects.ActivityInput{
 		OrgID:      orgID,
 		ProjectID:  projectID,

--- a/services/aep-api/internal/app/activity_adapters_test.go
+++ b/services/aep-api/internal/app/activity_adapters_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/contracts/activityvocab"
+	"github.com/wso2/aep/aep-api/internal/projects"
+)
+
+// captureActivityRepo records every inserted event so the adapter tests can
+// assert who ended up on the feed. Never a duplicate (inserted=true always).
+type captureActivityRepo struct{ rows []*projects.ActivityEvent }
+
+func (r *captureActivityRepo) Insert(_ context.Context, row *projects.ActivityEvent) (bool, error) {
+	r.rows = append(r.rows, row)
+	return true, nil
+}
+
+func (r *captureActivityRepo) ListByProject(context.Context, string, string, int, time.Time, string) ([]projects.ActivityEvent, error) {
+	return nil, nil
+}
+
+// newRecorders wires a turn + files recorder over a shared authorship coordinator
+// and a capturing service, exactly as app.go composes them.
+func newRecorders() (turnActivityRecorder, filesActivityRecorder, *captureActivityRepo) {
+	repo := &captureActivityRepo{}
+	svc := projects.NewActivityService(repo, projects.NewActivityHub())
+	authored := &specAuthorship{}
+	return turnActivityRecorder{svc: svc, authorship: authored},
+		filesActivityRecorder{svc: svc, authorship: authored},
+		repo
+}
+
+// The core issue #239 fix: an agent room turn records the agent line, and the
+// committer's later files/apply flush of that same doc is suppressed (not a
+// second, mis-attributed "user updated the spec" line).
+func TestSpecAuthorship_AgentTurnThenFlush_OneAgentLine(t *testing.T) {
+	turn, files, repo := newRecorders()
+
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-abc")
+
+	if len(repo.rows) != 1 {
+		t.Fatalf("recorded rows = %d, want 1 (agent line only, flush suppressed): %+v", len(repo.rows), repo.rows)
+	}
+	got := repo.rows[0]
+	if got.ActorKind != activityvocab.ActorAgent || got.ActorName != "Spec agent" {
+		t.Errorf("actor = (%q, %q), want the agent", got.ActorKind, got.ActorName)
+	}
+	if got.Type != activityvocab.TypeSpecUpdated || got.Title != "add a gym tracker" {
+		t.Errorf("event = (%q, %q), want spec_updated with the instruction subject", got.Type, got.Title)
+	}
+	if got.DedupKey != "turn:turn-1:committed" {
+		t.Errorf("dedupKey = %q, want the turn key", got.DedupKey)
+	}
+}
+
+// A genuine manual edit (no preceding agent turn) still reaches the feed as the
+// signed-in user — the "Both agent + manual" attribution the product wants.
+func TestSpecAuthorship_ManualFlush_RecordsUser(t *testing.T) {
+	_, files, repo := newRecorders()
+
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-manual")
+
+	if len(repo.rows) != 1 {
+		t.Fatalf("recorded rows = %d, want 1 (manual user edit): %+v", len(repo.rows), repo.rows)
+	}
+	got := repo.rows[0]
+	if got.ActorKind != activityvocab.ActorUser {
+		t.Errorf("actorKind = %q, want user (manual edit)", got.ActorKind)
+	}
+	if got.DedupKey != "apply:commit-sha-manual" {
+		t.Errorf("dedupKey = %q, want the apply key", got.DedupKey)
+	}
+}
+
+// The mark is consumed exactly once: a second flush after a single agent turn is
+// a genuine manual edit and records the user (the mark does not linger and
+// swallow later real edits).
+func TestSpecAuthorship_MarkConsumedOnce(t *testing.T) {
+	turn, files, repo := newRecorders()
+
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-1") // agent flush — suppressed
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-2") // later manual edit — user
+
+	if len(repo.rows) != 2 {
+		t.Fatalf("recorded rows = %d, want 2 (agent turn + later manual edit): %+v", len(repo.rows), repo.rows)
+	}
+	if repo.rows[0].ActorKind != activityvocab.ActorAgent {
+		t.Errorf("row 0 actor = %q, want agent", repo.rows[0].ActorKind)
+	}
+	if repo.rows[1].ActorKind != activityvocab.ActorUser || repo.rows[1].DedupKey != "apply:commit-2" {
+		t.Errorf("row 1 = (%q, %q), want the later manual edit as user", repo.rows[1].ActorKind, repo.rows[1].DedupKey)
+	}
+}
+
+// The mark is scoped per (org, project): an agent turn in one project does not
+// suppress a manual edit in another.
+func TestSpecAuthorship_ScopedPerProject(t *testing.T) {
+	turn, files, repo := newRecorders()
+
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
+	files.RecordSpecUpdated(context.Background(), "acme", "other", "commit-other")
+
+	if len(repo.rows) != 2 {
+		t.Fatalf("recorded rows = %d, want 2 (agent in web + user in other): %+v", len(repo.rows), repo.rows)
+	}
+	if repo.rows[1].ProjectID != "other" || repo.rows[1].ActorKind != activityvocab.ActorUser {
+		t.Errorf("row 1 = (%q, %q), want the other project's manual edit as user", repo.rows[1].ProjectID, repo.rows[1].ActorKind)
+	}
+}

--- a/services/aep-api/internal/app/activity_adapters_test.go
+++ b/services/aep-api/internal/app/activity_adapters_test.go
@@ -55,8 +55,8 @@ func newRecorders() (turnActivityRecorder, filesActivityRecorder, *captureActivi
 func TestSpecAuthorship_AgentTurnThenFlush_OneAgentLine(t *testing.T) {
 	turn, files, repo := newRecorders()
 
-	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
-	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-abc")
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker", []string{"specs/requirements/requirements.md"})
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-abc", []string{"specs/requirements/requirements.md"})
 
 	if len(repo.rows) != 1 {
 		t.Fatalf("recorded rows = %d, want 1 (agent line only, flush suppressed): %+v", len(repo.rows), repo.rows)
@@ -78,7 +78,7 @@ func TestSpecAuthorship_AgentTurnThenFlush_OneAgentLine(t *testing.T) {
 func TestSpecAuthorship_ManualFlush_RecordsUser(t *testing.T) {
 	_, files, repo := newRecorders()
 
-	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-manual")
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-sha-manual", []string{"specs/requirements/requirements.md"})
 
 	if len(repo.rows) != 1 {
 		t.Fatalf("recorded rows = %d, want 1 (manual user edit): %+v", len(repo.rows), repo.rows)
@@ -92,15 +92,42 @@ func TestSpecAuthorship_ManualFlush_RecordsUser(t *testing.T) {
 	}
 }
 
-// The mark is consumed exactly once: a second flush after a single agent turn is
-// a genuine manual edit and records the user (the mark does not linger and
-// swallow later real edits).
+// Marks are per PATH, not per project: the committer holds agent-marked
+// markdown until the session-end force flush, so a user's own edit can land in
+// an interim commit BETWEEN the agent turn and the agent flush. That disjoint
+// commit must record as the user, and the agent's flush — landing after it —
+// must still be suppressed. (With a project-wide mark both halves inverted:
+// the user's line vanished and the agent's commit recorded as the user.)
+func TestSpecAuthorship_UserFlushBetweenTurnAndAgentFlush(t *testing.T) {
+	turn, files, repo := newRecorders()
+
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker", []string{"specs/requirements/requirements.md"})
+	// Interim debounce flush: only the user's hand-edited file (the agent's
+	// markdown is still held pending review).
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-user", []string{"specs/design/design.json"})
+	// Session-end force flush finally lands the agent's markdown.
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-agent", []string{"specs/requirements/requirements.md"})
+
+	if len(repo.rows) != 2 {
+		t.Fatalf("recorded rows = %d, want 2 (agent turn + user's own edit): %+v", len(repo.rows), repo.rows)
+	}
+	if repo.rows[0].ActorKind != activityvocab.ActorAgent {
+		t.Errorf("row 0 actor = %q, want agent", repo.rows[0].ActorKind)
+	}
+	if repo.rows[1].ActorKind != activityvocab.ActorUser || repo.rows[1].DedupKey != "apply:commit-user" {
+		t.Errorf("row 1 = (%q, %q), want the user's interim edit as user", repo.rows[1].ActorKind, repo.rows[1].DedupKey)
+	}
+}
+
+// The mark is consumed exactly once: after the agent's paths land, a second
+// flush touching the same path is a genuine manual edit and records the user
+// (the mark does not linger and swallow later real edits).
 func TestSpecAuthorship_MarkConsumedOnce(t *testing.T) {
 	turn, files, repo := newRecorders()
 
-	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
-	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-1") // agent flush — suppressed
-	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-2") // later manual edit — user
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker", []string{"specs/requirements/requirements.md"})
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-1", []string{"specs/requirements/requirements.md"}) // agent flush — suppressed
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-2", []string{"specs/requirements/requirements.md"}) // later manual edit — user
 
 	if len(repo.rows) != 2 {
 		t.Fatalf("recorded rows = %d, want 2 (agent turn + later manual edit): %+v", len(repo.rows), repo.rows)
@@ -113,13 +140,30 @@ func TestSpecAuthorship_MarkConsumedOnce(t *testing.T) {
 	}
 }
 
+// A committed (non-room) turn passes no paths: it lands its own commit, so
+// nothing is marked and a user's next apply — even to the same file — records
+// as the user.
+func TestSpecAuthorship_CommittedTurnMarksNothing(t *testing.T) {
+	turn, files, repo := newRecorders()
+
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker", nil)
+	files.RecordSpecUpdated(context.Background(), "acme", "web", "commit-manual", []string{"specs/requirements/requirements.md"})
+
+	if len(repo.rows) != 2 {
+		t.Fatalf("recorded rows = %d, want 2 (agent turn + manual edit): %+v", len(repo.rows), repo.rows)
+	}
+	if repo.rows[1].ActorKind != activityvocab.ActorUser {
+		t.Errorf("row 1 actor = %q, want user (no mark from a committed turn)", repo.rows[1].ActorKind)
+	}
+}
+
 // The mark is scoped per (org, project): an agent turn in one project does not
-// suppress a manual edit in another.
+// suppress a manual edit to the same path in another.
 func TestSpecAuthorship_ScopedPerProject(t *testing.T) {
 	turn, files, repo := newRecorders()
 
-	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker")
-	files.RecordSpecUpdated(context.Background(), "acme", "other", "commit-other")
+	turn.RecordSpecUpdated(context.Background(), "acme", "web", "turn-1", "add a gym tracker", []string{"specs/requirements/requirements.md"})
+	files.RecordSpecUpdated(context.Background(), "acme", "other", "commit-other", []string{"specs/requirements/requirements.md"})
 
 	if len(repo.rows) != 2 {
 		t.Fatalf("recorded rows = %d, want 2 (agent in web + user in other): %+v", len(repo.rows), repo.rows)

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -127,6 +127,10 @@ func Assemble(cfg config.Config, in Infra) (*App, error) {
 	activityRepo := projects.NewActivityEventRepository(db)
 	activityHub := projects.NewActivityHub()
 	activitySvc := projects.NewActivityService(activityRepo, activityHub)
+	// Shared by the turn + files recorders: a room-scoped turn marks the project
+	// agent-authored; the committer's later files/apply flush claims the mark and
+	// suppresses its user line (issue #239 — see specAuthorship).
+	specAuthored := &specAuthorship{}
 
 	// Temporal devflow runtime. Constructed always, but connects lazily in the
 	// worker watcher's retry loop (never at Build time), so aep-api boots and
@@ -375,7 +379,7 @@ func Assemble(cfg config.Config, in Infra) (*App, error) {
 		Broker:     turnBroker,
 		Snapshots:  workspaceEngine,
 		SkillsRepo: skillsRepoForTurns,
-		Recorder:   turnActivityRecorder{svc: activitySvc},
+		Recorder:   turnActivityRecorder{svc: activitySvc, authorship: specAuthored},
 	}
 	// MCP discovery on design-generation turns (dependency-management Phase 5):
 	// the BFF mints a short-lived aud:aep-api-mcp token per turn so the agents
@@ -790,7 +794,7 @@ func Assemble(cfg config.Config, in Infra) (*App, error) {
 	specHandlers, err := spechttpapi.New(spec.Deps{
 		GenAI:         genaiSvc,
 		Files:         filesSvc,
-		FilesActivity: filesActivityRecorder{svc: activitySvc},
+		FilesActivity: filesActivityRecorder{svc: activitySvc, authorship: specAuthored},
 		Artifacts:     artifactSvcGit,
 		Skills:        skillSvc,
 		SkillMut:      skillMutationSvc,

--- a/services/aep-api/internal/platform/agentfold/manifest.go
+++ b/services/aep-api/internal/platform/agentfold/manifest.go
@@ -61,6 +61,21 @@ func (m Manifest) IsEmpty() bool {
 	return len(m.Files) == 0 && len(m.Deleted) == 0
 }
 
+// MutatedPaths returns every path the turn touched — written and deleted —
+// sorted, so callers get a deterministic list.
+func (m Manifest) MutatedPaths() []string {
+	if m.IsEmpty() {
+		return nil
+	}
+	paths := make([]string, 0, len(m.Files)+len(m.Deleted))
+	for p := range m.Files {
+		paths = append(paths, p)
+	}
+	paths = append(paths, m.Deleted...)
+	sort.Strings(paths)
+	return paths
+}
+
 // FoldParityError carries the exact paths on which the Go fold and the
 // agents-side FileBundle disagree. Any instance means the turn fails loudly
 // and main stays untouched (D14).

--- a/services/aep-api/internal/spec/files/handler.go
+++ b/services/aep-api/internal/spec/files/handler.go
@@ -93,7 +93,7 @@ func (h *Handler) ApplyFiles(ctx context.Context, request gen.ApplyFilesRequestO
 	// A byte-identical apply makes no commit — nothing happened, so nothing
 	// reaches the feed.
 	if h.activity != nil && res.Changed {
-		h.activity.RecordSpecUpdated(ctx, org, request.ProjectName, res.CommitSHA)
+		h.activity.RecordSpecUpdated(ctx, org, request.ProjectName, res.CommitSHA, appliedPaths(*request.Body, res))
 	}
 	return gen.ApplyFiles200JSONResponse(applyResultToWire(res)), nil
 }
@@ -110,6 +110,20 @@ func applyConflictsToWire(conflicts []spec.Conflict) gen.ApplyFiles409JSONRespon
 		})
 	}
 	return gen.ApplyFiles409JSONResponse(out)
+}
+
+// appliedPaths lists what the commit touched: the written files from the
+// result (authoritative — the service drops byte-identical writes) plus the
+// requested deletes.
+func appliedPaths(body gen.ApplyRequest, res *spec.ApplyResult) []string {
+	paths := make([]string, 0, len(res.Files)+len(body.Deletes))
+	for _, f := range res.Files {
+		paths = append(paths, f.Path)
+	}
+	for _, d := range body.Deletes {
+		paths = append(paths, d.Path)
+	}
+	return paths
 }
 
 // applyRequestFromWire converts the generated body into the service's shape.

--- a/services/aep-api/internal/spec/files_component_test.go
+++ b/services/aep-api/internal/spec/files_component_test.go
@@ -104,7 +104,7 @@ type captureSpecUpdated struct {
 	commits []string
 }
 
-func (c *captureSpecUpdated) RecordSpecUpdated(_ context.Context, _, _, commitSHA string) {
+func (c *captureSpecUpdated) RecordSpecUpdated(_ context.Context, _, _, commitSHA string, _ []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.commits = append(c.commits, commitSHA)

--- a/services/aep-api/internal/spec/files_service.go
+++ b/services/aep-api/internal/spec/files_service.go
@@ -125,7 +125,9 @@ type ApplyResult struct {
 // user's identity from ctx and appends via the projects activity service (spec
 // must not import projects).
 type SpecUpdatedRecorder interface {
-	RecordSpecUpdated(ctx context.Context, orgID, projectName, commitSHA string)
+	// paths are the files the commit touched (writes + deletes) — they let the
+	// implementation tell an agent-authored collab flush from a manual edit.
+	RecordSpecUpdated(ctx context.Context, orgID, projectName, commitSHA string, paths []string)
 }
 
 // Conflict is one failed baseSha precondition (the 409 body carries a list).

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -225,14 +225,15 @@ type ServiceDeps struct {
 }
 
 // TurnActivityRecorder appends the spec_updated activity line (issue #239) for
-// a turn that committed. Primitives only, so spec need not import projects (the
-// app-root adapter maps these onto the activity service's input). Best-effort:
-// implementations never return an error — recording must not fail a turn.
+// a turn that authored spec changes. Primitives only, so spec need not import
+// projects (the app-root adapter maps these onto the activity service's input).
+// Best-effort: implementations never return an error — recording must not fail
+// a turn. The actor is always the agent (a turn is the agent working), so no
+// user identity is passed.
 type TurnActivityRecorder interface {
-	// RecordSpecUpdated appends the line for turnID. title is the turn's
-	// instruction subject; actorEmail/actorName identify the prompting user
-	// and are "" when the turn carries no author identity.
-	RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title, actorEmail, actorName string)
+	// RecordSpecUpdated appends the agent-authored line for turnID. title is the
+	// turn's instruction subject.
+	RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string)
 }
 
 // Service is the typed entry point behind the turn/status/stream/rehydrate

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -232,8 +232,11 @@ type ServiceDeps struct {
 // user identity is passed.
 type TurnActivityRecorder interface {
 	// RecordSpecUpdated appends the agent-authored line for turnID. title is the
-	// turn's instruction subject.
-	RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string)
+	// turn's instruction subject. editedPaths are the collab-doc paths a room
+	// turn edited — they let the implementation suppress the committer's later
+	// flush of the same edits; a committed turn passes nil (its commit is its
+	// own, nothing flushes later).
+	RecordSpecUpdated(ctx context.Context, orgID, projectID, turnID, title string, editedPaths []string)
 }
 
 // Service is the typed entry point behind the turn/status/stream/rehydrate

--- a/services/aep-api/internal/spec/repository_turn.go
+++ b/services/aep-api/internal/spec/repository_turn.go
@@ -67,6 +67,11 @@ type TurnTerminal struct {
 	// signal). It is independent of NoChanges: a room turn is always NoChanges
 	// (git is untouched until the committer flushes the doc) yet still SpecEdited.
 	SpecEdited bool
+	// EditedPaths lists the collab-doc paths a room turn's manifest touched —
+	// the paths whose later committer flush must be attributed to the agent,
+	// not the flushing user (issue #239). In-process only (never persisted);
+	// empty for a committed turn.
+	EditedPaths []string
 }
 
 // TurnRepository is the agent_turns row store (design D17/D18): the durable

--- a/services/aep-api/internal/spec/repository_turn.go
+++ b/services/aep-api/internal/spec/repository_turn.go
@@ -61,6 +61,12 @@ type TurnTerminal struct {
 	Paths     []string
 	NoChanges bool
 	Message   string
+	// SpecEdited is true when the turn authored real spec changes: a committed
+	// turn whose fold produced a net change, or a room-scoped turn whose agent
+	// edited the collab doc (issue #239 — the activity feed's agent-authorship
+	// signal). It is independent of NoChanges: a room turn is always NoChanges
+	// (git is untouched until the committer flushes the doc) yet still SpecEdited.
+	SpecEdited bool
 }
 
 // TurnRepository is the agent_turns row store (design D17/D18): the durable

--- a/services/aep-api/internal/spec/turn_activity_test.go
+++ b/services/aep-api/internal/spec/turn_activity_test.go
@@ -51,6 +51,7 @@ func (r *genaiRig) startCollabTurn(t *testing.T, uuid, instruction string) strin
 // recordedTurnActivity is one captured spec.TurnActivityRecorder call.
 type recordedTurnActivity struct {
 	orgID, projectID, turnID, title string
+	editedPaths                     []string
 }
 
 // captureTurnActivity collects recorder calls for assertion (issue #239).
@@ -59,10 +60,10 @@ type captureTurnActivity struct {
 	rows []recordedTurnActivity
 }
 
-func (c *captureTurnActivity) RecordSpecUpdated(_ context.Context, orgID, projectID, turnID, title string) {
+func (c *captureTurnActivity) RecordSpecUpdated(_ context.Context, orgID, projectID, turnID, title string, editedPaths []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.rows = append(c.rows, recordedTurnActivity{orgID, projectID, turnID, title})
+	c.rows = append(c.rows, recordedTurnActivity{orgID, projectID, turnID, title, editedPaths})
 }
 
 func (c *captureTurnActivity) all() []recordedTurnActivity {
@@ -134,6 +135,11 @@ func TestTurnActivity_RoomScopedTurnRecordsAgentEdit(t *testing.T) {
 	}
 	if rows[0].turnID != turnID || rows[0].title != "add a gym tracker web app" {
 		t.Errorf("row = %+v, want the turn's id + instruction subject", rows[0])
+	}
+	// The manifest's paths ride along so the app-root authorship coordinator
+	// can suppress the committer's later flush of exactly these files.
+	if len(rows[0].editedPaths) != 1 || rows[0].editedPaths[0] != "requirements/requirements.md" {
+		t.Errorf("editedPaths = %v, want the manifest's mutated path", rows[0].editedPaths)
 	}
 }
 

--- a/services/aep-api/internal/spec/turn_activity_test.go
+++ b/services/aep-api/internal/spec/turn_activity_test.go
@@ -18,13 +18,39 @@ package spec_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"sync"
 	"testing"
 )
 
+// startCollabTurn POSTs a room-scoped (collab: true) turn and returns its id.
+// The requirements-chat useCase is the one the Spec view authors design.json
+// under; collab makes the agents service a live peer that writes into the doc
+// rather than committing to git.
+func (r *genaiRig) startCollabTurn(t *testing.T, uuid, instruction string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"useCase":     "requirements-chat",
+		"instruction": instruction,
+		"collab":      true,
+	})
+	rec := r.h.AsOrg(testOrg).Post(turnsPath(uuid), string(body))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("POST collab turn: code %d, want 202 (%s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || out.TurnID == "" {
+		t.Fatalf("202 body = %s (err %v)", rec.Body.String(), err)
+	}
+	return out.TurnID
+}
+
 // recordedTurnActivity is one captured spec.TurnActivityRecorder call.
 type recordedTurnActivity struct {
-	orgID, projectID, turnID, title, actorEmail, actorName string
+	orgID, projectID, turnID, title string
 }
 
 // captureTurnActivity collects recorder calls for assertion (issue #239).
@@ -33,10 +59,10 @@ type captureTurnActivity struct {
 	rows []recordedTurnActivity
 }
 
-func (c *captureTurnActivity) RecordSpecUpdated(_ context.Context, orgID, projectID, turnID, title, actorEmail, actorName string) {
+func (c *captureTurnActivity) RecordSpecUpdated(_ context.Context, orgID, projectID, turnID, title string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.rows = append(c.rows, recordedTurnActivity{orgID, projectID, turnID, title, actorEmail, actorName})
+	c.rows = append(c.rows, recordedTurnActivity{orgID, projectID, turnID, title})
 }
 
 func (c *captureTurnActivity) all() []recordedTurnActivity {
@@ -46,7 +72,8 @@ func (c *captureTurnActivity) all() []recordedTurnActivity {
 }
 
 // A turn that lands a real commit records exactly one spec_updated line,
-// actored by the prompting user and carrying the instruction subject.
+// carrying the instruction subject. The actor is the agent (decided by the
+// app-root adapter), so no user identity is threaded here.
 func TestTurnActivity_RecordedOnCommit(t *testing.T) {
 	rec := &captureTurnActivity{}
 	r := newGenaiRig(t, map[string]string{"specs/requirements/requirements.md": "# Reqs\n"}, withRecorder(rec))
@@ -78,8 +105,55 @@ func TestTurnActivity_RecordedOnCommit(t *testing.T) {
 	if got.title != "tidy the requirements" {
 		t.Errorf("title = %q, want the instruction subject", got.title)
 	}
-	if got.actorEmail != "componenttest-user@users.noreply.aep.dev" {
-		t.Errorf("actorEmail = %q, want the prompting user", got.actorEmail)
+}
+
+// A room-scoped turn commits nothing (the collab doc is the write surface), yet
+// it is the only place the agent's authorship is knowable — the committer's
+// later flush lands under the user's token. So a room turn whose agent edited
+// the doc still records the agent's spec_updated line (issue #239). This is the
+// regression that made the Spec view show only "Admin updated the spec".
+func TestTurnActivity_RoomScopedTurnRecordsAgentEdit(t *testing.T) {
+	rec := &captureTurnActivity{}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/requirements.md": "# Reqs\n"}, withRecorder(rec))
+
+	r.fake.parts = []string{
+		editFilePart("requirements/requirements.md", "# Reqs\n", "# Requirements\n"),
+	}
+	m := manifestPart(map[string]string{"requirements/requirements.md": "# Requirements\n"}, nil)
+	r.fake.manifest = &m
+
+	turnID := r.startCollabTurn(t, convUUID, "add a gym tracker web app")
+	st := r.waitTerminal(t, turnID)
+	if st.Status != "completed" || !st.NoChanges {
+		t.Fatalf("terminal = %+v, want completed no-changes (room turn never commits)", st)
+	}
+
+	rows := rec.all()
+	if len(rows) != 1 {
+		t.Fatalf("recorded rows = %d, want 1 (agent doc edit): %+v", len(rows), rows)
+	}
+	if rows[0].turnID != turnID || rows[0].title != "add a gym tracker web app" {
+		t.Errorf("row = %+v, want the turn's id + instruction subject", rows[0])
+	}
+}
+
+// A room-scoped turn whose agent edited nothing (empty manifest — a pure chat
+// reply) records no line.
+func TestTurnActivity_RoomScopedNoEditsRecordsNothing(t *testing.T) {
+	rec := &captureTurnActivity{}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/requirements.md": "# Reqs\n"}, withRecorder(rec))
+
+	r.fake.parts = []string{textPart("just answering your question")}
+	m := manifestPart(map[string]string{}, nil)
+	r.fake.manifest = &m
+
+	turnID := r.startCollabTurn(t, convUUID, "what does this project do?")
+	st := r.waitTerminal(t, turnID)
+	if st.Status != "completed" || !st.NoChanges {
+		t.Fatalf("terminal = %+v, want completed no-changes", st)
+	}
+	if rows := rec.all(); len(rows) != 0 {
+		t.Fatalf("recorded rows = %+v, want none (no doc edits)", rows)
 	}
 }
 

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -301,7 +301,15 @@ func (s *Service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		}
 		// Edits live in the room's doc; git is untouched (persistence is the
 		// #86 phase-3 committer). The base sha stays the "content as of" pin.
-		return TurnTerminal{Status: turnStatusCompleted, CommitSHA: job.baseRef, NoChanges: true}
+		// SpecEdited reflects the agent's doc edits (non-empty manifest) so the
+		// feed can attribute this agent work — the committer's later flush lands
+		// under the user's token and cannot (issue #239).
+		return TurnTerminal{
+			Status:     turnStatusCompleted,
+			CommitSHA:  job.baseRef,
+			NoChanges:  true,
+			SpecEdited: !manifest.IsEmpty(),
+		}
 	}
 
 	switch {
@@ -429,7 +437,12 @@ func (s *Service) commitFold(ctx context.Context, job turnJob, fold *agentfold.F
 	}
 	// Changed=false: the fold re-produced content identical to base — no
 	// commit object, but the turn is a valid completion.
-	return TurnTerminal{Status: turnStatusCompleted, CommitSHA: res.CommitSHA, NoChanges: !res.Changed}
+	return TurnTerminal{
+		Status:     turnStatusCompleted,
+		CommitSHA:  res.CommitSHA,
+		NoChanges:  !res.Changed,
+		SpecEdited: res.Changed,
+	}
 }
 
 // finishTurn stamps the terminal row state and emits the ONE terminal stream
@@ -460,21 +473,20 @@ func (s *Service) finishTurn(ctx context.Context, job turnJob, term TurnTerminal
 	}
 }
 
-// recordTurnActivity appends the spec_updated feed line for a turn that landed
-// a real commit (issue #239). Best-effort and observational: a nil recorder, a
-// failed turn, or a no-changes completion record nothing. The actor is the
-// prompting user (the commit author), so the console renders "You updated the
-// spec"; the turn id keys dedup so a re-finish is a no-op.
+// recordTurnActivity appends the spec_updated feed line for a turn that authored
+// real spec changes (issue #239). Best-effort and observational: a nil recorder,
+// a failed turn, or a turn that edited nothing records nothing. A genai turn is
+// the agent working, so the actor is the agent (the console renders "Spec agent
+// updated the spec") regardless of the git commit author — the committer flush
+// of a room turn lands under the user's token, which is exactly why the user
+// cannot be the feed actor here. The turn id keys dedup so a re-finish is a
+// no-op. SpecEdited (not NoChanges) is the gate: a room turn is always NoChanges
+// yet still authored the doc edits the feed must attribute.
 func (s *Service) recordTurnActivity(ctx context.Context, job turnJob, term TurnTerminal) {
-	if s.recorder == nil || term.Status != turnStatusCompleted || term.NoChanges {
+	if s.recorder == nil || term.Status != turnStatusCompleted || !term.SpecEdited {
 		return
 	}
-	var email, name string
-	if job.author != nil {
-		email, name = job.author.Email, job.author.Name
-	}
-	s.recorder.RecordSpecUpdated(ctx, job.orgID, job.projectID, job.turnID,
-		firstLine(job.summary, 96), email, name)
+	s.recorder.RecordSpecUpdated(ctx, job.orgID, job.projectID, job.turnID, firstLine(job.summary, 96))
 }
 
 // turnBaseReader adapts Workspace.ReadFile at the turn's base ref into the

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -305,10 +305,11 @@ func (s *Service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		// feed can attribute this agent work — the committer's later flush lands
 		// under the user's token and cannot (issue #239).
 		return TurnTerminal{
-			Status:     turnStatusCompleted,
-			CommitSHA:  job.baseRef,
-			NoChanges:  true,
-			SpecEdited: !manifest.IsEmpty(),
+			Status:      turnStatusCompleted,
+			CommitSHA:   job.baseRef,
+			NoChanges:   true,
+			SpecEdited:  !manifest.IsEmpty(),
+			EditedPaths: manifest.MutatedPaths(),
 		}
 	}
 
@@ -486,7 +487,7 @@ func (s *Service) recordTurnActivity(ctx context.Context, job turnJob, term Turn
 	if s.recorder == nil || term.Status != turnStatusCompleted || !term.SpecEdited {
 		return
 	}
-	s.recorder.RecordSpecUpdated(ctx, job.orgID, job.projectID, job.turnID, firstLine(job.summary, 96))
+	s.recorder.RecordSpecUpdated(ctx, job.orgID, job.projectID, job.turnID, firstLine(job.summary, 96), term.EditedPaths)
 }
 
 // turnBaseReader adapts Workspace.ReadFile at the turn's base ref into the


### PR DESCRIPTION
Follow-ups to #254/#265 from live testing of the activity feed (#239).

## What

**Spec-edit attribution (backend)** — live testing showed every spec change on the feed as "Admin updated the spec", even when the Spec agent authored it:

- Room-scoped turns commit nothing (the collab doc is the write surface), so the recorder — gated on `!NoChanges` — never recorded them; the collab committer's later flush (under the user's token) was the only line, mis-attributed to the user.
- Fix: a turn records the agent line at turn end and marks its manifest's **paths** in an app-root `specAuthorship` coordinator; a `files/apply` commit containing a marked path claims the marks and suppresses its (wrong) user line. Manual edits find no matching mark and record as the signed-in user — each collaborator's flush carries their own token, so multiple users appear under their own names.
- Marks are per **path**, not per project: the committer holds agent-marked markdown until the session-end force flush, so a user's own edit can land in an interim commit between turn and flush. A project-wide mark inverted both lines (user's line suppressed, agent's commit recorded as user); path scoping keeps the flushes independent. Committed (non-room) turns pass no paths, so nothing lingers.

**Console polish**

- Renamed the overview panel **Agent Activity → Recent activity** (component + file follow: `RecentActivity.tsx`) — with the real feed it shows user edits too.
- Capped the overview timeline at the **newest 6 events** — it's a glanceable summary; the feed keeps everything.
- Fixed the agent-chat `ActivityStep` status-glyph alignment: the check/cross sat ~2px high next to "Created \`file\`" chip rows (hand-tuned `mt: 3px` vs a 24px first row). The glyph now centers against the first row's height, and stays on the first line when a multi-line error wraps below.

Previous Recent Activity List
<img width="1480" height="801" alt="Screenshot 2026-07-22 at 19 03 19" src="https://github.com/user-attachments/assets/71453351-c105-4e28-8635-4e1ed3823c43" />

New Recent Activity List
<img width="1480" height="801" alt="Screenshot 2026-07-22 at 19 03 27" src="https://github.com/user-attachments/assets/d3ab149c-e3f0-45e4-aa5a-e91d0abb8c87" />


**Docs** — `services/aep-api/design/agent-activity-feed.md` updated to the shipped end state: the spec-edit attribution flow (+ known limits), the rename, and #265 in the PR map (replacing plan language).

## Proof of real execution

Live repro that motivated this (local stack, project `invoicing-freelancers-creates-jkhg`): both requirements and design generation recorded as the user —

```
     type     | actor_kind | actor_name |    at
--------------+------------+------------+----------
 spec_updated | user       | Admin      | 12:17:37   ← agent-generated requirements
 spec_updated | user       | Admin      | 12:26:02   ← agent-generated design
```

Test evidence: `go test ./...` green including new cases — interim user flush between turn and agent flush records the user AND the later agent flush stays suppressed; committed turns mark nothing; mark consumed once; per-project scoping. Console: 240 tests green (includes the new 6-cap test), tsc + eslint clean.

Closes the attribution gap left in #265 (noted in its review thread).