### PR TITLE
fix(resource-types): make local postgres-cnpg + thunder-app provisioning instant

### DIFF
--- a/deployments/single-cluster/resource-types/postgres-cnpg/resourcetype.yaml
+++ b/deployments/single-cluster/resource-types/postgres-cnpg/resourcetype.yaml
@@ -52,25 +52,31 @@ spec:
           maximum: 3
   resources:
     - id: cluster
-      # readyWhen gates the binding's ResourcesReady/Ready on the CNPG Cluster
-      # actually SERVING — not merely on a successful apply. This is load-bearing
-      # for P5's async-provisioning safety: OC 1.1.1's getUnknownResourceHealth
-      # returns `Healthy` UNCONDITIONALLY for unknown Kinds (a foreign CRD like the
-      # CNPG `Cluster`), so WITHOUT this gate the binding flips Ready=True at APPLY
-      # time — before Postgres serves — and the A5 watcher would mark the consumer
-      # task `deployed` against a non-serving DB.
+      # ─────────────────────────────────────────────────────────────────────────
+      # TEMPORARY WORKAROUND — readyWhen disabled. Tracking: openchoreo/openchoreo#4323
       #
-      # OC 1.1.1 DOES copy the foreign CRD's FULL live `status` into
-      # `applied.<id>.status` every reconcile, so `applied.cluster.status.phase` is
-      # available once CNPG writes it. The `has()` chain makes both the brief
-      # pre-APPLY window (the `applied.cluster` key does not exist yet) and the
-      # pre-PHASE window (status object exists but `.phase` not yet written)
-      # evaluate to `false` cleanly — fail-closed until the real CNPG healthy phase
-      # "Cluster in healthy state" appears. LIVE-VERIFIED 2026-06-30: the binding
-      # held Ready=False through "Setting up primary" / "Waiting for the instances
-      # to become active" and flipped Ready=True ONLY after phase reached "Cluster
-      # in healthy state" (gated transition, never an early flip).
-      readyWhen: '${has(applied.cluster) && has(applied.cluster.status) && has(applied.cluster.status.phase) && applied.cluster.status.phase == "Cluster in healthy state"}'
+      # OpenChoreo has no health check for foreign CRDs like the CNPG `Cluster`:
+      # getUnknownResourceHealth reports it `Healthy` the moment it is applied, so
+      # the RenderedRelease parks on the ~5-minute "stable" requeue instead of the
+      # 10s transitioning one. A readyWhen that reads applied.cluster.status.* is
+      # only re-evaluated when that status is re-observed, so the binding does not
+      # flip Ready until the next ~5-min requeue — even though Postgres is serving
+      # within ~30s (live-verified: DB healthy ~30s, binding Ready ~5m20s).
+      # Commenting out readyWhen lets the binding go Ready at apply time so local
+      # provisioning is fast (the outputs below are static / secretKeyRef and never
+      # read live status, so nothing else re-introduces the delay).
+      #
+      # TRADE-OFF: without this gate the binding reports Ready BEFORE Postgres is
+      # actually serving, so a consumer may connect to a not-yet-ready DB for the
+      # first ~30s. Restore the readyWhen line below once OpenChoreo adds foreign-CRD
+      # health checks or data-plane watch events (issue #4323). Unlike thunder-app,
+      # postgres has no deterministic ready signal to key off, so this stays a
+      # temporary measure rather than a redesign.
+      #
+      # Original gate (restore verbatim when #4323 lands): fail-closes through the
+      # pre-apply / pre-phase windows until the CNPG Cluster reaches phase
+      # "Cluster in healthy state".
+      # readyWhen: '${has(applied.cluster) && has(applied.cluster.status) && has(applied.cluster.status.phase) && applied.cluster.status.phase == "Cluster in healthy state"}'
       template:
         apiVersion: postgresql.cnpg.io/v1
         kind: Cluster

--- a/deployments/single-cluster/resource-types/thunder-app/resourcetype.yaml
+++ b/deployments/single-cluster/resource-types/thunder-app/resourcetype.yaml
@@ -101,21 +101,26 @@ spec:
           default: ""
   resources:
     - id: app
