### PR TITLE
feat(release): ship secret-manager-api stub image + keep OpenBao root token for local stubs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           - name: cluster-gateway-proxy
             dockerfile: deployments/local-cluster-gateway-proxy/Dockerfile
             context: deployments/local-cluster-gateway-proxy
+          - name: secret-manager-api
+            dockerfile: deployments/local-secret-manager-api/Dockerfile
+            context: deployments/local-secret-manager-api
 
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +148,7 @@ jobs:
           yq -i '.console.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
           yq -i '.console.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
           yq -i '.codingAgentDispatch.clusterGatewayProxy.image = "${{ env.IMAGE_PREFIX }}/cluster-gateway-proxy:${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.codingAgentDispatch.secretManagerApi.image = "${{ env.IMAGE_PREFIX }}/secret-manager-api:${{ inputs.version }}"' /tmp/platform/values.yaml
           yq -i '.codingAgentRunner.image = "${{ env.IMAGE_PREFIX }}/remote-worker:${{ inputs.version }}"' /tmp/platform/values.yaml
           yq -i '.validationRunner.image = "${{ env.IMAGE_PREFIX }}/remote-worker-validation:${{ inputs.version }}"' /tmp/platform/values.yaml
 

--- a/deployments/helm-charts/bootstrap/templates/aep-server/deployment.yaml
+++ b/deployments/helm-charts/bootstrap/templates/aep-server/deployment.yaml
@@ -55,6 +55,10 @@ spec:
               value: {{ .Values.aepServer.thunderRelease | quote }}
             - name: CONSOLE_URL
               value: {{ .Values.console.publicURL | quote }}
+            # LOCAL DEV ONLY — when true, Init keeps the OpenBao root token so the
+            # in-cluster secret-manager-api stub (root-token auth) works. Never in prod.
+            - name: LOCAL_STUBS_ENABLED
+              value: {{ .Values.localStubs.enabled | quote }}
           readinessProbe:
             grpc:
               port: {{ .Values.aepServer.port }}

--- a/deployments/helm-charts/bootstrap/values.yaml
+++ b/deployments/helm-charts/bootstrap/values.yaml
@@ -21,3 +21,12 @@ aepServer:
 
 console:
   publicURL: "http://console.openchoreo.localhost:8080"
+
+# LOCAL DEV ONLY. When enabled, aep-server's Init keeps the OpenBao root token
+# (does not revoke it) so the in-cluster secret-manager-api stub — which
+# authenticates with the root token — can stage external-resource secrets.
+# Must stay false in production, where SM-API is a managed service and the root
+# token is always revoked. Pair with the platform chart's
+# codingAgentDispatch.localStubs.enabled=true (which deploys the stub itself).
+localStubs:
+  enabled: false

