### PR TITLE
feat: detailed grilling questions and fully-explained answer options (#270)

### DIFF
--- a/apps/console/src/features/agent-chat/questionCards.test.ts
+++ b/apps/console/src/features/agent-chat/questionCards.test.ts
@@ -52,6 +52,12 @@ describe("parseQuestionsInput — ask_question (single)", () => {
     expect(parseQuestionsInput(ASK_QUESTION_TOOL, { ...SINGLE, multiSelect: "yes" })![0]!.multiSelect).toBeUndefined();
   });
 
+  it("keeps detail only when a non-empty string", () => {
+    expect(parseQuestionsInput(ASK_QUESTION_TOOL, { ...SINGLE, detail: "Why I ask." })![0]!.detail).toBe("Why I ask.");
+    expect(parseQuestionsInput(ASK_QUESTION_TOOL, { ...SINGLE, detail: "" })![0]!.detail).toBeUndefined();
+    expect(parseQuestionsInput(ASK_QUESTION_TOOL, { ...SINGLE, detail: 42 })![0]!.detail).toBeUndefined();
+  });
+
   it.each([
     ["missing question", { options: SINGLE.options }],
     ["empty options", { question: "q", options: [] }],

--- a/apps/console/src/features/agent-chat/questionCards.ts
+++ b/apps/console/src/features/agent-chat/questionCards.ts
@@ -55,6 +55,7 @@ function parseOneQuestion(value: unknown): AskQuestionInput | null {
   if (new Set(options.map((o) => o.label)).size !== options.length) return null;
   return {
     question: v.question,
+    ...(typeof v.detail === "string" && v.detail ? { detail: v.detail } : {}),
     options,
     ...(v.multiSelect === true ? { multiSelect: true } : {}),
   };

--- a/apps/console/src/features/spec/components/SpecQuestionForm.tsx
+++ b/apps/console/src/features/spec/components/SpecQuestionForm.tsx
@@ -26,7 +26,7 @@
 // user who triggered the turn (`ownerId`) can submit or skip — they hold the
 // SSE stream back to the agent; everyone else co-authors.
 
-import { Box, Button, Checkbox, Chip, Stack, TextField, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { Box, Button, Checkbox, Chip, Radio, Stack, TextField, Typography } from "@wso2/oxygen-ui";
 import { Sparkles, Users } from "@wso2/oxygen-ui-icons-react";
 import type { Doc } from "yjs";
 import type { AskQuestionInput, QuestionAnswer } from "@aep/agent-stream";
@@ -39,7 +39,76 @@ import {
   type RoomQuestion,
 } from "../../agent-chat/questionRoom";
 
-/** One question block: a heading, its options, and an "Other…" free-text row. */
+/**
+ * One selectable option card: radio/checkbox, label, "Recommended" badge, and
+ * the option's full description — always visible, so the user can weigh the
+ * choices without hunting through tooltips.
+ */
+function OptionCard({
+  opt,
+  multi,
+  isOn,
+  disabled,
+  onSelect,
+}: {
+  opt: AskQuestionInput["options"][number];
+  multi: boolean;
+  isOn: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const Control = multi ? Checkbox : Radio;
+  return (
+    <Box
+      role={multi ? "checkbox" : "radio"}
+      aria-checked={isOn}
+      tabIndex={disabled ? -1 : 0}
+      onClick={disabled ? undefined : onSelect}
+      onKeyDown={
+        disabled
+          ? undefined
+          : (e) => {
+              if (e.key === " " || e.key === "Enter") {
+                e.preventDefault();
+                onSelect();
+              }
+            }
+      }
+      sx={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 1,
+        p: 2,
+        border: 1,
+        borderColor: isOn ? "primary.main" : "divider",
+        borderRadius: 2,
+        bgcolor: isOn ? "action.selected" : "background.paper",
+        cursor: disabled ? "default" : "pointer",
+        transition: "border-color 120ms, background-color 120ms",
+        "&:hover": disabled ? undefined : { borderColor: "primary.main" },
+      }}
+    >
+      <Control size="small" checked={isOn} disabled={disabled} disableRipple sx={{ p: 0, mt: 0.25 }} />
+      <Box sx={{ minWidth: 0 }}>
+        <Stack direction="row" spacing={1} useFlexGap sx={{ alignItems: "center", flexWrap: "wrap" }}>
+          <Typography variant="body1" sx={{ fontWeight: 600 }}>
+            {opt.label}
+          </Typography>
+          {opt.recommended && (
+            <Chip label="Recommended" size="small" color="primary" variant="outlined" sx={{ height: 20 }} />
+          )}
+        </Stack>
+        {opt.description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {opt.description}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/** One question block: heading, context detail, option cards, and an "Other…" free-text row. */
 function QuestionBlock({
   q,
   answer,
@@ -56,53 +125,39 @@ function QuestionBlock({
   const multi = q.multiSelect === true;
   const selected = answer?.selected ?? [];
   return (
-    <Box sx={{ mb: 4 }}>
+    <Box sx={{ mb: 5 }}>
       <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
         {q.question}
       </Typography>
+      {q.detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {q.detail}
+        </Typography>
+      )}
       {multi && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
           Pick as many as apply
         </Typography>
       )}
-      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap", mt: 1 }}>
-        {q.options.map((opt) => {
-          const isOn = selected.includes(opt.label);
-          const chip = (
-            <Chip
-              key={opt.label}
-              label={
-                multi ? (
-                  <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
-                    <Checkbox size="small" checked={isOn} sx={{ p: 0, mr: 0.5 }} disableRipple />
-                    <span>{opt.label}</span>
-                  </Stack>
-                ) : (
-                  opt.label
-                )
-              }
-              onClick={disabled ? undefined : () => onSelect(opt.label)}
-              variant={isOn ? "filled" : "outlined"}
-              color={isOn ? "primary" : opt.recommended ? "primary" : "default"}
-              disabled={disabled}
-              sx={{ borderRadius: 8, py: 2, px: 0.5, cursor: disabled ? "default" : "pointer" }}
-            />
-          );
-          return opt.description ? (
-            <Tooltip key={opt.label} title={opt.description}>
-              <span>{chip}</span>
-            </Tooltip>
-          ) : (
-            chip
-          );
-        })}
+      <Stack spacing={1.5} role={multi ? "group" : "radiogroup"} aria-label={q.question} sx={{ mt: 1.5 }}>
+        {q.options.map((opt) => (
+          <OptionCard
+            key={opt.label}
+            opt={opt}
+            multi={multi}
+            isOn={selected.includes(opt.label)}
+            disabled={disabled}
+            onSelect={() => onSelect(opt.label)}
+          />
+        ))}
         <TextField
           size="small"
-          placeholder="Other…"
+          placeholder="Other — describe your own answer, or add context to a choice…"
           value={answer?.freeText ?? ""}
           disabled={disabled}
+          multiline
           onChange={(e) => onNote(e.target.value)}
-          sx={{ minWidth: 200, "& .MuiOutlinedInput-root": { borderRadius: 8 } }}
+          sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
         />
       </Stack>
     </Box>

--- a/apps/console/src/mocks/handlers/agent-chat.ts
+++ b/apps/console/src/mocks/handlers/agent-chat.ts
@@ -124,86 +124,238 @@ export const agentChatHandlers = [
           questions: [
             {
               question: "Who is the primary user of this app?",
+              detail:
+                "This shapes onboarding, permissions, and how much admin tooling the spec needs — it's the single biggest scope decision, so I'm asking it first.",
               options: [
-                { label: "Individual consumers", description: "Self-serve signup", recommended: true },
-                { label: "Internal teams", description: "SSO, org-managed access" },
-                { label: "Both from day one", description: "Two onboarding paths — more scope" },
+                {
+                  label: "Individual consumers",
+                  description:
+                    "People sign themselves up and get a personal workspace. Onboarding stays lightweight (email or social login, no org setup), but every account manages itself — there is no central admin who can provision or remove users.",
+                  recommended: true,
+                },
+                {
+                  label: "Internal teams",
+                  description:
+                    "An organization rolls the app out to its staff. That means SSO, org-managed access, and an admin who controls membership — more setup work up front, but access control and offboarding come for free.",
+                },
+                {
+                  label: "Both from day one",
+                  description:
+                    "Two onboarding paths, two permission models, and pricing that has to serve both. Roughly doubles the v1 scope; usually only worth it when both audiences are already committed.",
+                },
               ],
             },
             {
               question: "Which platform matters most first?",
+              detail:
+                "The first platform decides the UI stack and review/release process; the others can follow later without rework if we pick one now.",
               options: [
-                { label: "Web", recommended: true },
-                { label: "Mobile" },
-                { label: "Both" },
+                {
+                  label: "Web",
+                  description:
+                    "Ships fastest: one responsive app, instant updates, no store review. Works on phones through the browser, though without push notifications or offline polish.",
+                  recommended: true,
+                },
+                {
+                  label: "Mobile",
+                  description:
+                    "Native iOS/Android first. Best for push notifications, camera/location use, and on-the-go sessions — but store review slows iteration and it needs its own release pipeline.",
+                },
+                {
+                  label: "Both",
+                  description:
+                    "Web and mobile in parallel. Every feature is designed, built, and tested twice, so v1 takes noticeably longer — choose this only if mobile-only users are core to launch.",
+                },
               ],
             },
             {
               question: "Which capabilities are in scope for v1?",
+              detail:
+                "Everything selected here becomes a section of the requirements spec; anything unselected is explicitly deferred so the first release stays small.",
               multiSelect: true,
               options: [
-                { label: "Accounts" },
-                { label: "Payments" },
-                { label: "Notifications" },
-                { label: "Search" },
+                {
+                  label: "Accounts",
+                  description:
+                    "User registration, profiles, and session handling. Almost every other capability builds on this, so leaving it out only makes sense for a fully anonymous tool.",
+                },
+                {
+                  label: "Payments",
+                  description:
+                    "Checkout, receipts, and a payment provider integration (e.g. Stripe). Brings compliance and refund flows with it — the most expensive item on this list.",
+                },
+                {
+                  label: "Notifications",
+                  description:
+                    "Email or in-app alerts when something needs the user's attention. Cheap to add once accounts exist; pointless before there are events worth notifying about.",
+                },
+                {
+                  label: "Search",
+                  description:
+                    "Full-text search across the app's content. Valuable once data volume grows, but v1 can usually ship with simple filtering instead.",
+                },
               ],
             },
             {
               question: "How should users sign in?",
+              detail:
+                "Sign-in method affects both the signup conversion rate and how much credential handling the backend has to own.",
               options: [
-                { label: "Email + password" },
-                { label: "Social login", recommended: true },
-                { label: "SSO only" },
+                {
+                  label: "Email + password",
+                  description:
+                    "Works for everyone with no third-party dependency, but we own password reset, breach protection, and rate limiting ourselves.",
+                },
+                {
+                  label: "Social login",
+                  description:
+                    "Sign in with Google/GitHub — no passwords to store and the fastest signup flow. Users without those accounts are locked out unless we add email later.",
+                  recommended: true,
+                },
+                {
+                  label: "SSO only",
+                  description:
+                    "Enterprise identity providers (SAML/OIDC) only. Right when an organization mandates it; wrong for self-serve consumers, who can't sign up at all.",
+                },
               ],
             },
             {
               question: "What is the pricing model?",
+              detail:
+                "Pricing decides whether billing infrastructure is in the v1 spec at all, and how accounts and limits are modeled.",
               options: [
-                { label: "Free", recommended: true },
-                { label: "Subscription" },
-                { label: "One-off purchase" },
+                {
+                  label: "Free",
+                  description:
+                    "No billing code in v1 — the whole payments surface disappears from scope. Monetization can be layered on later once usage proves out.",
+                  recommended: true,
+                },
+                {
+                  label: "Subscription",
+                  description:
+                    "Recurring plans with trials, upgrades, and dunning. Predictable revenue, but it drags billing, plan gating, and invoicing into the first release.",
+                },
+                {
+                  label: "One-off purchase",
+                  description:
+                    "Pay once per item or unlock. Simpler than subscriptions, but still needs checkout, receipts, and refund handling in v1.",
+                },
               ],
             },
             {
               question: "Where does the data live?",
+              detail:
+                "The storage choice fixes the backup, migration, and multi-tenancy story — it's hard to reverse once real data exists.",
               options: [
-                { label: "Managed Postgres", recommended: true },
-                { label: "SQLite per tenant" },
-                { label: "Third-party BaaS" },
+                {
+                  label: "Managed Postgres",
+                  description:
+                    "One relational database run by a cloud provider. Boring, well-understood, easy to hire for, and scales past v1 without a rewrite.",
+                  recommended: true,
+                },
+                {
+                  label: "SQLite per tenant",
+                  description:
+                    "Each customer gets an isolated file database. Great isolation and trivially cheap at small scale, but cross-tenant reporting and migrations get harder.",
+                },
+                {
+                  label: "Third-party BaaS",
+                  description:
+                    "Firebase/Supabase-style hosted backend. Fastest to a demo, but data model and auth become coupled to the vendor — migrating away later is real work.",
+                },
               ],
             },
             {
               question: "Which integrations matter?",
+              detail:
+                "Each integration adds an external dependency to the spec — credentials, webhooks, and failure handling — so only pick the ones launch actually needs.",
               multiSelect: true,
               options: [
-                { label: "Slack" },
-                { label: "Email" },
-                { label: "Calendar" },
-                { label: "None yet", recommended: true },
+                {
+                  label: "Slack",
+                  description: "Post updates into channels. Needs a Slack app + OAuth install flow.",
+                },
+                {
+                  label: "Email",
+                  description: "Transactional mail (invites, digests) through a provider like SES or Resend.",
+                },
+                {
+                  label: "Calendar",
+                  description: "Create/read Google or Outlook events; the heaviest of the three to get right.",
+                },
+                {
+                  label: "None yet",
+                  description:
+                    "Ship self-contained and add integrations when users ask — keeps v1 free of external moving parts.",
+                  recommended: true,
+                },
               ],
             },
             {
               question: "What is the launch timeline?",
+              detail:
+                "The timeline calibrates how aggressively the spec cuts scope — a shorter runway means fewer capabilities make the v1 list.",
               options: [
-                { label: "2 weeks" },
-                { label: "1 month", recommended: true },
-                { label: "A quarter" },
+                {
+                  label: "2 weeks",
+                  description: "A demo-quality slice: one happy path, mocked edges, no polish. Good for validating interest only.",
+                },
+                {
+                  label: "1 month",
+                  description:
+                    "A real but minimal product: the core flow production-ready, secondary features stubbed or deferred.",
+                  recommended: true,
+                },
+                {
+                  label: "A quarter",
+                  description:
+                    "Room for the full selected scope plus polish — at the cost of three months before any user feedback arrives.",
+                },
               ],
             },
             {
               question: "How important is offline support?",
+              detail:
+                "Offline changes the data architecture fundamentally (local store + sync + conflict resolution), so it must be decided before the design phase, not after.",
               options: [
-                { label: "Not needed", recommended: true },
-                { label: "Nice to have" },
-                { label: "Critical" },
+                {
+                  label: "Not needed",
+                  description: "The app assumes a connection; a dropped network just shows a retry state. Simplest by far.",
+                  recommended: true,
+                },
+                {
+                  label: "Nice to have",
+                  description:
+                    "Read-only caching of recently viewed data — useful on flaky connections without full sync complexity.",
+                },
+                {
+                  label: "Critical",
+                  description:
+                    "Full offline editing with background sync and conflict resolution. Roughly doubles the data-layer work; only pick if users routinely work disconnected.",
+                },
               ],
             },
             {
               question: "Who administers the workspace?",
+              detail:
+                "The admin model decides whether v1 needs a roles/permissions system or can treat every user the same.",
               options: [
-                { label: "A single owner", recommended: true },
-                { label: "Multiple admins" },
-                { label: "No admin concept" },
+                {
+                  label: "A single owner",
+                  description:
+                    "The creator holds all admin rights — invite, remove, configure. No roles UI needed in v1.",
+                  recommended: true,
+                },
+                {
+                  label: "Multiple admins",
+                  description:
+                    "Owners can grant admin to others, which means a roles model, permission checks, and an audit story.",
+                },
+                {
+                  label: "No admin concept",
+                  description:
+                    "Every member is equal. Fine for small trusted groups; risky once anyone can delete shared data.",
+                },
               ],
             },
           ],
@@ -224,10 +376,25 @@ export const agentChatHandlers = [
       if (grillSingle) {
         const input = {
           question: "Who is the primary user of this app?",
+          detail:
+            "This shapes onboarding, permissions, and how much admin tooling the spec needs — it's the single biggest scope decision, so I'm asking it first.",
           options: [
-            { label: "Individual consumers", description: "Self-serve signup, personal workspaces", recommended: true },
-            { label: "Internal teams", description: "SSO, org-managed access" },
-            { label: "Both from day one", description: "Two onboarding paths — more scope" },
+            {
+              label: "Individual consumers",
+              description:
+                "People sign themselves up and get a personal workspace. Onboarding stays lightweight (email or social login, no org setup), but every account manages itself — there is no central admin who can provision or remove users.",
+              recommended: true,
+            },
+            {
+              label: "Internal teams",
+              description:
+                "An organization rolls the app out to its staff. That means SSO, org-managed access, and an admin who controls membership — more setup work up front, but access control and offboarding come for free.",
+            },
+            {
+              label: "Both from day one",
+              description:
+                "Two onboarding paths, two permission models, and pricing that has to serve both. Roughly doubles the v1 scope; usually only worth it when both audiences are already committed.",
+            },
           ],
           multiSelect: false,
         };

--- a/packages/agent-stream/src/contracts/sse-events.ts
+++ b/packages/agent-stream/src/contracts/sse-events.ts
@@ -137,7 +137,10 @@ export const ANSWERS_PREFIX = "Answers:" as const;
 export interface AskQuestionOption {
   /** Short display text — the value echoed back in the serialized answer. */
   label: string;
-  /** What choosing this option means or implies. */
+  /**
+   * The full explanation of this choice, rendered on the option card: what it
+   * means, what it implies, and its trade-offs — enough for the user to decide.
+   */
   description?: string;
   /** At most ONE option per question carries this — the agent's recommendation. */
   recommended?: boolean;
@@ -149,6 +152,11 @@ export interface AskQuestionOption {
  */
 export interface AskQuestionInput {
   question: string;
+  /**
+   * Context rendered under the question heading: why the agent is asking, what
+   * the decision affects, and anything the user needs to answer well.
+   */
+  detail?: string;
   /** 1–5 options; labels must be unique (they are the selection identity). */
   options: AskQuestionOption[];
   /** True → several options may be chosen together (checkboxes, not radios). */

--- a/packages/contracts/prompts/index.ts
+++ b/packages/contracts/prompts/index.ts
@@ -41,8 +41,10 @@
  */
 export const GRILLING_DIRECTIVE =
   "Before writing any files, interview me about this idea with the ask_question / ask_questions tools: " +
-  "structured questions with candidate options and the one you recommend, " +
-  "working through the idea's ambiguities until the requirements are unambiguous. " +
+  "structured questions with candidate options and the one you recommend. Make every question decidable " +
+  "on its own — explain in its detail why you ask and what it affects, and in each option's description " +
+  "what choosing it means and its trade-offs. " +
+  "Work through the idea's ambiguities until the requirements are unambiguous. " +
   "If a grilling skill is available in your catalog, load it first and follow it. " +
   "If I ask you to skip ahead or just generate, stop interviewing and proceed on " +
   "stated assumptions. When the interview is done, proceed with the following. ";

--- a/services/agents/src/agents/main/tools/files.ts
+++ b/services/agents/src/agents/main/tools/files.ts
@@ -102,12 +102,20 @@ export const removeFileInputSchema = z.object({
 
 const askQuestionOptionSchema = z.object({
   label: z.string().describe("Short display text for this choice — the exact value echoed back in the answer. Keep labels unique within a question."),
-  description: z.string().optional().describe("What choosing this option means or implies."),
+  description: z.string().optional().describe(
+    "The full explanation of this choice, shown on the option card. Write 2–4 sentences: what picking it " +
+    "means concretely, what it implies or rules out, and its trade-offs versus the other options — enough " +
+    "for a non-expert to decide confidently. Always provide it unless the label is truly self-explanatory.",
+  ),
   recommended: z.boolean().optional().describe("Mark the ONE option you recommend (at most one per question)."),
 });
 
 export const askQuestionInputSchema = z.object({
-  question: z.string().describe("The clarifying question to ask the user."),
+  question: z.string().describe("The clarifying question to ask the user — specific and self-contained, not a vague topic."),
+  detail: z.string().optional().describe(
+    "Context shown under the question: why you are asking, what part of the spec or design this decision " +
+    "affects, and any background the user needs to answer well. 1–3 sentences; plain language.",
+  ),
   options: z
     .array(askQuestionOptionSchema)
     .min(1)
@@ -147,8 +155,9 @@ void _drift;
 export const askQuestionTool: Tool = tool({
   description:
     "Ask the user ONE structured multiple-choice question when you cannot proceed safely without their decision. " +
-    "Give 1–5 options (mark at most one recommended); set multiSelect when several may apply together. " +
-    "Ends your turn; the user's answer arrives as the next message.",
+    "Make it decidable without prior context: put the why/what-it-affects in `detail`, and explain every option's " +
+    "meaning and trade-offs in its `description`. Give 1–5 options (mark at most one recommended); set multiSelect " +
+    "when several may apply together. Ends your turn; the user's answer arrives as the next message.",
   inputSchema: askQuestionInputSchema,
   execute: async (input) => ({ status: "awaiting_user_response" as const, ...input }),
 });


### PR DESCRIPTION
## What

Round 3 of #270: grilling questions become **decidable on their own**. The agent must now ask detailed questions and fully explain every answer option, and the console renders those explanations instead of hiding them.

Before: options rendered as compact chips whose descriptions only appeared on hover (tooltips), and a question was a bare one-liner. Users picked between labels like "Managed Postgres" and "Third-party BaaS" with no visible explanation of what either choice implies.

After: each question carries a `detail` paragraph (why the agent asks, what part of the spec the decision affects), and each option is a full-width selectable card — radio/checkbox, bold label, "Recommended" badge — with a 2–4 sentence description (meaning, implications, trade-offs) always visible.

## How

- **`@aep/agent-stream`** — optional `detail?: string` on `AskQuestionInput` (wire source of truth). Rides the existing `tool-call` frame; no new SSE event kinds, no OpenAPI change.
- **`services/agents`** — `detail` mirrored in the drift-guarded Zod schema (compile-time `Equal<>` guard keeps them in sync); schema + tool descriptions rewritten to demand self-contained questions and detailed option descriptions.
- **`@aep/contracts`** — the grilling directive now instructs the agent to explain each question (`detail`) and each option's meaning and trade-offs.
- **`apps/console`** — `SpecQuestionForm` option chips → detailed option cards (Oxygen UI; keyboard-accessible `radio`/`checkbox` roles); question heading + detail paragraph; full-width multiline "Other…" row. The fold parser (`questionCards.ts`) now keeps `detail` off the wire (it was dropped). Mock grilling fixtures carry realistic detailed content for both the single-question and 10-question-batch flows.

## Verification

- `turbo typecheck / lint / test` green across `@aep/agent-stream`, `@aep/agents`, `@aep/contracts`, `@aep/console` (392 console tests; new parser tests for `detail`).
- Mock-mode walkthrough on the dev server: `grill me about this spec` (single card) and `ask me everything all at once` (batch form) — selection, multi-select toggling, Recommended badges, detail paragraphs, Continue/Skip footer all verified in-browser. Screenshots below.

<img width="1200" height="762" alt="image" src="https://github.com/user-attachments/assets/45157653-f76e-4e39-bf42-a6c8467faaaa" />
<img width="1200" height="762" alt="image" src="https://github.com/user-attachments/assets/fb95c336-03df-4526-91d1-c65fcf5c711b" />


Closes nothing — #270 stays open per the flow; feedback on this round belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
