### PR TITLE
fix(aepctl): pull release charts by their real OCI names (aep-platform / aep-bootstrap)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           ### Install
 
           \`\`\`bash
-          helm install aep oci://ghcr.io/wso2/aep/charts/bootstrap \\
+          helm install aep oci://ghcr.io/wso2/aep/charts/aep-bootstrap \\
             --version ${{ inputs.version }} -n wso2-aep --create-namespace
 
           aep platform install \\

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -222,8 +222,9 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		// Local chart path — used for dev/local testing.
 		helmArgs = append([]string{helmArgs[0], helmArgs[1], initPlatformChart}, helmArgs[2:]...)
 	} else {
-		// Pull chart from GHCR.
-		helmArgs = append([]string{helmArgs[0], helmArgs[1], "oci://ghcr.io/wso2/aep/charts/platform"}, helmArgs[2:]...)
+		// Pull chart from GHCR. The OCI artifact is named after the chart's
+		// `name:` (aep-platform), not the directory (platform).
+		helmArgs = append([]string{helmArgs[0], helmArgs[1], "oci://ghcr.io/wso2/aep/charts/aep-platform"}, helmArgs[2:]...)
 		if initPlatformVersion != "latest" {
 			helmArgs = append(helmArgs, "--version", initPlatformVersion)
 		}

--- a/tools/aepctl/cmd/update.go
+++ b/tools/aepctl/cmd/update.go
@@ -118,7 +118,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if updatePlatformChart != "" {
 		helmArgs = append(helmArgs, updatePlatformChart)
 	} else {
-		helmArgs = append(helmArgs, "oci://ghcr.io/wso2/aep/charts/platform")
+		// OCI artifact is named after the chart's `name:` (aep-platform).
+		helmArgs = append(helmArgs, "oci://ghcr.io/wso2/aep/charts/aep-platform")
 		if updatePlatformVersion != "" {
 			helmArgs = append(helmArgs, "--version", updatePlatformVersion)
 		}


### PR DESCRIPTION
## Summary
The Helm charts are named **`aep-platform`** and **`aep-bootstrap`** in their `Chart.yaml`, so `helm push` publishes the OCI artifacts as:
- `ghcr.io/wso2/aep/charts/aep-platform`
- `ghcr.io/wso2/aep/charts/aep-bootstrap`

Three references used the **directory** name (`platform` / `bootstrap`) instead, which resolve to non-existent artifacts — `helm` fails with `not found`:

| File | Path | Impact |
|---|---|---|
| `tools/aepctl/cmd/init.go` | `charts/platform` → `charts/aep-platform` | `aep platform install --platform-version` couldn't pull the platform chart |
| `tools/aepctl/cmd/update.go` | `charts/platform` → `charts/aep-platform` | `aep platform update` same failure |
| `.github/workflows/release.yml` | `charts/bootstrap` → `charts/aep-bootstrap` | bootstrap install snippet in the platform release notes 404s |

**Without this, the released `aep` CLI cannot pull its own platform chart from GHCR.** Verified live: `helm show chart oci://ghcr.io/wso2/aep/charts/aep-bootstrap --version 0.6.0-rc` works; `.../charts/bootstrap` and `.../charts/platform` do not exist.

## Scope / not touched
- Local filesystem paths like `deployments/helm-charts/platform/...` are correct and left as-is.
- The `--platform-chart` (local path) flag was already unaffected.

## Verification
- `go build ./...` in `tools/aepctl` passes.
- `git grep` confirms no `oci://…/charts/{platform,bootstrap}` references remain.

## Follow-up
After merge, re-cut the release (e.g. `0.6.1` or re-run `0.6.0-rc`) so the shipped CLI can pull its chart.

> Note: separate from #318 (CTL install-URL fix) — both touch `release.yml` but at different lines, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)