### PR TITLE
fix(skills): join connection-injected URLs safely (backend consumers) — #306

### DIFF
--- a/runners/remote-worker/plugin/skills/aep/SKILL.md
+++ b/runners/remote-worker/plugin/skills/aep/SKILL.md
@@ -299,7 +299,10 @@ dependencies:
 ```
 
 Read each injected value from its env var at startup (no hardcoded
-fallback). If your issue has **no** "Platform-resolved dependencies"
+fallback). An injected `address` can end with a `/` (the provider
+endpoint's base path), so build request URLs by joining the path onto it
+rather than concatenating strings — a doubled slash (`//path`) misroutes
+the request. If your issue has **no** "Platform-resolved dependencies"
 comment, your component has no consumer-side dependencies — add no
 `dependencies:` block. The build's `generate-workload-cr` step propagates
 this block into the OpenChoreo `Workload` CR, and OpenChoreo resolves +

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -242,6 +242,30 @@ func problemJSON(w http.ResponseWriter, status int, title, detail string) {
 }
 ```
 
+Consuming another service — the platform injects the upstream's address into
+an env var (e.g. `SERVICE2_URL`) through an OpenChoreo connection (the `aep`
+skill covers the wiring). Build every request URL onto that address with
+`url.JoinPath`, which normalizes the slashes. The injected address can end with
+a `/` (the provider endpoint's `basePath` is `/`), and a bare `base + "/path"`
+on a slash-terminated address makes `//path` — see the pitfalls table for what
+that costs.
+
+```go
+base := os.Getenv("SERVICE2_URL") // may arrive as "http://…-service2…:9090/"
+if base == "" {
+    log.Fatal("SERVICE2_URL not set")
+}
+target, err := url.JoinPath(base, "simulated-work") // ".../simulated-work", never "//…"
+if err != nil {
+    log.Fatal(err)
+}
+resp, err := http.Post(target, "application/json", strings.NewReader(`{}`))
+if err != nil {
+    log.Fatal(err)
+}
+defer resp.Body.Close()
+```
+
 `Dockerfile` — multi-stage, pinned builder, slim runtime:
 
 ```dockerfile
@@ -318,6 +342,9 @@ absence. Only when you DO have external dependencies must the committed
   hashes cause `checksum mismatch ... SECURITY ERROR` at build time.
 - ❌ Use CGO. Set `CGO_ENABLED=0` explicitly or use the pure-Go driver
   to make sure you're not accidentally linking C code.
+- ❌ Concatenate a path onto an injected upstream address
+  (`base + "/path"`) — the address can end in `/`, so join with
+  `url.JoinPath(base, "path")` instead.
 
 ### Common pitfalls
 
@@ -330,4 +357,5 @@ absence. Only when you DO have external dependencies must the committed
 | `checksum mismatch ... SECURITY ERROR` at build | `go.sum` is stale or hand-edited | `go mod tidy` locally; commit the result. |
 | Build fails `COPY go.mod go.sum ./ ... go.sum: no such file or directory` | Dockerfile names `go.sum` but a stdlib-only service has none | Use the Dockerfile above (`COPY go.mod ./` only); `COPY . .` brings `go.sum` when it exists. |
 | Pod won't start; logs show "panic: listen tcp :8080" | Used wrong port | Use port 9090. |
+| `POST` to an injected upstream returns `405` (or a `301` then a `GET`) | The connection-injected address ended in `/`, so `base + "/path"` built `//path`; `net/http` `ServeMux` `301`-redirects to the clean path and the client re-issues the redirect as `GET`, which a `POST`-only route rejects with `405` | Join with `url.JoinPath(base, "path")` — it collapses the doubled slash. |
 | Create/POST 500s only when an optional list field is omitted (present, even `[]`, works) | A nil Go slice binds as SQL `NULL` (not `[]`), violating a `NOT NULL` array column; the column's `DEFAULT` is skipped because the INSERT lists it explicitly | Normalize nil→empty before the insert (`if s == nil { s = []T{} }`), or omit the column so its `DEFAULT '{}'` applies. |


### PR DESCRIPTION
## What

Teach backend (Go) consumers to join connection-injected upstream URLs safely, so the trailing-slash footgun in #306 can't produce a `405`.