-      # readyWhen gates the binding's ResourcesReady/Ready on the operator having
-      # actually minted the OAuth app on Thunder — not merely on a successful
-      # apply. OC 1.1.1's getUnknownResourceHealth returns `Healthy`
-      # UNCONDITIONALLY for unknown Kinds (a foreign CRD like ThunderApplication),
-      # so WITHOUT this gate the binding flips Ready=True at APPLY time — before
-      # the client_id exists — and a consumer would bind against an OAuth app that
-      # is not yet registered.
+      # ─────────────────────────────────────────────────────────────────────────
+      # INSTANT PROVISIONING — readyWhen relaxed to ${true} on purpose.
       #
-      # OC 1.1.1 copies the foreign CRD's live `status` into `applied.<id>.status`
-      # every reconcile, so `applied.app.status.ready` is available once the
-      # operator writes it. The `has()` chain makes both the pre-APPLY window (the
-      # `applied.app` key does not exist yet) and the pre-READY window (status
-      # object exists but `.ready` not yet written) evaluate to `false` cleanly —
-      # fail-closed until the operator reports ready.
-      readyWhen: '${has(applied.app) && has(applied.app.status) && has(applied.app.status.ready) && applied.app.status.ready}'
+      # The OAuth app's client_id is DETERMINISTIC: the operator always registers
+      # it on Thunder as "aep-<cr-namespace>-<cr-name>" (see thunderAppName in the
+      # operator's thunderapplication_controller.go), and Thunder honours a
+      # caller-supplied client_id. So the client_id is fully known at render time
+      # and does NOT need to be read back from the CR's live status (see the
+      # client_id output below).
+      #
+      # Gating readyWhen on applied.app.status.ready would tie readiness to live CR
+      # status, which OpenChoreo only re-observes on its ~5-minute "stable" requeue
+      # (it has no health check for foreign CRDs like ThunderApplication —
+      # getUnknownResourceHealth reports them Healthy immediately), making the
+      # binding take ~5 min to go Ready. Tracking: openchoreo/openchoreo#4323.
+      #
+      # TRADE-OFF: with ${true} the binding reports Ready before Thunder finishes
+      # registering the app, so a login attempt in the first ~few seconds can fail
+      # and then self-heal. Acceptable for these local single-cluster dev types.
+      readyWhen: '${true}'
       template:
         apiVersion: aep.wso2.com/v1alpha1
         kind: ThunderApplication
@@ -128,22 +133,23 @@ spec:
           scopes: ${parameters.scopes}
           redirectUris: ${environmentConfigs.redirectUris}
   outputs:
-    # client_id is read straight off the applied CR's live status (the operator
-    # writes `status.clientId` alongside `status.ready`). Emitting it as a CEL
-    # `value` makes OC deliver a LITERAL string in the binding's status.outputs
-    # — which the aep-api runtimeconfig env-config.js path requires (it reads
+    # client_id is DETERMINISTIC — the operator registers the OAuth app on Thunder
+    # as "aep-<cr-namespace>-<cr-name>" (thunderAppName in the operator), and
+    # Thunder honours that caller-supplied id. So we emit it as a rendered literal
+    # instead of reading `applied.app.status.clientId`. This keeps the output
+    # resolvable at APPLY time — no dependency on live CR status, which OpenChoreo
+    # only re-observes every ~5 min (openchoreo/openchoreo#4323) — and it is the
+    # `value` shape the aep-api runtimeconfig env-config.js path requires (it reads
     # `output.value` only; a configMapKeyRef-shaped output carries no value in
-    # binding status, leaving the client_id output unresolvable). Verified
-    # empirically on OC 1.1.1: outputs share readyWhen's CEL context, including
-    # `applied.<id>.status.*`. The readyWhen gate above means outputs are only
-    # surfaced once `status.ready=true`, and the operator sets `clientId`
-    # together with `ready`, so this never resolves empty on a Ready binding.
+    # binding status). metadata.namespace / metadata.name here resolve to the same
+    # rendered CR namespace/name the operator derives thunderAppName from, so the
+    # literal matches the registered client_id exactly.
     #
     # The operator ALSO publishes client_id in the `<cr-name>-oauth` ConfigMap;
     # that stays useful as a k8s-native artifact and for generic valueFrom-style
