### PR TITLE
fix(runner): one credential flow — the helper answers git's `get`

### DIFF
--- a/runners/AGENTS.md
+++ b/runners/AGENTS.md
@@ -12,11 +12,22 @@ edits (see `deployments/scripts/setup-k3d.sh`).
 
 - One entry point per pod (`src/oneshot.ts`); everything reachable from it.
 - **Never put a credential in a git URL or in argv.** All clones go through
-  `lib/git_clone.ts`, which passes the token via a `GIT_ASKPASS` shim in the
-  child env — an authenticated URL leaks into `child_process` error messages
-  (which the BFF forwards to the console build log), into `ps`, and into
+  `lib/git_clone.ts` — an authenticated URL leaks into `child_process` error
+  messages (which the BFF forwards to the console build log), into `ps`, and into
   `.git/config`. Rationale inline in `git_clone.ts`; the BFF keeps a shape-based
   second line of defense in `delivery/codingagent/redact.go`.
+- **ONE credential mechanism: the git credential helper in `lib/credhelper.ts`.**
+  Every authenticated git operation in a run goes through it, the provisioning
+  clone included — the clone wires it in with `git -c credential.<origin>.helper`
+  because `.git/config` doesn't exist yet, and `workspace.ts` installs the same
+  script durably afterwards. No GIT_ASKPASS, no token in argv or env, and the
+  runner process never holds a GitHub token. Don't add a second path: the last
+  one shipped a script serving two protocols that dispatched on `[ -n "$1" ]`,
+  which is true for both, so the clone worked and every agent operation failed
+  its auth silently. Putting the helper on the clone is what makes a break a
+  provisioning failure instead. Any change to the generated scripts must keep
+  `credhelper.test.ts` green — it drives them with real `git`, which is the only
+  thing that would have caught that.
 - Runner `console.*` is a **user-facing** channel — the BFF turns every
   non-NDJSON pod line into a build-log event. `installConsoleScrubber()` at each
   entry point routes it through the scrubber; don't bypass it.

--- a/runners/remote-worker/plugin/skills/aep/SKILL.md
+++ b/runners/remote-worker/plugin/skills/aep/SKILL.md
@@ -26,6 +26,13 @@ call, and it learns your branch and your PR from GitHub webhooks. What you
 **push**, and the pull request you open, are the record of this cycle — not the
 working tree.
 
+**If a `git` or `gh` command fails to authenticate, that is a platform fault,
+not an obstacle to work around.** Say so in one line and stop the run. Do not
+inspect `.aep/`, read the bearer file, run the credential helper by hand, call
+the refresh endpoint with `curl`, or set `GIT_ASKPASS` — none of it can fix a
+broken credential, and the attempt buries the real error in a long transcript.
+One clear report is worth more than an hour of probing.
+
 > **Validation runs**: if your prompt says this is a **validation task** and
 > points at a single validation issue, the `aep-validation` skill's workflow
 > REPLACES the workflow below — load it. The authentication model, git/gh