Fixes the **guidance** side of wso2/labs-agentic-engineer#306 (proposed fix #2). Two skills change:

- **`skills/go/SKILL.md`** — a "Consuming another service" subsection with the `url.JoinPath` idiom, a `Don't` bullet, and a `Common pitfalls` row for the `301 → GET → 405` signature.
- **`runners/remote-worker/plugin/skills/aep/SKILL.md`** — a language-agnostic rule where it already tells the agent to read injected addresses.

## Root cause (traced, not assumed)

A component that depends on another via an OpenChoreo connection gets the upstream's address injected into an env var (e.g. `SERVICE2_URL`). OpenChoreo builds that value in `formatEndpointAddress` (`openchoreo/internal/controller/releasebinding/controller_connections.go:268-291`) as `scheme://host:port + basePath`, **with no trailing-slash trim**. When the provider endpoint's `basePath` is `/`, the value ends with a slash. `basePath: "/"` is **not** an OpenChoreo CRD default — it comes from the workload spec (and our own `go` skill authors `basePath: /`).

A consumer joining `base + "/path"` then builds `//path`. On the platform's pinned Go (`golang:1.25-alpine`), `net/http` `ServeMux` answers the unclean path with a **301** to the clean path; the HTTP client re-issues the redirect as **GET**; a `POST`-only route replies **405** — surfacing downstream as a confusing 502.

### Why the frontend is *not* affected

The BFF trims the slash for `window._env_` URLs before emitting them: `strings.TrimRight(d.EndpointURL, "/")` in `services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go:267`. So `API_BASE_URL` / `<UPSTREAM>_URL` arrive clean and the existing `${BASE_URL}/todos` pattern in `react-webapp` / `thunder-authentication` is safe. Backend→backend connection addresses are injected by OpenChoreo **at runtime** and are never trimmed (the BFF only emits the env-var *name*), so the consumer must join defensively. This is a backend concern only.

### Why a consumer-side (skill) fix

Robust regardless of what `basePath` any provider sets (external deps, cross-org services, or any provider setting `basePath` still send a slash). Platform normalization (issue fix #1, marked *preferred*) lives in OpenChoreo and is out of scope for this skill-only change.

## Proof of real execution

Minimal reproduction (target registers only `POST /simulated-work`; injected address = `srv.URL + "/"`), run under the platform's pinned compiler `go1.25.0` across go.mod directives `go 1.22`–`1.25`:

```
############ go.mod go 1.22  (compiler go1.25.0) ############
[naive raw]  first-hop status = 301 Moved Permanently  Location="/simulated-work"
[naive]  FINAL status = 405 Method Not Allowed  (final method=GET)
[joined] FINAL status = 200 OK
############ go.mod go 1.25  (compiler go1.25.0) ############
[naive raw]  first-hop status = 301 Moved Permanently  Location="/simulated-work"
[naive]  FINAL status = 405 Method Not Allowed  (final method=GET)
[joined] FINAL status = 200 OK
```

- `base + "/simulated-work"` on a slash-terminated base → **405** (method downgraded POST→GET on the 301).
- `url.JoinPath(base, "simulated-work")` → **200**.

Nuance: Go 1.26 (dev) changed the `ServeMux` clean-redirect from `301` to `307` (which preserves POST), so the naive path happens to return 200 there — but the platform builds on **Go 1.25**, where the bug is live. `url.JoinPath` is correct on both.

The exact Go snippet added to the skill compiles clean under `go1.25.0` (`go build ./...`).

## Review

`/code-review` (Standards + Spec) run before this PR:
- Standards: conformant with the skill-authoring methodology (single source of truth, leading word `url.JoinPath`, positive framing, co-location); no hard violations.
- Spec: faithful and well-scoped to the guidance-only fix.
- Two low-severity findings applied: made the Go snippet self-contained/compilable, and trimmed the Go-specific `POST→GET` mechanism out of the language-neutral `aep` rule (kept solely in the `go` pitfalls row).

No Go tests are affected: the harvest goldens that embed skill bodies are asserted by **field set**, not content (`GoldenFieldSet`, `internal/platform/componenttest/problem.go`).

Refs wso2/labs-agentic-engineer#306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