--- a/tools/aepctl/cmd/aep-server/init.go
+++ b/tools/aepctl/cmd/aep-server/init.go
@@ -261,13 +261,24 @@ func (s *server) Init(req *adminpb.InitRequest, stream grpc.ServerStreamingServe
 
 	// Revoke the root token — all provisioning is done and it is no longer needed.
 	// Recovery, if ever required, uses the unseal keys via OpenBao's generate-root process.
-	if err := progress("Revoking root token..."); err != nil {
-		return err
+	//
+	// LOCAL DEV EXCEPTION: when local stubs are enabled, the in-cluster
+	// secret-manager-api stub authenticates to OpenBao with the root token, so
+	// revoking it would break external-resource secret staging. Keep it in that
+	// case only. In production (localStubs=false) the root token is always revoked.
+	if s.localStubs {
+		if err := progress("Local stubs enabled — keeping OpenBao root token (dev only)."); err != nil {
+			return err
+		}
+	} else {
+		if err := progress("Revoking root token..."); err != nil {
+			return err
+		}
+		if _, err := openbao.Must(ctx, "POST", s.openbaoAddr, rootToken, "/v1/auth/token/revoke-self", nil); err != nil {
+			return fatal(fmt.Sprintf("revoke root token: %v", err))
+		}
+		// rootToken was revoked above and is intentionally not referenced past this point.
 	}
-	if _, err := openbao.Must(ctx, "POST", s.openbaoAddr, rootToken, "/v1/auth/token/revoke-self", nil); err != nil {
-		return fatal(fmt.Sprintf("revoke root token: %v", err))
-	}
-	// rootToken was revoked above and is intentionally not referenced past this point.
 
 	// Send credentials — root token is intentionally omitted; it has been revoked.
 	return stream.Send(&adminpb.InitEvent{

--- a/tools/aepctl/cmd/aep-server/main.go
+++ b/tools/aepctl/cmd/aep-server/main.go
@@ -43,6 +43,11 @@ type server struct {
 	thunderNS      string
 	thunderRelease string
 	consoleURL     string
+	// localStubs: LOCAL DEV ONLY. When true, Init keeps the OpenBao root token
+	// (does not revoke it) so the in-cluster secret-manager-api stub — which
+	// authenticates with the root token — can read/write secrets. NEVER set in
+	// production, where SM-API is a managed service and the root token is revoked.
+	localStubs bool
 }
 
 func main() {
@@ -63,6 +68,7 @@ func main() {
 		thunderNS:      getEnv("THUNDER_NAMESPACE", "thunder"),
 		thunderRelease: getEnv("THUNDER_RELEASE", "thunder"),
 		consoleURL:     os.Getenv("CONSOLE_URL"),
+		localStubs:     os.Getenv("LOCAL_STUBS_ENABLED") == "true",
 	}
 
 	lis, err := net.Listen("tcp", ":9091")


### PR DESCRIPTION
## Problem
`aep platform install` can't run a build that uses a secret-bearing external resource (e.g. `stripe`) on a self-contained local install — it fails with `SM-API not configured but resource "…" has secret values`. Two root causes:

1. The **`secret-manager-api` stub image is never released** — the build matrix ships 9 images but not this one, so the platform chart's `codingAgentDispatch.secretManagerApi.image` (`…:latest`) resolves to nothing.
2. The **OpenBao root token is always revoked** during `aep-server` Init, but the stub authenticates to OpenBao with the root token — so even if deployed, it can't read/write secrets.

## Changes
**1. Release the stub image** (`.github/workflows/release.yml`)
- Add `secret-manager-api` to the image build matrix (built from `deployments/local-secret-manager-api`, same as `cluster-gateway-proxy`).
- Rewrite `codingAgentDispatch.secretManagerApi.image` to the released version when packaging the platform chart.

**2. Keep the root token when local stubs are enabled**
- `aep-server` reads `LOCAL_STUBS_ENABLED`; `Init` **skips** root-token revocation when `true` (`tools/aepctl/cmd/aep-server/{main,init}.go`). Production leaves it `false` → always revokes (unchanged behaviour).
- Bootstrap chart gains `localStubs.enabled` (default **false**) → sets the env on `aep-server`.

Pairs with the platform chart's `codingAgentDispatch.localStubs.enabled=true` (which deploys the stub itself).

## Usage (local dev)
```bash
helm install aep oci://ghcr.io/wso2/aep/charts/aep-bootstrap --version <v> \
  -n wso2-aep --create-namespace --set localStubs.enabled=true
AEP_CODINGAGENT_LOCAL_STUBS_ENABLED=true aep platform install --server … --platform-version <v> …
```

## Verification
- `go build ./...` in `tools/aepctl` passes.
- Bootstrap chart renders `LOCAL_STUBS_ENABLED: "true"` on `aep-server` when `localStubs.enabled=true`.
- `release.yml` is valid YAML with `secret-manager-api` in the matrix + chart-image rewrite.

## Notes / follow-ups
- **LOCAL DEV ONLY.** Both toggles default false; production is unchanged (root token revoked, managed SM-API via `--secret-manager-api-url`).
- Config is split across the bootstrap install (`--set localStubs.enabled=true`) and platform install (`AEP_CODINGAGENT_LOCAL_STUBS_ENABLED=true`) because they're separate Helm releases. A future `--local-stubs`/`--dev` convenience flag on `aep platform install` could unify this.
- Store-consistency (stub writes to / runner reads from the same OpenBao) should be validated end-to-end once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)