### PR TITLE
fix(console): render the "Other" free-text row on multi-select question cards

### DIFF
--- a/apps/console/src/features/agent-chat/components/QuestionCard.test.tsx
+++ b/apps/console/src/features/agent-chat/components/QuestionCard.test.tsx
@@ -90,6 +90,36 @@ describe("QuestionCard — single", () => {
   });
 });
 
+describe("QuestionCard — multiSelect", () => {
+  const multi = (): QuestionMessage => ({
+    id: "q3",
+    role: "question",
+    turnId: "t1",
+    toolCallId: "tc-3",
+    questions: [
+      {
+        question: "Which platforms?",
+        multiSelect: true,
+        options: [{ label: "Web" }, { label: "Mobile" }, { label: "Desktop" }],
+      },
+    ],
+  });
+
+  it("allows several selections plus an 'Other' free-text note", () => {
+    const onAnswer = renderCard(multi(), true);
+    fireEvent.click(screen.getByText("Web"));
+    fireEvent.click(screen.getByText("Mobile"));
+    // The "Other…" row must be offered on a multi-select question too — the
+    // answer model carries freeText for any question (ADR-0012).
+    fireEvent.change(screen.getByPlaceholderText("Other / add a note…"), {
+      target: { value: "CLI" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Answer" }));
+    const [, answers] = onAnswer.mock.calls[0]!;
+    expect(answers).toEqual([{ selected: ["Web", "Mobile"], freeText: "CLI" }]);
+  });
+});
+
 describe("QuestionCard — batch (ask_questions)", () => {
   it("renders each question and requires all answered before submit", () => {
     const onAnswer = renderCard(batch(), true);

--- a/apps/console/src/features/agent-chat/components/QuestionCard.tsx
+++ b/apps/console/src/features/agent-chat/components/QuestionCard.tsx
@@ -126,7 +126,7 @@ function OneQuestion({
               Note: {note}
             </Typography>
           )
-        : !multi && (
+        : (
             <TextField
               fullWidth
               size="small"


### PR DESCRIPTION
## What & why

Follow-up to #311 (agent question cards / ADR-0012). The `QuestionCard`
component's contract comment states *"each question has an 'Other…' free-text
row"*, and the **read-only** path already renders a saved note for any question
(multi-select included) — but the **editable** free-text input was gated on
`!multi`. So a `multiSelect` question showed a recorded note when read-only yet
offered no way to enter one when answering.

The answer model (`QuestionAnswer.freeText`) and the serializers
(`buildAnswerInstruction` / `buildAnswersInstruction`) already carry `freeText`
for any question, and `answered()` already accepts a note-only answer — only the
editable input was missing for multi-select.

## Change

- **`QuestionCard.tsx`** — drop the `!multi` gate so the "Other / add a note…"
  row renders for every question (single and multi). `multi` is still used to
  choose Checkbox vs Radio, so no unused binding.
- **`QuestionCard.test.tsx`** — new `multiSelect` test: select several options +
  type an "Other" note → asserts the answer is
  `[{ selected: ["Web", "Mobile"], freeText: "CLI" }]`.

## Proof of execution

- The new test **fails before** the fix (`Unable to find an element by
  placeholder text: Other / add a note…`) and **passes after**.
- `@aep/console` agent-chat suite: **125/125 passing** (after rebuilding
  `@aep/agent-stream`, whose dist was stale on the freshly-merged base).
- eslint on both files clean.
- Verified live: rebuilt the `aep-console` image and confirmed the container
  serves the change at `http://localhost:8090`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
