### PR TITLE
fix(release): CTL install URLs + real OCI chart names (aep-platform / aep-bootstrap)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           ### Install
 
           \`\`\`bash
-          helm install aep oci://ghcr.io/wso2/aep/charts/bootstrap \\
+          helm install aep oci://ghcr.io/wso2/aep/charts/aep-bootstrap \\
             --version ${{ inputs.version }} -n wso2-aep --create-namespace
 
           aep platform install \\

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,13 +272,13 @@ jobs:
 
           **Linux (amd64)**
           \`\`\`bash
-          curl -L https://github.com/wso2/aep/releases/download/ctl%2Fv${{ inputs.version }}/aep-linux-amd64 \
+          curl -L https://github.com/${{ github.repository }}/releases/download/ctl%2Fv${{ inputs.version }}/aep-linux-amd64 \
             -o /usr/local/bin/aep && chmod +x /usr/local/bin/aep
           \`\`\`
 
           **macOS (Apple Silicon)**
           \`\`\`bash
-          curl -L https://github.com/wso2/aep/releases/download/ctl%2Fv${{ inputs.version }}/aep-darwin-arm64 \
+          curl -L https://github.com/${{ github.repository }}/releases/download/ctl%2Fv${{ inputs.version }}/aep-darwin-arm64 \
             -o /usr/local/bin/aep && chmod +x /usr/local/bin/aep
           \`\`\`" \
             dist/aep-*

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -222,8 +222,9 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		// Local chart path — used for dev/local testing.
 		helmArgs = append([]string{helmArgs[0], helmArgs[1], initPlatformChart}, helmArgs[2:]...)
 	} else {
-		// Pull chart from GHCR.
-		helmArgs = append([]string{helmArgs[0], helmArgs[1], "oci://ghcr.io/wso2/aep/charts/platform"}, helmArgs[2:]...)
+		// Pull chart from GHCR. The OCI artifact is named after the chart's
+		// `name:` (aep-platform), not the directory (platform).
+		helmArgs = append([]string{helmArgs[0], helmArgs[1], "oci://ghcr.io/wso2/aep/charts/aep-platform"}, helmArgs[2:]...)
 		if initPlatformVersion != "latest" {
 			helmArgs = append(helmArgs, "--version", initPlatformVersion)
 		}

--- a/tools/aepctl/cmd/update.go
+++ b/tools/aepctl/cmd/update.go
@@ -118,7 +118,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if updatePlatformChart != "" {
 		helmArgs = append(helmArgs, updatePlatformChart)
 	} else {
-		helmArgs = append(helmArgs, "oci://ghcr.io/wso2/aep/charts/platform")
+		// OCI artifact is named after the chart's `name:` (aep-platform).
+		helmArgs = append(helmArgs, "oci://ghcr.io/wso2/aep/charts/aep-platform")
 		if updatePlatformVersion != "" {
 			helmArgs = append(helmArgs, "--version", updatePlatformVersion)
 		}


### PR DESCRIPTION
Two release-workflow / CLI fixes (originally split as #318 + #320, now combined here).

## 1. CTL install URLs point to the release repo
The `aep` CLI release notes hardcoded `github.com/wso2/aep/releases/download/...`, but the release is created in the repo the workflow runs in — so the `curl` install commands 404. Now uses `${{ github.repository }}`.

## 2. Pull release charts by their real OCI names
The Helm charts are named **`aep-platform`** / **`aep-bootstrap`** in `Chart.yaml`, so `helm push` publishes the OCI artifacts as `ghcr.io/wso2/aep/charts/aep-platform` and `.../aep-bootstrap`. Three references used the directory name (`platform` / `bootstrap`) → resolve to non-existent artifacts (`helm: not found`):

| File | Fix | Impact |
|---|---|---|
| `tools/aepctl/cmd/init.go` | `charts/platform` → `charts/aep-platform` | `aep platform install --platform-version` couldn't pull the chart |
| `tools/aepctl/cmd/update.go` | `charts/platform` → `charts/aep-platform` | `aep platform update` same failure |
| `.github/workflows/release.yml` | `charts/bootstrap` → `charts/aep-bootstrap` | bootstrap install snippet in platform release notes 404s |

**Without #2, the released `aep` CLI cannot pull its own platform chart from GHCR.** Verified live: `helm show chart oci://ghcr.io/wso2/aep/charts/aep-bootstrap --version 0.6.0-rc` works; the un-prefixed names don't exist.

## Scope / verification
- Local `deployments/helm-charts/{platform,bootstrap}` filesystem paths are correct, left as-is.
- `go build ./...` in `tools/aepctl` passes; `git grep` confirms no wrong OCI refs remain.

## Follow-up
After merge, re-cut the release so the shipped CLI can pull its chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)