-    # env injection — but the authoritative binding output is the CR status.
+    # env injection — but the authoritative binding output is this literal.
     - name: client_id
-      value: ${applied.app.status.clientId}
+      value: aep-${metadata.namespace}-${metadata.name}
     # Plain coordinates — exposed as values (the BFF surfaces them un-masked). The
     # issuer/jwks_url are the browser-reachable Thunder addresses (they match the
     # compose PLATFORM_IDP_ISSUER host thunder.openchoreo.localhost:8080).


### PR DESCRIPTION
## What & why

Local dependency provisioning for `postgres-cnpg` and `thunder-app` took **~5 minutes** to report `Ready`, even though the backing resource was actually serving within ~30s.

Root cause is in OpenChoreo (tracked at openchoreo/openchoreo#4323): it has no health check for foreign CRDs, so `getUnknownResourceHealth` reports them `Healthy` the moment they are applied. That parks the `RenderedRelease` on the ~5-minute **stable** requeue instead of the 10s transitioning one, and OpenChoreo does not watch data-plane objects — so any `readyWhen`/output that reads the CRD's **live status** is only re-observed every ~5 min. A resource whose readiness genuinely depends on post-apply settling therefore flips `Ready` up to ~5 min late.

This PR removes the local resource types' dependency on re-observing live CRD status, so provisioning is instant until the upstream fix lands.

## Changes

**`thunder-app` — proper fix (instant, no correctness loss on the output):**
- `client_id` output: `${applied.app.status.clientId}` → `aep-${metadata.namespace}-${metadata.name}`. The operator always registers the OAuth app on Thunder as `aep-<cr-namespace>-<cr-name>` (`thunderAppName`) and Thunder honours caller-supplied client_ids, so the id is deterministic and known at render time — no read-back needed.
- `readyWhen`: gated on `applied.app.status.ready` → `'${true}'`.

**`postgres-cnpg` — temporary workaround:**
- `readyWhen` (gated on `applied.cluster.status.phase`) commented out. Outputs are already static/`secretKeyRef`, so the binding now goes `Ready` at apply time. Kept as a comment (not deleted) with a note to restore verbatim once #4323 is fixed — postgres has no deterministic ready signal to key off, so this stays a temporary measure.

Plain `postgres` (StatefulSet) is intentionally untouched — it's a known kind that OpenChoreo health-checks, so it already reconciles on the 10s cadence and is not affected.

## Trade-off

Both types now report `Ready` before the backing resource is fully serving:
- postgres: a consumer may connect to a not-yet-serving DB for the first ~30s.
- thunder-app: a login attempt in the first ~few seconds can fail, then self-heal once Thunder finishes registering the app.

Acceptable for these local `single-cluster` dev types. The comments document this and reference #4323.

## Verification (live, on k3d-openchoreo)

Provisioned fresh instances of both types after the change:

| Type | Before | After |
|---|---|---|
| postgres-cnpg | 5m20s (measured: DB healthy ~30s, binding Ready ~5m20s) | **<1s** (created and `Ready` in the same second) |
| thunder-app | ~5 min | **<1s** |

- thunder-app `client_id` output resolved to **exactly** the operator-registered `ThunderApplication.status.clientId`.
- `ThunderApplication.status.ready = true` — Thunder accepted and registered the app with the deterministic id.
- Browser (agent-browser): an OAuth2 PKCE authorize request with the deterministic `client_id` returned `302 → /gate/signin` and rendered Thunder's real sign-in page (Username/Password form), with **no** `invalid_client` error.

## Follow-up

Revert both changes (restore `readyWhen`; thunder-app may keep the deterministic `client_id` value as a genuine improvement) once openchoreo/openchoreo#4323 ships foreign-CRD health checks or data-plane watch events.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