--- a/runners/remote-worker/src/lib/credhelper.test.ts
+++ b/runners/remote-worker/src/lib/credhelper.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The generated credential scripts, exercised as programs.
+//
+// These tests exist because the bug they now guard shipped undetected: the
+// script carried two credential protocols and picked between them with
+// `[ -n "$1" ]`, which is true for BOTH — git passes a credential helper its
+// action verb (`get`) in $1. The branch that emitted valid `username=`/
+// `password=` output was unreachable, so every git operation the coding agent
+// attempted failed to authenticate. Nothing caught it because nothing ran the
+// generated script; the dual-protocol claim lived only in a comment.
+//
+// So: assert against the real interpreter, and for the wiring assert against
+// real git. `gitCredentialFill` below is the test that would have failed on day
+// one.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { CREDHELPER_FILE, credHelperScript, ghWrapperScript } from "./credhelper.js";
+import { shellQuote } from "./shell.js";
+
+const execAsync = promisify(exec);
+
+const TASK_ID = "6f1a2b3c-4d5e-6f70-8192-a3b4c5d6e7f8";
+const GH_TOKEN = "ghs_TESTONLYabcdefghijklmnopqrstuvwxyz01";
+const BEARER = "test-platform-bearer";
+
+interface StubResponse {
+  token?: string;
+  taskId?: string;
+  identity?: Record<string, string>;
+}
+
+interface Stub {
+  url: string;
+  /** Refresh requests received — 0 proves a code path returned before the round-trip. */
+  requests: () => number;
+  authHeaders: () => Array<string | undefined>;
+  close: () => Promise<void>;
+}
+
+// A stand-in for POST /internal/v1/executions/{id}/credentials/refresh. Port 0
+// so concurrent test files can't collide.
+async function startStub(body: StubResponse): Promise<Stub> {
+  let requests = 0;
+  const authHeaders: Array<string | undefined> = [];
+  const server = http.createServer((req, res) => {
+    requests += 1;
+    authHeaders.push(req.headers.authorization);
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (addr === null || typeof addr === "string") throw new Error("stub failed to bind");
+  return {
+    url: `http://127.0.0.1:${addr.port}/internal/v1/executions/${TASK_ID}/credentials/refresh`,
+    requests: () => requests,
+    authHeaders: () => authHeaders,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+interface Fixture {
+  dir: string;
+  workspace: string;
+  helper: string;
+  bearerFile: string;
+  env: NodeJS.ProcessEnv;
+}
+
+// Writes the helper exactly as provisionWorkspace does, plus an empty git repo
+// standing in for the cloned work tree.
+async function fixture(refreshUrl: string, opts?: { bearer?: string }): Promise<Fixture> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-credhelper-"));
+  const workspace = path.join(dir, "workspace");
+  await execAsync(`git init -q ${shellQuote(workspace)}`);
+
+  const helper = path.join(dir, CREDHELPER_FILE);
+  await fs.promises.writeFile(
+    helper,
+    credHelperScript({ taskId: TASK_ID, workspaceDir: workspace, refreshUrl }),
+    { mode: 0o700 },
+  );
+
+  const bearerFile = path.join(dir, "bearer");
+  await fs.promises.writeFile(bearerFile, opts?.bearer ?? BEARER, { mode: 0o600 });
+
+  return {
+    dir,
+    workspace,
+    helper,
+    bearerFile,
+    // A controlled env: PUBLISHER_* must be absent so these tests exercise the
+    // bearer-file path deterministically even on a machine that has them set.
+    env: {
+      PATH: process.env.PATH,
+      HOME: dir,
+      AEP_BEARER_FILE: bearerFile,
+      AEP_CORRELATION_ID: "corr-test-1",
+    },
+  };
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function run(cmd: string, env: NodeJS.ProcessEnv): Promise<RunResult> {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { env });
+    return { code: 0, stdout, stderr };
+  } catch (e) {
+    const err = e as { code?: number; stdout?: string; stderr?: string };
+    return { code: err.code ?? 1, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
+  }
+}
+
+// The credential description git writes on stdin, which the helper drains and
+// discards (it is config-scoped to one origin, so there is nothing to match).
+const GIT_STDIN = "protocol=https\\nhost=github.com\\n\\n";
+const withStdin = (script: string, action: string): string =>
+  `printf '${GIT_STDIN}' | ${shellQuote(script)} ${action}`;
+
+// ---- the credential-helper protocol ----------------------------------------
+
+test("credhelper get: emits key=value lines git can parse", async () => {
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(withStdin(f.helper, "get"), f.env);
+
+    assert.equal(r.code, 0, `helper failed: ${r.stderr}`);
+    // Exactly the two lines, in git's key=value form. A bare token here is what
+    // the old script emitted: git answers it with "warning: invalid credential
+    // line" and then fails the operation for want of a username.
+    assert.deepEqual(r.stdout.trimEnd().split("\n"), [
+      "username=x-access-token",
+      `password=${GH_TOKEN}`,
+    ]);
+    assert.equal(stub.requests(), 1);
+    assert.deepEqual(stub.authHeaders(), [`Bearer ${BEARER}`]);
+  } finally {
+    await stub.close();
+  }
+});
+
+test("credhelper get: defaults to get when invoked with no action", async () => {
+  // Not how git calls it, but it keeps a by-hand invocation useful for debugging
+  // instead of silently doing nothing.
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(`${shellQuote(f.helper)} </dev/null`, f.env);
+    assert.equal(r.code, 0, `helper failed: ${r.stderr}`);
+    assert.match(r.stdout, new RegExp(`^password=${GH_TOKEN}$`, "m"));
+  } finally {
+    await stub.close();
+  }
+});
+
+for (const action of ["store", "erase"]) {
+  test(`credhelper ${action}: no output and no refresh round-trip`, async () => {
+    const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+    const f = await fixture(stub.url);
+    try {
+      const r = await run(withStdin(f.helper, action), f.env);
+
+      assert.equal(r.code, 0, `${action} must exit 0: ${r.stderr}`);
+      assert.equal(r.stdout, "", `${action} must print nothing`);
+      // The token is re-minted per operation and never cached, so there is
+      // nothing to store or erase — and no reason to burn a token mint.
+      assert.equal(stub.requests(), 0, `${action} must not call the refresh endpoint`);
+    } finally {
+      await stub.close();
+    }
+  });
+}
+
+test("credhelper: an unknown action is ignored, not failed", async () => {
+  // gitcredentials(7) asks helpers to ignore operations they don't implement, so
+  // a future git that probes for a new action must not become an auth failure.
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(withStdin(f.helper, "capability"), f.env);
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, "");
+    assert.equal(stub.requests(), 0);
+  } finally {
+    await stub.close();
+  }
+});
+
+// ---- real git, real protocol -------------------------------------------------
+
+test("git credential fill: git accepts the helper's output for the configured origin", async () => {
+  // The end-to-end wiring assertion, and the one that pins the regression: git
+  // parses our `credential.<origin>.helper` key, invokes the script with `get`,
+  // and accepts what it prints. Everything below the transport is covered.
+  //
+  // GIT_CONFIG_GLOBAL/SYSTEM must be neutered: an unisolated `credential fill`
+  // consults the developer's osxkeychain/gh helper, which answers with a real
+  // credential and would make a completely broken helper look like it worked.
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url);
+  try {
+    const scope = "https://github.com";
+    const cfg = shellQuote(`credential.${scope}.helper=${f.helper}`);
+    const r = await run(
+      `printf 'protocol=https\\nhost=github.com\\n\\n' | git -c ${cfg} credential fill`,
+      {
+        ...f.env,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    );
+
+    assert.equal(r.code, 0, `git credential fill failed: ${r.stderr}`);
+    assert.ok(
+      !r.stderr.includes("invalid credential line"),
+      `git rejected the helper's output: ${r.stderr}`,
+    );
+    assert.match(r.stdout, /^username=x-access-token$/m);
+    assert.match(r.stdout, new RegExp(`^password=${GH_TOKEN}$`, "m"));
+  } finally {
+    await stub.close();
+  }
+});
+
+// ---- anti-misroute tripwire (PR D §6.6) -------------------------------------
+
+test("credhelper: refuses when the response's taskId is not the bound task", async () => {
+  const stub = await startStub({ token: GH_TOKEN, taskId: "11111111-2222-3333-4444-555555555555" });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(withStdin(f.helper, "get"), f.env);
+
+    assert.notEqual(r.code, 0, "a misrouted bearer must not yield a credential");
+    assert.ok(!r.stdout.includes(GH_TOKEN), `leaked the token anyway: ${r.stdout}`);
+    assert.match(r.stderr, /refusing/);
+    assert.match(r.stderr, new RegExp(TASK_ID));
+  } finally {
+    await stub.close();
+  }
+});
+
+test("credhelper: tolerates a response that echoes no taskId", async () => {
+  // Older git-service versions don't echo it; in that mode the bearer's
+  // signature is the only credential check.
+  const stub = await startStub({ token: GH_TOKEN });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(withStdin(f.helper, "get"), f.env);
+    assert.equal(r.code, 0, `helper failed: ${r.stderr}`);
+    assert.match(r.stdout, new RegExp(`^password=${GH_TOKEN}$`, "m"));
+  } finally {
+    await stub.close();
+  }
+});
+
+// ---- identity drift (PR D §6.6) ---------------------------------------------
+
+// The wire contract CAPITALIZES Identity field names while the envelope keys are
+// lowercase (packages/contracts/api/internal/v1/openapi.yaml). Reading only the
+// lowercase form left this whole feature dead in production, so both cases are
+// pinned here.
+for (const [label, identity] of [
+  ["capitalized (the wire contract)", { Login: "aep-bot", Name: "AEP Bot", Email: "bot@aep.dev" }],
+  ["lowercase (tolerated)", { login: "aep-bot", name: "AEP Bot", email: "bot@aep.dev" }],
+] as const) {
+  test(`credhelper: rewrites .git/config identity on drift — ${label}`, async () => {
+    const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID, identity });
+    const f = await fixture(stub.url);
+    try {
+      await execAsync(`git -C ${shellQuote(f.workspace)} config user.name 'Stale Name'`);
+      await execAsync(`git -C ${shellQuote(f.workspace)} config user.email 'stale@example.com'`);
+
+      const r = await run(withStdin(f.helper, "get"), f.env);
+      assert.equal(r.code, 0, `helper failed: ${r.stderr}`);
+
+      const name = await execAsync(`git -C ${shellQuote(f.workspace)} config user.name`);
+      const email = await execAsync(`git -C ${shellQuote(f.workspace)} config user.email`);
+      assert.equal(name.stdout.trim(), "AEP Bot");
+      assert.equal(email.stdout.trim(), "bot@aep.dev");
+      assert.match(r.stderr, /identity drift detected/);
+    } finally {
+      await stub.close();
+    }
+  });
+}
+
+test("credhelper: leaves identity alone when it has not drifted", async () => {
+  const stub = await startStub({
+    token: GH_TOKEN,
+    taskId: TASK_ID,
+    identity: { Login: "aep-bot", Name: "AEP Bot", Email: "bot@aep.dev" },
+  });
+  const f = await fixture(stub.url);
+  try {
+    await execAsync(`git -C ${shellQuote(f.workspace)} config user.name 'AEP Bot'`);
+    await execAsync(`git -C ${shellQuote(f.workspace)} config user.email 'bot@aep.dev'`);
+
+    const r = await run(withStdin(f.helper, "get"), f.env);
+    assert.equal(r.code, 0, `helper failed: ${r.stderr}`);
+    assert.ok(!r.stderr.includes("identity drift"), `spurious rewrite: ${r.stderr}`);
+  } finally {
+    await stub.close();
+  }
+});
+
+// ---- failure diagnostics -----------------------------------------------------
+
+test("credhelper: names the missing bearer instead of failing mutely", async () => {
+  // The failure mode that produced an hour of agent self-debugging: git's own
+  // message ("could not read Username for …") says nothing about the cause.
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url, { bearer: "" });
+  try {
+    const r = await run(withStdin(f.helper, "get"), f.env);
+
+    assert.notEqual(r.code, 0);
+    assert.equal(r.stdout, "");
+    assert.match(r.stderr, /no platform credential/);
+    assert.equal(stub.requests(), 0);
+  } finally {
+    await stub.close();
+  }
+});
+
+test("credhelper: names a refresh endpoint that will not answer", async () => {
+  // `.invalid` is reserved and never resolves.
+  const f = await fixture("http://aep-refresh.invalid/internal/v1/executions/x/credentials/refresh");
+  const r = await run(withStdin(f.helper, "get"), f.env);
+
+  assert.notEqual(r.code, 0);
+  assert.equal(r.stdout, "");
+  assert.match(r.stderr, /credential refresh failed/);
+});
+
+test("credhelper: never prints the platform bearer", async () => {
+  const stub = await startStub({ token: GH_TOKEN, taskId: "mismatched-on-purpose" });
+  const f = await fixture(stub.url);
+  try {
+    const r = await run(withStdin(f.helper, "get"), f.env);
+    assert.ok(
+      !`${r.stdout}${r.stderr}`.includes(BEARER),
+      `diagnostics leaked the bearer: ${r.stdout}${r.stderr}`,
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+// ---- the gh wrapper ----------------------------------------------------------
+
+test("gh wrapper: gets its token from credhelper.sh and writes hosts.yml", async () => {
+  // The wrapper used to carry its own copy of the exchange that read
+  // $AEP_BEARER_FILE only, so a publisher-cc run served whatever token was
+  // minted at pod start and degraded silently once it expired. It now delegates,
+  // which is what this asserts: one implementation of the refresh.
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url);
+  try {
+    const ghConfigDir = path.join(f.dir, "gh-config");
+    // A stub "real gh" that reports its argv, proving the wrapper execs through.
+    const fakeGh = path.join(f.dir, "real-gh");
+    await fs.promises.writeFile(fakeGh, '#!/bin/sh\necho "GH_ARGS:$*"\n', { mode: 0o755 });
+
+    const wrapper = path.join(f.dir, "gh");
+    await fs.promises.writeFile(wrapper, ghWrapperScript(fakeGh), { mode: 0o755 });
+
+    const r = await run(`${shellQuote(wrapper)} pr create --title x`, {
+      ...f.env,
+      GH_CONFIG_DIR: ghConfigDir,
+    });
+
+    assert.equal(r.code, 0, `wrapper failed: ${r.stderr}`);
+    assert.match(r.stdout, /GH_ARGS:pr create --title x/);
+
+    const hosts = await fs.promises.readFile(path.join(ghConfigDir, "hosts.yml"), "utf-8");
+    assert.match(hosts, new RegExp(`oauth_token: ${GH_TOKEN}`));
+    assert.equal(stub.requests(), 1, "the wrapper should refresh exactly once, via the helper");
+  } finally {
+    await stub.close();
+  }
+});
+
+test("gh wrapper: still execs gh when the refresh fails", async () => {
+  // hosts.yml from an earlier call may still be valid; gh reports its own auth
+  // error if it isn't. A hard failure here would break `gh` for reasons
+  // unrelated to what the agent was doing.
+  const f = await fixture("http://aep-refresh.invalid/internal/v1/executions/x/credentials/refresh");
+  const fakeGh = path.join(f.dir, "real-gh");
+  await fs.promises.writeFile(fakeGh, '#!/bin/sh\necho "GH_RAN"\n', { mode: 0o755 });
+  const wrapper = path.join(f.dir, "gh");
+  await fs.promises.writeFile(wrapper, ghWrapperScript(fakeGh), { mode: 0o755 });
+
+  const r = await run(`${shellQuote(wrapper)} auth status`, {
+    ...f.env,
+    GH_CONFIG_DIR: path.join(f.dir, "gh-config"),
+  });
+
+  assert.equal(r.code, 0, `wrapper should not hard-fail: ${r.stderr}`);
+  assert.match(r.stdout, /GH_RAN/);
+  assert.match(r.stderr, /credential refresh failed/);
+});

--- a/runners/remote-worker/src/lib/credhelper.ts
+++ b/runners/remote-worker/src/lib/credhelper.ts
@@ -18,26 +18,46 @@
 
 import { shellQuote } from "./shell.js";
 
-// Templates for the workspace credential helpers.
+// Templates for the workspace credential scripts.
+//
+// ONE mechanism, ONE protocol. Every authenticated git operation in a run goes
+// through `credhelper.sh` acting as a git credential helper — including the
+// provisioning clone, which wires it in with `git -c credential.<origin>.helper`
+// (see git_clone.ts) before `.git/config` exists to hold it. Nothing uses
+// GIT_ASKPASS, and no GitHub token is ever handed to git through an env var, a
+// URL, or argv.
+//
+// That single-path property is load-bearing, and was learned the hard way: an
+// earlier version of this file carried BOTH protocols in one script and chose
+// between them with `[ -n "$1" ]`, on the belief that only GIT_ASKPASS passes an
+// argument. Git invokes a credential helper as `credhelper.sh get`, so `$1` is
+// non-empty in both modes; the helper branch was unreachable and every git
+// operation the agent attempted failed to authenticate, while the clone (real
+// GIT_ASKPASS, prompt text in `$1`) kept working and hid the breakage. Putting
+// the helper on the clone too means the mechanism the agent depends on is
+// exercised before the agent starts: a break is now a provisioning failure, not
+// a mystery an hour into a run.
 //
 // Two scripts live inside each task's `.aep/` directory:
 //
-//   - `credhelper.sh`: a git credential helper that, on every git op,
-//     POSTs to /credentials/refresh on git-service to get a fresh token.
-//     Phase 0's long-lived PAT makes this trivial; Phase 2's short-lived
-//     App tokens use the same code path. The script also enforces the
-//     PR D §6.6 anti-misroute tripwire (response.taskId must match the
-//     workspace's task) and rewrites .git/config user fields when the
-//     credential's identity drifted on the server side mid-task.
+//   - `credhelper.sh`: the git credential helper. On every `get` it POSTs to
+//     the execution-scoped credentials/refresh endpoint for a fresh GitHub
+//     token. Phase 0's long-lived PAT makes the refresh trivial; Phase 2's
+//     short-lived App tokens use the same code path, so token expiry mid-run
+//     needs no special handling. It also enforces the PR D §6.6 anti-misroute
+//     tripwire (response.taskId must match the workspace's task) and rewrites
+//     .git/config user fields when the credential's identity drifted on the
+//     server side mid-task.
 //
-//   - `gh` (a wrapper): pre-flights every `gh` invocation by refreshing
-//     the token and rewriting `$GH_CONFIG_DIR/hosts.yml` before exec'ing
-//     the real binary. Same anti-misroute tripwire as credhelper.sh.
+//   - `gh` (a wrapper): pre-flights every `gh` invocation by rewriting
+//     `$GH_CONFIG_DIR/hosts.yml` with a fresh token before exec'ing the real
+//     binary. It obtains that token BY CALLING `credhelper.sh get`, so there is
+//     exactly one implementation of the exchange.
 //
-// Both scripts read the per-task bearer from a chmod-600 file rather than
-// from env, so transcripts and process listings can't leak it. taskId
-// and workspace path are baked into the script at provisioning time so
-// the agent process doesn't need to thread them through env.
+// Both scripts read the per-task bearer from a chmod-600 file rather than from
+// env, so transcripts and process listings can't leak it. taskId, workspace
+// path and the refresh URL are baked in at provisioning time so the agent
+// process doesn't need to thread them through env.
 
 export interface CredHelperParams {
   // Per-task identifier baked into the script for the anti-misroute
@@ -45,108 +65,128 @@ export interface CredHelperParams {
   taskId: string;
   // Absolute workspace path for `.git/config` rewrites on identity drift.
   workspaceDir: string;
+  // Fully-resolved credentials/refresh endpoint. Baked in rather than rebuilt
+  // from env inside bash: workspace.ts already owns this URL for its own use
+  // (resolveRefreshUrl), and one owner means the clone and the agent cannot
+  // end up pointed at different endpoints.
+  refreshUrl: string;
 }
 
-// Env var carrying a clone token into the git child process, where only the
-// askpass shim below reads it. It is set on a per-child env object and NEVER
-// on `process.env`: runner.ts spreads `process.env` into the agent's child
-// env, so a token placed there would reach the agent and everything it spawns.
-export const CLONE_TOKEN_ENV = "AEP_CLONE_TOKEN";
-
-// The shim's filename on disk. Written into a scratch dir, never the work tree.
-export const ASKPASS_FILE = "askpass.sh";
-
-// askpassScript answers git's credential prompts from the child environment.
-// Mirrors services/aep-api/internal/platform/gitfs/askpass.go: because the
-// token travels in the environment rather than in the clone URL, it cannot
-// appear in argv (a `ps` listing), in a `Command failed: git clone '<url>'`
-// error message, or in the cloned repo's `.git/config` — git preserves URL
-// userinfo verbatim, so an authenticated clone URL leaves the credential at
-// rest in the work tree for the whole run.
-//
-// Unlike credhelper.sh this shim performs no refresh round-trip: the caller
-// has already minted the token. It is static, so writing it is idempotent.
-export function askpassScript(): string {
-  return `#!/bin/sh
-# AEP clone credential shim — answers git's GIT_ASKPASS prompts from the
-# child environment so the token never reaches argv, an error message, or
-# .git/config.
-case "$1" in
-*sername*) echo x-access-token ;;
-*) printf %s "$${CLONE_TOKEN_ENV}" ;;
-esac
-`;
-}
+// The script's filename inside `.aep/`. The gh wrapper locates it relative to
+// its own path, so the two must stay siblings.
+export const CREDHELPER_FILE = "credhelper.sh";
 
 export function credHelperScript(params: CredHelperParams): string {
-  const { taskId, workspaceDir } = params;
+  const { taskId, workspaceDir, refreshUrl } = params;
   return `#!/usr/bin/env bash
-# Git credential helper for AEP platform-managed repos.
-# Two auth modes (WS2.6 — both call the path-scoped endpoint
-# POST /internal/v1/executions/{executionId}/credentials/refresh, which accepts
-# either token; the bound id below is the execution id, §9.2):
+# Git credential helper for AEP platform-managed repos. This is the ONLY way a
+# GitHub token reaches a git process in a run: the provisioning clone wires it in
+# with \`git -c credential.<origin>.helper=…\`, and the workspace's .git/config
+# carries it for every operation the agent performs afterwards.
+#
+# Two ways to authenticate to the platform (WS2.6 — both call the path-scoped
+# endpoint POST /internal/v1/executions/{executionId}/credentials/refresh, which
+# accepts either token; the bound id below is the execution id, §9.2):
 #   (a) publisher cc — when PUBLISHER_CLIENT_ID/SECRET/TOKEN_URL are set,
 #       mint a Thunder access token via client_credentials.
 #   (b) legacy TaskJWT — read the per-task bearer from \$AEP_BEARER_FILE.
-# Stays silent on errors so git's own error message reaches the user.
 #
-# Phase 2 PR D §6.6 anti-misroute: refuses if the refresh response's
-# taskId doesn't match this script's bound task — defends against a
-# bearer mistakenly mounted in the wrong workspace from rewriting this
-# task's identity or borrowing this task's credential.
+# \$AEP_BEARER_FILE is supplied by whoever invokes git, which is what lets the
+# same bytes serve both phases of a run: the provisioning clone points it at a
+# staged bearer (the workspace does not exist yet), and the agent's environment
+# points it at .aep/bearer. The script is never rewritten between the two.
 #
-# Phase 2 PR D §6.6 identity drift: when the server-side credential's
-# identity changed mid-task (PAT replaced with a different-user PAT,
-# or App account renamed), rewrite .git/config user.name / user.email
-# so subsequent commits attribute correctly. The first in-flight commit
-# may still carry the old identity (best-effort, not transactional).
+# Diagnostics go to stderr deliberately. An earlier version stayed silent on
+# every failure "so git's own error message reaches the user"; git's message for
+# a helper that returns nothing is \`could not read Username for …\`, which says
+# nothing about why, and the resulting debugging spiral is what motivated this
+# rewrite. Git relays helper stderr, and the BFF scrubs it before it reaches the
+# build log, so naming the failure costs nothing.
+#
+# Phase 2 PR D §6.6 anti-misroute: refuses if the refresh response's taskId
+# doesn't match this script's bound task — defends against a bearer mistakenly
+# mounted in the wrong workspace from rewriting this task's identity or
+# borrowing this task's credential.
+#
+# Phase 2 PR D §6.6 identity drift: when the server-side credential's identity
+# changed mid-task (PAT replaced with a different-user PAT, or App account
+# renamed), rewrite .git/config user.name / user.email so subsequent commits
+# attribute correctly. The first in-flight commit may still carry the old
+# identity (best-effort, not transactional).
 set -e
 expected_task_id=${shellQuote(taskId)}
 workspace_dir=${shellQuote(workspaceDir)}
+refresh_url=${shellQuote(refreshUrl)}
+
+# Drain the credential description git writes to our stdin. We don't need it —
+# the helper is config-scoped to a single origin, so there is nothing to match
+# on — but leaving it unread risks git taking EPIPE on a long description.
+cat >/dev/null 2>&1 || true
+
+# Protocol dispatch, before any work. Git invokes a credential helper as
+# \`credhelper.sh <action>\` with the credential description on stdin, where
+# action is exactly one of get / store / erase (verified against git 2.54).
+# Only \`get\` wants a credential.
+#
+# Everything else returns immediately, without a refresh round-trip: store and
+# erase have nothing to persist (the token is re-minted per operation and never
+# cached), and an unknown action is one gitcredentials(7) tells helpers to
+# ignore — a future git that probes for a new action must not turn into an
+# authentication failure here. Exit 0, silently, for both.
+case "\${1:-get}" in
+  get) ;;
+  *) exit 0 ;;
+esac
 
 corr_header=()
-if [ -n "$AEP_CORRELATION_ID" ]; then
-  corr_header=(-H "X-Correlation-ID: $AEP_CORRELATION_ID")
+if [ -n "\$AEP_CORRELATION_ID" ]; then
+  corr_header=(-H "X-Correlation-ID: \$AEP_CORRELATION_ID")
 fi
 
+# Tier 1 — the platform credential. Prefer publisher client_credentials, fall
+# back to the staged bearer. Minted per invocation, so a long run never serves
+# git an expired token.
 bearer=""
-refresh_url=""
-if [ -n "$PUBLISHER_CLIENT_ID" ] && [ -n "$PUBLISHER_CLIENT_SECRET" ] && [ -n "$PUBLISHER_TOKEN_URL" ]; then
-  # WS2.4 — mint cc token via Basic auth, call path-scoped endpoint.
-  cc_resp="$(curl -fsS -X POST \\
-    -u "$PUBLISHER_CLIENT_ID:$PUBLISHER_CLIENT_SECRET" \\
+if [ -n "\$PUBLISHER_CLIENT_ID" ] && [ -n "\$PUBLISHER_CLIENT_SECRET" ] && [ -n "\$PUBLISHER_TOKEN_URL" ]; then
+  cc_resp="\$(curl -fsS -X POST \\
+    -u "\$PUBLISHER_CLIENT_ID:\$PUBLISHER_CLIENT_SECRET" \\
     -H "Content-Type: application/x-www-form-urlencoded" \\
     -d 'grant_type=client_credentials' \\
-    "$PUBLISHER_TOKEN_URL" 2>/dev/null || true)"
-  if [ -n "$cc_resp" ] && command -v python3 >/dev/null 2>&1; then
-    bearer="$(printf '%s' "$cc_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
-  elif [ -n "$cc_resp" ]; then
-    bearer="$(echo "$cc_resp" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')"
+    "\$PUBLISHER_TOKEN_URL" 2>/dev/null || true)"
+  if [ -n "\$cc_resp" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      bearer="\$(printf '%s' "\$cc_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+    else
+      bearer="\$(printf '%s' "\$cc_resp" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')"
+    fi
   fi
-  if [ -n "$bearer" ]; then
-    refresh_url="\${AEP_PLATFORM_URL:-$AEP_GIT_SERVICE_URL}/internal/v1/executions/$expected_task_id/credentials/refresh"
+  if [ -z "\$bearer" ]; then
+    echo "credhelper: publisher client_credentials mint failed; falling back to \\\$AEP_BEARER_FILE" >&2
   fi
 fi
-if [ -z "$bearer" ]; then
-  bearer="$(cat "$AEP_BEARER_FILE" 2>/dev/null || true)"
-  refresh_url="\${AEP_PLATFORM_URL:-$AEP_GIT_SERVICE_URL}/internal/v1/executions/$expected_task_id/credentials/refresh"
+if [ -z "\$bearer" ]; then
+  bearer="\$(cat "\$AEP_BEARER_FILE" 2>/dev/null || true)"
 fi
-if [ -z "$bearer" ]; then
+if [ -z "\$bearer" ]; then
+  echo "credhelper: no platform credential — PUBLISHER_* unset or mint failed, and \\\$AEP_BEARER_FILE (\$AEP_BEARER_FILE) is missing or empty" >&2
   exit 1
 fi
 
-resp="$(curl -fsS -X POST \\
-  -H "Authorization: Bearer $bearer" \\
+# Tier 2 — exchange the platform credential for a GitHub token.
+resp="\$(curl -fsS -X POST \\
+  -H "Authorization: Bearer \$bearer" \\
   -H "Content-Type: application/json" \\
   "\${corr_header[@]}" \\
   -d '{}' \\
-  "$refresh_url" 2>/dev/null || true)"
-if [ -z "$resp" ]; then
+  "\$refresh_url" 2>/dev/null || true)"
+if [ -z "\$resp" ]; then
+  echo "credhelper: credential refresh failed — POST \$refresh_url returned nothing" >&2
   exit 1
 fi
 
-# Parse the JSON response in a single python3 process — five fields,
-# one line each, read in order. Falls back to sed if python3 is missing.
+# Parse the JSON response in a single python3 process — five fields, one line
+# each, read in order. Falls back to sed if python3 is missing, which covers
+# the two required fields only; identity drift needs the structured parse.
 resp_token=""
 resp_task_id=""
 resp_login=""
@@ -159,134 +199,98 @@ if command -v python3 >/dev/null 2>&1; then
     read -r resp_login || true
     read -r resp_name || true
     read -r resp_email || true
-  } < <(printf '%s' "$resp" | python3 -c '
+  } < <(printf '%s' "\$resp" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
-i = d.get("identity") or {}
+i = d.get("identity") or d.get("Identity") or {}
+def pick(upper, lower):
+    # Identity field names are CAPITALIZED on the wire (contract
+    # packages/contracts/api/internal/v1 Identity) while the envelope keys are
+    # lowercase. Accept either case: reading only one of them is what left the
+    # drift rewrite below dead for the whole of its first life.
+    return i.get(upper) or i.get(lower) or ""
 print(d.get("token", ""))
 print(d.get("taskId", ""))
-print(i.get("login", ""))
-print(i.get("name", ""))
-print(i.get("email", ""))
+print(pick("Login", "login"))
+print(pick("Name", "name"))
+print(pick("Email", "email"))
 ' 2>/dev/null)
 else
-  resp_token="$(echo "$resp" | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')"
-  resp_task_id="$(echo "$resp" | sed -n 's/.*"taskId":"\\([^"]*\\)".*/\\1/p')"
+  resp_token="\$(printf '%s' "\$resp" | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')"
+  resp_task_id="\$(printf '%s' "\$resp" | sed -n 's/.*"taskId":"\\([^"]*\\)".*/\\1/p')"
 fi
 
-if [ -z "$resp_token" ]; then
+if [ -z "\$resp_token" ]; then
+  echo "credhelper: refresh response carried no token" >&2
   exit 1
 fi
 
 # Anti-misroute tripwire (PR D §6.6). Empty taskId in the response is
-# tolerated — older git-service versions may not echo it; in that mode
-# the workspace bearer's signature is the only credential check. Once
-# git-service ships the echo (this PR), every refresh carries it and
-# mismatch surfaces here.
-if [ -n "$resp_task_id" ] && [ "$resp_task_id" != "$expected_task_id" ]; then
-  echo "credhelper: refusing — response.taskId ($resp_task_id) != bound task ($expected_task_id)" >&2
+# tolerated — older git-service versions may not echo it; in that mode the
+# workspace bearer's signature is the only credential check.
+if [ -n "\$resp_task_id" ] && [ "\$resp_task_id" != "\$expected_task_id" ]; then
+  echo "credhelper: refusing — response.taskId (\$resp_task_id) != bound task (\$expected_task_id)" >&2
   exit 1
 fi
 
-# Identity drift rewrite (PR D §6.6). Only applies when the response
-# actually carries identity fields and they differ from what's in
-# .git/config. Soft-fails — git op continues with the credential even
-# if .git/config rewrite fails (subsequent commits would still attribute
-# under the old identity in that case, surfaced in audit later).
-if [ -n "$resp_login" ] && [ -d "$workspace_dir/.git" ]; then
-  current_name="$(git -C "$workspace_dir" config user.name 2>/dev/null || true)"
-  current_email="$(git -C "$workspace_dir" config user.email 2>/dev/null || true)"
-  new_name="\${resp_name:-$resp_login}"
-  new_email="\${resp_email:-$resp_login@users.noreply.github.com}"
-  if [ "$current_name" != "$new_name" ] || [ "$current_email" != "$new_email" ]; then
-    echo "credhelper: identity drift detected ($current_name → $new_name); rewriting .git/config" >&2
-    git -C "$workspace_dir" config user.name "$new_name" >/dev/null 2>&1 || true
-    git -C "$workspace_dir" config user.email "$new_email" >/dev/null 2>&1 || true
+# Identity drift rewrite (PR D §6.6). Only applies when the response actually
+# carries identity fields and they differ from what's in .git/config. Soft-fails
+# — the git op continues with the credential even if the rewrite fails
+# (subsequent commits would still attribute under the old identity in that case,
+# surfaced in audit later). No-ops during the provisioning clone, where
+# \$workspace_dir does not exist yet.
+if [ -n "\$resp_login" ] && [ -d "\$workspace_dir/.git" ]; then
+  current_name="\$(git -C "\$workspace_dir" config user.name 2>/dev/null || true)"
+  current_email="\$(git -C "\$workspace_dir" config user.email 2>/dev/null || true)"
+  new_name="\${resp_name:-\$resp_login}"
+  new_email="\${resp_email:-\$resp_login@users.noreply.github.com}"
+  if [ "\$current_name" != "\$new_name" ] || [ "\$current_email" != "\$new_email" ]; then
+    echo "credhelper: identity drift detected (\$current_name → \$new_name); rewriting .git/config" >&2
+    git -C "\$workspace_dir" config user.name "\$new_name" >/dev/null 2>&1 || true
+    git -C "\$workspace_dir" config user.email "\$new_email" >/dev/null 2>&1 || true
   fi
 fi
 
-# Dual-protocol output:
-#   - GIT_ASKPASS: invoked once per prompt, prompt text in \$1, expects ONE line.
-#   - credential.helper get: invoked with action on stdin (get/store/erase),
-#     expects 'username=...\\npassword=...' on stdout.
-# A non-empty \$1 means git is using us as GIT_ASKPASS (workspace clone path).
-if [ -n "\$1" ]; then
-  case "\$1" in
-    *[Uu]sername*) echo "x-access-token" ;;
-    *[Pp]assword*) echo "$resp_token" ;;
-    *)             echo "$resp_token" ;;
-  esac
-else
-  echo "username=x-access-token"
-  echo "password=$resp_token"
-fi
+# The credential-helper \`get\` response: key=value lines on stdout. A bare token
+# here is silently useless — git answers it with \`warning: invalid credential
+# line\` and then fails the operation for want of a username.
+echo "username=x-access-token"
+echo "password=\$resp_token"
 `;
 }
 
-export function ghWrapperScript(realGhPath: string, params: CredHelperParams): string {
-  const { taskId } = params;
+export function ghWrapperScript(realGhPath: string): string {
   return `#!/usr/bin/env bash
-# gh CLI wrapper. Refreshes the GitHub token and rewrites
-# $GH_CONFIG_DIR/hosts.yml on every invocation, then execs the real
-# binary. Phase 0's long-lived PAT makes the refresh redundant; Phase 2's
-# 1h App tokens require it for any task that runs > 1h between gh calls.
+# gh CLI wrapper. Rewrites \$GH_CONFIG_DIR/hosts.yml with a fresh GitHub token on
+# every invocation, then execs the real binary. Phase 0's long-lived PAT makes
+# that redundant; Phase 2's 1h App tokens require it for any task that runs > 1h
+# between gh calls.
 #
-# Phase 2 PR D §6.6 anti-misroute: refuses if the refresh response's
-# taskId doesn't match this script's bound task. Same shape as the
-# credhelper.sh tripwire.
+# The token comes from credhelper.sh through its own \`get\` contract rather than
+# from a second copy of the exchange. One script owns the refresh, so both auth
+# modes (publisher cc and legacy TaskJWT) and the anti-misroute tripwire apply to
+# \`gh\` without being reimplemented. The duplicate this replaces read
+# \$AEP_BEARER_FILE only, so on a cc-only run it served whatever token was minted
+# at pod start and degraded silently once that expired, while \`git\` kept working.
+#
+# A refresh failure is not fatal: hosts.yml from an earlier call may still be
+# valid, so we warn and let gh report its own auth error if it isn't.
 set -e
-expected_task_id=${shellQuote(taskId)}
+helper="\$(dirname "\${BASH_SOURCE[0]}")/${CREDHELPER_FILE}"
 
-bearer="$(cat "$AEP_BEARER_FILE" 2>/dev/null || true)"
-if [ -n "$bearer" ]; then
-  corr_header=()
-  if [ -n "$AEP_CORRELATION_ID" ]; then
-    corr_header=(-H "X-Correlation-ID: $AEP_CORRELATION_ID")
-  fi
-  resp="$(curl -fsS -X POST \\
-    -H "Authorization: Bearer $bearer" \\
-    -H "Content-Type: application/json" \\
-    "\${corr_header[@]}" \\
-    -d '{}' \\
-    "\${AEP_PLATFORM_URL:-$AEP_GIT_SERVICE_URL}/internal/v1/executions/$expected_task_id/credentials/refresh" 2>/dev/null || true)"
-  if [ -n "$resp" ]; then
-    token=""
-    login=""
-    resp_task_id=""
-    if command -v python3 >/dev/null 2>&1; then
-      {
-        read -r token || true
-        read -r resp_task_id || true
-        read -r login || true
-      } < <(printf '%s' "$resp" | python3 -c '
-import json, sys
-d = json.load(sys.stdin)
-i = d.get("identity") or {}
-print(d.get("token", ""))
-print(d.get("taskId", ""))
-print(i.get("login", ""))
-' 2>/dev/null)
-    else
-      token="$(echo "$resp" | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')"
-      login="$(echo "$resp" | sed -n 's/.*"login":"\\([^"]*\\)".*/\\1/p')"
-      resp_task_id="$(echo "$resp" | sed -n 's/.*"taskId":"\\([^"]*\\)".*/\\1/p')"
-    fi
-    if [ -n "$resp_task_id" ] && [ "$resp_task_id" != "$expected_task_id" ]; then
-      echo "gh wrapper: refusing — response.taskId ($resp_task_id) != bound task ($expected_task_id)" >&2
-      exit 1
-    fi
-    if [ -n "$token" ]; then
-      mkdir -p "$GH_CONFIG_DIR"
-      cat > "$GH_CONFIG_DIR/hosts.yml" <<EOF
+creds="\$("\$helper" get </dev/null || true)"
+token="\$(printf '%s\\n' "\$creds" | sed -n 's/^password=//p')"
+if [ -n "\$token" ]; then
+  mkdir -p "\$GH_CONFIG_DIR"
+  cat > "\$GH_CONFIG_DIR/hosts.yml" <<EOF
 github.com:
-    oauth_token: $token
-    user: \${login:-x-access-token}
+    oauth_token: \$token
+    user: x-access-token
     git_protocol: https
 EOF
-    fi
-  fi
+else
+  echo "gh: credential refresh failed — proceeding with the auth already on disk" >&2
 fi
-exec ${JSON.stringify(realGhPath)} "$@"
+exec ${JSON.stringify(realGhPath)} "\$@"
 `;
 }
-

--- a/runners/remote-worker/src/lib/git_clone.test.ts
+++ b/runners/remote-worker/src/lib/git_clone.test.ts
@@ -16,6 +16,10 @@
  * under the License.
  */
 
+// The clone's credential wiring. That the helper git is pointed at actually
+// speaks git's protocol is covered by credhelper.test.ts, which drives it with
+// real git; these tests cover the invocation this module builds.
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
@@ -23,41 +27,65 @@ import os from "node:os";
 import path from "node:path";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { CLONE_TOKEN_ENV } from "./credhelper.js";
-import { buildCloneInvocation, cloneWithToken, writeAskpassShim } from "./git_clone.js";
+import { buildCloneInvocation, cloneCredentialScope, cloneWithHelper } from "./git_clone.js";
 import { shellQuote } from "./shell.js";
 
 const execAsync = promisify(exec);
 
-// A realistically-shaped token. Shape matters for one test only (the scrubber
-// covers shapes independently); every other assertion here must hold for a
-// credential of ANY shape, which is the point of keeping it out of argv.
-const TOKEN = "github_pat_11TESTONLY_abcdefghijklmnopqrstuvwxyz0123456789";
+const HELPER = "/home/aep/aep-workspace/default/store/abc.stage/credhelper.sh";
+const BEARER_FILE = "/home/aep/aep-workspace/default/store/abc.stage/bearer";
 
 async function tmpDir(): Promise<string> {
   return fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-clone-test-"));
 }
 
+// ---- cloneCredentialScope ---------------------------------------------------
+
+test("cloneCredentialScope: scheme + host, so the helper is offered to one origin", () => {
+  assert.equal(
+    cloneCredentialScope("https://github.com/asdlc-repos/store.git"),
+    "https://github.com",
+  );
+  // Host-scoped rather than a bare credential.helper: a redirect to another host
+  // cannot draw the credential out of the helper.
+  assert.equal(cloneCredentialScope("https://ghe.corp.example/o/r.git"), "https://ghe.corp.example");
+  assert.equal(cloneCredentialScope("http://127.0.0.1:8080/o/r.git"), "http://127.0.0.1:8080");
+});
+
+test("cloneCredentialScope: undefined for origins that need no credential", () => {
+  assert.equal(cloneCredentialScope("/tmp/origin.git"), undefined);
+  assert.equal(cloneCredentialScope("file:///tmp/origin.git"), undefined);
+  assert.equal(cloneCredentialScope("git@github.com:o/r.git"), undefined);
+});
+
 // ---- buildCloneInvocation (pure seam) ---------------------------------------
 
-test("buildCloneInvocation: token is in the env, never in the command", () => {
+test("buildCloneInvocation: wires the helper in, carries no credential anywhere", () => {
   const { cmd, env } = buildCloneInvocation({
     repoUrl: "https://github.com/asdlc-repos/store-handmade-ceramics.git",
     destDir: "/home/aep/aep-workspace/default/store/abc",
-    token: TOKEN,
-    askpassPath: "/stage/askpass.sh",
+    helperPath: HELPER,
+    bearerFile: BEARER_FILE,
     baseEnv: {},
   });
 
-  assert.ok(!cmd.includes(TOKEN), "command must not contain the token");
-  assert.ok(!cmd.includes("x-access-token"), "command must not carry URL userinfo");
+  // `git -c` BEFORE the subcommand: applies to this command only, and is not
+  // written into the cloned repo's config (`git clone -c` would persist it).
+  //
+  // The empty `credential.helper=` must come FIRST. Git takes the first helper
+  // that answers, so a helper inherited from system config (Homebrew's git ships
+  // `credential.helper=osxkeychain`) would authenticate the clone instead of
+  // ours, and would be handed our token by git's post-success `store`.
   assert.equal(
     cmd,
-    "git clone 'https://github.com/asdlc-repos/store-handmade-ceramics.git' " +
+    `git -c credential.helper= -c 'credential.https://github.com.helper=${HELPER}' ` +
+      "clone 'https://github.com/asdlc-repos/store-handmade-ceramics.git' " +
       "'/home/aep/aep-workspace/default/store/abc'",
   );
-  assert.equal(env[CLONE_TOKEN_ENV], TOKEN);
-  assert.equal(env.GIT_ASKPASS, "/stage/askpass.sh");
+  assert.ok(!cmd.includes("x-access-token"), "command must not carry URL userinfo");
+
+  // The bearer travels as a PATH, never a value: the helper reads the file.
+  assert.equal(env.AEP_BEARER_FILE, BEARER_FILE);
   assert.equal(env.GIT_TERMINAL_PROMPT, "0");
 });
 
@@ -65,24 +93,39 @@ test("buildCloneInvocation: --depth 1 when requested", () => {
   const { cmd } = buildCloneInvocation({
     repoUrl: "https://github.com/acme/org-skills.git",
     destDir: "/tmp/skills",
-    token: TOKEN,
-    askpassPath: "/tmp/askpass.sh",
+    helperPath: HELPER,
+    bearerFile: BEARER_FILE,
     depth1: true,
     baseEnv: {},
   });
-  assert.equal(cmd, "git clone --depth 1 'https://github.com/acme/org-skills.git' '/tmp/skills'");
+  assert.ok(cmd.startsWith("git -c credential.helper= -c "), cmd);
+  assert.match(cmd, /clone --depth 1 'https:\/\/github\.com\/acme\/org-skills\.git' '\/tmp\/skills'$/);
 });
 
-test("buildCloneInvocation: an empty token configures no askpass at all", () => {
-  const { env } = buildCloneInvocation({
-    repoUrl: "/tmp/origin.git",
+test("buildCloneInvocation: no helperPath configures no helper at all", () => {
+  // So a genuinely missing credential surfaces as git's own error rather than as
+  // a helper that answers with nothing.
+  const { cmd, env } = buildCloneInvocation({
+    repoUrl: "https://github.com/o/r.git",
     destDir: "/tmp/dest",
-    token: "",
-    askpassPath: "/tmp/askpass.sh",
+    helperPath: "",
+    bearerFile: "",
     baseEnv: {},
   });
-  assert.equal(env.GIT_ASKPASS, undefined);
-  assert.equal(env[CLONE_TOKEN_ENV], undefined);
+  assert.equal(cmd, "git clone 'https://github.com/o/r.git' '/tmp/dest'");
+  assert.equal(env.AEP_BEARER_FILE, undefined);
+});
+
+test("buildCloneInvocation: an origin needing no credential gets no helper", () => {
+  const { cmd, env } = buildCloneInvocation({
+    repoUrl: "/tmp/origin.git",
+    destDir: "/tmp/dest",
+    helperPath: HELPER,
+    bearerFile: BEARER_FILE,
+    baseEnv: {},
+  });
+  assert.equal(cmd, "git clone '/tmp/origin.git' '/tmp/dest'");
+  assert.equal(env.AEP_BEARER_FILE, undefined);
 });
 
 test("buildCloneInvocation: does not mutate the caller's base env", () => {
@@ -90,68 +133,43 @@ test("buildCloneInvocation: does not mutate the caller's base env", () => {
   buildCloneInvocation({
     repoUrl: "https://example.invalid/r.git",
     destDir: "/tmp/d",
-    token: TOKEN,
-    askpassPath: "/tmp/a.sh",
+    helperPath: HELPER,
+    bearerFile: BEARER_FILE,
     baseEnv,
   });
   assert.deepEqual(baseEnv, { PATH: "/usr/bin" });
 });
 
-// ---- writeAskpassShim -------------------------------------------------------
-
-test("writeAskpassShim: writes an executable shim that holds no secret", async () => {
-  const dir = await tmpDir();
-  const shim = await writeAskpassShim(dir);
-  const body = await fs.promises.readFile(shim, "utf-8");
-
-  assert.ok(!body.includes(TOKEN));
-  // It reads the token from the environment rather than baking one in.
-  assert.match(body, new RegExp(`\\$${CLONE_TOKEN_ENV}`));
-  const mode = (await fs.promises.stat(shim)).mode & 0o777;
-  assert.equal(mode, 0o700, `expected 0700, got ${mode.toString(8)}`);
-});
-
-test("writeAskpassShim: answers the username prompt and the password prompt", async () => {
-  const dir = await tmpDir();
-  const shim = await writeAskpassShim(dir);
-  const env = { ...process.env, [CLONE_TOKEN_ENV]: TOKEN };
-
-  const user = await execAsync(`${shellQuote(shim)} "Username for 'https://github.com': "`, { env });
-  assert.equal(user.stdout.trim(), "x-access-token");
-
-  const pass = await execAsync(`${shellQuote(shim)} "Password for 'https://github.com': "`, { env });
-  assert.equal(pass.stdout.trim(), TOKEN);
-});
-
 // ---- the reported leak ------------------------------------------------------
 
-test("cloneWithToken: a failed clone's error message carries no token", async () => {
+test("cloneWithHelper: a failed clone's error message carries no credential", async () => {
   // Regression for the credential leak: the runner logs this error and the BFF
   // forwards it into the console build log. `.invalid` is reserved and never
   // resolves, reproducing the exact "Could not resolve host" failure that
-  // surfaced the token.
+  // surfaced the token. With the helper doing the exchange there is no token in
+  // the process at all, but the command must still be safe to print verbatim.
   const dir = await tmpDir();
   await assert.rejects(
-    cloneWithToken({
+    cloneWithHelper({
       repoUrl: "https://aep-does-not-exist.invalid/asdlc-repos/store.git",
       destDir: path.join(dir, "dest"),
-      token: TOKEN,
-      shimDir: path.join(dir, "stage"),
+      helperPath: path.join(dir, "credhelper.sh"),
+      bearerFile: path.join(dir, "bearer"),
     }),
     (err: unknown) => {
       const text = err instanceof Error ? `${err.stack ?? ""}${err.message}` : String(err);
-      assert.ok(text.includes("git clone"), `expected the clone command in the error, got: ${text}`);
-      assert.ok(!text.includes(TOKEN), `clone error leaked the token: ${text}`);
+      assert.ok(text.includes("git "), `expected the clone command in the error, got: ${text}`);
       assert.ok(!text.includes("x-access-token"), `clone error leaked URL userinfo: ${text}`);
       return true;
     },
   );
 });
 
-test("cloneWithToken: a successful clone leaves no token at rest in the work tree", async () => {
-  // The .git/config analogue of gitfs/hygiene_test.go: git preserves URL
-  // userinfo verbatim, so an authenticated clone URL would persist the
-  // credential in the cloned tree for the whole run.
+test("cloneWithHelper: a successful clone leaves no credential at rest", async () => {
+  // The .git/config analogue of gitfs/hygiene_test.go. Two things are asserted:
+  // the clone works, and `git -c` did NOT persist the helper into the cloned
+  // config — workspace.ts installs the durable one itself, pointed at the
+  // helper's FINAL path, not the staging path used here.
   const dir = await tmpDir();
   const origin = path.join(dir, "origin.git");
   const seed = path.join(dir, "seed");
@@ -170,35 +188,27 @@ test("cloneWithToken: a successful clone leaves no token at rest in the work tre
   await execAsync(`git -C ${shellQuote(origin)} symbolic-ref HEAD refs/heads/main`);
 
   const dest = path.join(dir, "clone");
-  await cloneWithToken({
+  const stageHelper = path.join(dir, "stage", "credhelper.sh");
+  await cloneWithHelper({
     repoUrl: origin,
     destDir: dest,
-    token: TOKEN,
-    shimDir: path.join(dir, "stage"),
+    helperPath: stageHelper,
+    bearerFile: path.join(dir, "stage", "bearer"),
   });
 
   assert.ok(fs.existsSync(path.join(dest, "README.md")), "clone should have checked out the tree");
 
-  // runner.ts spreads process.env into the agent's child env, so a token that
-  // ever landed there would reach the agent and everything it spawns.
+  // runner.ts spreads process.env into the agent's child env, so anything the
+  // clone needed must have stayed on the child's env object.
   assert.equal(
-    process.env[CLONE_TOKEN_ENV],
+    process.env.AEP_BEARER_FILE,
     undefined,
-    "clone token must never be written to process.env",
+    "the clone's bearer path must never be written to process.env",
   );
 
-  const offenders: string[] = [];
-  const walk = async (d: string): Promise<void> => {
-    for (const e of await fs.promises.readdir(d, { withFileTypes: true })) {
-      const full = path.join(d, e.name);
-      if (e.isDirectory()) {
-        await walk(full);
-      } else if (e.isFile()) {
-        const body = await fs.promises.readFile(full);
-        if (body.includes(TOKEN)) offenders.push(full);
-      }
-    }
-  };
-  await walk(dest);
-  assert.deepEqual(offenders, [], `token found at rest in: ${offenders.join(", ")}`);
+  const clonedConfig = await fs.promises.readFile(path.join(dest, ".git", "config"), "utf-8");
+  assert.ok(
+    !clonedConfig.includes(stageHelper),
+    `git -c leaked the staging helper into the cloned config:\n${clonedConfig}`,
+  );
 });

--- a/runners/remote-worker/src/lib/git_clone.ts
+++ b/runners/remote-worker/src/lib/git_clone.ts
@@ -17,12 +17,18 @@
  */
 
 // Authenticated `git clone` — the single owner of "clone a platform repo with
-// an org token". Both clone sites in the runner go through it: the project
-// work tree (workspace.ts) and the org-skills repo (skills_resolver.ts).
+// the run's credential". Both clone sites in the runner go through it: the
+// project work tree (workspace.ts) and the org-skills repo (skills_resolver.ts).
 //
-// The token is handed to git through a static GIT_ASKPASS shim rather than
-// embedded in the clone URL. Embedding it puts the credential in four places
-// the runner cannot control:
+// The credential is supplied by the same credential helper that authenticates
+// every later git operation (lib/credhelper.ts), wired in for this one command
+// with `git -c credential.<origin>.helper=…`. No token is passed to git at all:
+// not in the URL, not in argv, not in the environment. The helper mints one
+// itself and hands it to git over its stdout pipe.
+//
+// Why not embed the token in the clone URL — the constraint that shapes all of
+// this. `https://x-access-token:TOKEN@github.com/o/r` puts the credential in
+// four places the runner cannot control:
 //
 //   - argv, visible in a `ps` listing for the clone's duration;
 //   - the `Command failed: git clone '<url>' …` message that child_process
@@ -32,14 +38,21 @@
 //     the credential would sit at rest in the work tree for the whole run;
 //   - any later `git remote -v` the agent happens to run.
 //
-// Same shape as the Go side's platform/gitfs/askpass.go. With the token in the
-// child environment only, a clone failure can print the whole command safely.
+// An earlier version of this module avoided that with a GIT_ASKPASS shim and the
+// token in the clone child's env. That worked, but it meant the clone
+// authenticated through a *different* mechanism than the agent's own operations
+// — and when the shared script's protocol dispatch was wrong, the clone kept
+// working and masked the fact that nothing else could authenticate at all.
+// Putting the helper on the clone collapses the two paths into one and makes a
+// credential break fail provisioning, loudly, before the agent starts.
+//
+// `git -c <key>=<value>` (before the subcommand) applies to this command only
+// and is NOT written into the cloned repo's config — unlike `git clone -c`,
+// which persists. workspace.ts installs the durable helper itself, pointed at
+// the helper's final path.
 
-import fs from "node:fs";
-import path from "node:path";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { ASKPASS_FILE, CLONE_TOKEN_ENV, askpassScript } from "./credhelper.js";
 import { shellQuote } from "./shell.js";
 
 const execAsync = promisify(exec);
@@ -48,15 +61,23 @@ const execAsync = promisify(exec);
 // call sites used before they shared this module.
 const CLONE_MAX_BUFFER = 16 * 1024 * 1024;
 
-export interface CloneOptions {
+/**
+ * How a clone authenticates. Both fields empty means an unauthenticated origin
+ * (file:// in tests), which configures no helper at all so a genuinely missing
+ * credential surfaces as git's own error rather than an empty password.
+ */
+export interface CloneAuth {
+  /** Absolute path to the credential helper script (see credhelper.ts). */
+  helperPath: string;
+  /** Absolute path to the platform bearer the helper exchanges for a token. */
+  bearerFile: string;
+}
+
+export interface CloneOptions extends CloneAuth {
   /** Plain https clone URL — never carries credentials. */
   repoUrl: string;
   /** Destination directory; must not exist (git refuses a non-empty dir). */
   destDir: string;
-  /** Org token. Empty means an unauthenticated origin (file:// in tests). */
-  token: string;
-  /** Scratch dir the askpass shim is written into — never the work tree. */
-  shimDir: string;
   /** `--depth 1` for the skills repo, where history is not needed. */
   depth1?: boolean;
 }
@@ -66,41 +87,66 @@ export interface CloneInvocation {
   env: NodeJS.ProcessEnv;
 }
 
-// buildCloneInvocation is the pure seam: it returns the exact command string
-// and environment a clone runs with, so a test can assert that the token is
-// absent from the command and present only in the environment.
+/**
+ * The `credential.<scope>.helper` config scope for a clone URL — its scheme and
+ * host, e.g. `https://github.com`. Returns undefined for a non-http(s) URL
+ * (file:// origins in tests), which needs no credential at all.
+ *
+ * Exported because workspace.ts must derive the DURABLE config key the same way
+ * it is derived here: a helper the clone honours but `.git/config` scopes to a
+ * different host would authenticate provisioning and nothing afterwards.
+ * Host-scoping rather than a bare `credential.helper` also means a redirect to
+ * another host cannot draw the credential out of the helper.
+ */
+export function cloneCredentialScope(repoUrl: string): string | undefined {
+  try {
+    const u = new URL(repoUrl);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return undefined;
+    return u.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+// buildCloneInvocation is the pure seam: it returns the exact command string and
+// environment a clone runs with, so a test can assert that no credential appears
+// in either, and that the helper is wired in when one is expected.
 export function buildCloneInvocation(
-  opts: Omit<CloneOptions, "shimDir"> & { askpassPath: string; baseEnv?: NodeJS.ProcessEnv },
+  opts: CloneOptions & { baseEnv?: NodeJS.ProcessEnv },
 ): CloneInvocation {
   const depth = opts.depth1 ? " --depth 1" : "";
-  const cmd = `git clone${depth} ${shellQuote(opts.repoUrl)} ${shellQuote(opts.destDir)}`;
+  const scope = cloneCredentialScope(opts.repoUrl);
+  const authed = opts.helperPath !== "" && scope !== undefined;
+
+  // An EMPTY credential.helper resets the inherited helper list, then the scoped
+  // one is the only entry. Order matters and this is not belt-and-braces: git
+  // consults helpers in config order and takes the FIRST that answers, so a
+  // helper in system config (Homebrew's git ships `credential.helper=osxkeychain`
+  // that way, and a base image could too) would authenticate the clone as
+  // something else entirely — and would also be handed our token by git's
+  // post-success `store`. Reset first so ours is the only credential source.
+  const helperFlag = authed
+    ? `-c credential.helper= -c ${shellQuote(`credential.${scope}.helper=${opts.helperPath}`)} `
+    : "";
+  const cmd = `git ${helperFlag}clone${depth} ${shellQuote(opts.repoUrl)} ${shellQuote(opts.destDir)}`;
+
   const env: NodeJS.ProcessEnv = {
     ...(opts.baseEnv ?? process.env),
     GIT_TERMINAL_PROMPT: "0",
   };
-  // An unauthenticated origin gets no shim at all, so a genuinely missing
-  // credential surfaces as git's own error rather than an empty password.
-  if (opts.token !== "") {
-    env.GIT_ASKPASS = opts.askpassPath;
-    env[CLONE_TOKEN_ENV] = opts.token;
+  // The helper reads the bearer from this path. It is a PATH, not a secret, and
+  // it is set on a per-child env object rather than process.env: runner.ts
+  // spreads process.env into the agent's child env, and provisioning's staged
+  // bearer is gone by the time the agent starts.
+  if (authed && opts.bearerFile !== "") {
+    env.AEP_BEARER_FILE = opts.bearerFile;
   }
   return { cmd, env };
 }
 
-// writeAskpassShim writes the static shim (0700) into dir and returns its path.
-// The shim holds no secret, so re-writing it is idempotent.
-export async function writeAskpassShim(dir: string): Promise<string> {
-  await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-  const shimPath = path.join(dir, ASKPASS_FILE);
-  await fs.promises.writeFile(shimPath, askpassScript(), { mode: 0o700 });
-  return shimPath;
-}
-
-// cloneWithToken stages the shim and runs the clone. Rejects with git's own
-// error on failure — safe to log, since neither the command nor the message
-// can contain the token.
-export async function cloneWithToken(opts: CloneOptions): Promise<void> {
-  const askpassPath = await writeAskpassShim(opts.shimDir);
-  const { cmd, env } = buildCloneInvocation({ ...opts, askpassPath });
+// cloneWithHelper runs the clone. Rejects with git's own error on failure — safe
+// to log, since neither the command nor the message can contain a credential.
+export async function cloneWithHelper(opts: CloneOptions): Promise<void> {
+  const { cmd, env } = buildCloneInvocation(opts);
   await execAsync(cmd, { env, maxBuffer: CLONE_MAX_BUFFER });
 }

--- a/runners/remote-worker/src/lib/progress/scrubber.test.ts
+++ b/runners/remote-worker/src/lib/progress/scrubber.test.ts
@@ -172,9 +172,9 @@ test("scrub: redacts a token inside a failed `git clone` command string", () => 
 });
 
 test("scrub: redacts an enrolled token whose shape no pattern matches", () => {
-  // Shape-independence: refreshGitToken enrolls whatever the credential
-  // endpoint returns, so a classic 40-hex PAT or an opaque App token is
-  // covered without the denylist knowing its prefix.
+  // Shape-independence: an enrolled literal is redacted whatever it looks like,
+  // so a classic 40-hex PAT or an opaque App token is covered without the
+  // denylist knowing its prefix.
   const s = fresh();
   const opaque = "aQ7fL2mZ9xR4tY6uP1sD3gH5jK8nB0vC";
   s.addLiteral(opaque);

--- a/runners/remote-worker/src/lib/provision_e2e.test.ts
+++ b/runners/remote-worker/src/lib/provision_e2e.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Provisioning end-to-end, against a REAL authenticated git remote
+// (`git-http-backend` behind Basic auth). Nothing is mocked below the credential
+// layer: provisionWorkspace clones, then this drives the exact git operations the
+// coding agent performs, all authenticating through the credential helper.
+//
+// This test exists because the bug it guards lived in the COMBINATION, which is
+// what the unit tests around it each miss a piece of: the clone's `git -c`
+// wiring, the durable `.git/config` entry, and the helper's protocol only add up
+// to a working run together. The original break — a helper that dispatched on
+// `[ -n "$1" ]` and so never answered git's `get` — left the clone working and
+// every agent operation failing, and shipped because nothing ran the real path.
+//
+// Host isolation is mandatory here, not hygiene: the 401 this server returns makes
+// git consult every configured credential helper, and Homebrew's git ships
+// `credential.helper=osxkeychain` in system config. Without GIT_CONFIG_SYSTEM
+// neutered, a developer running this gets keychain prompts and git's post-success
+// `store` writes the test token into their real keychain.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { exec, spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+const TASK_ID = "6f1a2b3c-4d5e-6f70-8192-a3b4c5d6e7f8";
+const GH_TOKEN = "ghs_TESTONLYabcdefghijklmnopqrstuv01";
+const BEARER = "test-platform-bearer";
+const EXPECTED_BASIC = Buffer.from(`x-access-token:${GH_TOKEN}`).toString("base64");
+
+// Neuter host git config BEFORE anything imports or runs git. buildCloneInvocation
+// spreads process.env into the clone child, so setting it here covers that too.
+process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+process.env.GIT_CONFIG_NOSYSTEM = "1";
+process.env.GIT_TERMINAL_PROMPT = "0";
+
+// config.workspaceBasePath is captured at module load and defaults to the
+// developer's homedir, so it must be set before workspace.js is imported —
+// hence the dynamic import below rather than a static one.
+const WORKSPACE_ROOT = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-e2e-ws-"));
+process.env.WORKSPACE_BASE_PATH = WORKSPACE_ROOT;
+const { provisionWorkspace } = await import("./workspace.js");
+
+const GIT_EXEC_PATH = (await execAsync("git --exec-path")).stdout.trim();
+const HAS_HTTP_BACKEND = fs.existsSync(path.join(GIT_EXEC_PATH, "git-http-backend"));
+
+interface GitServer {
+  port: number;
+  authed: () => number;
+  rejected: () => number;
+  close: () => Promise<void>;
+}
+
+// A git HTTP server that DEMANDS Basic auth, so clone/fetch/push succeed only if
+// the credential helper actually supplied a credential.
+function startGitServer(projectRoot: string): Promise<GitServer> {
+  let authed = 0;
+  let rejected = 0;
+  const server = http.createServer((req, res) => {
+    if (req.headers.authorization !== `Basic ${EXPECTED_BASIC}`) {
+      rejected += 1;
+      req.resume();
+      res.writeHead(401, { "WWW-Authenticate": 'Basic realm="git"' }).end("auth required");
+      return;
+    }
+    authed += 1;
+
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const cgi = spawn(path.join(GIT_EXEC_PATH, "git-http-backend"), [], {
+      env: {
+        PATH: process.env.PATH,
+        GIT_PROJECT_ROOT: projectRoot,
+        GIT_HTTP_EXPORT_ALL: "1",
+        REQUEST_METHOD: req.method ?? "GET",
+        PATH_INFO: url.pathname,
+        QUERY_STRING: url.search.replace(/^\?/, ""),
+        CONTENT_TYPE: req.headers["content-type"] ?? "",
+        CONTENT_LENGTH: req.headers["content-length"] ?? "",
+        REMOTE_USER: "x-access-token",
+      },
+    });
+    req.pipe(cgi.stdin);
+
+    const chunks: Buffer[] = [];
+    cgi.stdout.on("data", (c: Buffer) => chunks.push(c));
+    cgi.on("close", () => {
+      // git-http-backend speaks CGI: headers, blank line, body.
+      const out = Buffer.concat(chunks);
+      const split = out.indexOf("\r\n\r\n");
+      const body = split === -1 ? out : out.subarray(split + 4);
+      const headers: Record<string, string> = {};
+      let status = 200;
+      for (const line of (split === -1 ? "" : out.subarray(0, split).toString()).split("\r\n")) {
+        const i = line.indexOf(":");
+        if (i === -1) continue;
+        const k = line.slice(0, i).trim();
+        const v = line.slice(i + 1).trim();
+        if (k.toLowerCase() === "status") status = Number.parseInt(v, 10) || 200;
+        else headers[k] = v;
+      }
+      res.writeHead(status, headers).end(body);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") throw new Error("git server bind failed");
+      resolve({
+        port: addr.port,
+        authed: () => authed,
+        rejected: () => rejected,
+        close: () => new Promise<void>((r) => {
+          server.closeAllConnections();
+          server.close(() => r());
+        }),
+      });
+    });
+  });
+}
+
+interface RefreshStub {
+  url: string;
+  calls: () => number;
+  close: () => Promise<void>;
+}
+
+function startRefreshStub(taskId: string): Promise<RefreshStub> {
+  let calls = 0;
+  const server = http.createServer((req, res) => {
+    calls += 1;
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "application/json" }).end(
+        JSON.stringify({
+          token: GH_TOKEN,
+          expiresAt: "2099-01-01T00:00:00Z",
+          taskId,
+          // CAPITALIZED, as the wire contract specifies.
+          identity: { Name: "AEP Bot", Email: "bot@aep.dev", Login: "aep-bot" },
+        }),
+      );
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") throw new Error("stub bind failed");
+      resolve({
+        url: `http://127.0.0.1:${addr.port}/internal/v1/executions/${taskId}/credentials/refresh`,
+        calls: () => calls,
+        close: () => new Promise<void>((r) => {
+          server.closeAllConnections();
+          server.close(() => r());
+        }),
+      });
+    });
+  });
+}
+
+test(
+  "provisioning e2e: clone, fetch and push all authenticate through the credential helper",
+  {
+    skip: HAS_HTTP_BACKEND ? false : "git-http-backend not available",
+    // Bounded on purpose: a broken credential path must FAIL this suite, never
+    // hang it. node:test applies no default per-test timeout.
+    timeout: 90_000,
+  },
+  async () => {
+    // Belt and braces on the isolation: if a helper is still reachable, this test
+    // would read (and git's `store` would write) the developer's real keychain.
+    const inherited = await execAsync("git config --get-all credential.helper || true");
+    assert.equal(inherited.stdout.trim(), "", "host credential helpers must be isolated");
+
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-e2e-"));
+    const serveRoot = path.join(root, "serve");
+    const origin = path.join(serveRoot, "store.git");
+    await fs.promises.mkdir(serveRoot, { recursive: true });
+    await execAsync(`git init --bare -q "${origin}"`);
+    await execAsync(`git -C "${origin}" symbolic-ref HEAD refs/heads/main`);
+    await execAsync(`git -C "${origin}" config http.receivepack true`);
+
+    const seed = path.join(root, "seed");
+    await execAsync(`git init -q "${seed}"`);
+    await fs.promises.writeFile(path.join(seed, "README.md"), "seed\n");
+    await execAsync(`git -C "${seed}" add .`);
+    await execAsync(`git -C "${seed}" -c user.name=T -c user.email=t@e.com commit -qm seed`);
+    await execAsync(`git -C "${seed}" push -q "${origin}" HEAD:refs/heads/main`);
+
+    const gitServer = await startGitServer(serveRoot);
+    const stub = await startRefreshStub(TASK_ID);
+
+    try {
+      const layout = await provisionWorkspace({
+        orgId: "default",
+        projectId: "store",
+        taskId: TASK_ID,
+        repoUrl: `http://127.0.0.1:${gitServer.port}/store.git`,
+        bearer: BEARER,
+        identity: { name: "AEP Bot", email: "bot@aep.dev", login: "aep-bot" },
+        gitServiceUrl: `http://127.0.0.1:${gitServer.port}`,
+        refreshUrl: stub.url,
+        correlationId: "e2e-corr-1",
+      });
+
+      // ---- provisioning ---------------------------------------------------
+      assert.ok(fs.existsSync(path.join(layout.workspace, "README.md")), "clone should check out");
+      assert.ok(gitServer.rejected() > 0, "the origin must actually have demanded auth");
+      assert.ok(stub.calls() > 0, "the helper must have performed the exchange");
+      assert.equal((await fs.promises.stat(layout.helperBin)).mode & 0o777, 0o700);
+      assert.equal((await fs.promises.stat(layout.bearerFile)).mode & 0o777, 0o600);
+      assert.ok(!fs.existsSync(`${layout.workspace}.stage`), "staging dir must be cleaned up");
+
+      const cfg = await fs.promises.readFile(path.join(layout.workspace, ".git", "config"), "utf-8");
+      assert.ok(
+        cfg.includes(`[credential "http://127.0.0.1:${gitServer.port}"]`),
+        `durable helper must be scoped to the origin:\n${cfg}`,
+      );
+      assert.ok(cfg.includes(layout.helperBin), "durable helper must point at .aep/credhelper.sh");
+      assert.match(cfg, /\[credential\]\s*\n\s*helper =\s*\n/, "must reset inherited helpers");
+      assert.ok(!cfg.includes(GH_TOKEN), "no credential at rest in .git/config");
+
+      // ---- the operations that failed in production ------------------------
+      const agentEnv = {
+        PATH: `${layout.aepDir}:${process.env.PATH ?? ""}`,
+        HOME: root,
+        GH_CONFIG_DIR: layout.ghConfigDir,
+        AEP_BEARER_FILE: layout.bearerFile,
+        AEP_CORRELATION_ID: "e2e-corr-1",
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+      };
+      const g = (cmd: string) => execAsync(`git -C "${layout.workspace}" ${cmd}`, { env: agentEnv });
+
+      // SKILL.md branch-identity discovery: the first thing a run does, and the
+      // exact pair that produced "could not read Username for 'https://github.com'".
+      await g("fetch origin");
+      await g('ls-remote --heads origin "aep/m1-*"');
+
+      // SKILL.md per-issue commit + push.
+      await g("checkout -q -b aep/m1-c1");
+      await fs.promises.writeFile(path.join(layout.workspace, "feature.txt"), "work\n");
+      await g("add feature.txt");
+      await g('commit -qm "feat: add feature (#1)"');
+      await g("push -q -u origin HEAD");
+
+      const refs = await execAsync(`git -C "${origin}" for-each-ref --format='%(refname)'`);
+      assert.match(refs.stdout, /refs\/heads\/aep\/m1-c1/, "the pushed branch must land on origin");
+
+      // Identity came from the refresh response's CAPITALIZED fields — the path
+      // that was dead for the whole of its first life.
+      const author = await g("log -1 --format='%an <%ae>'");
+      assert.equal(author.stdout.trim(), "AEP Bot <bot@aep.dev>");
+
+      // ---- hygiene --------------------------------------------------------
+      const offenders: string[] = [];
+      const walk = async (d: string): Promise<void> => {
+        for (const e of await fs.promises.readdir(d, { withFileTypes: true })) {
+          const full = path.join(d, e.name);
+          if (e.isDirectory()) await walk(full);
+          else if (e.isFile() && (await fs.promises.readFile(full)).includes(GH_TOKEN)) {
+            offenders.push(full);
+          }
+        }
+      };
+      await walk(layout.workspace);
+      assert.deepEqual(offenders, [], `token found at rest in: ${offenders.join(", ")}`);
+    } finally {
+      await gitServer.close();
+      await stub.close();
+      await fs.promises.rm(root, { recursive: true, force: true });
+      await fs.promises.rm(WORKSPACE_ROOT, { recursive: true, force: true });
+    }
+  },
+);

--- a/runners/remote-worker/src/lib/skills_resolver.test.ts
+++ b/runners/remote-worker/src/lib/skills_resolver.test.ts
@@ -254,9 +254,9 @@ test("resolveTaskSkills: end-to-end with an injected clone", async () => {
     workspace: ws,
     scope: { kind: "component", componentName: "api" },
     skillsRepoURL: "https://github.com/acme/org-skills",
-    pat: "tok",
+    cloneAuth: { helperPath: "/stage/credhelper.sh", bearerFile: "/stage/bearer" },
     scratchDir,
-    clone: async (repoURL, _pat, dest) => {
+    clone: async (repoURL, _auth, dest) => {
       clonedRepoURL = repoURL;
       cloneCount += 1;
       // Fake the clone: copy the fixture tree into the scratch dir.
@@ -279,7 +279,7 @@ test("resolveTaskSkills: no applied skills → no clone, empty result", async ()
     workspace: ws,
     scope: { kind: "component", componentName: "api" },
     skillsRepoURL: "https://github.com/acme/org-skills",
-    pat: "tok",
+    cloneAuth: { helperPath: "/stage/credhelper.sh", bearerFile: "/stage/bearer" },
     scratchDir: path.join(os.tmpdir(), "aep-skills-noop", "task-2"),
     clone: async () => {
       cloned = true;
@@ -303,9 +303,9 @@ test("resolveTaskSkills: project scope materialises skills from every component"
     workspace: ws,
     scope: { kind: "project" },
     skillsRepoURL: "https://github.com/acme/org-skills",
-    pat: "tok",
+    cloneAuth: { helperPath: "/stage/credhelper.sh", bearerFile: "/stage/bearer" },
     scratchDir: path.join(os.tmpdir(), "aep-skills-project", "cycle-1"),
-    clone: async (_repoURL, _pat, dest) => {
+    clone: async (_repoURL, _auth, dest) => {
       await fs.promises.cp(cloneSrc, dest, { recursive: true });
     },
   });

--- a/runners/remote-worker/src/lib/skills_resolver.ts
+++ b/runners/remote-worker/src/lib/skills_resolver.ts
@@ -43,7 +43,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
-import { cloneWithToken } from "./git_clone.js";
+import { type CloneAuth, cloneWithHelper } from "./git_clone.js";
 import type { SkillKind, SkillResolution } from "./skills_materializer.js";
 
 const SKILLS_ROOT = "skills";
@@ -76,14 +76,19 @@ export interface ResolveTaskSkillsArgs {
   scope: SkillsScope;
   /** AEP_SKILLS_REPO_URL — the org's `org-skills` clone URL. */
   skillsRepoURL: string;
-  /** Org-wide GitHub PAT (x-access-token) for the clone. */
-  pat: string;
+  /**
+   * How the clone authenticates: the workspace's credential helper and bearer.
+   * The refresh endpoint returns an org/installation-wide token, so the same
+   * helper serves both the project repo and org-skills. Both fields empty for an
+   * unauthenticated origin (the local harness and tests).
+   */
+  cloneAuth: CloneAuth;
   /** Scratch dir to clone org-skills into — MUST be outside `workspace`. */
   scratchDir: string;
   /** Per-line log sink; defaults to console.log. */
   log?: (line: string) => void;
   /** Injected for tests; defaults to the real `git clone --depth 1`. */
-  clone?: (repoURL: string, pat: string, destDir: string) => Promise<void>;
+  clone?: (repoURL: string, auth: CloneAuth, destDir: string) => Promise<void>;
 }
 
 /**
@@ -105,7 +110,7 @@ export async function resolveTaskSkills(args: ResolveTaskSkillsArgs): Promise<Sk
   }
 
   const clone = args.clone ?? cloneSkillsRepo;
-  await clone(args.skillsRepoURL, args.pat, args.scratchDir);
+  await clone(args.skillsRepoURL, args.cloneAuth, args.scratchDir);
 
   return resolveSkillsFromClone(args.scratchDir, names, log);
 }
@@ -223,22 +228,18 @@ export async function resolveSkillsFromClone(
   return out;
 }
 
-// cloneSkillsRepo shallow-clones the org-skills repo into destDir, authing with
-// the org-wide PAT via the askpass shim (file:// origins — tests — pass an empty
-// token and clone unauthed). Wipes destDir first so a resumed pod's stale dir
-// never blocks `git clone`.
-async function cloneSkillsRepo(repoURL: string, pat: string, destDir: string): Promise<void> {
+// cloneSkillsRepo shallow-clones the org-skills repo into destDir, authing
+// through the workspace's credential helper (file:// origins — tests — pass an
+// empty CloneAuth and clone unauthed). Wipes destDir first so a resumed pod's
+// stale dir never blocks `git clone`.
+async function cloneSkillsRepo(
+  repoURL: string,
+  auth: CloneAuth,
+  destDir: string,
+): Promise<void> {
   await fs.promises.rm(destDir, { recursive: true, force: true });
   await fs.promises.mkdir(path.dirname(destDir), { recursive: true });
-  await cloneWithToken({
-    repoUrl: repoURL,
-    destDir,
-    token: pat,
-    // Sibling of the clone target, inside the caller's scratch dir — never the
-    // work tree, and removed with the scratch dir.
-    shimDir: path.dirname(destDir),
-    depth1: true,
-  });
+  await cloneWithHelper({ repoUrl: repoURL, destDir, ...auth, depth1: true });
 }
 
 // readReferences recursively walks the full skill dir (any depth) and returns

--- a/runners/remote-worker/src/lib/workspace.ts
+++ b/runners/remote-worker/src/lib/workspace.ts
@@ -27,6 +27,11 @@
 // creates the feature branch and opens the PR with `Closes #<issueNumber>`
 // — see remote-worker/plugin/skills/aep/SKILL.md.
 //
+// The clone and every operation after it authenticate through the SAME
+// credential helper (lib/credhelper.ts): the clone gets it via `git -c`, since
+// `.git/config` does not exist yet, and step 2 installs it durably afterwards.
+// The runner process itself never holds a GitHub token.
+//
 // Layout inside the workspace:
 //
 //   <workspace>/
@@ -44,12 +49,9 @@ import fs from "node:fs";
 import { exec } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
-import http from "node:http";
-import https from "node:https";
 import { config } from "../config.js";
-import { credHelperScript, ghWrapperScript } from "./credhelper.js";
-import { cloneWithToken } from "./git_clone.js";
-import { primeScrubber } from "./progress/emitter.js";
+import { CREDHELPER_FILE, credHelperScript, ghWrapperScript } from "./credhelper.js";
+import { cloneCredentialScope, cloneWithHelper } from "./git_clone.js";
 import { shellQuote } from "./shell.js";
 
 const execAsync = promisify(exec);
@@ -90,112 +92,36 @@ export function computeLayout(orgId: string, projectId: string, taskId: string):
     ghConfigDir: path.join(workspace, ".gh-config"),
     bearerFile: path.join(aepDir, "bearer"),
     aepDir,
-    helperBin: path.join(aepDir, "credhelper.sh"),
+    helperBin: path.join(aepDir, CREDHELPER_FILE),
     ghWrapper: path.join(aepDir, "gh"),
   };
 }
 
-// GitTokenRequest is the minimal shape refreshGitToken needs — satisfied by
-// both ProvisionRequest and the oneshot DispatchRequest.
-export interface GitTokenRequest {
-  taskId: string;
-  gitServiceUrl: string;
-  refreshUrl?: string;
-  correlationId?: string;
-}
-
-// refreshGitToken POSTs to the path-scoped credentials/refresh endpoint with
-// the given runner bearer and returns the GitHub PAT. The endpoint returns an
-// org/installation-wide token, so the SAME PAT clones both the project repo
-// (workspace provisioning) and the org-skills repo (per-task skills clone).
+// resolveRefreshUrl is the one owner of the credentials/refresh endpoint URL.
+// It is baked into the helper script at provisioning time, so the clone and
+// every later git operation cannot end up pointed at different endpoints.
 //
-// This is the one place a git token enters the runner process, so it is also
-// where the token is enrolled as a scrubber literal — every later emission,
-// log line or error message is redacted by shape-independent exact match, not
-// by hoping the credential looks like a `github_pat_…`.
-export async function refreshGitToken(req: GitTokenRequest, bearer: string): Promise<string> {
-  if (!bearer.trim()) {
-    throw new Error("bearer is empty");
-  }
-
-  // WS2.6 — refreshUrl (set by oneshot.ts) is the path-scoped endpoint. The
-  // fallback builds the same path-scoped URL from gitServiceUrl for the rare
-  // case oneshot didn't set it (AEP_PLATFORM_URL unset).
-  let url: URL;
-  if (req.refreshUrl && req.refreshUrl !== "") {
-    url = new URL(req.refreshUrl);
-  } else {
-    url = new URL(req.gitServiceUrl);
-    if (!url.pathname.endsWith("/")) url.pathname += "/";
-    url.pathname += `internal/v1/executions/${encodeURIComponent(req.taskId)}/credentials/refresh`;
-  }
-
-  const headers: Record<string, string> = {
-    "Authorization": `Bearer ${bearer.trim()}`,
-    "Content-Type": "application/json",
-  };
-  if (req.correlationId) {
-    headers["X-Correlation-ID"] = req.correlationId;
-  }
-
-  // Pick the transport by URL scheme: in cloud the BFF/git endpoint is https
-  // (gateway), locally it's http. Node's http.request rejects https URLs with
-  // "Protocol \"https:\" not supported", so this must branch on the scheme.
-  const lib = url.protocol === "https:" ? https : http;
-
-  return new Promise((resolve, reject) => {
-    const hReq = lib.request(
-      url,
-      { method: "POST", headers, timeout: 10000 },
-      (res) => {
-        let body = "";
-        res.on("data", (chunk: Buffer) => { body += chunk.toString(); });
-        res.on("end", () => {
-          if (res.statusCode !== 200) {
-            return reject(new Error(`git-service returned ${res.statusCode}: ${body.slice(0, 200)}`));
-          }
-          try {
-            const data = JSON.parse(body);
-            if (!data.token) {
-              return reject(new Error("git-service response missing token"));
-            }
-            const token = data.token as string;
-            primeScrubber([token]);
-            resolve(token);
-          } catch {
-            // Never quote the body: this is the credential-bearing payload,
-            // and an unparseable one is exactly the case where a token could
-            // ride out inside a fragment that matches no known shape.
-            reject(new Error(`invalid git-service response (${body.length} bytes, not JSON)`));
-          }
-        });
-      },
-    );
-    hReq.on("error", reject);
-    hReq.on("timeout", () => { hReq.destroy(); reject(new Error("git-service request timed out")); });
-    hReq.write("{}");
-    hReq.end();
-  });
+// WS2.6 — req.refreshUrl (set by oneshot.ts from AEP_PLATFORM_URL) is already
+// the path-scoped endpoint. The fallback builds the same path-scoped URL from
+// gitServiceUrl for the rare case oneshot didn't set it.
+function resolveRefreshUrl(req: ProvisionRequest): string {
+  if (req.refreshUrl && req.refreshUrl !== "") return req.refreshUrl;
+  const url = new URL(req.gitServiceUrl);
+  if (!url.pathname.endsWith("/")) url.pathname += "/";
+  url.pathname += `internal/v1/executions/${encodeURIComponent(req.taskId)}/credentials/refresh`;
+  return url.toString();
 }
 
-// resolvePATForClone reads the staged bearer file and refreshes the GitHub PAT
-// the workspace clone authenticates with.
-async function resolvePATForClone(bearerFile: string, req: ProvisionRequest): Promise<string> {
-  const bearer = await fs.promises.readFile(bearerFile, "utf-8");
-  if (!bearer.trim()) {
-    throw new Error("bearer file is empty");
-  }
-  return refreshGitToken(req, bearer);
-}
 // provisionWorkspace clones the feature branch and writes credentials.
 // Idempotent: it removes any existing workspace first (§12.1 step 5
 // resume-safety: a crash mid-clone leaves DispatchedAt=null, the resume
 // sweep re-enters this step, which begins with rm -rf).
 //
 // Order matters: `git clone <url> <dir>` refuses to write into an existing
-// non-empty directory. So we stage the clone's credentials in a sibling tmp
-// dir, clone into the workspace path (which must not exist yet), and only
-// then drop the .aep/ and .gh-config/ directories inside the cloned tree.
+// non-empty directory. So we stage the bearer AND the credential helper in a
+// sibling tmp dir, clone into the workspace path (which must not exist yet)
+// authenticating through that staged helper, and only then drop the .aep/ and
+// .gh-config/ directories inside the cloned tree.
 export async function provisionWorkspace(req: ProvisionRequest): Promise<WorkspaceLayout> {
   const layout = computeLayout(req.orgId, req.projectId, req.taskId);
   const stageDir = layout.workspace + ".stage";
@@ -207,41 +133,46 @@ export async function provisionWorkspace(req: ProvisionRequest): Promise<Workspa
   await fs.promises.mkdir(path.dirname(layout.workspace), { recursive: true, mode: 0o755 });
   await fs.promises.mkdir(stageDir, { recursive: true, mode: 0o700 });
 
-  // Stage the bearer in the sibling dir: refreshGitToken reads it to mint the
-  // clone token, and it has to live somewhere outside the not-yet-existing
-  // workspace. The askpass shim lands here too (see cloneWithToken below).
-  // The runtime credhelper is written into the cloned tree afterwards.
+  // The helper body is generated ONCE and written twice, byte-identical: to the
+  // stage dir for the clone, and into the cloned tree for the agent. It reads
+  // the bearer from $AEP_BEARER_FILE, so only that path differs between the two
+  // phases — the script itself is never rewritten, which is what makes "one
+  // credential flow" literal rather than aspirational.
+  const helperBody = credHelperScript({
+    taskId: req.taskId,
+    workspaceDir: layout.workspace,
+    refreshUrl: resolveRefreshUrl(req),
+  });
+
+  // Stage the bearer and helper in the sibling dir: they have to live somewhere
+  // outside the not-yet-existing workspace, and are removed with it below.
   const stageBearer = path.join(stageDir, "bearer");
+  const stageHelper = path.join(stageDir, CREDHELPER_FILE);
   await fs.promises.writeFile(stageBearer, req.bearer, { mode: 0o600 });
+  await fs.promises.writeFile(stageHelper, helperBody, { mode: 0o700 });
 
   try {
-    // Resolve the PAT from git-service, then clone the PLAIN URL with the
-    // token handed to git via the askpass shim (see git_clone.ts). The token
-    // stays in the clone child's environment: not in argv, not in the error
-    // message on failure, and not left behind in .git/config. `.git/config`
-    // gets the long-lived credential.https://github.com.helper below, which is
+    // Clone the PLAIN URL, authenticating through the staged helper (see
+    // git_clone.ts). No token is passed to git at all — the helper mints one
+    // itself — so nothing lands in argv, in the error message on failure, or in
+    // .git/config. The durable copy of the same helper is installed below and is
     // what authenticates the agent's own later fetch/push.
     //
     // No --branch: clone the remote's default branch (HEAD). The agent
     // creates its own feature branch via `git checkout -b ...` once it
     // starts working, per the aep skill workflow.
-    const patResp = await resolvePATForClone(stageBearer, req);
-    await cloneWithToken({
+    await cloneWithHelper({
       repoUrl: req.repoUrl,
       destDir: layout.workspace,
-      token: patResp,
-      shimDir: stageDir,
+      helperPath: stageHelper,
+      bearerFile: stageBearer,
     });
 
     // Materialise the runtime layout inside the cloned tree.
     await fs.promises.mkdir(layout.aepDir, { recursive: true, mode: 0o755 });
     await fs.promises.mkdir(layout.ghConfigDir, { recursive: true, mode: 0o755 });
     await fs.promises.writeFile(layout.bearerFile, req.bearer, { mode: 0o600 });
-    await fs.promises.writeFile(
-      layout.helperBin,
-      credHelperScript({ taskId: req.taskId, workspaceDir: layout.workspace }),
-      { mode: 0o700 },
-    );
+    await fs.promises.writeFile(layout.helperBin, helperBody, { mode: 0o700 });
 
     // gh wrapper (chmod 755). Resolve the real gh binary path eagerly so the
     // wrapper doesn't have to. If gh is not on PATH we fall back to
@@ -253,23 +184,31 @@ export async function provisionWorkspace(req: ProvisionRequest): Promise<Workspa
     } catch {
       realGhPath = "/usr/bin/env gh";
     }
-    await fs.promises.writeFile(
-      layout.ghWrapper,
-      ghWrapperScript(realGhPath, { taskId: req.taskId, workspaceDir: layout.workspace }),
-      { mode: 0o755 },
-    );
+    await fs.promises.writeFile(layout.ghWrapper, ghWrapperScript(realGhPath), { mode: 0o755 });
 
-    // .git/config: identity + credential helper so subsequent ops don't need
-    // GIT_ASKPASS env.
+    // .git/config: commit identity + the durable credential helper. The scope is
+    // derived from the repo URL with the same function the clone used, so a
+    // self-hosted origin gets a helper that actually fires — hardcoding
+    // github.com here meant a GHE repo cloned fine and then failed every
+    // subsequent operation.
     await execAsync(
       `git -C ${shellQuote(layout.workspace)} config user.name ${shellQuote(req.identity.name)}`,
     );
     await execAsync(
       `git -C ${shellQuote(layout.workspace)} config user.email ${shellQuote(req.identity.email)}`,
     );
-    await execAsync(
-      `git -C ${shellQuote(layout.workspace)} config credential.https://github.com.helper ${shellQuote(layout.helperBin)}`,
-    );
+    const scope = cloneCredentialScope(req.repoUrl);
+    if (scope) {
+      // Empty value first: it resets any helper list inherited from system or
+      // global config. Git takes the FIRST helper that answers, so an inherited
+      // one would authenticate the agent's pushes as something else and would be
+      // handed our token by git's post-success `store`. Mirrors the `-c` pair the
+      // clone uses (git_clone.ts).
+      await execAsync(`git -C ${shellQuote(layout.workspace)} config credential.helper ""`);
+      await execAsync(
+        `git -C ${shellQuote(layout.workspace)} config ${shellQuote(`credential.${scope}.helper`)} ${shellQuote(layout.helperBin)}`,
+      );
+    }
   } finally {
     await fs.promises.rm(stageDir, { recursive: true, force: true });
   }

--- a/runners/remote-worker/src/local.ts
+++ b/runners/remote-worker/src/local.ts
@@ -170,10 +170,11 @@ async function main(): Promise<number> {
         // union of every component's skillsApplied, never one componentName.
         scope: { kind: "project" },
         skillsRepoURL: "local:working-tree",
-        pat: "",
+        // No git, no platform: the clone below is a working-tree copy.
+        cloneAuth: { helperPath: "", bearerFile: "" },
         scratchDir: path.join(run.runDir, "skills-clone"),
         log: (l) => console.log(l),
-        clone: (_url, _pat, dest) => copyLocalSkillLibrary(skillsDir, dest),
+        clone: (_url, _auth, dest) => copyLocalSkillLibrary(skillsDir, dest),
       });
       // Materialize under the run dir — never inside the user's project tree.
       const result = await materializeSkills(run.runDir, resolutions);

--- a/runners/remote-worker/src/oneshot.ts
+++ b/runners/remote-worker/src/oneshot.ts
@@ -34,7 +34,7 @@
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { provisionWorkspace, refreshGitToken } from "./lib/workspace.js";
+import { provisionWorkspace } from "./lib/workspace.js";
 import { runClaudeQuery } from "./lib/runner.js";
 import { openTaskLog } from "./lib/logger.js";
 import { isUUID, isSlug } from "./lib/uuid.js";
@@ -207,13 +207,13 @@ async function main(): Promise<number> {
     console.log("[oneshot] validation run — no design skills apply; using the aep-validation skill only");
   } else if (skillsRepoURL) {
     try {
-      const skillsBearer = ccProvider ? await ccProvider.getToken() : req.bearer;
-      const pat = await refreshGitToken(req, skillsBearer);
       const resolutions = await resolveTaskSkills({
         workspace: layout.workspace,
         scope: { kind: "project" },
         skillsRepoURL,
-        pat,
+        // Same credential helper the project clone used — one exchange
+        // implementation, and no GitHub token in this process.
+        cloneAuth: { helperPath: layout.helperBin, bearerFile: layout.bearerFile },
         // Clone OUTSIDE the work tree so its nested .git never enters the
         // agent's git status / commits.
         scratchDir: path.join(os.tmpdir(), "aep-skills", req.taskId),

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -25,6 +25,7 @@ import (
 
 	ocgen "github.com/wso2/aep/aep-api/internal/clients/openchoreo/gen"
 	"github.com/wso2/aep/aep-api/internal/gen"
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
 )
 
 //go:generate go run github.com/matryer/moq@v0.7.1 -rm -fmt goimports -pkg mocks -out mocks/component_client_mock.go . ComponentClient
@@ -1208,6 +1209,19 @@ func codingAgentParameters(p CodingAgentParams) map[string]interface{} {
 // goes into the network-error wrap to keep slog logs distinguishable
 // (trigger build / trigger coding-agent).
 func (c *componentClient) createWorkflowRun(ctx context.Context, orgName string, body ocgen.CreateWorkflowRunJSONRequestBody, opName string) (*gen.WorkflowRun, error) {
+	// Refuse a name OpenChoreo would accept and then never build. This is the
+	// one choke point every WorkflowRun create passes through, and the check is
+	// here rather than in the name generators because it has to hold for names
+	// they do not own — a caller-supplied runName included. The failure it
+	// replaces is the worst kind: a 201 Created, then no build pod, then a run
+	// stuck at WorkflowPending forever with nothing on its status explaining it.
+	if n := body.Metadata.Name; len(n) > k8sname.MaxLabelValueLen {
+		return nil, fmt.Errorf(
+			"%s: WorkflowRun name %q is %d chars, over the %d-char Kubernetes label-value limit "+
+				"(OpenChoreo and Argo both copy it into a label, so this run would be accepted and then never render)",
+			opName, n, len(n), k8sname.MaxLabelValueLen)
+	}
+
 	resp, err := c.oc.CreateWorkflowRunWithResponse(ctx, orgName, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to %s: %w", opName, err)

--- a/services/aep-api/internal/clients/openchoreo/oc_names.go
+++ b/services/aep-api/internal/clients/openchoreo/oc_names.go
@@ -20,6 +20,20 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
+)
+
+// unixMilliDigits is the width of the timestamp NewBuildRunName appends. Thirteen
+// digits covers every instant from 2001 to 2286.
+const unixMilliDigits = 13
+
+// buildRunNameWidths cap the readable head. See delivery's equivalents: both
+// halves are recoverable in full from the run's own labels, so the cap costs
+// readability and nothing else.
+const (
+	runNameProjectWidth   = 18
+	runNameComponentWidth = 18
 )
 
 // NewBuildRunName produces the WorkflowRun metadata.name for a new build of
@@ -27,10 +41,21 @@ import (
 // name and stage the per-WorkflowRun build Secret (named
 // `<runName>-git-secret`) before POSTing the WorkflowRun — see
 // docs/design/build-credential-injection.md. The millisecond timestamp
-// keeps successive triggers unique while staying well inside DNS-1123
-// length once suffixed with `-git-secret`.
+// keeps successive triggers unique.
+//
+// Composed through k8sname.Bounded against MaxLabelValueLen, for the reason
+// given there: the binding budget on a run name is the 63-char label-value
+// limit, not the 253-char name limit, and a name over it is accepted by
+// OpenChoreo and then never builds. Formatting the parts directly used to leave
+// this path with ZERO headroom (a 32-char project and a 16-char component land
+// on exactly 63), so any slightly longer name would have broken the console's
+// Build button the same silent way.
 func NewBuildRunName(projectName, componentName string) string {
-	return fmt.Sprintf("%s-%d", ScopedComponentName(projectName, componentName), time.Now().UnixMilli())
+	head := k8sname.Bounded(k8sname.MaxLabelValueLen-1-unixMilliDigits,
+		k8sname.Capped(projectName, runNameProjectWidth),
+		k8sname.Capped(componentName, runNameComponentWidth),
+	)
+	return fmt.Sprintf("%s-%d", head, time.Now().UnixMilli())
 }
 
 // ScopedComponentName is the k8s metadata name OC uses for a component. OC

--- a/services/aep-api/internal/clients/openchoreo/oc_names_test.go
+++ b/services/aep-api/internal/clients/openchoreo/oc_names_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	ocgen "github.com/wso2/aep/aep-api/internal/clients/openchoreo/gen"
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
+)
+
+// TestNewBuildRunNameFitsLabelBudget guards the console "Build" path, which
+// composes its own run name. Before the budget was enforced this sat at EXACTLY
+// 63 for a 32-char project and a 16-char component, so any slightly longer name
+// would have broken it the same silent way the fan-out path broke: accepted by
+// OpenChoreo, then no build pod, then pending forever.
+func TestNewBuildRunNameFitsLabelBudget(t *testing.T) {
+	cases := []struct{ name, project, component string }{
+		{"the pair that sat on exactly 63", "invoicing-freelancers-creates621", "invoicing-webapp"},
+		{"short names", "shop", "api"},
+		{"absurd project", strings.Repeat("p", 500), "api"},
+		{"absurd both", strings.Repeat("p", 500), strings.Repeat("c", 500)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewBuildRunName(tc.project, tc.component)
+			if len(got) > k8sname.MaxLabelValueLen {
+				t.Errorf("NewBuildRunName = %q (%d chars), over the %d-char label budget",
+					got, len(got), k8sname.MaxLabelValueLen)
+			}
+			// The staged build Secret is named `<runName>-git-secret`. That is a
+			// resource NAME, not a label value, so it only has to clear 253.
+			if secret := got + "-git-secret"; len(secret) > 253 {
+				t.Errorf("derived secret name %q is %d chars, over the 253-char name limit", secret, len(secret))
+			}
+		})
+	}
+}
+
+// TestCreateWorkflowRunRejectsOverlongName pins the guard at the choke point
+// every WorkflowRun create passes through.
+//
+// The point is that the request must never be SENT: OpenChoreo answers 201 for a
+// name it cannot later render, so a client that optimistically POSTs and trusts
+// the status code produces a run that is stuck forever with nothing on its
+// status to explain it. The fake server therefore records whether it was called
+// at all, rather than asserting on a response.
+func TestCreateWorkflowRunRejectsOverlongName(t *testing.T) {
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL}).(*componentClient)
+
+	// 64 chars: the exact overflow that wedged a real build, one over the limit.
+	overlong := "invoicing-freelancers-creates621-invoicing-webapp-4b4fede2508f-1"
+	if len(overlong) != 64 {
+		t.Fatalf("fixture is %d chars, want the 64-char production overflow", len(overlong))
+	}
+
+	_, err := c.createWorkflowRun(context.Background(), "default", ocgen.CreateWorkflowRunJSONRequestBody{
+		Metadata: ocgen.ObjectMeta{Name: overlong},
+	}, "trigger build")
+
+	if err == nil {
+		t.Fatal("createWorkflowRun accepted a 64-char name, want it refused before the request is sent")
+	}
+	if !strings.Contains(err.Error(), "label-value limit") {
+		t.Errorf("error = %q, want it to name the label-value limit so the cause is obvious", err)
+	}
+	if n := called.Load(); n != 0 {
+		t.Errorf("server was called %d times, want 0 — an unrenderable run must never be created", n)
+	}
+}
+
+// TestCreateWorkflowRunAcceptsNameAtLimit pins the boundary from the other side,
+// so the guard cannot drift into rejecting names that are actually fine.
+func TestCreateWorkflowRunAcceptsNameAtLimit(t *testing.T) {
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"metadata":{"name":"ok"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL}).(*componentClient)
+
+	atLimit := strings.Repeat("a", k8sname.MaxLabelValueLen)
+	if _, err := c.createWorkflowRun(context.Background(), "default", ocgen.CreateWorkflowRunJSONRequestBody{
+		Metadata: ocgen.ObjectMeta{Name: atLimit},
+	}, "trigger build"); err != nil {
+		t.Fatalf("createWorkflowRun rejected a %d-char name (exactly the limit): %v", len(atLimit), err)
+	}
+	if n := called.Load(); n != 1 {
+		t.Errorf("server was called %d times, want 1", n)
+	}
+}

--- a/services/aep-api/internal/delivery/build_fanout.go
+++ b/services/aep-api/internal/delivery/build_fanout.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
 )
 
 // The merged-pull-request → builds contract, shared by the two halves of the
@@ -89,8 +91,13 @@ func fileUnder(file, appPath string) bool {
 }
 
 // ShortSHA is the 12-hex-character form of a commit used in run names, dedupe
-// keys and issue prose. Twelve is git's own long-enough-to-be-unique default
-// and keeps a WorkflowRun name inside the Kubernetes name budget.
+// keys and issue prose. Twelve is git's own long-enough-to-be-unique default.
+//
+// It is NOT what keeps a run name inside its Kubernetes budget — believing that
+// is what produced a 64-char name that silently never built. The budget is
+// enforced where the name is composed (BuildRunNamePrefix, via k8sname.Bounded),
+// so this width is free to serve readability and the GitHub dedupe keys that
+// also embed it.
 func ShortSHA(sha string) string {
 	s := strings.ToLower(strings.TrimSpace(sha))
 	if len(s) > 12 {
@@ -99,13 +106,46 @@ func ShortSHA(sha string) string {
 	return s
 }
 
+// Widths of the readable head of a build run name. The project and component
+// are capped because neither has a bounded length — a project carries a
+// generated uniqueness suffix, and a component is named by the design agent —
+// while the commit is never truncated, because matching a build to a commit is
+// the main reason anyone reads one of these names. Both are recoverable in full
+// from the run's own `openchoreo.dev/{project,component}` labels, so capping
+// them costs nothing but readability.
+const (
+	runNameProjectWidth   = 18
+	runNameComponentWidth = 18
+	// maxAttemptDigits is the room reserved for the trailing ordinal. The
+	// re-trigger budget allows two attempts per (component, commit); two digits
+	// leaves that room an order of magnitude of headroom.
+	maxAttemptDigits = 2
+)
+
+// buildRunNameBudget is what the prefix may spend: the whole label-value budget
+// less the "-<attempt>" that BuildRunName appends. Subtracting the suffix HERE
+// is what makes every attempt name bounded by construction.
+const buildRunNameBudget = k8sname.MaxLabelValueLen - 1 - maxAttemptDigits
+
 // BuildRunNamePrefix is the (component, commit) half of a build WorkflowRun's
 // name — the key both the automatic re-trigger budget and the supervisor's
 // cycle-build read count on. Attempts share it and differ only in the trailing
 // ordinal, so counting the runs whose name carries this prefix IS the attempt
 // count, derived from OpenChoreo rather than stored anywhere.
+//
+// The name is composed through k8sname.Bounded rather than formatted directly,
+// because it must fit MaxLabelValueLen for ANY project and component name: a
+// name one character over is accepted by OpenChoreo and then never builds
+// (k8sname.MaxLabelValueLen explains why). Bounded truncates the readable head
+// to fit and appends a digest of the untruncated identity, so two components
+// that share a truncated head still get distinct prefixes and cannot
+// contaminate each other's attempt count.
 func BuildRunNamePrefix(projectID, component, sha string) string {
-	return strings.ToLower(fmt.Sprintf("%s-%s-%s-", projectID, component, ShortSHA(sha)))
+	return k8sname.Bounded(buildRunNameBudget,
+		k8sname.Capped(projectID, runNameProjectWidth),
+		k8sname.Capped(component, runNameComponentWidth),
+		k8sname.Whole(ShortSHA(sha)),
+	) + "-"
 }
 
 // BuildRunName names attempt n (1-based) of a component's build at a commit.

--- a/services/aep-api/internal/delivery/build_fanout_test.go
+++ b/services/aep-api/internal/delivery/build_fanout_test.go
@@ -18,9 +18,11 @@ package delivery_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
 )
 
 // TestDiffComponents pins the merged-PR path diff — the ONE rule the event
@@ -142,4 +144,87 @@ func TestBuildsAtMerge(t *testing.T) {
 			t.Fatalf("builds = %+v, want none", got)
 		}
 	})
+
+	// A long project and component must round-trip exactly like short ones. The
+	// names they produce are truncated, so this is the case where a naive
+	// shortening would quietly break the read side.
+	t.Run("long names still round-trip", func(t *testing.T) {
+		const longProject = "invoicing-freelancers-creates621"
+		const longComponent = "invoicing-webapp-admin-portal"
+		got := delivery.BuildsAtMerge([]delivery.MergeBuild{
+			{
+				Component: longComponent,
+				RunName:   delivery.BuildRunName(longProject, longComponent, sha, 2),
+				Status:    "Succeeded", Completed: true,
+			},
+		}, longProject, sha)
+
+		if len(got) != 1 || got[0].Attempt != 2 || got[0].Component != longComponent {
+			t.Fatalf("builds = %+v, want the truncated-name component at attempt 2", got)
+		}
+	})
+}
+
+// TestBuildRunNameFitsLabelBudget is the regression gate for the failure this
+// naming scheme exists to prevent: a run name one character over the 63-char
+// Kubernetes label-value limit is ACCEPTED by OpenChoreo and then never builds,
+// leaving the run pending forever with nothing on its status to explain it.
+//
+// The bound has to hold for every project and component name, not for the ones
+// that happen to exist today: a project carries a generated uniqueness suffix
+// and a component is named by the design agent, so neither length is bounded at
+// the point the name is composed.
+func TestBuildRunNameFitsLabelBudget(t *testing.T) {
+	const sha = "4b4fede2508f5354161ca86f0c6dc178f999c002"
+
+	cases := []struct{ name, project, component string }{
+		{"the pair that overflowed in production", "invoicing-freelancers-creates621", "invoicing-webapp"},
+		{"the pair that fit, one char under", "invoicing-freelancers-creates621", "invoicing-api"},
+		{"short names", "shop", "api"},
+		{"absurd project", strings.Repeat("p", 500), "api"},
+		{"absurd component", "shop", strings.Repeat("c", 500)},
+		{"absurd both", strings.Repeat("p", 500), strings.Repeat("c", 500)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Attempts beyond the re-trigger budget are included so the reserved
+			// room for the ordinal is exercised, not assumed.
+			for _, attempt := range []int{1, 2, 99} {
+				got := delivery.BuildRunName(tc.project, tc.component, sha, attempt)
+				if len(got) > k8sname.MaxLabelValueLen {
+					t.Errorf("BuildRunName attempt %d = %q (%d chars), over the %d-char label budget",
+						attempt, got, len(got), k8sname.MaxLabelValueLen)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildRunPrefixSeparatesSimilarComponents pins that two components whose
+// names survive truncation identically still get distinct prefixes.
+//
+// This is a correctness invariant, not a cosmetic one. The prefix IS the attempt
+// count: ensureBuildRun counts the runs carrying it to decide whether a red
+// build has already spent its one automatic re-trigger. Two components sharing a
+// prefix would pool their attempts, so one could consume the other's budget and
+// silently never be rebuilt.
+func TestBuildRunPrefixSeparatesSimilarComponents(t *testing.T) {
+	const project = "invoicing-freelancers-creates621"
+	const sha = "4b4fede2508f"
+
+	seen := map[string]string{}
+	for _, component := range []string{
+		"invoicing-webapp",
+		"invoicing-webapp-admin",
+		"invoicing-webapp-admin-portal",
+		"invoicing-webapp-reporting",
+	} {
+		prefix := delivery.BuildRunNamePrefix(project, component, sha)
+		if prior, dup := seen[prefix]; dup {
+			t.Errorf("components %q and %q share prefix %q — their attempt counts would pool",
+				prior, component, prefix)
+		}
+		seen[prefix] = component
+	}
 }

--- a/services/aep-api/internal/delivery/run/cycle.go
+++ b/services/aep-api/internal/delivery/run/cycle.go
@@ -211,6 +211,19 @@ func (l *loop) awaitLanding(ctx workflow.Context, deadline workflow.Future) land
 // eventually sees every expected component settle — and inventing a timeout
 // here would create a failure class §7 does not name, which is exactly how
 // terminal reasons stop being honest.
+//
+// That premise has a dependency worth stating, because it has been broken once:
+// a WorkflowRun only inherits the platform's deadline once it RENDERS into an
+// Argo Workflow. A run that OpenChoreo accepts but cannot render never gets one,
+// and it is indistinguishable from a slow build from here — its status says
+// WorkflowPending with no condition and no event naming the cause. The known way
+// to produce that is a run name over the Kubernetes label-value budget, which is
+// now refused at creation (see k8sname.MaxLabelValueLen and the guard in the
+// OpenChoreo client's createWorkflowRun), so this loop's premise holds by
+// construction rather than by luck. If another render failure is ever found, the
+// fix belongs there too — at the point of creation, where the cause is still
+// known — and not in a timeout here, which could only report "something took too
+// long" about a run that was never going to start.
 func (l *loop) awaitBuilds(ctx workflow.Context) (cycleResult, error) {
 	for {
 		state, err := l.pollBuilds(ctx)

--- a/services/aep-api/internal/platform/k8sname/bounded.go
+++ b/services/aep-api/internal/platform/k8sname/bounded.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package k8sname
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// MaxLabelValueLen is the Kubernetes limit on a label VALUE.
+//
+// This — not the 253-char limit on a resource NAME — is the budget that binds
+// any name a controller copies into a label, and two independent systems do
+// exactly that to a build's name:
+//
+//   - OpenChoreo's workflowrun-controller stamps it into
+//     `openchoreo.dev/workflowrun` on the resources it renders for the run.
+//   - Argo stamps it into `workflows.argoproj.io/workflow` on every pod.
+//
+// Overflowing it is silent and total: the WorkflowRun is ACCEPTED (its own name
+// is well inside the 253-char name budget), then the render that would create
+// the Argo Workflow fails validation, so no build pod is ever created and the
+// run sits at WorkflowPending forever with nothing on its status to say why.
+// Because Argo caps it too, fixing this upstream in OpenChoreo would not lift
+// the budget — treat 63 as structural.
+const MaxLabelValueLen = 63
+
+// digestLen is the width of the disambiguating digest Bounded appends. Eight
+// hex characters is 32 bits, which is many orders of magnitude more than the
+// hundreds of names any one project generates, and it only has to break ties
+// between inputs whose readable heads already collided.
+const digestLen = 8
+
+// Segment is one readable part of a bounded name.
+type Segment struct {
+	Value string
+	// Max caps this segment's readable contribution. Zero means "never
+	// truncate": use it for the parts whose whole value is what makes the name
+	// worth reading, such as a commit SHA.
+	Max int
+}
+
+// Whole returns a Segment that is never truncated.
+func Whole(v string) Segment { return Segment{Value: v} }
+
+// Capped returns a Segment whose readable contribution is at most max chars.
+func Capped(v string, max int) Segment { return Segment{Value: v, Max: max} }
+
+// Bounded composes a deterministic, RFC 1123 name identifying segs that is
+// never longer than budget, and appends a digest of the UNTRUNCATED segments.
+//
+// The digest is the point. Truncating names to fit a budget is otherwise unsafe
+// in a way that fails silently and late: two components whose names agree on
+// their first Max characters would produce the same name, and any caller that
+// derives identity from that name — counting a component's build attempts by
+// matching its name prefix, say — would silently merge two different things.
+// Appending a digest of the full input makes truncation lossy for HUMANS while
+// keeping the name injective for MACHINES, so callers may cap segments as hard
+// as their budget requires without inventing a correctness risk.
+//
+// budget is the caller's whole allowance for the returned string. A caller that
+// appends its own suffix must subtract it (separator included) before calling,
+// so that the composed result is bounded by construction rather than by anyone
+// remembering to check afterwards.
+func Bounded(budget int, segs ...Segment) string {
+	digest := identityDigest(segs)
+	// The digest carries injectivity, so it is the last thing sacrificed: a
+	// budget too small to hold a readable head still yields a distinct name.
+	if budget <= digestLen {
+		if budget < 0 {
+			return ""
+		}
+		return digest[:min(budget, digestLen)]
+	}
+
+	parts := make([]string, 0, len(segs))
+	for _, s := range segs {
+		v := sanitize(s.Value)
+		if s.Max > 0 && len(v) > s.Max {
+			v = strings.Trim(v[:s.Max], "-")
+		}
+		if v != "" {
+			parts = append(parts, v)
+		}
+	}
+
+	// room is what is left for the readable head once the digest and the
+	// separator joining it are paid for.
+	room := budget - digestLen - 1
+	readable := strings.Join(parts, "-")
+	if len(readable) > room {
+		readable = readable[:room]
+	}
+	readable = strings.Trim(readable, "-")
+	if readable == "" {
+		return digest
+	}
+	return readable + "-" + digest
+}
+
+// identityDigest hashes the segments' sanitized values, NUL-separated.
+//
+// Sanitized, because the read side of a name contract may recover a segment
+// from a Kubernetes label (already reduced to the RFC 1123 character set) while
+// the write side passes the original: hashing the sanitized form is what makes
+// those two agree. NUL-separated, because concatenation alone is ambiguous —
+// ("ab", "c") and ("a", "bc") must not hash alike, or two distinct identities
+// would share a digest.
+func identityDigest(segs []Segment) string {
+	h := sha256.New()
+	for _, s := range segs {
+		h.Write([]byte(sanitize(s.Value)))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:digestLen]
+}

--- a/services/aep-api/internal/platform/k8sname/bounded_test.go
+++ b/services/aep-api/internal/platform/k8sname/bounded_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package k8sname_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
+)
+
+// rfc1123Label is the character set a name may use if it is to survive being
+// copied into a label value: lowercase alphanumerics and dashes, starting and
+// ending alphanumeric.
+var rfc1123Label = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// TestBoundedRespectsBudget is the property the whole helper exists for: no
+// input, however long, may produce a name over the caller's budget. The
+// incident this replaces was a name ONE character over a 63-char limit, so the
+// test sweeps adversarial lengths rather than checking a single happy case.
+func TestBoundedRespectsBudget(t *testing.T) {
+	for _, budget := range []int{63, 60, 49, 32, 12, 9, 8, 4, 1, 0} {
+		for _, n := range []int{0, 1, 8, 40, 200, 5000} {
+			long := strings.Repeat("a", n)
+			for _, segs := range [][]k8sname.Segment{
+				{k8sname.Capped(long, 18)},
+				{k8sname.Capped(long, 18), k8sname.Capped(long, 18), k8sname.Whole("4b4fede2508f")},
+				{k8sname.Whole(long)},
+			} {
+				got := k8sname.Bounded(budget, segs...)
+				if len(got) > budget {
+					t.Errorf("Bounded(%d) with %d-char segs = %q (%d chars), over budget",
+						budget, n, got, len(got))
+				}
+				if got != "" && !rfc1123Label.MatchString(got) {
+					t.Errorf("Bounded(%d) = %q, not a valid RFC 1123 label", budget, got)
+				}
+			}
+		}
+	}
+}
+
+// TestBoundedIsInjectiveUnderTruncation is the reason the digest is worth its
+// characters. Two components whose names agree well past the cap must not
+// collapse to one name: a caller deriving identity from the name (counting a
+// component's build attempts by prefix, say) would otherwise silently merge two
+// different components, which is far harder to notice than a length error.
+func TestBoundedIsInjectiveUnderTruncation(t *testing.T) {
+	const budget = 60
+	const project = "invoicing-freelancers-creates621"
+
+	seen := map[string]string{}
+	components := []string{
+		"invoicing-webapp",
+		"invoicing-webapp-admin",
+		"invoicing-webapp-admin-portal",
+		"invoicing-webapp-admin-portal-v2",
+		// Differs only past the 18-char cap.
+		"a-very-long-compo-one",
+		"a-very-long-compo-two",
+	}
+	for _, c := range components {
+		got := k8sname.Bounded(budget,
+			k8sname.Capped(project, 18),
+			k8sname.Capped(c, 18),
+			k8sname.Whole("4b4fede2508f"),
+		)
+		if prior, dup := seen[got]; dup {
+			t.Errorf("components %q and %q both produced %q — truncation collided", prior, c, got)
+		}
+		seen[got] = c
+	}
+}
+
+// TestBoundedNeverTruncatesWholeSegments pins that Whole means whole: the commit
+// is the part of a build name humans actually read, so it must survive even when
+// the rest of the head is cut down to fit.
+func TestBoundedNeverTruncatesWholeSegments(t *testing.T) {
+	const sha = "4b4fede2508f"
+	got := k8sname.Bounded(60,
+		k8sname.Capped(strings.Repeat("p", 200), 18),
+		k8sname.Capped(strings.Repeat("c", 200), 18),
+		k8sname.Whole(sha),
+	)
+	if !strings.Contains(got, sha) {
+		t.Errorf("Bounded = %q, want the whole commit %q to survive truncation", got, sha)
+	}
+}
+
+// TestBoundedIsDeterministic pins that write side and read side, which compose
+// the name independently, agree — including when one of them recovered a segment
+// from a Kubernetes label and so passes it already sanitized.
+func TestBoundedIsDeterministic(t *testing.T) {
+	call := func(project, component string) string {
+		return k8sname.Bounded(60,
+			k8sname.Capped(project, 18),
+			k8sname.Capped(component, 18),
+			k8sname.Whole("4b4fede2508f"),
+		)
+	}
+	base := call("shop", "api")
+	if again := call("shop", "api"); again != base {
+		t.Errorf("Bounded is not deterministic: %q then %q", base, again)
+	}
+	// Sanitizing is applied before hashing, so a caller holding the un-normalized
+	// form composes the same name as one holding the label's version.
+	if mixed := call("Shop", "API"); mixed != base {
+		t.Errorf("Bounded(%q) = %q, want the sanitized form %q", "Shop/API", mixed, base)
+	}
+}
+
+// TestBoundedDropsEmptySegments pins that an absent segment contributes nothing
+// rather than the "component" fallback ToK8sName substitutes — a composed name
+// must not grow a phantom word.
+func TestBoundedDropsEmptySegments(t *testing.T) {
+	got := k8sname.Bounded(60, k8sname.Capped("", 18), k8sname.Capped("api", 18))
+	if strings.Contains(got, "component") {
+		t.Errorf("Bounded = %q, want no 'component' fallback for an empty segment", got)
+	}
+	if !strings.HasPrefix(got, "api-") {
+		t.Errorf("Bounded = %q, want it to lead with the segment that was present", got)
+	}
+}
+
+// TestBoundedShape pins the composed form for the exact project/component pair
+// that overflowed in production, so a reader can see what these names look like
+// without running a build, and so a change to the widths or the digest shows up
+// as a diff here rather than as a surprise in the cluster.
+func TestBoundedShape(t *testing.T) {
+	const want = "invoicing-freelanc-invoicing-webapp-4b4fede2508f-80ca1f42"
+	got := k8sname.Bounded(60,
+		k8sname.Capped("invoicing-freelancers-creates621", 18),
+		k8sname.Capped("invoicing-webapp", 18),
+		k8sname.Whole("4b4fede2508f"),
+	)
+	if got != want {
+		t.Errorf("Bounded = %q (%d chars), want %q", got, len(got), want)
+	}
+}

--- a/services/aep-api/internal/platform/k8sname/k8sname.go
+++ b/services/aep-api/internal/platform/k8sname/k8sname.go
@@ -29,12 +29,20 @@ var invalidNameChars = regexp.MustCompile(`[^a-z0-9-]`)
 
 // ToK8sName converts a human-readable name to an RFC 1123 compliant k8s name.
 func ToK8sName(name string) string {
-	s := strings.ToLower(strings.TrimSpace(name))
-	s = strings.ReplaceAll(s, " ", "-")
-	s = invalidNameChars.ReplaceAllString(s, "")
-	s = strings.Trim(s, "-")
+	s := sanitize(name)
 	if s == "" {
 		s = "component"
 	}
 	return s
+}
+
+// sanitize is ToK8sName without the non-empty fallback: it reduces a name to
+// the RFC 1123 character set and nothing more. Bounded needs the unsubstituted
+// form so an empty segment contributes nothing to a composed name instead of
+// silently becoming the literal "component".
+func sanitize(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = strings.ReplaceAll(s, " ", "-")
+	s = invalidNameChars.ReplaceAllString(s, "")
+	return strings.Trim(s, "-")
 }


### PR DESCRIPTION
## Why

Coding runs could not authenticate any git operation. The runner's `credhelper.sh`
served both the git-credential-helper and `GIT_ASKPASS` protocols and chose between
them with `[ -n "$1" ]` — but git invokes a credential helper as `credhelper.sh get`,
so `$1` is non-empty in *both* modes. The helper branch was unreachable and emitted a
bare token, which git rejects:

```
warning: invalid credential line: ghs_…
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The clone used a *separate* askpass shim, so it kept working and hid the breakage —
the failure only surfaced once the agent ran its first `git fetch`, an hour into a run.

## What changed

**One mechanism, one protocol.** Every authenticated git operation now goes through the
same credential helper, the provisioning clone included: the clone wires it in with
`git -c credential.<origin>.helper` (`.git/config` does not exist yet) and provisioning
installs the same script durably afterwards, byte-identical — only the env-supplied
`$AEP_BEARER_FILE` path differs between the two phases.

Putting the helper on the clone is the point: the mechanism the agent depends on is now
exercised *before* the agent starts, so a break is a provisioning failure rather than a
mystery mid-run.

Also fixed, all on the same paths:

- **Inherited helpers could win.** Git takes the *first* helper that answers, so one in
  system config (Homebrew's git ships `credential.helper=osxkeychain`) would authenticate
  instead of ours — and be handed our token by git's post-success `store`. Both the clone
  and the durable config now reset the list with an empty `credential.helper` first.
- **Helper scope was hardcoded** to `https://github.com`, so a self-hosted origin cloned
  fine then failed every later operation. Now derived from the repo URL on both paths.
- **Identity fields were read lowercase** while the wire contract CAPITALIZES them, leaving
  the identity-drift rewrite dead. Now case-tolerant.
- **The `gh` wrapper duplicated the exchange** and read `$AEP_BEARER_FILE` only, so a
  publisher-cc run degraded silently once the pod-start token expired. It now delegates to
  `credhelper.sh get`.
- `store`/`erase` return before the refresh round-trip; unknown actions exit 0 per
  gitcredentials(7); failures name themselves on stderr instead of leaving git's opaque
  message as the only signal.

**Removed:** the `GIT_ASKPASS` shim, `AEP_CLONE_TOKEN`, `refreshGitToken`,
`resolvePATForClone`. The runner process no longer holds a GitHub token at all — the
credential exists only in the helper's stdout pipe to git.

Also included: `fix(delivery): bound build run names to the 63-char label budget`.

## Tests

This shipped because nothing ran the generated script. Two new suites:

- `credhelper.test.ts` — drives the script as a program, including `git credential fill`
  with real git.
- `provision_e2e.test.ts` — provisions against a real `git-http-backend` behind Basic auth,
  then performs the agent's own clone / fetch / ls-remote / push.

Reverting the old dispatch fails 7 of the former and all of the latter, reproducing the
exact production error.

> **Note for anyone running these locally:** host git config must be neutered
> (`GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`). The 401 the e2e returns makes
> git consult every configured credential helper, so without it macOS prompts for keychain
> access and git's `store` writes the test token into the developer's real keychain. Both
> suites assert the isolation before doing anything.

## Verification

`make test` (219 pass, 0 fail), `lint`, `license-check`, `deadcode-ts-check` all green on
this base.

Live on a local cluster: runner image rebuilt and k3d-imported, then a real milestone run
completed end to end — `git fetch origin`, the `gh` calls, commit, push and `gh pr create`
all succeeded, PR merged, zero credential errors. Both suites also pass *inside* the
deployed image (git 2.39.5, bash 5.2, Python 3.11), which differs from the dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)