### PR TITLE
update cell diagram with theme, animation, move components

### DIFF
--- a/apps/console/src/features/spec/components/CellDiagramPanel.tsx
+++ b/apps/console/src/features/spec/components/CellDiagramPanel.tsx
@@ -87,6 +87,7 @@ export function CellDiagramPanel({
       )}
       <CellDiagramView
         source={source ?? undefined}
+        layoutKey={projectName}
         emptyState={
           agentBusy ? (
             <Typography variant="body2">

--- a/packages/ui/cell-diagram-react/package.json
+++ b/packages/ui/cell-diagram-react/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@aep/ui-cell-diagram-react",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
-  "description": "Cell architecture diagram renderer (React + xyflow) over the cell DSL. Vendored in-house from @kanushka/cell-diagram-react.",
+  "description": "Cell architecture diagram renderer (React + xyflow) over the cell DSL. Vendored in-house from @kanushka/cell-diagram-react (synced at upstream tag v0.3.0).",
   "main": "src/index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": [
@@ -18,7 +18,8 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.1.5",
     "@xyflow/react": "^12.8.4",
-    "html-to-image": "^1.11.13"
+    "html-to-image": "^1.11.13",
+    "lz-string": "^1.5.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/ui/cell-diagram-react/src/domain/cellModel.ts
+++ b/packages/ui/cell-diagram-react/src/domain/cellModel.ts
@@ -22,6 +22,7 @@ export type EdgeKind = "internal" | "inbound" | "outbound" | "exposure";
 
 export interface Diagnostic {
   severity: "error";
+  code?: string;
   message: string;
   line: number;
   column: number;

--- a/packages/ui/cell-diagram-react/src/index.ts
+++ b/packages/ui/cell-diagram-react/src/index.ts
@@ -19,7 +19,13 @@
 export { compileProject } from "./compiler/compileProject";
 export { compileCellSource } from "./compiler/compileCellSource";
 export { parseProject } from "./parser/parseProject";
+export {
+  MIXED_CELL_MODE_DIAGNOSTIC_CODE,
+  MIXED_CELL_MODE_MESSAGE
+} from "./parser/parseProject";
+export { planMixedDslConversion } from "./parser/planMixedDslConversion";
 export { DiagramCanvas } from "./renderer/DiagramCanvas";
+export { fingerprintSource, parsePortableSource, serializePortableSource } from "./renderer/customLayout";
 export { CellDiagram } from "./renderer/CellDiagram";
 
 export type {
@@ -35,3 +41,6 @@ export type {
   BoundaryDirection
 } from "./domain/cellModel";
 export type { CellDiagramProps } from "./renderer/CellDiagram";
+export type { MixedDslConversion } from "./parser/planMixedDslConversion";
+export type { CanvasMessage, DiagramCanvasProps, DiagramTheme } from "./renderer/DiagramCanvas";
+export type { CustomLayout, CustomNodePosition, PortableCellSource } from "./renderer/customLayout";

--- a/packages/ui/cell-diagram-react/src/parser/parseCellDsl.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseCellDsl.ts
@@ -336,3 +336,11 @@ export function parseCellDsl(source: string): ParseResult {
 
   return { document, diagnostics };
 }
+
+export function isCellDslStatement(statement: string): boolean {
+  const trimmed = statement.trim();
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+    return false;
+  }
+  return parseCellDsl(trimmed).diagnostics.length === 0;
+}

--- a/packages/ui/cell-diagram-react/src/parser/parseProject.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseProject.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { parseProject } from "./parseProject";
+import { MIXED_CELL_MODE_DIAGNOSTIC_CODE, MIXED_CELL_MODE_MESSAGE, parseProject } from "./parseProject";
 
 describe("parseProject", () => {
   it("parses a single implicit cell (backward compatible)", () => {
@@ -82,14 +82,29 @@ describe("parseProject", () => {
   it("flags top-level component statements mixed with cell blocks", () => {
     const source = "component loose\ncell a {\n  component x\n}";
     const result = parseProject(source);
-    expect(result.diagnostics.some((d) => /outside a cell/i.test(d.message))).toBe(true);
+    expect(result.diagnostics).toContainEqual({
+      severity: "error",
+      code: MIXED_CELL_MODE_DIAGNOSTIC_CODE,
+      message: MIXED_CELL_MODE_MESSAGE,
+      line: 1,
+      column: 1
+    });
   });
 
-  it("rejects an unqualified source on a top-level cross edge", () => {
+  it("marks an unqualified source on a top-level cross edge as convertible mixed DSL", () => {
     const source = "cell a {\n  component x\n}\nx -> b.y";
     const result = parseProject(source);
-    expect(result.diagnostics.some((d) => /qualified source/i.test(d.message))).toBe(true);
+    expect(result.diagnostics[0]).toMatchObject({ code: MIXED_CELL_MODE_DIAGNOSTIC_CODE, line: 4 });
     expect(result.project.crossEdges).toEqual([]);
+  });
+
+  it("keeps the generic outside-cell diagnostic for malformed loose syntax", () => {
+    const result = parseProject("not valid DSL\ncell a {\n  component x\n}");
+    expect(result.diagnostics[0]).toMatchObject({
+      message: "Only `title`, comments, and cross-cell edges are allowed outside a cell block.",
+      line: 1
+    });
+    expect(result.diagnostics[0].code).toBeUndefined();
   });
 
   it("flags a top-level bare-south cross edge", () => {

--- a/packages/ui/cell-diagram-react/src/parser/parseProject.ts
+++ b/packages/ui/cell-diagram-react/src/parser/parseProject.ts
@@ -17,7 +17,7 @@
  */
 
 import { CrossEntry, CrossExit, Diagnostic, ParsedCellDocument } from "../domain/cellModel";
-import { parseCellDsl } from "./parseCellDsl";
+import { isCellDslStatement, parseCellDsl } from "./parseCellDsl";
 import { CellBlock, SourceLine, splitCells } from "./splitCells";
 import { ParsedCrossEdge, parseCrossEdge } from "./crossEdge";
 
@@ -49,6 +49,20 @@ export interface ParsedProject {
 export interface ParseProjectResult {
   project: ParsedProject;
   diagnostics: Diagnostic[];
+}
+
+export const MIXED_CELL_MODE_DIAGNOSTIC_CODE = "mixed-cell-mode";
+export const MIXED_CELL_MODE_MESSAGE =
+  "This document uses cell blocks. Components and local dependencies must be inside a named cell.";
+
+function mixedCellModeDiagnostic(line: number): Diagnostic {
+  return {
+    severity: "error",
+    code: MIXED_CELL_MODE_DIAGNOSTIC_CODE,
+    message: MIXED_CELL_MODE_MESSAGE,
+    line,
+    column: 1
+  };
 }
 
 function crossEdgeId(sourceCell: string, sourceComp: string, targetCell: string, targetComp: string, line: number) {
@@ -136,23 +150,22 @@ export function parseProject(source: string): ParseProjectResult {
     }
     if (cross) {
       if (!cross.sourceCell) {
-        diagnostics.push({
-          severity: "error",
-          message: "A cross-cell edge outside a cell block must use a qualified source, e.g. `a.x -> b.y`.",
-          line: cross.line,
-          column: 1
-        });
+        diagnostics.push(mixedCellModeDiagnostic(cross.line));
         return;
       }
       crossEdges.push(buildResolvedEdge(cross, cross.sourceCell));
       return;
     }
-    diagnostics.push({
-      severity: "error",
-      message: "Only `title`, comments, and cross-cell edges are allowed outside a cell block.",
-      line: entry.line,
-      column: 1
-    });
+    diagnostics.push(
+      isCellDslStatement(entry.text)
+        ? mixedCellModeDiagnostic(entry.line)
+        : {
+            severity: "error",
+            message: "Only `title`, comments, and cross-cell edges are allowed outside a cell block.",
+            line: entry.line,
+            column: 1
+          }
+    );
   });
 
   return { project: { title, cells, crossEdges }, diagnostics };

--- a/packages/ui/cell-diagram-react/src/parser/planMixedDslConversion.test.ts
+++ b/packages/ui/cell-diagram-react/src/parser/planMixedDslConversion.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { planMixedDslConversion } from "./planMixedDslConversion";
+
+describe("planMixedDslConversion", () => {
+  it("moves loose cell statements and their leading trivia into cell main", () => {
+    const source = [
+      "# Existing single-cell content",
+      "component Users API",
+      "",
+      "Courses -> Users",
+      "",
+      "cell orders {",
+      "  component api",
+      "}"
+    ].join("\n");
+
+    expect(planMixedDslConversion(source)).toEqual({
+      cellId: "main",
+      movedLineCount: 2,
+      source: [
+        "cell main {",
+        "  # Existing single-cell content",
+        "  component Users API",
+        "",
+        "  Courses -> Users",
+        "}",
+        "",
+        "cell orders {",
+        "  component api",
+        "}"
+      ].join("\n")
+    });
+  });
+
+  it("keeps project title, qualified cross-cell links, and existing blocks unchanged", () => {
+    const existingBlocks = [
+      "cell orders as \"Order Cell\" {",
+      "    component api",
+      "}",
+      "cell products {",
+      "\tcomponent api",
+      "}"
+    ].join("\n");
+    const source = [
+      "title Commerce",
+      "component loose",
+      "orders.api -> products.api",
+      existingBlocks
+    ].join("\n");
+    const conversion = planMixedDslConversion(source);
+
+    expect(conversion?.source).toContain("title Commerce\norders.api -> products.api\ncell main {");
+    expect(conversion?.source.endsWith(existingBlocks)).toBe(true);
+  });
+
+  it("moves a cross-cell edge with an unqualified local source", () => {
+    const source = "component api\napi -> east-north products.api\ncell products {\n  component api\n}";
+    const conversion = planMixedDslConversion(source);
+
+    expect(conversion?.movedLineCount).toBe(2);
+    expect(conversion?.source).toContain("  api -> east-north products.api");
+  });
+
+  it("uses the next available generated cell identifier", () => {
+    const source = [
+      "component loose",
+      "cell main {",
+      "  component a",
+      "}",
+      "cell main-2 {",
+      "  component b",
+      "}"
+    ].join("\n");
+
+    expect(planMixedDslConversion(source)?.cellId).toBe("main-3");
+  });
+
+  it("leaves malformed top-level lines and their trivia untouched", () => {
+    const source = [
+      "component loose",
+      "// Explain the malformed line",
+      "not valid DSL",
+      "",
+      "cell existing {",
+      "  component api",
+      "}"
+    ].join("\n");
+    const conversion = planMixedDslConversion(source);
+
+    expect(conversion?.source).toContain("// Explain the malformed line\nnot valid DSL");
+    expect(conversion?.source).toContain("not valid DSL\ncell main {");
+  });
+
+  it("preserves CRLF and final-newline behavior", () => {
+    const withFinalNewline = "component loose\r\ncell existing {\r\n  component api\r\n}\r\n";
+    const withoutFinalNewline = "component loose\r\ncell existing {\r\n  component api\r\n}";
+
+    const withFinalResult = planMixedDslConversion(withFinalNewline)?.source;
+    const withoutFinalResult = planMixedDslConversion(withoutFinalNewline)?.source;
+
+    expect(withFinalResult?.endsWith("\r\n")).toBe(true);
+    expect(withFinalResult?.replaceAll("\r\n", "")).not.toContain("\n");
+    expect(withoutFinalResult?.endsWith("\r\n")).toBe(false);
+  });
+
+  it("returns null when there is no safe mixed-mode conversion", () => {
+    expect(planMixedDslConversion("component api")).toBeNull();
+    expect(planMixedDslConversion("cell existing {\n  component api\n}")).toBeNull();
+    expect(planMixedDslConversion("not valid DSL\ncell existing {\n  component api\n}")).toBeNull();
+    expect(planMixedDslConversion("component loose\ncell existing {\n  component api")).toBeNull();
+  });
+});

--- a/packages/ui/cell-diagram-react/src/parser/planMixedDslConversion.ts
+++ b/packages/ui/cell-diagram-react/src/parser/planMixedDslConversion.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isCellDslStatement } from "./parseCellDsl";
+import { parseCrossEdge } from "./crossEdge";
+import { parseCellHeader, splitCells } from "./splitCells";
+
+export interface MixedDslConversion {
+  source: string;
+  cellId: string;
+  movedLineCount: number;
+}
+
+function nextCellId(existingIds: Set<string>): string {
+  if (!existingIds.has("main")) {
+    return "main";
+  }
+
+  let suffix = 2;
+  while (existingIds.has(`main-${suffix}`)) {
+    suffix += 1;
+  }
+  return `main-${suffix}`;
+}
+
+function isComment(statement: string): boolean {
+  return statement.startsWith("#") || statement.startsWith("//");
+}
+
+export function planMixedDslConversion(source: string): MixedDslConversion | null {
+  const split = splitCells(source);
+  if (split.implicit || split.diagnostics.length > 0 || split.cells.length === 0) {
+    return null;
+  }
+
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const lines = source.split(newline);
+  const movedIndices = new Set<number>();
+  let pendingTrivia: number[] = [];
+  let insideCell = false;
+  let insertionIndex = -1;
+  let movedLineCount = 0;
+
+  lines.forEach((rawLine, index) => {
+    const statement = rawLine.trim();
+
+    if (!insideCell) {
+      const header = parseCellHeader(statement);
+      if (header) {
+        if (insertionIndex === -1) {
+          insertionIndex = pendingTrivia[0] ?? index;
+        }
+        pendingTrivia = [];
+        insideCell = true;
+        return;
+      }
+    }
+
+    if (insideCell) {
+      if (statement === "}") {
+        insideCell = false;
+      }
+      return;
+    }
+
+    if (!statement || isComment(statement)) {
+      pendingTrivia.push(index);
+      return;
+    }
+
+    if (statement.startsWith("title ")) {
+      pendingTrivia = [];
+      return;
+    }
+
+    const crossEdge = parseCrossEdge(statement, index + 1);
+    const isConvertibleCrossEdge = crossEdge !== null && !("error" in crossEdge) && crossEdge.sourceCell === null;
+    const isConvertibleCellStatement = crossEdge === null && isCellDslStatement(statement);
+    const isConvertible = isConvertibleCrossEdge || isConvertibleCellStatement;
+
+    if (isConvertible) {
+      pendingTrivia.forEach((triviaIndex) => movedIndices.add(triviaIndex));
+      pendingTrivia = [];
+      movedIndices.add(index);
+      movedLineCount += 1;
+      return;
+    }
+
+    pendingTrivia = [];
+  });
+
+  if (insertionIndex === -1 || movedLineCount === 0) {
+    return null;
+  }
+
+  const cellId = nextCellId(new Set(split.cells.map((cell) => cell.id)));
+  const movedLines = lines
+    .filter((_, index) => movedIndices.has(index))
+    .map((line) => (line.trim().length === 0 ? "" : `  ${line.trimStart()}`));
+  const separator = lines[insertionIndex].trim().length === 0 ? [] : [""];
+  const generatedBlock = [`cell ${cellId} {`, ...movedLines, "}", ...separator];
+  const convertedLines: string[] = [];
+
+  lines.forEach((line, index) => {
+    if (index === insertionIndex) {
+      convertedLines.push(...generatedBlock);
+    }
+    if (!movedIndices.has(index)) {
+      convertedLines.push(line);
+    }
+  });
+
+  return {
+    source: convertedLines.join(newline),
+    cellId,
+    movedLineCount
+  };
+}

--- a/packages/ui/cell-diagram-react/src/parser/splitCells.ts
+++ b/packages/ui/cell-diagram-react/src/parser/splitCells.ts
@@ -39,6 +39,19 @@ export interface SplitResult {
 
 const headerPattern = /^cell\s+(\S+)(?:\s+as\s+(?:"([^"]*)"|(\S+)))?\s*\{$/;
 
+export interface CellHeader {
+  id: string;
+  label?: string;
+}
+
+export function parseCellHeader(statement: string): CellHeader | null {
+  const header = headerPattern.exec(statement.trim());
+  if (!header) {
+    return null;
+  }
+  return { id: header[1], label: (header[2] || header[3]) || undefined };
+}
+
 export function splitCells(source: string): SplitResult {
   const rawLines = source.split(/\r?\n/);
   const hasBlocks = rawLines.some(
@@ -62,13 +75,13 @@ export function splitCells(source: string): SplitResult {
     const trimmed = rawLines[index].trim();
     if (trimmed.length === 0) { continue; }
 
-    const header = headerPattern.exec(trimmed);
+    const header = parseCellHeader(trimmed);
     if (header) {
       if (current) {
         diagnostics.push({ severity: "error", message: "Nested cells are not supported.", line, column: 1 });
         continue;
       }
-      current = { id: header[1], label: (header[2] || header[3]) || undefined, headerLine: line, lines: [] };
+      current = { id: header.id, label: header.label, headerLine: line, lines: [] };
       continue;
     }
 
@@ -92,11 +105,11 @@ export function splitCells(source: string): SplitResult {
   }
 
   if (current) {
+    diagnostics.push({ severity: "error", message: "Unbalanced braces: a cell block was not closed.", line: current.headerLine, column: 1 });
     // Auto-close the still-open block at EOF so a growing DSL prefix (streaming
     // a `design.cell`) still yields the in-progress cell. The diagnostic remains,
     // so non-tolerant compiles keep collapsing to `model: null` as before.
     cells.push(current);
-    diagnostics.push({ severity: "error", message: "Unbalanced braces: a cell block was not closed.", line: current.headerLine, column: 1 });
   }
 
   return { implicit: false, cells, topLevel, diagnostics };

--- a/packages/ui/cell-diagram-react/src/renderer/CellDiagram.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/CellDiagram.tsx
@@ -19,7 +19,8 @@
 import { useEffect, useMemo, type CSSProperties } from "react";
 import { compileProject } from "../compiler/compileProject";
 import type { Diagnostic, ProjectModel } from "../domain/cellModel";
-import { DiagramCanvas } from "./DiagramCanvas";
+import { DiagramCanvas, type DiagramTheme } from "./DiagramCanvas";
+import type { CustomLayout } from "./customLayout";
 
 export interface CellDiagramProps {
   /** Cell DSL source text; compiled internally. */
@@ -30,14 +31,33 @@ export interface CellDiagramProps {
   style?: CSSProperties;
   /** Called with parse/compile diagnostics whenever `source` changes. */
   onDiagnostics?: (diagnostics: Diagnostic[]) => void;
+  /** Light or dark color theme. Defaults to `"light"`. */
+  theme?: DiagramTheme;
   /**
    * Best-effort compile: render the partial diagram from a still-incomplete
    * `source` (e.g. a streaming `design.cell`) instead of the error placeholder.
    */
   tolerant?: boolean;
+  /**
+   * Manually dragged node positions (see `captureCustomPosition`). Without a
+   * round-trip through these two props a dragged node snaps back to the
+   * auto-layout on drop.
+   */
+  customLayout?: CustomLayout | null;
+  onCustomLayoutChange?: (layout: CustomLayout) => void;
 }
 
-export function CellDiagram({ source, model, className, style, onDiagnostics, tolerant }: CellDiagramProps) {
+export function CellDiagram({
+  source,
+  model,
+  className,
+  style,
+  onDiagnostics,
+  theme = "light",
+  tolerant,
+  customLayout,
+  onCustomLayoutChange
+}: CellDiagramProps) {
   const compiled = useMemo(
     () => (source !== undefined ? compileProject(source, { tolerant }) : null),
     [source, tolerant]
@@ -53,7 +73,13 @@ export function CellDiagram({ source, model, className, style, onDiagnostics, to
 
   return (
     <div className={className} style={{ width: "100%", height: "100%", ...style }}>
-      <DiagramCanvas model={resolvedModel} />
+      <DiagramCanvas
+        model={resolvedModel}
+        theme={theme}
+        source={source ?? ""}
+        customLayout={customLayout}
+        onCustomLayoutChange={onCustomLayoutChange}
+      />
     </div>
   );
 }

--- a/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.test.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.test.tsx
@@ -161,6 +161,60 @@ describe("DiagramCanvas component styling", () => {
   });
 });
 
+describe("DiagramCanvas live-edit motion", () => {
+  it("keeps the initial graph still, then animates only a newly added circle", () => {
+    const initialModel = buildModel("component API service");
+    const { rerender } = render(<DiagramCanvas model={initialModel} motionContextKey="doc-1" />);
+
+    expect(screen.getByText("API").closest(".react-flow__node")).not.toHaveClass("diagram-node--entering");
+
+    const nextModel = buildModel("component API service\ncomponent Worker service");
+    rerender(<DiagramCanvas model={nextModel} motionContextKey="doc-1" />);
+
+    expect(screen.getByText("Worker").closest(".react-flow__node")).toHaveClass("diagram-node--entering");
+    expect(screen.getByText("API").closest(".react-flow__node")).toHaveClass(
+      "diagram-node--position-animated"
+    );
+  });
+
+  it("updates labels quietly without replaying an entrance", () => {
+    const { rerender } = render(
+      <DiagramCanvas model={buildModel('component api as "Orders API" service')} motionContextKey="doc-1" />
+    );
+
+    rerender(
+      <DiagramCanvas model={buildModel('component api as "Checkout API" service')} motionContextKey="doc-1" />
+    );
+
+    expect(screen.getByText("Checkout API").closest(".react-flow__node")).not.toHaveClass("diagram-node--entering");
+  });
+
+  it("updates an identifier on the same source line without replaying an entrance", () => {
+    const { rerender } = render(
+      <DiagramCanvas model={buildModel("component W service")} motionContextKey="doc-1" />
+    );
+
+    rerender(<DiagramCanvas model={buildModel("component Wo service")} motionContextKey="doc-1" />);
+
+    expect(screen.getByText("Wo").closest(".react-flow__node")).not.toHaveClass("diagram-node--entering");
+  });
+
+  it("does not animate the incoming graph when the document context changes", () => {
+    const { rerender } = render(
+      <DiagramCanvas model={buildModel("component API service")} motionContextKey="doc-1" />
+    );
+
+    rerender(
+      <DiagramCanvas
+        model={buildModel("component API service\ncomponent Worker service")}
+        motionContextKey="doc-2"
+      />
+    );
+
+    expect(screen.getByText("Worker").closest(".react-flow__node")).not.toHaveClass("diagram-node--entering");
+  });
+});
+
 describe("DiagramCanvas zoom controls", () => {
   it("shows the current zoom level as a percentage", () => {
     const model = buildModel("component API service\nnorth -> API");
@@ -201,5 +255,86 @@ describe("DiagramCanvas zoom controls", () => {
     render(<DiagramCanvas model={model} />);
     expect(screen.queryByRole("button", { name: /export png/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /export svg/i })).not.toBeInTheDocument();
+  });
+
+  // AEP divergence from upstream: the Auto arrange button is removed, and the
+  // remaining zoom controls carry matching title tooltips.
+  it("renders no Auto arrange control", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(
+      <DiagramCanvas
+        model={model}
+        customLayout={{
+          version: 1,
+          sourceFingerprint: "test",
+          nodes: { API: { kind: "component", cellId: "main", x: 200, y: 200 } }
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /auto arrange/i })).not.toBeInTheDocument();
+  });
+
+  it("gives each zoom control a title tooltip", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(<DiagramCanvas model={model} />);
+
+    for (const name of ["Zoom out", "Zoom in", "Fit diagram to view"]) {
+      expect(screen.getByRole("button", { name })).toHaveAttribute("title", name);
+    }
+  });
+
+  it("renders a supplied canvas message in the shared slot", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    render(
+      <DiagramCanvas
+        model={model}
+        canvasMessage={{ id: 1, tone: "warning", text: "Manual arrangement is temporary." }}
+      />
+    );
+
+    const message = screen.getByRole("status");
+    expect(message).toHaveTextContent("Manual arrangement is temporary.");
+    expect(message).toHaveClass("canvas-notification");
+    expect(message).toHaveAttribute("data-tone", "warning");
+    expect(document.querySelectorAll(".canvas-notification")).toHaveLength(1);
+  });
+
+  it("uses the shared slot for the resting focus hint", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { container } = render(<DiagramCanvas model={model} />);
+
+    const slot = screen.getByText("Click a component to focus its connections.");
+    expect(slot).toHaveClass("canvas-notification");
+    expect(slot).toHaveAttribute("data-mode", "hint");
+    expect(container.querySelectorAll(".canvas-notification")).toHaveLength(1);
+  });
+});
+
+describe("DiagramCanvas theming", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the light theme when no theme is supplied", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { container } = render(<DiagramCanvas model={model} />);
+
+    expect(container.querySelector(".cell-diagram-root")).toHaveAttribute("data-cd-theme", "light");
+  });
+
+  it("stamps the dark theme onto the diagram root", () => {
+    const model = buildModel("component API service\nnorth -> API");
+    const { container } = render(<DiagramCanvas model={model} theme="dark" />);
+
+    expect(container.querySelector(".cell-diagram-root")).toHaveAttribute("data-cd-theme", "dark");
+  });
+
+  it("themes the empty-state placeholder too", () => {
+    const { container } = render(<DiagramCanvas model={null} theme="dark" />);
+
+    const root = container.querySelector(".cell-diagram-root");
+    expect(root).toHaveClass("empty-canvas");
+    expect(root).toHaveAttribute("data-cd-theme", "dark");
   });
 });

--- a/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.tsx
+++ b/packages/ui/cell-diagram-react/src/renderer/DiagramCanvas.tsx
@@ -26,21 +26,25 @@ import {
   useInternalNode,
   useReactFlow,
   useViewport,
+  applyNodeChanges,
   type Edge,
   type EdgeProps,
   type InternalNode,
   type Node,
+  type NodeChange,
   type NodeProps,
   getBezierPath,
   getSmoothStepPath
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import "./diagram.css";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ProjectModel } from "../domain/cellModel";
 import { FitScreenIcon, ZoomInIcon, ZoomOutIcon } from "../ui/ControlIcons";
 // TODO: re-enable when the PNG/SVG image export feature is complete.
 // import { exportPng, exportSvg } from "./exportImage";
+import { applyCustomLayout, captureCustomPosition, type CustomLayout } from "./customLayout";
+import { classifyDiagramMotion, type DiagramMotionSnapshot } from "./diagramMotion";
 import { getFloatingAnchors, shapeForNodeType, type NodeRect } from "./floatingGeometry";
 import { toReactFlow } from "./flowLayout";
 import { connectionIdsForNode, edgeConnectionId, highlightedNodeIdsForConnections } from "./highlightModel";
@@ -134,13 +138,26 @@ function GatewayNode({ data }: NodeProps) {
   );
 }
 
-function EdgeLabel({ label, x, y }: { label: EdgeProps["label"]; x: number; y: number }) {
+function EdgeLabel({
+  label,
+  x,
+  y,
+  entering = false
+}: {
+  label: EdgeProps["label"];
+  x: number;
+  y: number;
+  entering?: boolean;
+}) {
   if (!label) {
     return null;
   }
   return (
     <EdgeLabelRenderer>
-      <div className="edge-label" style={{ transform: `translate(-50%, -50%) translate(${x}px,${y}px)` }}>
+      <div
+        className={entering ? "edge-label edge-label--entering" : "edge-label"}
+        style={{ transform: `translate(-50%, -50%) translate(${x}px,${y}px)` }}
+      >
         {label}
       </div>
     </EdgeLabelRenderer>
@@ -150,10 +167,16 @@ function EdgeLabel({ label, x, y }: { label: EdgeProps["label"]; x: number; y: n
 function makePathEdge(computePath: (props: EdgeProps) => [string, number, number, ...unknown[]]) {
   return function PathEdge(props: EdgeProps) {
     const [edgePath, labelX, labelY] = computePath(props);
+    const isEntering = props.data?.motionStatus === "entering";
     return (
       <>
-        <path className="react-flow__edge-path" d={edgePath} markerEnd={props.markerEnd} />
-        <EdgeLabel label={props.label} x={labelX} y={labelY} />
+        <path
+          className="react-flow__edge-path"
+          d={edgePath}
+          markerEnd={props.markerEnd}
+          pathLength={isEntering ? 1 : undefined}
+        />
+        <EdgeLabel label={props.label} x={labelX} y={labelY} entering={isEntering} />
       </>
     );
   };
@@ -211,11 +234,17 @@ function FloatingEdge(props: EdgeProps) {
     targetY: ty,
     targetPosition: positions.target
   });
+  const isEntering = props.data?.motionStatus === "entering";
 
   return (
     <>
-      <path className="react-flow__edge-path" d={edgePath} markerEnd={props.markerEnd} />
-      <EdgeLabel label={props.label} x={labelX} y={labelY} />
+      <path
+        className="react-flow__edge-path"
+        d={edgePath}
+        markerEnd={props.markerEnd}
+        pathLength={isEntering ? 1 : undefined}
+      />
+      <EdgeLabel label={props.label} x={labelX} y={labelY} entering={isEntering} />
     </>
   );
 }
@@ -245,6 +274,7 @@ export interface DiagramCanvasInsets {
 const DEFAULT_INSETS: DiagramCanvasInsets = { left: 0, right: 0 };
 const FIT_VIEW_VERTICAL_PADDING: `${number}px` = "112px";
 const FIT_VIEW_LEFT_PADDING = 112;
+const MOTION_SETTLE_MS = 420;
 
 interface FitPadding {
   top: `${number}px`;
@@ -289,23 +319,40 @@ function FitViewController({
   return null;
 }
 
+// AEP divergence from upstream: the "Auto arrange" button is dropped (a moved
+// component is a transient viewing aid here — the layout resets whenever the
+// DSL changes, so a manual reset control isn't worth the chrome), and the
+// remaining controls carry `title` tooltips.
 function ZoomControls({ insets }: { insets: DiagramCanvasInsets }) {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const { zoom } = useViewport();
 
   return (
     <div className="zoom-controls">
-      <button type="button" className="zoom-controls__button" aria-label="Zoom out" onClick={() => zoomOut()}>
+      <button
+        type="button"
+        className="zoom-controls__button"
+        aria-label="Zoom out"
+        title="Zoom out"
+        onClick={() => zoomOut()}
+      >
         <ZoomOutIcon size={16} />
       </button>
       <span className="zoom-controls__level">{Math.round(zoom * 100)}%</span>
-      <button type="button" className="zoom-controls__button" aria-label="Zoom in" onClick={() => zoomIn()}>
+      <button
+        type="button"
+        className="zoom-controls__button"
+        aria-label="Zoom in"
+        title="Zoom in"
+        onClick={() => zoomIn()}
+      >
         <ZoomInIcon size={16} />
       </button>
       <button
         type="button"
         className="zoom-controls__button zoom-controls__button--fit"
         aria-label="Fit diagram to view"
+        title="Fit diagram to view"
         onClick={() => fitView({ padding: buildFitPadding(insets), duration: 200 })}
       >
         <FitScreenIcon size={16} />
@@ -338,17 +385,54 @@ function ZoomControls({ insets }: { insets: DiagramCanvasInsets }) {
 //   );
 // }
 
-interface DiagramCanvasProps {
+/** Color theme applied to the rendered diagram. */
+export type DiagramTheme = "light" | "dark";
+
+export interface DiagramCanvasProps {
   model: ProjectModel | null;
   insets?: DiagramCanvasInsets;
   fitKey?: string;
+  motionContextKey?: string;
+  source?: string;
+  customLayout?: CustomLayout | null;
+  onCustomLayoutChange?: (layout: CustomLayout) => void;
+  canvasMessage?: CanvasMessage | null;
+  /** Light or dark color theme. Defaults to `"light"`. */
+  theme?: DiagramTheme;
 }
 
-export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: DiagramCanvasProps) {
+export interface CanvasMessage {
+  id: number;
+  tone: "warning" | "info";
+  text: string;
+}
+
+export function DiagramCanvas({
+  model,
+  insets = DEFAULT_INSETS,
+  fitKey,
+  motionContextKey = "default",
+  source = "",
+  customLayout = null,
+  onCustomLayoutChange,
+  canvasMessage = null,
+  theme = "light"
+}: DiagramCanvasProps) {
   const [activeConnectionIds, setActiveConnectionIds] = useState<string[]>([]);
+  const [, setMotionVersion] = useState(0);
+  const previousMotionSnapshot = useRef<DiagramMotionSnapshot | null>(null);
   const flow = useMemo<ReturnType<typeof toReactFlow>>(
     () => (model ? toReactFlow(model) : { nodes: [], edges: [], cellSize: { width: 0, height: 0 } }),
     [model]
+  );
+  const positionedNodes = useMemo(() => applyCustomLayout(flow.nodes, customLayout), [customLayout, flow.nodes]);
+  const [dragNodes, setDragNodes] = useState<Node[] | null>(null);
+  const liveNodes = dragNodes ?? positionedNodes;
+  const motion = classifyDiagramMotion(
+    previousMotionSnapshot.current,
+    positionedNodes,
+    flow.edges,
+    motionContextKey
   );
   const activeConnectionIdSet = useMemo(() => new Set(activeConnectionIds), [activeConnectionIds]);
   const highlightedNodeIds = useMemo(() => {
@@ -368,22 +452,34 @@ export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: Diagra
   const isFocusView = activeConnectionIdSet.size > 0;
   const nodes = useMemo<Node[]>(
     () =>
-      flow.nodes.map((node) => ({
+      liveNodes.map((node) => ({
         ...node,
-        className: isFocusView
-          ? highlightedNodeIds.has(node.id)
-            ? "connection-highlight-node"
-            : "connection-dimmed-node"
-          : node.className
+        className: [
+          node.className,
+          motion.enteringNodeIds.has(node.id) ? "diagram-node--entering" : "",
+          motion.movingNodeIds.has(node.id) ? "diagram-node--position-animated" : "",
+          isFocusView
+            ? highlightedNodeIds.has(node.id)
+              ? "connection-highlight-node"
+              : "connection-dimmed-node"
+            : ""
+        ]
+          .filter(Boolean)
+          .join(" ")
       })),
-    [flow.nodes, highlightedNodeIds, isFocusView]
+    [highlightedNodeIds, isFocusView, liveNodes, motion.enteringNodeIds, motion.movingNodeIds]
   );
   const edges = useMemo<Edge[]>(
     () =>
       flow.edges.map((edge) => ({
         ...edge,
+        data: {
+          ...edge.data,
+          motionStatus: motion.enteringEdgeIds.has(edge.id) ? "entering" : "idle"
+        },
         className: [
           edge.className,
+          motion.enteringEdgeIds.has(edge.id) ? "diagram-edge--entering" : "",
           isFocusView
             ? activeConnectionIdSet.has(edgeConnectionId(edge))
               ? "connection-highlight-edge"
@@ -393,8 +489,21 @@ export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: Diagra
           .filter(Boolean)
           .join(" ")
       })),
-    [activeConnectionIdSet, flow.edges, isFocusView]
+    [activeConnectionIdSet, flow.edges, isFocusView, motion.enteringEdgeIds]
   );
+
+  useEffect(() => {
+    previousMotionSnapshot.current = motion.snapshot;
+  }, [flow.edges, motion.snapshot, motionContextKey, positionedNodes]);
+
+  useEffect(() => {
+    if (motion.enteringNodeIds.size === 0 && motion.enteringEdgeIds.size === 0) {
+      return;
+    }
+
+    const settleTimer = window.setTimeout(() => setMotionVersion((current) => current + 1), MOTION_SETTLE_MS);
+    return () => window.clearTimeout(settleTimer);
+  }, [motion.enteringEdgeIds, motion.enteringNodeIds]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -407,16 +516,41 @@ export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: Diagra
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [setActiveConnections]);
 
+  const handleNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const positionChanges = changes.filter((change) => change.type === "position");
+      if (positionChanges.length === 0) {
+        return;
+      }
+      setDragNodes((current) => applyNodeChanges(positionChanges, current ?? positionedNodes));
+    },
+    [positionedNodes]
+  );
+
+  const handleNodeDragStop = useCallback(
+    (_event: MouseEvent | TouchEvent, node: Node) => {
+      const nextLayout = captureCustomPosition(customLayout, source, node, flow.nodes);
+      if (!nextLayout) {
+        setDragNodes(null);
+        return;
+      }
+      setDragNodes(null);
+      onCustomLayoutChange?.(nextLayout);
+    },
+    [customLayout, flow.nodes, onCustomLayoutChange, source]
+  );
+
   if (!model) {
     return (
-      <div className="empty-canvas">
+      <div className="cell-diagram-root empty-canvas" data-cd-theme={theme}>
         <span>Fix the DSL errors to render the diagram.</span>
       </div>
     );
   }
 
   return (
-    <ReactFlowProvider>
+    <div className="cell-diagram-root" data-cd-theme={theme}>
+      <ReactFlowProvider key={motionContextKey}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -424,24 +558,35 @@ export function DiagramCanvas({ model, insets = DEFAULT_INSETS, fitKey }: Diagra
         edgeTypes={edgeTypes}
         minZoom={0.25}
         maxZoom={1.35}
-        nodesDraggable={false}
+        nodesDraggable
         nodesConnectable={false}
         elementsSelectable
         proOptions={{ hideAttribution: true }}
+        onNodesChange={handleNodesChange}
+        onNodeDragStop={handleNodeDragStop}
         onNodeClick={(_, node) => setActiveConnections(getConnectionIdsForNode(node.id))}
         onPaneClick={() => setActiveConnections([])}
       >
         <FitViewController insets={insets} model={model} fitKey={fitKey} />
-        <Background color="#cbd5e1" gap={22} />
+        <Background color={theme === "dark" ? "#334155" : "#cbd5e1"} gap={22} />
         <ZoomControls insets={insets} />
         {/* TODO: re-enable when the PNG/SVG image export feature is complete.
         <ExportControls filename={model.title?.trim() || "cell-diagram"} /> */}
-        <div className="focus-hint" data-focus-mode={isFocusView ? "active" : "idle"}>
-          {isFocusView
-            ? "Focus view: click outside or press Esc to return to the full diagram."
-            : "Click a component to focus its connections."}
+        <div
+          key={canvasMessage?.id ?? "focus-hint"}
+          className="canvas-notification"
+          data-mode={canvasMessage ? "message" : "hint"}
+          data-tone={canvasMessage?.tone ?? "neutral"}
+          data-focus-mode={isFocusView ? "active" : "idle"}
+          role={canvasMessage ? "status" : undefined}
+        >
+          {canvasMessage?.text ??
+            (isFocusView
+              ? "Focus view: click outside or press Esc to return to the full diagram."
+              : "Click a component to focus its connections.")}
         </div>
       </ReactFlow>
-    </ReactFlowProvider>
+      </ReactFlowProvider>
+    </div>
   );
 }

--- a/packages/ui/cell-diagram-react/src/renderer/customLayout.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/customLayout.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import {
+  applyCustomLayout,
+  captureCustomPosition,
+  createCustomLayout,
+  parsePortableSource,
+  PORTABLE_LAYOUT_PREFIX,
+  serializePortableSource
+} from "./customLayout";
+
+const source = "cell orders {\n  component api\n  east s3\n  api -> s3\n}";
+
+function baseNodes(): Node[] {
+  return [
+    {
+      id: "cell-orders",
+      type: "cellBoundary",
+      position: { x: 100, y: 200 },
+      data: { layoutKind: "cell", cellId: "orders", width: 640, height: 640 }
+    },
+    {
+      id: "orders::api",
+      type: "component",
+      position: { x: 300, y: 400 },
+      data: { layoutKind: "component", cellId: "orders" }
+    },
+    {
+      id: "external-orders-s3",
+      type: "external",
+      position: { x: 890, y: 460 },
+      data: { layoutKind: "external", cellId: "orders", direction: "east" }
+    },
+    {
+      id: "external-shared",
+      type: "external",
+      position: { x: 900, y: 300 },
+      data: { layoutKind: "shared-external" }
+    },
+    {
+      id: "gateway-orders-east",
+      type: "gateway",
+      position: { x: 723, y: 503 },
+      data: { layoutKind: "gateway", cellId: "orders", direction: "east" }
+    }
+  ];
+}
+
+describe("custom layout", () => {
+  it("captures and reapplies internal positions relative to their cell", () => {
+    const nodes = baseNodes();
+    const dragged = { ...nodes[1], position: { x: 430, y: 510 } };
+    const layout = captureCustomPosition(null, source, dragged, nodes);
+
+    expect(layout?.nodes["orders::api"]).toEqual({
+      kind: "component",
+      cellId: "orders",
+      x: 330,
+      y: 310
+    });
+    expect(applyCustomLayout(nodes, layout).find((node) => node.id === "orders::api")?.position).toEqual({
+      x: 430,
+      y: 510
+    });
+  });
+
+  it("clamps internal components inside their cell padding", () => {
+    const nodes = baseNodes();
+    const dragged = { ...nodes[1], position: { x: -500, y: 2000 } };
+    const layout = captureCustomPosition(null, source, dragged, nodes);
+
+    expect(applyCustomLayout(nodes, layout).find((node) => node.id === "orders::api")?.position).toEqual({
+      x: 172,
+      y: 656
+    });
+  });
+
+  it("stores a local external as an offset along its declared side", () => {
+    const nodes = baseNodes();
+    const dragged = { ...nodes[2], position: { x: 400, y: 307 } };
+    const layout = captureCustomPosition(null, source, dragged, nodes);
+
+    expect(layout?.nodes["external-orders-s3"]).toEqual({
+      kind: "external",
+      cellId: "orders",
+      side: "east",
+      offset: 0.2
+    });
+    expect(applyCustomLayout(nodes, layout).find((node) => node.id === "external-orders-s3")?.position).toEqual({
+      x: 890,
+      y: 306.8
+    });
+  });
+
+  it("projects shared externals outside cell interiors", () => {
+    const nodes = baseNodes();
+    const dragged = { ...nodes[3], position: { x: 300, y: 350 } };
+    const layout = captureCustomPosition(null, source, dragged, nodes);
+    const position = applyCustomLayout(nodes, layout).find((node) => node.id === "external-shared")?.position;
+
+    expect(position).toEqual({ x: 300, y: 94 });
+  });
+
+  it("does not capture gateways or cell boundaries", () => {
+    const nodes = baseNodes();
+    expect(captureCustomPosition(null, source, nodes[0], nodes)).toBeNull();
+    expect(captureCustomPosition(null, source, nodes[4], nodes)).toBeNull();
+  });
+
+  it("round-trips an opaque portable layout line", () => {
+    const layout = captureCustomPosition(null, source, { ...baseNodes()[1], position: { x: 430, y: 510 } }, baseNodes());
+    const portable = serializePortableSource(source, layout);
+
+    expect(portable.split("\n").at(-1)).toMatch(/^# @layout=\S+$/);
+    expect(parsePortableSource(portable)).toEqual({ source, layout, layoutError: false });
+  });
+
+  it("omits metadata for an empty layout", () => {
+    expect(serializePortableSource(source, createCustomLayout(source))).toBe(source);
+  });
+
+  it("ignores malformed, duplicate, and stale metadata", () => {
+    const malformed = `${source}\n${PORTABLE_LAYOUT_PREFIX}garbage`;
+    expect(parsePortableSource(malformed)).toMatchObject({ source, layout: null, layoutError: true });
+
+    const layout = captureCustomPosition(null, source, { ...baseNodes()[1], position: { x: 430, y: 510 } }, baseNodes());
+    const portable = serializePortableSource(source, layout);
+    expect(parsePortableSource(`${portable}\n${portable.split("\n").at(-1)}`)).toMatchObject({
+      source,
+      layout: null,
+      layoutError: true
+    });
+    expect(parsePortableSource(portable.replace("component api", "component changed"))).toMatchObject({
+      layout: null,
+      layoutError: true
+    });
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/customLayout.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/customLayout.ts
@@ -1,0 +1,358 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import LZString from "lz-string";
+import type { Node, XYPosition } from "@xyflow/react";
+import type { BoundaryDirection } from "../domain/cellModel";
+
+export const PORTABLE_LAYOUT_PREFIX = "# @layout=";
+
+const INTERNAL_PADDING = 72;
+const COMPONENT_SIZE = 112;
+const EXTERNAL_SIZE = 106;
+
+type LayoutKind = "component" | "external" | "shared-external";
+
+export type CustomNodePosition =
+  | { kind: "component"; cellId: string; x: number; y: number }
+  | { kind: "external"; cellId: string; side: BoundaryDirection; offset: number }
+  | { kind: "shared-external"; x: number; y: number };
+
+export interface CustomLayout {
+  version: 1;
+  sourceFingerprint: string;
+  nodes: Record<string, CustomNodePosition>;
+}
+
+export interface PortableCellSource {
+  source: string;
+  layout: CustomLayout | null;
+  layoutError: boolean;
+}
+
+interface LayoutNodeData extends Record<string, unknown> {
+  layoutKind?: LayoutKind | "cell" | "gateway";
+  cellId?: string;
+  direction?: BoundaryDirection;
+  width?: number;
+  height?: number;
+}
+
+function cleanSource(source: string) {
+  return source
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .filter((line) => !line.startsWith(PORTABLE_LAYOUT_PREFIX))
+    .join("\n")
+    .trimEnd();
+}
+
+export function fingerprintSource(source: string) {
+  const normalized = cleanSource(source);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < normalized.length; index += 1) {
+    hash ^= normalized.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function createCustomLayout(source: string): CustomLayout {
+  return { version: 1, sourceFingerprint: fingerprintSource(source), nodes: {} };
+}
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), Math.max(minimum, maximum));
+}
+
+function rounded(value: number) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function nodeData(node: Node): LayoutNodeData {
+  return node.data as LayoutNodeData;
+}
+
+function findCell(nodes: Node[], cellId: string) {
+  return nodes.find((node) => node.id === `cell-${cellId}`);
+}
+
+function cellSize(cell: Node) {
+  const data = nodeData(cell);
+  return {
+    width: Number(data.width) || Number(cell.width) || 0,
+    height: Number(data.height) || Number(cell.height) || 0
+  };
+}
+
+function constrainComponent(position: XYPosition, cell: Node) {
+  const { width, height } = cellSize(cell);
+  return {
+    x: clamp(position.x, cell.position.x + INTERNAL_PADDING, cell.position.x + width - INTERNAL_PADDING - COMPONENT_SIZE),
+    y: clamp(position.y, cell.position.y + INTERNAL_PADDING, cell.position.y + height - INTERNAL_PADDING - COMPONENT_SIZE)
+  };
+}
+
+function boxesOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number }
+) {
+  return (
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y
+  );
+}
+
+function projectOutsideCell(position: XYPosition, cell: Node): XYPosition {
+  const { width, height } = cellSize(cell);
+  const nodeBox = { ...position, width: EXTERNAL_SIZE, height: EXTERNAL_SIZE };
+  const cellBox = { ...cell.position, width, height };
+  if (!boxesOverlap(nodeBox, cellBox)) {
+    return position;
+  }
+
+  const candidates = [
+    { x: cell.position.x - EXTERNAL_SIZE, y: position.y },
+    { x: cell.position.x + width, y: position.y },
+    { x: position.x, y: cell.position.y - EXTERNAL_SIZE },
+    { x: position.x, y: cell.position.y + height }
+  ];
+
+  return candidates.reduce((nearest, candidate) => {
+    const nearestDistance = Math.hypot(nearest.x - position.x, nearest.y - position.y);
+    const candidateDistance = Math.hypot(candidate.x - position.x, candidate.y - position.y);
+    return candidateDistance < nearestDistance ? candidate : nearest;
+  });
+}
+
+function constrainSharedExternal(position: XYPosition, nodes: Node[]) {
+  const cells = nodes.filter((node) => nodeData(node).layoutKind === "cell");
+  let constrained = position;
+  for (let pass = 0; pass < Math.max(1, cells.length * 2); pass += 1) {
+    cells.forEach((cell) => {
+      constrained = projectOutsideCell(constrained, cell);
+    });
+  }
+  return constrained;
+}
+
+export function isCustomLayoutNode(node: Node) {
+  const kind = nodeData(node).layoutKind;
+  return kind === "component" || kind === "external" || kind === "shared-external";
+}
+
+export function captureCustomPosition(
+  current: CustomLayout | null,
+  source: string,
+  draggedNode: Node,
+  baseNodes: Node[]
+): CustomLayout | null {
+  const data = nodeData(draggedNode);
+  const kind = data.layoutKind;
+  if (kind !== "component" && kind !== "external" && kind !== "shared-external") {
+    return current;
+  }
+
+  const layout = current ?? createCustomLayout(source);
+  let entry: CustomNodePosition;
+
+  if (kind === "component") {
+    if (!data.cellId) {
+      return current;
+    }
+    const cell = findCell(baseNodes, data.cellId);
+    if (!cell) {
+      return current;
+    }
+    const position = constrainComponent(draggedNode.position, cell);
+    entry = {
+      kind,
+      cellId: data.cellId,
+      x: rounded(position.x - cell.position.x),
+      y: rounded(position.y - cell.position.y)
+    };
+  } else if (kind === "external") {
+    if (!data.cellId || !data.direction) {
+      return current;
+    }
+    const cell = findCell(baseNodes, data.cellId);
+    if (!cell) {
+      return current;
+    }
+    const { width, height } = cellSize(cell);
+    const horizontal = data.direction === "north" || data.direction === "south";
+    const available = horizontal ? width - EXTERNAL_SIZE : height - EXTERNAL_SIZE;
+    const along = horizontal
+      ? draggedNode.position.x - cell.position.x
+      : draggedNode.position.y - cell.position.y;
+    entry = {
+      kind,
+      cellId: data.cellId,
+      side: data.direction,
+      offset: rounded(clamp(available > 0 ? along / available : 0.5, 0, 1))
+    };
+  } else {
+    const position = constrainSharedExternal(draggedNode.position, baseNodes);
+    entry = { kind, x: rounded(position.x), y: rounded(position.y) };
+  }
+
+  return {
+    ...layout,
+    sourceFingerprint: fingerprintSource(source),
+    nodes: { ...layout.nodes, [draggedNode.id]: entry }
+  };
+}
+
+export function applyCustomLayout(baseNodes: Node[], layout: CustomLayout | null): Node[] {
+  if (!layout) {
+    return baseNodes;
+  }
+
+  return baseNodes.map((node) => {
+    const entry = layout.nodes[node.id];
+    const data = nodeData(node);
+    if (!entry || entry.kind !== data.layoutKind) {
+      return node;
+    }
+
+    if (entry.kind === "component") {
+      if (entry.cellId !== data.cellId) {
+        return node;
+      }
+      const cell = findCell(baseNodes, entry.cellId);
+      if (!cell) {
+        return node;
+      }
+      const position = constrainComponent({ x: cell.position.x + entry.x, y: cell.position.y + entry.y }, cell);
+      return { ...node, position };
+    }
+
+    if (entry.kind === "external") {
+      if (entry.cellId !== data.cellId || entry.side !== data.direction) {
+        return node;
+      }
+      const cell = findCell(baseNodes, entry.cellId);
+      if (!cell) {
+        return node;
+      }
+      const { width, height } = cellSize(cell);
+      const offset = clamp(entry.offset, 0, 1);
+      const position = { ...node.position };
+      if (entry.side === "north" || entry.side === "south") {
+        position.x = cell.position.x + offset * (width - EXTERNAL_SIZE);
+      } else {
+        position.y = cell.position.y + offset * (height - EXTERNAL_SIZE);
+      }
+      return { ...node, position };
+    }
+
+    return { ...node, position: constrainSharedExternal({ x: entry.x, y: entry.y }, baseNodes) };
+  });
+}
+
+function isDirection(value: unknown): value is BoundaryDirection {
+  return value === "north" || value === "east" || value === "south" || value === "west";
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isCustomPosition(value: unknown): value is CustomNodePosition {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const position = value as Partial<CustomNodePosition>;
+  if (position.kind === "component") {
+    return typeof position.cellId === "string" && isFiniteNumber(position.x) && isFiniteNumber(position.y);
+  }
+  if (position.kind === "external") {
+    return (
+      typeof position.cellId === "string" &&
+      isDirection(position.side) &&
+      isFiniteNumber(position.offset) &&
+      position.offset >= 0 &&
+      position.offset <= 1
+    );
+  }
+  return position.kind === "shared-external" && isFiniteNumber(position.x) && isFiniteNumber(position.y);
+}
+
+function isCustomLayout(value: unknown): value is CustomLayout {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const layout = value as Partial<CustomLayout>;
+  return (
+    layout.version === 1 &&
+    typeof layout.sourceFingerprint === "string" &&
+    Boolean(layout.nodes) &&
+    typeof layout.nodes === "object" &&
+    !Array.isArray(layout.nodes) &&
+    Object.values(layout.nodes).every(isCustomPosition)
+  );
+}
+
+function encodeLayout(layout: CustomLayout) {
+  return LZString.compressToEncodedURIComponent(JSON.stringify(layout));
+}
+
+function decodeLayout(payload: string): CustomLayout | null {
+  try {
+    const decoded = LZString.decompressFromEncodedURIComponent(payload);
+    if (!decoded) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(decoded);
+    return isCustomLayout(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function serializePortableSource(source: string, layout: CustomLayout | null) {
+  if (!layout && !source.includes(PORTABLE_LAYOUT_PREFIX)) {
+    return source;
+  }
+  const clean = cleanSource(source);
+  if (!layout || Object.keys(layout.nodes).length === 0) {
+    return clean;
+  }
+  const portableLayout = { ...layout, sourceFingerprint: fingerprintSource(clean) };
+  return `${clean}\n${PORTABLE_LAYOUT_PREFIX}${encodeLayout(portableLayout)}`;
+}
+
+export function parsePortableSource(portableSource: string): PortableCellSource {
+  const lines = portableSource.replace(/\r\n/g, "\n").split("\n");
+  const metadataLines = lines.filter((line) => line.startsWith(PORTABLE_LAYOUT_PREFIX));
+  if (metadataLines.length === 0) {
+    return { source: portableSource, layout: null, layoutError: false };
+  }
+  const source = lines
+    .filter((line) => !line.startsWith(PORTABLE_LAYOUT_PREFIX))
+    .join("\n")
+    .trimEnd();
+  const payload = metadataLines.at(-1)!.slice(PORTABLE_LAYOUT_PREFIX.length);
+  const layout = decodeLayout(payload);
+  if (!layout || metadataLines.length > 1 || layout.sourceFingerprint !== fingerprintSource(source)) {
+    return { source, layout: null, layoutError: true };
+  }
+  return { source, layout, layoutError: false };
+}

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css
@@ -1,11 +1,150 @@
-:root {
-  --muted: #64748b;
-  --line: #d6dee8;
-  --north: #0284c7;
-  --east: #ea580c;
-  --south: #059669;
-  --west: #7c3aed;
+/*
+ * Theme token layer.
+ *
+ * Every color the diagram renders is defined here as a `--cd-*` custom property
+ * so consumers can retheme the diagram with plain CSS (see README "Theming").
+ * Light values below are the diagram's original palette, so light mode renders
+ * identically to before theming existed. The `[data-cd-theme="dark"]` block
+ * further down overrides the same tokens for dark mode.
+ *
+ * `:where(...)` keeps the defaults at zero specificity so a single
+ * `.cell-diagram-root { --cd-node-border: ... }` from a consumer wins.
+ */
+:where(.cell-diagram-root) {
+  /* text */
+  --cd-title-text: #0f172a;
+  --cd-node-text: #172033;
+  --cd-body-text: #334155;
+  --cd-muted-text: #64748b;
+  --cd-subtle-text: #475569;
+  --cd-disabled-text: #94a3b8;
+  --cd-boundary-color: #263447;
+
+  /* surfaces */
+  --cd-surface: #ffffff;
+  --cd-surface-hover: #f1f5f9;
+  --cd-canvas-bg: #f8fafc;
+  --cd-chip-bg: rgba(255, 255, 255, 0.88);
+  --cd-chip-bg-strong: rgba(255, 255, 255, 0.92);
+  --cd-title-bg: rgba(255, 255, 255, 0.86);
+
+  /* lines & borders */
+  --cd-line: #d6dee8;
+  --cd-line-strong: #cbd5e1;
+  --cd-node-border: #334155;
+  --cd-external-border: #64748b;
+  --cd-dots: #cbd5e1;
+
+  /* boundary zones / directions */
+  --cd-north: #0284c7;
+  --cd-east: #ea580c;
+  --cd-south: #059669;
+  --cd-west: #7c3aed;
+  --cd-cross: #7c3aed;
+  --cd-edge: #475569;
+
+  /* shadows */
+  --cd-shadow-controls: 0 4px 12px rgba(15, 23, 42, 0.1);
+  --cd-shadow-node: 0 10px 28px rgba(15, 23, 42, 0.12);
+  --cd-shadow-external: 0 14px 30px rgba(15, 23, 42, 0.1);
+  --cd-shadow-gateway: 0 8px 18px rgba(15, 23, 42, 0.18);
+  --cd-shadow-chip: 0 10px 26px rgba(15, 23, 42, 0.1);
+  --cd-shadow-info: 0 10px 28px rgba(15, 23, 42, 0.2);
+  --cd-highlight-ring: 0 0 0 6px rgba(14, 165, 233, 0.18), 0 18px 34px rgba(15, 23, 42, 0.2);
+  --cd-highlight-edge-shadow: drop-shadow(0 2px 5px rgba(15, 23, 42, 0.24));
+
+  /* notification: focus hint (active) */
+  --cd-hint-active-text: #0f172a;
+  --cd-hint-active-border: #93c5fd;
+  --cd-hint-active-shadow: 0 12px 30px rgba(37, 99, 235, 0.16);
+
+  /* notification: warning */
+  --cd-warn-text: #854d0e;
+  --cd-warn-bg: rgba(254, 249, 195, 0.96);
+  --cd-warn-border: #facc15;
+  --cd-warn-shadow: 0 12px 30px rgba(113, 63, 18, 0.2);
+
+  /* notification: info */
+  --cd-info-text: #ffffff;
+  --cd-info-bg: #334155;
+  --cd-info-border: #334155;
+
+  /* motion */
   --panel-edge-offset: 14px;
+  --diagram-layout-duration: 300ms;
+  --diagram-node-enter-duration: 360ms;
+  --diagram-edge-enter-duration: 220ms;
+  --diagram-edge-enter-delay: 80ms;
+  --diagram-layout-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --diagram-arrive-ease: cubic-bezier(0.16, 1.28, 0.3, 1);
+}
+
+.cell-diagram-root[data-cd-theme="dark"] {
+  /* text */
+  --cd-title-text: #e2e8f0;
+  --cd-node-text: #e2e8f0;
+  --cd-body-text: #cbd5e1;
+  --cd-muted-text: #94a3b8;
+  --cd-subtle-text: #cbd5e1;
+  --cd-disabled-text: #64748b;
+  --cd-boundary-color: #cbd5e1;
+
+  /* surfaces */
+  --cd-surface: #1e293b;
+  --cd-surface-hover: #334155;
+  --cd-canvas-bg: #0f172a;
+  --cd-chip-bg: rgba(30, 41, 59, 0.88);
+  --cd-chip-bg-strong: rgba(30, 41, 59, 0.92);
+  --cd-title-bg: rgba(30, 41, 59, 0.86);
+
+  /* lines & borders */
+  --cd-line: #334155;
+  --cd-line-strong: #475569;
+  --cd-node-border: #64748b;
+  --cd-external-border: #94a3b8;
+  --cd-dots: #334155;
+
+  /* boundary zones / directions (brightened for dark backgrounds) */
+  --cd-north: #38bdf8;
+  --cd-east: #fb923c;
+  --cd-south: #34d399;
+  --cd-west: #a78bfa;
+  --cd-cross: #a78bfa;
+  --cd-edge: #94a3b8;
+
+  /* shadows */
+  --cd-shadow-controls: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --cd-shadow-node: 0 10px 28px rgba(0, 0, 0, 0.45);
+  --cd-shadow-external: 0 14px 30px rgba(0, 0, 0, 0.4);
+  --cd-shadow-gateway: 0 8px 18px rgba(0, 0, 0, 0.5);
+  --cd-shadow-chip: 0 10px 26px rgba(0, 0, 0, 0.45);
+  --cd-shadow-info: 0 10px 28px rgba(0, 0, 0, 0.5);
+  --cd-highlight-ring: 0 0 0 6px rgba(56, 189, 248, 0.25), 0 18px 34px rgba(0, 0, 0, 0.5);
+  --cd-highlight-edge-shadow: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6));
+
+  /* notification: focus hint (active) */
+  --cd-hint-active-text: #f8fafc;
+  --cd-hint-active-border: #38bdf8;
+  --cd-hint-active-shadow: 0 12px 30px rgba(56, 189, 248, 0.24);
+
+  /* notification: warning */
+  --cd-warn-text: #fde68a;
+  --cd-warn-bg: rgba(66, 32, 6, 0.96);
+  --cd-warn-border: #b45309;
+  --cd-warn-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+
+  /* notification: info */
+  --cd-info-text: #0f172a;
+  --cd-info-bg: #cbd5e1;
+  --cd-info-border: #cbd5e1;
+
+  /* drive react-flow's own canvas background from the theme */
+  --xy-background-color: var(--cd-canvas-bg);
+}
+
+.cell-diagram-root {
+  width: 100%;
+  height: 100%;
 }
 
 .zoom-controls {
@@ -17,10 +156,10 @@
   align-items: center;
   gap: 4px;
   padding: 4px 6px;
-  background: #ffffff;
-  border: 1px solid var(--line);
+  background: var(--cd-surface);
+  border: 1px solid var(--cd-line);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+  box-shadow: var(--cd-shadow-controls);
 }
 
 .zoom-controls__button {
@@ -28,7 +167,7 @@
   height: 26px;
   display: grid;
   place-items: center;
-  color: #334155;
+  color: var(--cd-body-text);
   background: transparent;
   border: 0;
   border-radius: 6px;
@@ -36,25 +175,56 @@
 }
 
 .zoom-controls__button:hover {
-  background: #f1f5f9;
+  background: var(--cd-surface-hover);
 }
 
 .zoom-controls__level {
   min-width: 34px;
   text-align: center;
-  color: #475569;
+  color: var(--cd-subtle-text);
   font-size: 11px;
   font-weight: 750;
+}
+
+.zoom-controls__auto {
+  min-height: 26px;
+  margin-left: 2px;
+  padding: 0 8px;
+  color: var(--cd-body-text);
+  background: transparent;
+  border-left: 1px solid var(--cd-line);
+  border-radius: 0 6px 6px 0;
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.zoom-controls__auto:hover:not(:disabled) {
+  background: var(--cd-surface-hover);
+}
+
+.zoom-controls__auto:disabled {
+  color: var(--cd-disabled-text);
+  cursor: not-allowed;
 }
 
 .cell-boundary {
   position: relative;
   aspect-ratio: 1;
-  color: #263447;
+  color: var(--cd-boundary-color);
   background: transparent;
   border: 0;
   overflow: visible;
   pointer-events: none;
+}
+
+.diagram-node--position-animated {
+  transition: transform var(--diagram-layout-duration) var(--diagram-layout-ease);
+}
+
+.diagram-node--position-animated .cell-boundary {
+  transition:
+    width var(--diagram-layout-duration) var(--diagram-layout-ease),
+    height var(--diagram-layout-duration) var(--diagram-layout-ease);
 }
 
 .cell-boundary__outline {
@@ -74,9 +244,9 @@
   align-items: center;
   gap: 10px;
   padding: 8px 14px;
-  color: #0f172a;
-  background: rgba(255, 255, 255, 0.86);
-  border: 1px solid #d6dee8;
+  color: var(--cd-title-text);
+  background: var(--cd-title-bg);
+  border: 1px solid var(--cd-line);
   border-radius: 8px;
   font-weight: 900;
   white-space: nowrap;
@@ -84,7 +254,7 @@
 }
 
 .cell-boundary__title small {
-  color: var(--muted);
+  color: var(--cd-muted-text);
   font-size: 12px;
   font-weight: 800;
 }
@@ -93,9 +263,9 @@
   position: absolute;
   z-index: 1;
   padding: 5px 9px;
-  color: #334155;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid #d6dee8;
+  color: var(--cd-body-text);
+  background: var(--cd-chip-bg);
+  border: 1px solid var(--cd-line);
   border-radius: 999px;
   font-size: 11px;
   font-weight: 900;
@@ -107,28 +277,28 @@
 .cell-gate-label--north {
   left: 30%;
   top: -30px;
-  color: var(--north);
+  color: var(--cd-north);
   transform: translateX(-50%);
 }
 
 .cell-gate-label--east {
   right: -54px;
   top: 28%;
-  color: var(--east);
+  color: var(--cd-east);
   transform: translateY(-50%) rotate(90deg);
 }
 
 .cell-gate-label--south {
   left: 70%;
   bottom: -30px;
-  color: var(--south);
+  color: var(--cd-south);
   transform: translateX(-50%);
 }
 
 .cell-gate-label--west {
   left: -54px;
   top: 72%;
-  color: var(--west);
+  color: var(--cd-west);
   transform: translateY(-50%) rotate(-90deg);
 }
 
@@ -141,11 +311,11 @@
   place-items: center;
   padding: 14px;
   text-align: center;
-  color: #172033;
-  background: #ffffff;
-  border: 2px solid #334155;
+  color: var(--cd-node-text);
+  background: var(--cd-surface);
+  border: 2px solid var(--cd-node-border);
   border-radius: 50%;
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--cd-shadow-node);
 }
 
 .component-node span {
@@ -157,7 +327,7 @@
 }
 
 .component-node small {
-  color: var(--muted);
+  color: var(--cd-muted-text);
   max-width: 78px;
   font-size: 10px;
   font-weight: 800;
@@ -174,15 +344,15 @@
   place-items: center;
   padding: 13px;
   text-align: center;
-  background: #ffffff;
-  border: 2px solid #64748b;
+  background: var(--cd-surface);
+  border: 2px solid var(--cd-external-border);
   border-radius: 50%;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.1);
+  box-shadow: var(--cd-shadow-external);
 }
 
 .external-node span {
   max-width: 80px;
-  color: #172033;
+  color: var(--cd-node-text);
   font-size: 12px;
   font-weight: 850;
   line-height: 1.1;
@@ -190,7 +360,7 @@
 }
 
 .external-node small {
-  color: var(--muted);
+  color: var(--cd-muted-text);
   max-width: 78px;
   font-size: 10px;
   font-weight: 800;
@@ -199,44 +369,68 @@
 }
 
 .external-node--north {
-  border-color: var(--north);
+  border-color: var(--cd-north);
 }
 
 .external-node--east {
-  border-color: var(--east);
+  border-color: var(--cd-east);
 }
 
 .external-node--south {
-  border-color: var(--south);
+  border-color: var(--cd-south);
 }
 
 .external-node--west {
-  border-color: var(--west);
+  border-color: var(--cd-west);
 }
 
 .gateway-node {
   width: 34px;
   height: 34px;
-  background: #ffffff;
-  border: 4px solid #334155;
+  background: var(--cd-surface);
+  border: 4px solid var(--cd-node-border);
   border-radius: 50%;
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--cd-shadow-gateway);
 }
 
 .gateway-node--north {
-  border-color: var(--north);
+  border-color: var(--cd-north);
 }
 
 .gateway-node--east {
-  border-color: var(--east);
+  border-color: var(--cd-east);
 }
 
 .gateway-node--south {
-  border-color: var(--south);
+  border-color: var(--cd-south);
 }
 
 .gateway-node--west {
-  border-color: var(--west);
+  border-color: var(--cd-west);
+}
+
+.diagram-node--entering .component-node,
+.diagram-node--entering .external-node,
+.diagram-node--entering .gateway-node {
+  transform-origin: center;
+  animation: diagram-node-arrive var(--diagram-node-enter-duration) var(--diagram-arrive-ease) backwards;
+}
+
+@keyframes diagram-node-arrive {
+  0% {
+    opacity: 0;
+    transform: scale(0.68);
+  }
+
+  68% {
+    opacity: 1;
+    transform: scale(1.045);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .react-flow__handle {
@@ -249,9 +443,9 @@
   position: absolute;
   max-width: 150px;
   padding: 4px 7px;
-  color: #334155;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid #d6dee8;
+  color: var(--cd-body-text);
+  background: var(--cd-chip-bg);
+  border: 1px solid var(--cd-line);
   border-radius: 999px;
   font-size: 11px;
   font-weight: 800;
@@ -259,31 +453,63 @@
 }
 
 .react-flow__edge-path {
-  stroke: #475569;
+  stroke: var(--cd-edge);
   stroke-width: 2;
   transition: stroke-width 140ms ease, opacity 140ms ease, filter 140ms ease;
 }
 
+.diagram-edge--entering .react-flow__edge-path {
+  animation: diagram-edge-arrive var(--diagram-edge-enter-duration) ease-out var(--diagram-edge-enter-delay) backwards;
+}
+
+.edge-label--entering {
+  animation: diagram-edge-label-arrive 150ms ease-out 160ms backwards;
+}
+
+@keyframes diagram-edge-arrive {
+  0% {
+    opacity: 0;
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+  }
+
+  20% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 1;
+    stroke-dasharray: 1;
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes diagram-edge-label-arrive {
+  from {
+    opacity: 0;
+  }
+}
+
 .edge-north .react-flow__edge-path {
-  stroke: var(--north);
+  stroke: var(--cd-north);
 }
 
 .edge-east .react-flow__edge-path {
-  stroke: var(--east);
+  stroke: var(--cd-east);
 }
 
 .edge-south .react-flow__edge-path {
-  stroke: var(--south);
+  stroke: var(--cd-south);
 }
 
 .edge-west .react-flow__edge-path {
-  stroke: var(--west);
+  stroke: var(--cd-west);
 }
 
 .connection-highlight-edge .react-flow__edge-path {
   opacity: 1;
   stroke-width: 4;
-  filter: drop-shadow(0 2px 5px rgba(15, 23, 42, 0.24));
+  filter: var(--cd-highlight-edge-shadow);
 }
 
 .connection-dimmed-edge .react-flow__edge-path {
@@ -293,7 +519,7 @@
 .connection-highlight-node .component-node,
 .connection-highlight-node .external-node,
 .connection-highlight-node .gateway-node {
-  box-shadow: 0 0 0 6px rgba(14, 165, 233, 0.18), 0 18px 34px rgba(15, 23, 42, 0.2);
+  box-shadow: var(--cd-highlight-ring);
 }
 
 .connection-dimmed-node .component-node,
@@ -302,45 +528,86 @@
   opacity: 0.34;
 }
 
-.focus-hint {
+.canvas-notification {
   position: absolute;
   left: 50%;
   bottom: 18px;
   z-index: 5;
+  width: max-content;
+  max-width: min(620px, calc(100% - 32px));
   transform: translateX(-50%);
   padding: 8px 12px;
-  color: #334155;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid #d6dee8;
+  color: var(--cd-body-text);
+  background: var(--cd-chip-bg-strong);
+  border: 1px solid var(--cd-line);
   border-radius: 999px;
-  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.1);
+  box-shadow: var(--cd-shadow-chip);
   font-size: 12px;
   font-weight: 850;
+  line-height: 1.4;
   pointer-events: none;
+  text-align: center;
+}
+
+.canvas-notification[data-mode="hint"] {
   white-space: nowrap;
 }
 
-.focus-hint[data-focus-mode="active"] {
-  color: #0f172a;
-  border-color: #93c5fd;
-  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.16);
+.canvas-notification[data-mode="hint"][data-focus-mode="active"] {
+  color: var(--cd-hint-active-text);
+  border-color: var(--cd-hint-active-border);
+  box-shadow: var(--cd-hint-active-shadow);
+}
+
+.canvas-notification[data-mode="message"] {
+  border-radius: 10px;
+  font-weight: 750;
+  animation: canvas-notification-pop 180ms ease-out;
+}
+
+.canvas-notification[data-tone="warning"] {
+  color: var(--cd-warn-text);
+  background: var(--cd-warn-bg);
+  border: 1px solid var(--cd-warn-border);
+  box-shadow: var(--cd-warn-shadow);
+}
+
+.canvas-notification[data-tone="info"] {
+  color: var(--cd-info-text);
+  background: var(--cd-info-bg);
+  border-color: var(--cd-info-border);
+  box-shadow: var(--cd-shadow-info);
+}
+
+@keyframes canvas-notification-pop {
+  from {
+    opacity: 0;
+    scale: 0.96;
+    translate: 0 6px;
+  }
+
+  to {
+    opacity: 1;
+    scale: 1;
+    translate: 0 0;
+  }
 }
 
 .empty-canvas {
   height: 100%;
   display: grid;
   place-items: center;
-  color: #64748b;
-  background: #f8fafc;
+  color: var(--cd-muted-text);
+  background: var(--cd-canvas-bg);
   font-weight: 800;
 }
 
 .export-controls { position: absolute; top: 16px; right: 16px; z-index: 5; display: flex; gap: 6px; }
-.export-controls__button { padding: 6px 10px; font-size: 12px; font-weight: 600; border-radius: 8px; border: 1px solid #cbd5e1; background: #ffffff; color: #334155; cursor: pointer; }
-.export-controls__button:hover { background: #f1f5f9; }
+.export-controls__button { padding: 6px 10px; font-size: 12px; font-weight: 600; border-radius: 8px; border: 1px solid var(--cd-line-strong); background: var(--cd-surface); color: var(--cd-body-text); cursor: pointer; }
+.export-controls__button:hover { background: var(--cd-surface-hover); }
 
 .react-flow__edge.edge-cross .react-flow__edge-path {
-  stroke: #7c3aed;
+  stroke: var(--cd-cross);
   stroke-width: 2;
   stroke-dasharray: 6 4;
 }
@@ -351,11 +618,32 @@
     bottom: 8px;
   }
 
-  .focus-hint {
+  .canvas-notification {
     left: 8px;
     right: 8px;
     bottom: 54px;
+    width: auto;
+    max-width: none;
     transform: none;
     text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-notification[data-mode="message"] {
+    animation: none;
+  }
+
+  .diagram-node--position-animated,
+  .diagram-node--position-animated .cell-boundary {
+    transition: none;
+  }
+
+  .diagram-node--entering .component-node,
+  .diagram-node--entering .external-node,
+  .diagram-node--entering .gateway-node,
+  .diagram-edge--entering .react-flow__edge-path,
+  .edge-label--entering {
+    animation: none;
   }
 }

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css
@@ -221,6 +221,13 @@
   transition: transform var(--diagram-layout-duration) var(--diagram-layout-ease);
 }
 
+/* AEP divergence from upstream: while a node is under the pointer (React Flow
+   marks it `.dragging`), the layout transition would ease every pointer-move
+   transform and make the node trail and stutter — track the pointer directly. */
+.react-flow__node.dragging {
+  transition: none;
+}
+
 .diagram-node--position-animated .cell-boundary {
   transition:
     width var(--diagram-layout-duration) var(--diagram-layout-ease),

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
@@ -28,6 +28,14 @@ function ruleFor(selector: string) {
   return styles.match(pattern)?.[0] ?? "";
 }
 
+const lightTokenBlock = styles.match(/:where\(\.cell-diagram-root\) \{[\s\S]*?\n\}/)?.[0] ?? "";
+const darkTokenBlock =
+  styles.match(/\.cell-diagram-root\[data-cd-theme="dark"\] \{[\s\S]*?\n\}/)?.[0] ?? "";
+
+function themeTokensIn(block: string) {
+  return new Set([...block.matchAll(/(--cd-[a-z-]+):/g)].map((match) => match[1]));
+}
+
 describe("diagram interaction styles", () => {
   it("does not resize nodes while highlighting connections", () => {
     const highlightRule = styles.match(/\.connection-highlight-node \.component-node,[\s\S]*?\}/)?.[0] ?? "";
@@ -43,5 +51,48 @@ describe("diagram interaction styles", () => {
     expect(componentRule).not.toContain("text-transform:");
     expect(externalRule).toContain("font-size: 10px;");
     expect(externalRule).not.toContain("text-transform:");
+  });
+
+  it("defines a coherent live-edit motion sequence", () => {
+    expect(ruleFor(".diagram-node--position-animated")).toContain("transition: transform");
+    expect(styles).toContain("@keyframes diagram-node-arrive");
+    expect(styles).toContain("@keyframes diagram-edge-arrive");
+    expect(styles).toContain("--diagram-edge-enter-delay: 80ms;");
+  });
+
+  it("visually distinguishes temporary layout state and disabled auto arrange", () => {
+    expect(ruleFor(".canvas-notification")).toContain("position: absolute;");
+    expect(ruleFor(".canvas-notification")).toContain("pointer-events: none;");
+    expect(ruleFor('.canvas-notification[data-tone="warning"]')).toContain("var(--cd-warn-border)");
+    expect(ruleFor('.canvas-notification[data-mode="message"]')).toContain("canvas-notification-pop");
+    expect(ruleFor(".zoom-controls__auto:disabled")).toContain("cursor: not-allowed;");
+  });
+
+  it("keeps every rendered color behind a theme token", () => {
+    expect(lightTokenBlock).not.toBe("");
+    expect(darkTokenBlock).not.toBe("");
+
+    const rules = styles.replace(lightTokenBlock, "").replace(darkTokenBlock, "");
+
+    expect(rules).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(rules).not.toMatch(/\brgba?\(/);
+  });
+
+  it("overrides every light token in the dark theme", () => {
+    const lightTokens = themeTokensIn(lightTokenBlock);
+    const darkTokens = themeTokensIn(darkTokenBlock);
+
+    expect(lightTokens.size).toBeGreaterThan(0);
+    const missing = [...lightTokens].filter((token) => !darkTokens.has(token));
+    expect(missing).toEqual([]);
+  });
+
+  it("turns diagram construction motion off for reduced-motion users", () => {
+    const reducedMotionRule = styles.match(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n\}/)?.[0] ?? "";
+
+    expect(reducedMotionRule).toContain(".diagram-node--position-animated");
+    expect(reducedMotionRule).toContain("transition: none;");
+    expect(reducedMotionRule).toContain(".diagram-edge--entering .react-flow__edge-path");
+    expect(reducedMotionRule).toContain("animation: none;");
   });
 });

--- a/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/diagram.css.test.ts
@@ -60,6 +60,13 @@ describe("diagram interaction styles", () => {
     expect(styles).toContain("--diagram-edge-enter-delay: 80ms;");
   });
 
+  // AEP divergence from upstream: without this exemption the layout transition
+  // eases every pointer-move transform of the node being dragged, so it trails
+  // and stutters instead of tracking the pointer.
+  it("exempts the actively dragged node from the layout transition", () => {
+    expect(ruleFor(".react-flow__node.dragging")).toContain("transition: none;");
+  });
+
   it("visually distinguishes temporary layout state and disabled auto arrange", () => {
     expect(ruleFor(".canvas-notification")).toContain("position: absolute;");
     expect(ruleFor(".canvas-notification")).toContain("pointer-events: none;");

--- a/packages/ui/cell-diagram-react/src/renderer/diagramMotion.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/diagramMotion.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { classifyDiagramMotion } from "./diagramMotion";
+
+function node(id: string, type = "component", motionKey?: string): Node {
+  return { id, type, position: { x: 0, y: 0 }, data: { motionKey } };
+}
+
+function edge(id: string, source: string, target: string, label?: string): Edge {
+  return { id, source, target, type: "smoothstep", label };
+}
+
+describe("classifyDiagramMotion", () => {
+  it("does not animate every element on the first render", () => {
+    const result = classifyDiagramMotion(null, [node("cell-main", "cellBoundary"), node("api")], [], "doc-1");
+
+    expect(result.enteringNodeIds).toEqual(new Set());
+    expect(result.movingNodeIds).toEqual(new Set());
+    expect(result.enteringEdgeIds).toEqual(new Set());
+  });
+
+  it("classifies new circles and connections while keeping surviving nodes movable", () => {
+    const initial = classifyDiagramMotion(null, [node("cell-main", "cellBoundary"), node("api")], [], "doc-1");
+    const next = classifyDiagramMotion(
+      initial.snapshot,
+      [node("cell-main", "cellBoundary"), node("api"), node("worker")],
+      [edge("internal-api-worker-4", "api", "worker")],
+      "doc-1"
+    );
+
+    expect(next.enteringNodeIds).toEqual(new Set(["worker"]));
+    expect(next.movingNodeIds).toEqual(new Set(["cell-main", "api"]));
+    expect(next.enteringEdgeIds).toEqual(new Set(["internal-api-worker-4"]));
+  });
+
+  it("uses connection semantics instead of line-number-based edge ids", () => {
+    const initial = classifyDiagramMotion(
+      null,
+      [node("api"), node("db")],
+      [edge("internal-api-db-3", "api", "db")],
+      "doc-1"
+    );
+    const next = classifyDiagramMotion(
+      initial.snapshot,
+      [node("api"), node("db"), node("worker")],
+      [edge("internal-api-db-4", "api", "db")],
+      "doc-1"
+    );
+
+    expect(next.enteringEdgeIds).toEqual(new Set());
+  });
+
+  it("does not treat label-only changes as new graph elements", () => {
+    const initial = classifyDiagramMotion(
+      null,
+      [node("api"), node("db")],
+      [edge("internal-api-db-3", "api", "db", "calls")],
+      "doc-1"
+    );
+    const next = classifyDiagramMotion(
+      initial.snapshot,
+      [node("api"), node("db")],
+      [edge("internal-api-db-3", "api", "db", "requests")],
+      "doc-1"
+    );
+
+    expect(next.enteringNodeIds).toEqual(new Set());
+    expect(next.enteringEdgeIds).toEqual(new Set());
+  });
+
+  it("does not replay a circle entrance while an identifier is being renamed", () => {
+    const initial = classifyDiagramMotion(
+      null,
+      [node("cell-main", "cellBoundary"), node("W", "component", "main:component:2")],
+      [],
+      "doc-1"
+    );
+    const nextKeystroke = classifyDiagramMotion(
+      initial.snapshot,
+      [node("cell-main", "cellBoundary"), node("Wo", "component", "main:component:2")],
+      [],
+      "doc-1"
+    );
+
+    expect(nextKeystroke.enteringNodeIds).toEqual(new Set());
+  });
+
+  it("still animates a new component inserted on a line previously occupied by an existing component", () => {
+    const initial = classifyDiagramMotion(
+      null,
+      [node("API", "component", "main:component:2")],
+      [],
+      "doc-1"
+    );
+    const inserted = classifyDiagramMotion(
+      initial.snapshot,
+      [node("Worker", "component", "main:component:2"), node("API", "component", "main:component:3")],
+      [],
+      "doc-1"
+    );
+
+    expect(inserted.enteringNodeIds).toEqual(new Set(["Worker"]));
+  });
+
+  it("does not replay connections when a connected identifier is renamed", () => {
+    const initial = classifyDiagramMotion(
+      null,
+      [node("Worker", "component", "main:component:1"), node("DB", "component", "main:component:2")],
+      [edge("internal-Worker-DB-3", "Worker", "DB")],
+      "doc-1"
+    );
+    const renamed = classifyDiagramMotion(
+      initial.snapshot,
+      [node("JobRunner", "component", "main:component:1"), node("DB", "component", "main:component:2")],
+      [edge("internal-JobRunner-DB-3", "JobRunner", "DB")],
+      "doc-1"
+    );
+
+    expect(renamed.enteringNodeIds).toEqual(new Set());
+    expect(renamed.enteringEdgeIds).toEqual(new Set());
+  });
+
+  it("resets motion history when the document context changes", () => {
+    const initial = classifyDiagramMotion(null, [node("api")], [], "doc-1");
+    const next = classifyDiagramMotion(initial.snapshot, [node("api"), node("worker")], [], "doc-2");
+
+    expect(next.enteringNodeIds).toEqual(new Set());
+    expect(next.movingNodeIds).toEqual(new Set());
+  });
+});

--- a/packages/ui/cell-diagram-react/src/renderer/diagramMotion.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/diagramMotion.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+
+export interface DiagramMotionSnapshot {
+  contextKey: string;
+  nodeIds: Set<string>;
+  nodeIdsByMotionKey: Map<string, string>;
+  edgeKeys: Set<string>;
+}
+
+export interface DiagramMotionClassification {
+  enteringNodeIds: Set<string>;
+  movingNodeIds: Set<string>;
+  enteringEdgeIds: Set<string>;
+  snapshot: DiagramMotionSnapshot;
+}
+
+function edgeMotionEntries(edges: Edge[]) {
+  const occurrences = new Map<string, number>();
+
+  return edges.map((edge) => {
+    const signature = [edge.source, edge.sourceHandle, edge.target, edge.targetHandle, edge.type].join("|");
+    const occurrence = occurrences.get(signature) ?? 0;
+    occurrences.set(signature, occurrence + 1);
+
+    return { id: edge.id, key: `${signature}|${occurrence}` };
+  });
+}
+
+function nodeMotionKey(node: Node) {
+  const motionKey = node.data?.motionKey;
+  return typeof motionKey === "string" && motionKey ? motionKey : `id:${node.id}`;
+}
+
+export function classifyDiagramMotion(
+  previous: DiagramMotionSnapshot | null,
+  nodes: Node[],
+  edges: Edge[],
+  contextKey: string
+): DiagramMotionClassification {
+  const edgeEntries = edgeMotionEntries(edges);
+  const snapshot: DiagramMotionSnapshot = {
+    contextKey,
+    nodeIds: new Set(nodes.map((node) => node.id)),
+    nodeIdsByMotionKey: new Map(nodes.map((node) => [nodeMotionKey(node), node.id])),
+    edgeKeys: new Set(edgeEntries.map((edge) => edge.key))
+  };
+
+  if (!previous || previous.contextKey !== contextKey) {
+    return {
+      enteringNodeIds: new Set(),
+      movingNodeIds: new Set(),
+      enteringEdgeIds: new Set(),
+      snapshot
+    };
+  }
+
+  const currentNodeIds = snapshot.nodeIds;
+  const isExistingNode = (node: Node) => {
+    if (previous.nodeIds.has(node.id)) {
+      return true;
+    }
+
+    const previousIdOnSameSourceLine = previous.nodeIdsByMotionKey.get(nodeMotionKey(node));
+    return Boolean(previousIdOnSameSourceLine && !currentNodeIds.has(previousIdOnSameSourceLine));
+  };
+  const hasRenamedNode = nodes.some((node) => !previous.nodeIds.has(node.id) && isExistingNode(node));
+  const isConnectedRename = hasRenamedNode && edgeEntries.length === previous.edgeKeys.size;
+
+  return {
+    enteringNodeIds: new Set(
+      nodes
+        .filter((node) => node.type !== "cellBoundary" && !isExistingNode(node))
+        .map((node) => node.id)
+    ),
+    movingNodeIds: new Set(nodes.filter(isExistingNode).map((node) => node.id)),
+    enteringEdgeIds: new Set(
+      isConnectedRename
+        ? []
+        : edgeEntries.filter((edge) => !previous.edgeKeys.has(edge.key)).map((edge) => edge.id)
+    ),
+    snapshot
+  };
+}

--- a/packages/ui/cell-diagram-react/src/renderer/flowLayout.test.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/flowLayout.test.ts
@@ -307,7 +307,7 @@ describe("toReactFlow", () => {
     expect(internalEdge?.type).toBe("floating");
     // A React Flow arrow marker (orient="auto") is used so it aligns to the path tangent.
     expect(internalEdge?.markerEnd).toEqual(
-      expect.objectContaining({ type: "arrow", color: "#475569" })
+      expect.objectContaining({ type: "arrow", color: "var(--cd-edge)" })
     );
   });
 
@@ -345,7 +345,7 @@ describe("toReactFlow", () => {
     // The terminal segment landing on the external carries the colored arrow marker.
     expect(gatewayExternal?.type).toBe("smoothstep");
     expect(gatewayExternal?.markerEnd).toEqual(
-      expect.objectContaining({ type: "arrow", color: "#ea580c" })
+      expect.objectContaining({ type: "arrow", color: "var(--cd-east)" })
     );
   });
 
@@ -656,5 +656,33 @@ cell products {
     expect(middleSegment?.target).toBe("gateway-products-north");
     const lastSegment = flow.edges.find((e) => e.id === "x2-gateway-component");
     expect(lastSegment?.targetHandle).toBe("component-top-target");
+  });
+
+  it("marks only manually arrangeable node kinds as draggable", () => {
+    const project = compileProject(`
+cell orders {
+  component api
+  api -> east stripe
+  api -> products.api
+}
+cell products {
+  component api
+}
+`).model;
+    expect(project).not.toBeNull();
+
+    const flow = toReactFlow(project!);
+    const component = flow.nodes.find((node) => node.id === "orders::api");
+    const external = flow.nodes.find((node) => node.id === "external-orders-stripe");
+    const cell = flow.nodes.find((node) => node.id === "cell-orders");
+    const gateway = flow.nodes.find((node) => node.id === "gateway-orders-east");
+
+    expect(component).toMatchObject({ draggable: true, data: { layoutKind: "component", cellId: "orders" } });
+    expect(external).toMatchObject({
+      draggable: true,
+      data: { layoutKind: "external", cellId: "orders", direction: "east" }
+    });
+    expect(cell).toMatchObject({ draggable: false, data: { layoutKind: "cell", cellId: "orders" } });
+    expect(gateway).toMatchObject({ draggable: false, data: { layoutKind: "gateway", cellId: "orders" } });
   });
 });

--- a/packages/ui/cell-diagram-react/src/renderer/flowLayout.ts
+++ b/packages/ui/cell-diagram-react/src/renderer/flowLayout.ts
@@ -239,15 +239,17 @@ function connectionData(connectionId: string, connectedNodeIds: string[]) {
   };
 }
 
-// Arrow-head colors mirror the per-direction edge stroke colors in diagram.css.
+// Arrow-head colors reference the same theme tokens as the edge strokes in
+// diagram.css. The markers render inside `.cell-diagram-root`, so these CSS
+// variables resolve to the active (light/dark) theme automatically.
 const EDGE_ARROW_COLORS: Record<string, string> = {
-  north: "#0284c7",
-  east: "#ea580c",
-  south: "#059669",
-  west: "#7c3aed"
+  north: "var(--cd-north)",
+  east: "var(--cd-east)",
+  south: "var(--cd-south)",
+  west: "var(--cd-west)"
 };
-const DEFAULT_ARROW_COLOR = "#475569";
-const CROSS_ARROW_COLOR = "#7c3aed";
+const DEFAULT_ARROW_COLOR = "var(--cd-edge)";
+const CROSS_ARROW_COLOR = "var(--cd-cross)";
 
 // A React Flow arrow marker (orient="auto" so it aligns to the path tangent),
 // colored to match the edge. Used on the terminal segment of each logical edge.
@@ -270,6 +272,18 @@ function directionArrow(direction: string) {
 
 function namespaced(cellId: string, id: string, multi: boolean) {
   return multi ? `${cellId}::${id}` : id;
+}
+
+function motionKeyForLine(cellId: string, kind: "component" | "external", line: number | undefined, id: string) {
+  return typeof line === "number" ? `${cellId}:${kind}:${line}` : `${cellId}:${kind}:id:${id}`;
+}
+
+function componentSourceLine(cell: CellModel, componentId: string, declaredLine: number | undefined) {
+  if (typeof declaredLine === "number") {
+    return declaredLine;
+  }
+
+  return cell.edges.find((edge) => edge.source === componentId || edge.target === componentId)?.line;
 }
 
 function gatewayNodeId(cellId: string, direction: string, multi: boolean) {
@@ -497,9 +511,11 @@ function emitDecoupledCrossEdges(
         nodeId: stubOutId,
         label: `${edge.targetCell}.${edge.targetComp}`,
         externalType: undefined,
-        direction: edge.exit
+        direction: edge.exit,
+        layoutKind: "external",
+        cellId: edge.sourceCell
       },
-      draggable: false
+      draggable: true
     });
     nodes.push({
       id: stubInId,
@@ -509,9 +525,11 @@ function emitDecoupledCrossEdges(
         nodeId: stubInId,
         label: `${edge.sourceCell}.${edge.sourceComp}`,
         externalType: undefined,
-        direction: edge.entry
+        direction: edge.entry,
+        layoutKind: "external",
+        cellId: edge.targetCell
       },
-      draggable: false
+      draggable: true
     });
 
     const outData = connectionData(`${edge.id}-out`, [srcComp, srcGate, stubOutId]);
@@ -628,7 +646,9 @@ export function toReactFlow(project: ProjectModel) {
         title: cell.label ?? (multi ? cell.id : project.title),
         version: cell.version,
         width: layout.width,
-        height: layout.height
+        height: layout.height,
+        layoutKind: "cell",
+        cellId: cell.id
       },
       draggable: false,
       selectable: false
@@ -636,12 +656,20 @@ export function toReactFlow(project: ProjectModel) {
 
     layout.nodes.forEach(({ component, x, y }) => {
       const id = namespaced(cell.id, component.id, multi);
+      const sourceLine = componentSourceLine(cell, component.id, component.line);
       nodes.push({
         id,
         type: "component",
         position: { x: originX + x, y: originY + y },
-        data: { nodeId: id, label: component.label ?? component.id, componentType: component.type },
-        draggable: false
+        data: {
+          nodeId: id,
+          label: component.label ?? component.id,
+          componentType: component.type,
+          motionKey: motionKeyForLine(cell.id, "component", sourceLine, component.id),
+          layoutKind: "component",
+          cellId: cell.id
+        },
+        draggable: true
       });
     });
 
@@ -658,7 +686,7 @@ export function toReactFlow(project: ProjectModel) {
         id,
         type: "gateway",
         position: { x: originX + position.x, y: originY + position.y },
-        data: { nodeId: id, direction },
+        data: { nodeId: id, direction, layoutKind: "gateway", cellId: cell.id },
         draggable: false
       });
     });
@@ -681,9 +709,12 @@ export function toReactFlow(project: ProjectModel) {
           nodeId: id,
           label: external.label ?? external.id,
           externalType: external.type,
-          direction: external.direction
+          direction: external.direction,
+          motionKey: motionKeyForLine(cell.id, "external", external.line, external.id),
+          layoutKind: "external",
+          cellId: cell.id
         },
-        draggable: false
+        draggable: true
       });
     });
 
@@ -703,9 +734,11 @@ export function toReactFlow(project: ProjectModel) {
         nodeId: `external-${ext.id}`,
         label: ext.label ?? ext.id,
         externalType: ext.type,
-        direction: ext.direction ?? "east"
+        direction: ext.direction ?? "east",
+        motionKey: motionKeyForLine("shared", "external", ext.line, ext.id),
+        layoutKind: "shared-external"
       },
-      draggable: false
+      draggable: true
     });
   });
 

--- a/packages/ui/cell-diagram-view/package.json
+++ b/packages/ui/cell-diagram-view/package.json
@@ -7,7 +7,8 @@
   "types": "src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aep/ui-cell-diagram-react": "workspace:*"
@@ -21,6 +22,10 @@
     "@types/react": "19.1.6",
     "@types/react-dom": "19.0.2",
     "typescript": "5.9.3",
-    "@wso2/oxygen-ui": "0.11.0"
+    "@wso2/oxygen-ui": "0.11.0",
+    "@testing-library/react": "^16.3.2",
+    "@vitejs/plugin-react-swc": "4.2.0",
+    "jsdom": "^25.0.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/ui/cell-diagram-view/src/CellDiagramInner.test.tsx
+++ b/packages/ui/cell-diagram-view/src/CellDiagramInner.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CustomLayout } from "@aep/ui-cell-diagram-react";
+import CellDiagramInner from "./CellDiagramInner";
+
+// The renderer itself is exercised in @aep/ui-cell-diagram-react; here only
+// the theme and layout-persistence wiring matters, so record the props it
+// receives and expose the layout-change callback. The fingerprint stub keeps
+// match/mismatch under test control.
+let lastLayoutChange: ((layout: CustomLayout) => void) | undefined;
+vi.mock("@aep/ui-cell-diagram-react", () => ({
+  fingerprintSource: (source: string) => `fp:${source}`,
+  CellDiagram: ({
+    source,
+    theme,
+    tolerant,
+    customLayout,
+    onCustomLayoutChange,
+  }: {
+    source: string;
+    theme?: string;
+    tolerant?: boolean;
+    customLayout?: CustomLayout | null;
+    onCustomLayoutChange?: (layout: CustomLayout) => void;
+  }) => {
+    lastLayoutChange = onCustomLayoutChange;
+    return (
+      <div
+        data-testid="cell-diagram"
+        data-source={source}
+        data-theme={theme}
+        data-tolerant={String(tolerant)}
+        data-layout={customLayout ? JSON.stringify(customLayout.nodes) : "none"}
+      />
+    );
+  },
+}));
+
+// Color-scheme hooks are stubbed per test: MUI's useColorScheme is the live
+// signal (ColorSchemeToggle drives it), palette.mode the static fallback.
+const mockColorScheme = vi.fn();
+const mockPaletteMode = vi.fn();
+vi.mock("@wso2/oxygen-ui", () => ({
+  useColorScheme: () => mockColorScheme(),
+  useTheme: () => ({ palette: { mode: mockPaletteMode() } }),
+}));
+
+const STORAGE_KEY = "aep.cell-diagram.layout:proj1";
+
+function layoutFor(source: string): CustomLayout {
+  return {
+    version: 1,
+    sourceFingerprint: `fp:${source}`,
+    nodes: { api: { kind: "component", cellId: "main", x: 10, y: 20 } },
+  } as CustomLayout;
+}
+
+beforeEach(() => {
+  mockColorScheme.mockReturnValue({ mode: "light", systemMode: undefined });
+  mockPaletteMode.mockReturnValue("light");
+  lastLayoutChange = undefined;
+  window.localStorage.clear();
+});
+
+describe("CellDiagramInner theme wiring", () => {
+  it("passes the source with tolerant compile and the active light scheme", () => {
+    render(<CellDiagramInner source="title X\n" />);
+    const el = screen.getByTestId("cell-diagram");
+    expect(el.dataset.source).toBe("title X\\n");
+    expect(el.dataset.tolerant).toBe("true");
+    expect(el.dataset.theme).toBe("light");
+  });
+
+  it("follows an explicit dark scheme", () => {
+    mockColorScheme.mockReturnValue({ mode: "dark", systemMode: undefined });
+    render(<CellDiagramInner source="title X" />);
+    expect(screen.getByTestId("cell-diagram").dataset.theme).toBe("dark");
+  });
+
+  it("resolves the system scheme through systemMode", () => {
+    mockColorScheme.mockReturnValue({ mode: "system", systemMode: "dark" });
+    render(<CellDiagramInner source="title X" />);
+    expect(screen.getByTestId("cell-diagram").dataset.theme).toBe("dark");
+  });
+
+  it("falls back to palette.mode when no color-scheme context is available", () => {
+    mockColorScheme.mockReturnValue({ mode: undefined, systemMode: undefined });
+    mockPaletteMode.mockReturnValue("dark");
+    render(<CellDiagramInner source="title X" />);
+    expect(screen.getByTestId("cell-diagram").dataset.theme).toBe("dark");
+  });
+});
+
+describe("CellDiagramInner dragged-layout persistence", () => {
+  it("holds an emitted layout so a dragged node does not snap back, and stores it per key", () => {
+    render(<CellDiagramInner source="title X" layoutKey="proj1" />);
+    expect(screen.getByTestId("cell-diagram").dataset.layout).toBe("none");
+
+    act(() => lastLayoutChange?.(layoutFor("title X")));
+
+    expect(screen.getByTestId("cell-diagram").dataset.layout).toContain("api");
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}").sourceFingerprint).toBe(
+      "fp:title X",
+    );
+  });
+
+  it("restores a stored layout for the same key and source", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(layoutFor("title X")));
+    render(<CellDiagramInner source="title X" layoutKey="proj1" />);
+    expect(screen.getByTestId("cell-diagram").dataset.layout).toContain("api");
+  });
+
+  it("resets and removes the stored layout when the DSL changes", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(layoutFor("title X")));
+    render(<CellDiagramInner source="title CHANGED" layoutKey="proj1" />);
+
+    expect(screen.getByTestId("cell-diagram").dataset.layout).toBe("none");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("keeps dragged positions in memory only without a layoutKey", () => {
+    render(<CellDiagramInner source="title X" />);
+
+    act(() => lastLayoutChange?.(layoutFor("title X")));
+
+    expect(screen.getByTestId("cell-diagram").dataset.layout).toContain("api");
+    expect(window.localStorage.length).toBe(0);
+  });
+});

--- a/packages/ui/cell-diagram-view/src/CellDiagramInner.tsx
+++ b/packages/ui/cell-diagram-view/src/CellDiagramInner.tsx
@@ -21,8 +21,88 @@
 // actually shown. The component self-imports its CSS, so no separate
 // stylesheet import is needed here. `tolerant` lets a still-growing
 // `design.cell` render its partial diagram instead of the error placeholder.
-import { CellDiagram } from "@aep/ui-cell-diagram-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  CellDiagram,
+  fingerprintSource,
+  type CustomLayout,
+  type DiagramTheme,
+} from "@aep/ui-cell-diagram-react";
+import { useColorScheme, useTheme } from "@wso2/oxygen-ui";
 
-export default function CellDiagramInner({ source }: { source: string }) {
-  return <CellDiagram source={source} tolerant style={{ width: "100%", height: "100%" }} />;
+const STORAGE_PREFIX = "aep.cell-diagram.layout:";
+
+// localStorage can be absent or throwing (privacy modes); dragged positions
+// then simply live in memory for the mounted diagram.
+function readStoredLayout(layoutKey: string | undefined): CustomLayout | null {
+  if (!layoutKey) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + layoutKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CustomLayout;
+    return parsed?.version === 1 && typeof parsed.sourceFingerprint === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredLayout(layoutKey: string | undefined, layout: CustomLayout | null): void {
+  if (!layoutKey) return;
+  try {
+    if (layout) window.localStorage.setItem(STORAGE_PREFIX + layoutKey, JSON.stringify(layout));
+    else window.localStorage.removeItem(STORAGE_PREFIX + layoutKey);
+  } catch {
+    /* memory-only */
+  }
+}
+
+export default function CellDiagramInner({
+  source,
+  layoutKey,
+}: {
+  source: string;
+  layoutKey?: string | undefined;
+}) {
+  // Follow the app's active color scheme so the diagram flips with the
+  // ColorSchemeToggle. `useColorScheme` tracks the toggle (including its
+  // "system" setting via `systemMode`); the static `palette.mode` is only a
+  // fallback for hosts rendered outside a color-scheme-aware provider.
+  const { mode, systemMode } = useColorScheme();
+  const paletteMode = useTheme().palette.mode;
+  const theme: DiagramTheme =
+    (mode === "system" ? systemMode : mode) ?? (paletteMode === "dark" ? "dark" : "light");
+
+  // Manually dragged positions round-trip through here — without holding the
+  // emitted layout, a dropped node snaps straight back to the auto-layout.
+  // The layout is a viewing aid, not saved diagram state: it persists per
+  // `layoutKey` in localStorage but is keyed to a fingerprint of the DSL, so
+  // any design.cell change (a streamed edit, a restructure) resets it.
+  const [layout, setLayout] = useState<CustomLayout | null>(() => readStoredLayout(layoutKey));
+  const activeLayout = layout && layout.sourceFingerprint === fingerprintSource(source) ? layout : null;
+
+  useEffect(() => {
+    if (layout && !activeLayout) {
+      setLayout(null);
+      writeStoredLayout(layoutKey, null);
+    }
+  }, [layout, activeLayout, layoutKey]);
+
+  const handleLayoutChange = useCallback(
+    (next: CustomLayout) => {
+      setLayout(next);
+      writeStoredLayout(layoutKey, next);
+    },
+    [layoutKey],
+  );
+
+  return (
+    <CellDiagram
+      source={source}
+      tolerant
+      theme={theme}
+      customLayout={activeLayout}
+      onCustomLayoutChange={handleLayoutChange}
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
 }

--- a/packages/ui/cell-diagram-view/src/CellDiagramView.tsx
+++ b/packages/ui/cell-diagram-view/src/CellDiagramView.tsx
@@ -34,11 +34,20 @@ export interface CellDiagramViewProps {
   source?: string | undefined;
   /** Optional override for the empty-state copy. */
   emptyState?: React.ReactNode;
+  /**
+   * Stable identity (e.g. a project name) under which manually dragged node
+   * positions persist in localStorage. The stored layout is keyed to a
+   * fingerprint of `source`, so any change to the DSL discards it — moving
+   * components is a viewing aid, never saved diagram state. Omit to keep
+   * dragged positions in memory only.
+   */
+  layoutKey?: string | undefined;
 }
 
 export const CellDiagramView = memo(function CellDiagramView({
   source,
   emptyState,
+  layoutKey,
 }: CellDiagramViewProps) {
   const hasSource = typeof source === "string" && source.trim().length > 0;
   if (!hasSource) {
@@ -73,7 +82,7 @@ export const CellDiagramView = memo(function CellDiagramView({
           </Box>
         }
       >
-        <CellDiagram source={source} />
+        <CellDiagram source={source} layoutKey={layoutKey} />
       </Suspense>
     </Box>
   );

--- a/packages/ui/cell-diagram-view/vitest.config.ts
+++ b/packages/ui/cell-diagram-view/vitest.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    // `pnpm build` compiles src (tests included) into dist/ — only the
+    // authored tests count.
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -321,18 +324,30 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.0.2(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: 19.1.6
         version: 19.1.6
       '@types/react-dom':
         specifier: 19.0.2
         version: 19.0.2(@types/react@19.1.6)
+      '@vitejs/plugin-react-swc':
+        specifier: 4.2.0
+        version: 4.2.0(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@wso2/oxygen-ui':
         specifier: 0.11.0
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(react@19.2.3))(@types/react@19.1.6)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/browser-playwright@4.1.10)(jsdom@25.0.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/ui/design-view:
     dependencies:


### PR DESCRIPTION
> **Depends on #304** — this branch is stacked on `feat/design-cell-first-sync`. Until #304 merges, the diff below includes its commits; review only the two commits of this PR (`33e131d1`, `bb1e8285`). It rebases to a clean diff once #304 lands.

## What

Updates the cell diagram renderer (`@aep/ui-cell-diagram-react`, **0.1.1 → 0.3.0**) and integrates the console theme:

- **Light/dark theming** — a `--cd-*` CSS token layer + `data-cd-theme` attribute; edge arrow markers follow via CSS vars. The view wrapper resolves the app's active color scheme (`useColorScheme`, with `palette.mode` fallback), so the **ColorSchemeToggle flips the diagram** with no per-consumer wiring.
- **Movable components** — drag a node to reposition it. Positions round-trip through the new `customLayout` props and persist per project in localStorage (`aep.cell-diagram.layout:<project>`), keyed to a fingerprint of the DSL text: **any design.cell change resets to auto-layout**. A viewing aid — nothing is committed to the spec repo (ADR-0008 stands). Auto-layout (dagre) still runs every render; stored positions are per-node overrides on top.
- **Entrance motion** — nodes added by a streamed/edited design.cell zoom in (`diagramMotion` diff classification + CSS keyframes, `prefers-reduced-motion` respected); composes with #304's editFile-in-place protocol.

## How

- Renderer refresh of `packages/ui/cell-diagram-react/src`, with every AEP-specific behavior re-verified (header-stripped diff against the previous version) and re-applied: `tolerant` streaming compile, `globals.d.ts`, license headers, zoom-button CSS fix. New dep `lz-string`.
- AEP-specific changes on top of the refresh (each marked in-code):
  - **Auto-arrange button removed** — the layout auto-resets on every DSL change, so a manual reset control isn't worth the chrome.
  - **Zoom controls carry `title` tooltips.**
  - **`.react-flow__node.dragging { transition: none }`** — the layout glide transition applied to the node under the pointer, easing every pointer-move transform over 300ms so the node trailed and stuttered. Measured in the running console: with the fix the rendered position matches the drag target on every frame (8ms sampling); the post-drop clamp settle still glides.
- `@aep/ui-cell-diagram-view` gains the layout persistence layer + a minimal vitest setup; console's `CellDiagramPanel` passes `layoutKey={projectName}` (one line).

## Proof of real execution

- Deployed to the local docker stack; verified in the running console (gym-workout-tracker): drag tracks the pointer frame-perfectly, positions survive reload, stored layout appears under the expected localStorage key with the source fingerprint, and clears when the DSL changes.
- Frame-by-frame instrumentation (8ms sampling) of drag/drop/focus-refetch cycles: no diagram remounts, no spurious re-fits, no spinner blips.

**Known issue (why draft):** a whole-diagram flicker while moving components is still reported on real pointer input (reproduced in incognito, so not stale-cache) that synthetic drags don't trigger — under investigation before marking ready.

## Tests

- `@aep/ui-cell-diagram-react`: 151 tests (upstream v0.3.0 suite incl. `customLayout`/`diagramMotion`/`planMixedDslConversion`, re-applied tolerant tests, new no-auto-arrange/tooltip/drag-transition assertions).
- `@aep/ui-cell-diagram-view`: 8 tests — theme resolution (explicit/system/fallback) and layout persistence (hold on drop, store per key, restore, reset+purge on DSL change, memory-only without a key).
- Root gates all green: `make build`, `typecheck`, `test`, `lint`, `license-check`, `deadcode-ts-check`.
