### PR TITLE
fix(validation): key the runner's identity on its cycle, and let its PR merge

### DIFF
--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -94,6 +94,12 @@ const mockReport = {
   data: undefined as { content: string } | undefined,
 };
 
+// build.version is the NEWEST run's version and deploy.version the newest
+// SUCCEEDED one; they differ for exactly as long as a run is live, which is the
+// whole time validation is running. Both are settable so a test can pin that gap.
+let mockBuildVersion = "v1";
+let mockDeployVersion = "v1";
+
 vi.mock("../../projects/api/queries", () => ({
   useProjectStatus: () => ({
     isPending: false,
@@ -102,18 +108,22 @@ vi.mock("../../projects/api/queries", () => ({
     refetch: vi.fn(),
     data: {
       repoUrl: "https://github.com/acme/demo",
-      deploy: { version: "v1", validation: mockValidation },
+      build: { version: mockBuildVersion, status: "running" },
+      deploy: { version: mockDeployVersion, validation: mockValidation },
     },
   }),
 }));
 
 vi.mock("../../builds/api/queries", () => ({
-  useBuildRuns: () => ({
+  // Models the real hook's `enabled: Boolean(tag)`: with no tag the query never
+  // runs and there is no data. A mock that answered regardless of tag would hide
+  // the bug where this page asked for a version the status did not have yet.
+  useBuildRuns: (_project: string, tag: string | undefined) => ({
     isPending: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-    data: { tag: "v1", milestoneNumber: 1, runs: mockRun ? [mockRun] : [] },
+    data: tag ? { tag, milestoneNumber: 1, runs: mockRun ? [mockRun] : [] } : undefined,
   }),
 }));
 
@@ -174,6 +184,8 @@ function renderPage(view: "logs" | undefined, onViewChange = vi.fn()) {
 afterEach(() => {
   mockValidation = "none";
   mockRun = undefined;
+  mockBuildVersion = "v1";
+  mockDeployVersion = "v1";
   mockCriteria.isPending = false;
   mockCriteria.isError = false;
   mockCriteria.data = undefined;
@@ -201,6 +213,39 @@ describe("ValidationPage lifecycle", () => {
     // The feed streams the WHOLE run; the page filters it to the one phase it
     // owns, so a coding cycle's output never leaks onto the validation page.
     expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
+  });
+
+  // The regression: validation is the last cycle before a run settles, so while
+  // it runs the run is still `running` and deploy.version — the newest SUCCEEDED
+  // run's version — names nothing on a project's first version. Keyed on that,
+  // the page found no run at all and claimed validation had not started, while
+  // the header chip beside it read "Validating".
+  it("finds the run mid-validation on a first version, when nothing has been delivered yet", () => {
+    mockValidation = "running";
+    mockDeployVersion = ""; // no spec-build run has SUCCEEDED yet
+    mockBuildVersion = "v1"; // ...but v1's run is live and validating
+    mockRun = run({ cycles: [validationCycle] });
+
+    renderPage(undefined);
+
+    expect(screen.queryByText(/No validation has run yet/)).not.toBeInTheDocument();
+    expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
+  });
+
+  // The same gap on a later build points the other way: deploy.version still
+  // names the PREVIOUS version, so keying on it would show v1's settled report
+  // under a chip announcing that v2 is validating.
+  it("follows the newest run, not the last delivered version", () => {
+    mockValidation = "running";
+    mockDeployVersion = "v1"; // v1 is live in dev
+    mockBuildVersion = "v2"; // v2's run is validating right now
+    mockRun = run({ cycles: [validationCycle] });
+
+    renderPage(undefined);
+
+    // The run story is fetched for v2 — the version the chip is talking about.
+    expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
+    expect(screen.queryByText(/No validation has run yet/)).not.toBeInTheDocument();
   });
 
   it("shows the feed for a run whose validation failed", () => {

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -120,11 +120,21 @@ export function ValidationPage({
 }) {
   const status = useProjectStatus(projectName);
   const deploy = status.data?.deploy;
-  const version = deploy?.version ?? "";
   const running = deploy?.validation === "running";
 
-  // The deployed version's runs: the newest is the one that landed it, and its
-  // validation record is this page's subject.
+  // The version this page is about is the NEWEST run's — the same run
+  // `deploy.validation` (the chip) describes.
+  //
+  // NOT deploy.version, which names the newest SUCCEEDED run. Validation is the
+  // last cycle before a run settles, so while it is in flight the run is still
+  // `running` and deploy.version names either nothing (the first version) or the
+  // PREVIOUS one. Keyed on that, this page said "No validation has run yet" about
+  // a validation that was running, and on any later build would have shown the
+  // previous version's report under a chip reading "Validating".
+  const version = status.data?.build.version ?? "";
+
+  // The version's runs: the newest is the one that landed it, and its validation
+  // record is this page's subject.
   const runs = useBuildRuns(projectName, version || undefined);
   const run = runs.data?.runs?.[0];
   // The verdict VALUE drives every decision below. Deriving them from the chip's

--- a/packages/contracts/api/internal/v1/openapi.yaml
+++ b/packages/contracts/api/internal/v1/openapi.yaml
@@ -44,7 +44,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error
-  /executions/{executionId}/validation-context:
+  /validation/{cycleId}/context:
     get:
       operationId: runner-validation-context
       summary: Fetch a validation run's deployed endpoints (runner callback)
@@ -54,9 +54,11 @@ paths:
       - taskJWT: []
       - publisherCC: []
       parameters:
-      - description: Execution id the runner callback is scoped to
+      - description: Validation cycle id the runner callback is scoped to — the
+          run cycle the platform dispatched this runner for, carried to the pod as
+          AEP_TASK_ID and bound into its bearer token
         in: path
-        name: executionId
+        name: cycleId
         required: true
         schema:
           type: string
@@ -73,7 +75,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error
-  /executions/{executionId}/test-credentials:
+  /validation/{cycleId}/test-credentials:
     post:
       operationId: runner-validation-credentials
       summary: Request test credentials for a validation run (runner callback)
@@ -83,9 +85,11 @@ paths:
       - taskJWT: []
       - publisherCC: []
       parameters:
-      - description: Execution id the runner callback is scoped to
+      - description: Validation cycle id the runner callback is scoped to — the
+          run cycle the platform dispatched this runner for, carried to the pod as
+          AEP_TASK_ID and bound into its bearer token
         in: path
-        name: executionId
+        name: cycleId
         required: true
         schema:
           type: string

--- a/runners/remote-worker/local/token-stub.mjs
+++ b/runners/remote-worker/local/token-stub.mjs
@@ -23,10 +23,11 @@
 //   POST /internal/v1/tasks/{taskId}/credentials/refresh
 //     -> { "token": $GITHUB_PAT, "taskId": <echoed from path> }
 //
-// For a validation run it also plays the validation-context endpoint so the
-// aep-validation skill can fetch its deployed endpoints (never in the issue):
+// For a validation run it also plays the validation-context endpoint, which the
+// runner PREFLIGHTS before starting the agent (deployed endpoints are never in
+// the issue). Without it the local validation run exits before the agent starts:
 //
-//   GET /internal/v1/executions/{id}/validation-context
+//   GET /internal/v1/validation/{cycleId}/context
 //     -> { endpoints:[{component,url}], credentials:null, criteriaPath }
 //
 // The endpoints point at localhost dev servers the agent starts in-container
@@ -64,7 +65,9 @@ const expectedBearer = process.env.STUB_BEARER ?? "";
 // (git-service fallback) and executions/{id} when it is set (the current
 // execution-keyed model). Match either so the stub serves both run shapes.
 const REFRESH_RE = /^\/internal\/v1\/(?:tasks|executions)\/([^/]+)\/credentials\/refresh$/;
-const VALIDATION_CONTEXT_RE = /^\/internal\/v1\/executions\/([^/]+)\/validation-context$/;
+// Validation callbacks live under the feature that owns them and are keyed by the
+// CYCLE id the runner carries (AEP_TASK_ID).
+const VALIDATION_CONTEXT_RE = /^\/internal\/v1\/validation\/([^/]+)\/context$/;
 const JSON_HEADERS = { "Content-Type": "application/json", "Cache-Control": "no-store" };
 
 // The validation-context payload the stub returns. Localhost dev servers the
@@ -106,7 +109,7 @@ const server = http.createServer((req, res) => {
     return;
   }
   if (contextM) {
-    console.error(`[token-stub] 200 validation-context for execution ${contextM[1]}`);
+    console.error(`[token-stub] 200 validation-context for cycle ${contextM[1]}`);
     res.writeHead(200, JSON_HEADERS).end(JSON.stringify(validationContext));
     return;
   }

--- a/runners/remote-worker/plugin/skills/aep-validation/SKILL.md
+++ b/runners/remote-worker/plugin/skills/aep-validation/SKILL.md
@@ -42,16 +42,27 @@ requirements. If a required section is missing, post an issue comment
 naming what's missing and exit with failure.
 
 Deployed endpoint URLs and any test credentials are NOT in the issue —
-they are runtime inputs kept out of the public issue. You fetch them from
-the platform in step 4.
+they are runtime inputs kept out of the public issue. The endpoints are
+already on disk for you (step 4); credentials you request on demand.
 
 Post a brief opening comment (`Starting validation: <one-line plan>`).
 
 ### 2. Branch
 
+The `aep/m<milestone#>-` prefix is a CONTRACT, not a style: the platform keys
+your merged pull request back to this run by the branch name. A branch outside
+that shape reads as a stranger's pull request — it is refused auto-merge, and
+your tests and report never reach the run. The milestone is the one your
+validation issue is filed under:
+
 ```bash
-git checkout -b validation/issue-<N>
+MILESTONE=$(gh issue view <N> --repo <owner/repo> --json milestone -q .milestone.number)
+git checkout -b "aep/m${MILESTONE}-validation"
 ```
+
+If `MILESTONE` comes back empty the issue was filed without one — a platform
+fault, not something to work around. Say so in an issue comment and stop; a
+branch without the prefix would strand everything you are about to do.
 
 ### 3. Partition the criteria
 
@@ -70,21 +81,23 @@ For each criterion:
 - `method: scenario` → no automation in this run; the report lists them
   as not validated.
 
-### 4. Fetch the validation context, then confirm the app is reachable
+### 4. Read the validation context, then confirm the app is reachable
 
-Deployed endpoint URLs come from the platform's secure validation-context
-endpoint — never from the issue. Test credentials are a separate on-demand
-request (below), made only when a criterion needs a login. `AEP_TASK_ID`
-carries this run's execution id; the bearer rides a file.
+Deployed endpoint URLs come from the platform, never from the issue. The
+platform fetched them **before you started** and left them at
+`/tmp/validation-context.json`:
 
 ```bash
-curl -sf "$AEP_PLATFORM_URL/internal/v1/executions/$AEP_TASK_ID/validation-context" \
-  -H "Authorization: Bearer $(cat "$AEP_BEARER_FILE")" > /tmp/validation-context.json
+cat /tmp/validation-context.json
 ```
 
-The response is `{ "endpoints": [{"component","url"}], "criteriaPath":
-"..." }`. If the fetch fails or `AEP_PLATFORM_URL` is unset, post an issue
-comment and exit with failure — do not guess endpoints.
+The content is `{ "endpoints": [{"component","url"}], "criteriaPath":
+"..." }`. It is present and non-empty whenever you are running: the runner
+exits before starting you if the platform could not resolve it, so there is
+no failure mode here for you to recover from. If the file were somehow
+missing, that is a platform fault — say so in one line and stop. Do not
+probe, scan, or infer endpoints, and do not call the platform for them
+yourself; the URL is not something you can work out from inside the cluster.
 
 - **Endpoints** become `tests/e2e/targets.json` (step 5) and your target
   list. Probe each URL (`curl -sf -o /dev/null <url>` or a playwright-cli
@@ -93,10 +106,11 @@ comment and exit with failure — do not guess endpoints.
   comment + exit failure.
 - **Test credentials (on demand):** request them only when a criterion
   needs a login — POST the test-credentials endpoint with an optional
-  `role` hint (the role the flow requires):
+  `role` hint (the role the flow requires). `AEP_TASK_ID` is this run's
+  validation cycle id; the bearer rides a file:
 
   ```bash
-  curl -sf -X POST "$AEP_PLATFORM_URL/internal/v1/executions/$AEP_TASK_ID/test-credentials" \
+  curl -sf -X POST "$AEP_PLATFORM_URL/internal/v1/validation/$AEP_TASK_ID/test-credentials" \
     -H "Authorization: Bearer $(cat "$AEP_BEARER_FILE")" \
     -H "Content-Type: application/json" \
     --data '{"role":"admin"}' > /tmp/creds.json
@@ -152,7 +166,8 @@ tests/e2e/
 - `targets.json` shape: `{"targets": {"<component>": "<url>", ...},
   "primary": "<the web-facing component>"}`, filled from the step-4
   validation-context `endpoints`. On a re-validation run, refresh it from
-  the newly fetched context.
+  the context file — a committed `targets.json` may name URLs from an
+  earlier deployment.
 - Install with `npm install` on first scaffold (commit the lockfile),
   `npm ci` on later runs.
 - `scripts/generate-report.mjs` is platform-owned: the REPORT step

--- a/runners/remote-worker/src/lib/validation_context.test.ts
+++ b/runners/remote-worker/src/lib/validation_context.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  fetchValidationContext,
+  validationContextUrl,
+  VALIDATION_CONTEXT_FILE,
+} from "./validation_context.js";
+
+const CYCLE = "9d90f001-67bb-4c51-a5f3-7fd808c06c36";
+const BEARER = "task-jwt";
+
+async function tmpFile(): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-valctx-"));
+  return path.join(dir, "validation-context.json");
+}
+
+/** A fetch stub that records the request it was handed. */
+function stubFetch(status: number, body: string) {
+  const calls: { url: string; auth: string }[] = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push({ url: String(url), auth: headers.get("Authorization") ?? "" });
+    return new Response(body, { status });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+// The path is keyed by the CYCLE the runner was dispatched for. It used to be
+// /internal/v1/executions/{id}/validation-context, resolved against a table the
+// milestone supervisor never writes — a 404 on every validation run.
+test("validationContextUrl targets the cycle-scoped validation path", () => {
+  assert.equal(
+    validationContextUrl("https://bff.example", CYCLE),
+    `https://bff.example/internal/v1/validation/${CYCLE}/context`,
+  );
+  // A trailing slash on AEP_PLATFORM_URL must not double up.
+  assert.equal(
+    validationContextUrl("https://bff.example/", CYCLE),
+    `https://bff.example/internal/v1/validation/${CYCLE}/context`,
+  );
+});
+
+test("writes the platform's payload verbatim and reports its endpoints", async () => {
+  const file = await tmpFile();
+  const payload = JSON.stringify({
+    endpoints: [{ component: "hello-webapp", url: "https://hello.example" }],
+    criteriaPath: "specs/validation/validation-criteria.json",
+    somethingNewer: "must survive",
+  });
+  const { impl, calls } = stubFetch(200, payload);
+
+  const ctx = await fetchValidationContext({
+    platformUrl: "https://bff.example",
+    cycleId: CYCLE,
+    bearer: BEARER,
+    file,
+    fetchImpl: impl,
+  });
+
+  assert.equal(ctx.endpoints.length, 1);
+  assert.equal(ctx.endpoints[0]?.url, "https://hello.example");
+  assert.equal(calls[0]?.auth, `Bearer ${BEARER}`);
+  // Verbatim: the skill's contract is the platform's payload, so a field this
+  // runner does not model still reaches it.
+  assert.equal(await fs.promises.readFile(file, "utf8"), payload);
+});
+
+// The failure that mattered: the platform does not recognise the runner's cycle
+// id. This must throw so the caller can exit before the agent starts, rather than
+// leave an agent to work out where the app is on its own.
+test("a 404 throws and writes nothing", async () => {
+  const file = await tmpFile();
+  const { impl } = stubFetch(404, '{"code":"not_found","message":"no validation cycle with this id"}');
+
+  await assert.rejects(
+    fetchValidationContext({
+      platformUrl: "https://bff.example",
+      cycleId: CYCLE,
+      bearer: BEARER,
+      file,
+      fetchImpl: impl,
+    }),
+    /HTTP 404/,
+  );
+  assert.equal(fs.existsSync(file), false);
+});
+
+// Validation is dispatched at deployed-green, so an empty endpoint list means the
+// platform cannot say where the system is. "No targets" is precisely the state
+// that made the agent start probing, so it is a failure and not an empty success.
+test("a context with no endpoints throws", async () => {
+  const file = await tmpFile();
+  const { impl } = stubFetch(200, JSON.stringify({ endpoints: [], criteriaPath: "x" }));
+
+  await assert.rejects(
+    fetchValidationContext({
+      platformUrl: "https://bff.example",
+      cycleId: CYCLE,
+      bearer: BEARER,
+      file,
+      fetchImpl: impl,
+    }),
+    /no deployed endpoints/,
+  );
+  assert.equal(fs.existsSync(file), false);
+});
+
+test("an unset platform URL throws before any request", async () => {
+  const { impl, calls } = stubFetch(200, "{}");
+  await assert.rejects(
+    fetchValidationContext({ platformUrl: "", cycleId: CYCLE, bearer: BEARER, fetchImpl: impl }),
+    /AEP_PLATFORM_URL is unset/,
+  );
+  assert.equal(calls.length, 0);
+});
+
+// The default target is outside the work tree AND outside `.aep/`, which the base
+// skill forbids the agent from reading — it must not have to break that rule to
+// find its own targets.
+test("the default context file is outside the workspace and outside .aep", () => {
+  assert.equal(VALIDATION_CONTEXT_FILE.startsWith("/tmp/"), true);
+  assert.equal(VALIDATION_CONTEXT_FILE.includes("/.aep/"), false);
+});

--- a/runners/remote-worker/src/lib/validation_context.ts
+++ b/runners/remote-worker/src/lib/validation_context.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The validation run's PREFLIGHT: where the deployed system actually is.
+//
+// This is a platform fact, so platform code fetches it — before the agent
+// starts, and fatally. It used to be a `curl` in the aep-validation skill, with
+// prose telling the agent to stop if the fetch failed. The agent did not stop: on
+// a 404 it spent half an hour scanning the pod network and reading an Envoy admin
+// config dump trying to infer the URL itself. An unanswerable platform question
+// is not an obstacle for an agent to work around, so it never reaches one.
+
+import fs from "node:fs";
+import path from "node:path";
+
+// The file the aep-validation skill reads. Deliberately under /tmp and NOT under
+// the workspace's `.aep/` — the base skill forbids the agent from looking in
+// there at all, and it must not need to break that rule to find its targets.
+// Outside the work tree either way, so it can never be committed.
+export const VALIDATION_CONTEXT_FILE = "/tmp/validation-context.json";
+
+/** One deployed component's reachable URL — the runner's e2e target. */
+export interface ComponentEndpoint {
+  component: string;
+  url: string;
+}
+
+export interface ValidationContext {
+  endpoints: ComponentEndpoint[];
+  criteriaPath: string;
+}
+
+export interface FetchValidationContextOptions {
+  /** AEP_PLATFORM_URL, with or without a trailing slash. */
+  platformUrl: string;
+  /** The dispatched CYCLE id — AEP_TASK_ID, and the subject its bearer is bound to. */
+  cycleId: string;
+  bearer: string;
+  /** Overridable for tests; defaults to VALIDATION_CONTEXT_FILE. */
+  file?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** The callback URL for a cycle's validation context. */
+export function validationContextUrl(platformUrl: string, cycleId: string): string {
+  const base = platformUrl.endsWith("/") ? platformUrl.slice(0, -1) : platformUrl;
+  return `${base}/internal/v1/validation/${encodeURIComponent(cycleId)}/context`;
+}
+
+/**
+ * Fetch the run's validation context and write it where the skill reads it.
+ *
+ * Throws on every outcome the agent could not honestly proceed from — an unset
+ * platform URL, a non-2xx answer, an unparseable body, or a context naming no
+ * endpoints. That last one matters: validation is dispatched at deployed-green,
+ * so an empty endpoint list means the platform cannot say where the system is,
+ * and "no targets" is exactly the state that made the agent start guessing.
+ */
+export async function fetchValidationContext(
+  opts: FetchValidationContextOptions,
+): Promise<ValidationContext> {
+  const { platformUrl, cycleId, bearer } = opts;
+  if (platformUrl === "") {
+    throw new Error("AEP_PLATFORM_URL is unset — the deployed endpoints cannot be resolved");
+  }
+  if (bearer === "") {
+    throw new Error("no bearer token for the validation-context callback");
+  }
+  const url = validationContextUrl(platformUrl, cycleId);
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers: { Authorization: `Bearer ${bearer}` } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`GET ${url}: ${msg}`);
+  }
+  const body = await res.text();
+  if (!res.ok) {
+    // The status is the diagnosis: 404 means the platform does not recognise this
+    // runner's cycle id, 403 means its bearer is not bound to it.
+    throw new Error(`GET ${url} → HTTP ${res.status}: ${body.slice(0, 500)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`validation context is not JSON: ${body.slice(0, 200)}`);
+  }
+  const ctx = parsed as Partial<ValidationContext>;
+  if (!Array.isArray(ctx.endpoints) || ctx.endpoints.length === 0) {
+    throw new Error(
+      "validation context names no deployed endpoints — there is nothing to validate against",
+    );
+  }
+
+  const file = opts.file ?? VALIDATION_CONTEXT_FILE;
+  await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  // Written verbatim, not re-serialised from the parsed shape: the skill's
+  // contract is the platform's payload, and a field this runner does not model
+  // must still reach it.
+  await fs.promises.writeFile(file, body, { mode: 0o600 });
+  return {
+    endpoints: ctx.endpoints,
+    criteriaPath: typeof ctx.criteriaPath === "string" ? ctx.criteriaPath : "",
+  };
+}

--- a/runners/remote-worker/src/oneshot.ts
+++ b/runners/remote-worker/src/oneshot.ts
@@ -44,6 +44,10 @@ import { installConsoleScrubber } from "./lib/progress/console_scrub.js";
 import { resolveTaskSkills } from "./lib/skills_resolver.js";
 import { materializeSkills } from "./lib/skills_materializer.js";
 import { ClientCredentialsTokenProvider } from "./lib/oauth.js";
+import {
+  fetchValidationContext,
+  VALIDATION_CONTEXT_FILE,
+} from "./lib/validation_context.js";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -205,6 +209,25 @@ async function main(): Promise<number> {
   const skillsRepoURL = process.env.AEP_SKILLS_REPO_URL ?? "";
   if (req.taskKind === "validation") {
     console.log("[oneshot] validation run — no design skills apply; using the aep-validation skill only");
+    // PREFLIGHT: where the deployed system is, fetched by the platform before the
+    // agent starts. Fatal on purpose — an agent that cannot learn its targets has
+    // no honest way forward, and when this was the skill's own `curl` a 404 sent
+    // it scanning the pod network for half an hour instead of stopping.
+    try {
+      const ctx = await fetchValidationContext({
+        platformUrl: platformURL,
+        cycleId: req.taskId,
+        bearer: req.bearer,
+      });
+      console.log(
+        `[oneshot] validation context: ${ctx.endpoints.length} deployed endpoint(s) → ${VALIDATION_CONTEXT_FILE}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      emit({ kind: "result", status: "failure", error: `validation_context: ${msg}` });
+      console.error(`[oneshot] validation context unavailable — not starting the agent: ${msg}`);
+      return 2;
+    }
   } else if (skillsRepoURL) {
     try {
       const resolutions = await resolveTaskSkills({

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -713,24 +713,26 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 		cfg.GitHubAppClientID,
 	)
 
-	// Internal S2S runner authorizer — re-keyed to executions (§9.2): the id in
-	// the runner bearer is an execution id, and the publisher-cc branch resolves
-	// the acting org by execution id.
+	// Internal S2S runner authorizer — keyed to the CYCLE: the id in the runner
+	// bearer is the run cycle the pod was dispatched for, and the publisher-cc
+	// branch resolves the acting org by that cycle id. Every agent pod in the
+	// system is launched by the milestone supervisor, so a cycle id is the only
+	// runner identity there is; an execution id named in a path fails closed.
 	publisherVerifier := authn.NewPublisherTokenVerifier(thunderJWKS, cfg.PlatformIDP.Issuer, "aep-publisher-")
-	runnerAuth := authn.NewRunnerAuthorizer(taskTokens, publisherVerifier, executionOrgLookup(db))
+	runnerAuth := authn.NewRunnerAuthorizer(taskTokens, publisherVerifier, cycleOrgLookup(db))
 
 	// Validation-context runner callback: resolves the run's deployed endpoint
 	// URLs so they never enter the public issue.
 	validationContextSvc := validation.NewContextService(
-		validationExecLocator{repo: executionRepo},
+		validationCycleLocator{repo: runCycleRepo},
 		validationEndpointResolver{store: artifactStore, comp: componentService},
 	)
 	// Test-credentials runner callback: the runner requests a login on demand
 	// (only when a criterion needs one). v1 returns a shared mock account; the
-	// execution→project fence + request contract are what real per-project user
+	// cycle→project fence + request contract are what real per-project user
 	// provisioning slots into later.
 	validationCredentialsSvc := validation.NewCredentialService(
-		validationExecLocator{repo: executionRepo},
+		validationCycleLocator{repo: runCycleRepo},
 		mockValidationCredentials{},
 	)
 

--- a/services/aep-api/internal/app/tasks_adapters.go
+++ b/services/aep-api/internal/app/tasks_adapters.go
@@ -329,12 +329,19 @@ func githubBotLogin(appSlug string) string {
 	return appSlug + "[bot]"
 }
 
-// executionOrgLookup resolves an execution id to its owning org handle — the
-// RunnerAuthorizer's publisher-cc branch (re-keyed from task to execution).
-func executionOrgLookup(db *gorm.DB) func(ctx context.Context, executionID string) (string, error) {
-	return func(ctx context.Context, executionID string) (string, error) {
-		var row delivery.Execution
-		if err := db.WithContext(ctx).Select("org_id").First(&row, "id = ?", executionID).Error; err != nil {
+// cycleOrgLookup resolves a run-cycle id to its owning org handle — the
+// RunnerAuthorizer's publisher-cc branch.
+//
+// It reads run_cycles because that is what a runner callback names: every agent
+// pod is launched by the milestone supervisor, which carries the cycle id to the
+// pod as AEP_TASK_ID. It deliberately does NOT fall back to the executions table.
+// The only rows left there are dependency-provisioning gates, which run no agent
+// and are not a callback identity, so an execution id named in a path resolves to
+// nothing and the request fails closed.
+func cycleOrgLookup(db *gorm.DB) func(ctx context.Context, cycleID string) (string, error) {
+	return func(ctx context.Context, cycleID string) (string, error) {
+		var row delivery.RunCycle
+		if err := db.WithContext(ctx).Select("org_id").First(&row, "id = ?", cycleID).Error; err != nil {
 			return "", err
 		}
 		return row.OrgID, nil

--- a/services/aep-api/internal/app/validation_adapters.go
+++ b/services/aep-api/internal/app/validation_adapters.go
@@ -52,15 +52,20 @@ func (a validationCriteria) ReadValidationCriteria(ctx context.Context, orgID, p
 	return []byte(fc.Content), true, nil
 }
 
-// validationExecLocator adapts the executions repository to validation's
-// ExecutionLocator port: it resolves a runner's execution id to its project,
-// org-fenced (GetByIDScoped returns nil for a different org — the tenant fence).
-type validationExecLocator struct {
-	repo delivery.ExecutionRepository
+// validationCycleLocator adapts the run-cycle repository to validation's
+// CycleLocator port: it resolves a runner's cycle id to its project, org-fenced
+// (GetByIDScoped returns nil for a different org — the tenant fence).
+//
+// The CYCLE is the runner's identity. This used to read the executions table,
+// which the milestone supervisor never writes — so a dispatched validation runner
+// was told its own dispatch did not exist, and the run reported `skipped` over an
+// oracle it had just filed.
+type validationCycleLocator struct {
+	repo delivery.RunCycleRepository
 }
 
-func (l validationExecLocator) LookupExecutionProject(ctx context.Context, orgHandle, executionID string) (string, bool, error) {
-	row, err := l.repo.GetByIDScoped(ctx, orgHandle, executionID)
+func (l validationCycleLocator) LookupCycleProject(ctx context.Context, orgHandle, cycleID string) (string, bool, error) {
+	row, err := l.repo.GetByIDScoped(ctx, orgHandle, cycleID)
 	if err != nil {
 		return "", false, err
 	}

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -101,7 +101,7 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
 | `GateResolver` (author dependencies + mint gates into a milestone) | needs | `build` → `dependencies/provisioning`. Gates are dispatch holds, never agent work |
 | `BuildTrigger` (trigger at commit + list a component's runs) | needs | `clients/openchoreo` — the fan-out, and the run list the re-trigger budget is derived from |
 | `IssueClient` (mint · milestone membership · milestone counts · assign) · `PRReader` · `PRMerger` | needs | `sourcecontrol` — every GitHub write the event plane makes, on the org's own credential |
-| `ValidationContext` · `ValidationCredentials` | offers | the S2S runner callbacks (`/internal/v1`, via the internalServer — not the public edge) |
+| `ValidationContext` · `ValidationCredentials` | offers | the S2S runner callbacks (`/internal/v1/validation/{cycleId}/…`, via the internalServer — not the public edge). Keyed by the CYCLE the pod was dispatched for, which is the only identity a runner has |
 
 ## Owns
 - The **executions** store (now provisioning gates only) and the Temporal `Runtime` + the one workflow on it.

--- a/services/aep-api/internal/delivery/codingagent/coding_executor.go
+++ b/services/aep-api/internal/delivery/codingagent/coding_executor.go
@@ -629,6 +629,13 @@ type dispatchShape struct {
 // buildValidationPrompt is the validation-runner directive: it points at the
 // validation issue and defers the workflow to the aep-validation skill (the
 // runner preloads it because AEP_TASK_KIND=validation).
+//
+// It names NO milestone, and that is load-bearing: a validation cycle is
+// issue-anchored — one issue, one run — where a coding prompt's milestone
+// reference is an instruction to discover a whole working set. The skill still
+// needs the milestone for its branch identity (the platform keys a merged pull
+// request back to its run by an `aep/m<milestone#>-…` branch); it reads it off
+// the issue, which is filed under that milestone at mint time.
 func buildValidationPrompt(issueURL string, issueNumber int) string {
-	return fmt.Sprintf("This is a validation task. Work on this GitHub validation issue: %s\n\nFollow the `aep-validation` skill's workflow: fetch the validation context, author and run the e2e tests against the deployed system, commit the tests and report, and open a PR whose body includes `Closes #%d` so the platform links it back.", issueURL, issueNumber)
+	return fmt.Sprintf("This is a validation task. Work on this GitHub validation issue: %s\n\nFollow the `aep-validation` skill's workflow: read the validation context, author and run the e2e tests against the deployed system, commit the tests and report, and open a PR whose body includes `Closes #%d` so the platform links it back.", issueURL, issueNumber)
 }

--- a/services/aep-api/internal/delivery/eventcore/policy.go
+++ b/services/aep-api/internal/delivery/eventcore/policy.go
@@ -40,7 +40,21 @@ type mergeDecision struct {
 }
 
 // decideAutoMerge IS the merge policy: a pull request whose Resolves list
-// references at least one agent-work issue in the run's milestone squash-merges.
+// references at least one issue THIS RUN IS WORKING in its milestone
+// squash-merges. That is the milestone's agent work (`aep`) plus its validation
+// issue (`aep:validation`), which is the validation cycle's whole output.
+//
+// The validation issue has to be named explicitly precisely BECAUSE it carries
+// no `aep` label: that omission keeps it out of the working set so it cannot hold
+// the settle predicate open, and reading it as "not this run's work" here would
+// leave the validation cycle's pull request — tests, report and all — sitting
+// unmerged until its landing deadline, so the run could never read a verdict.
+// One label decision, two opposite consequences; this is the second one.
+//
+// Merging it is safe for the same reason it was excluded: OpenNonGateWork
+// subtracts the validation issue either way, so closing it moves no predicate.
+// It also has to close — an open validation issue left in a settled milestone is
+// what the reconcile sweep sees as unworked.
 //
 // There is deliberately no verification BEFORE the merge. The verification is
 // the POST-MERGE build: the merge is what triggers it, so gating the merge on a
@@ -61,7 +75,8 @@ func decideAutoMerge(resolves []int, milestoneIssues []sourcecontrol.IssueInfo) 
 	}
 	work := make(map[int]bool, len(milestoneIssues))
 	for _, iss := range milestoneIssues {
-		if delivery.HasLabel(iss.Labels, delivery.LabelAgentWork) {
+		if delivery.HasLabel(iss.Labels, delivery.LabelAgentWork) ||
+			delivery.HasLabel(iss.Labels, delivery.LabelValidationWork) {
 			work[iss.Number] = true
 		}
 	}
@@ -72,9 +87,9 @@ func decideAutoMerge(resolves []int, milestoneIssues []sourcecontrol.IssueInfo) 
 		}
 	}
 	if len(matched) == 0 {
-		return mergeDecision{Reason: "no resolved issue is agent work in this milestone"}
+		return mergeDecision{Reason: "no resolved issue is this run's work in this milestone"}
 	}
-	return mergeDecision{Merge: true, Reason: "resolves agent work in the run's milestone", Matched: matched}
+	return mergeDecision{Merge: true, Reason: "resolves this run's work in its milestone", Matched: matched}
 }
 
 // The path diff itself is delivery.DiffComponents in the domain root: the run

--- a/services/aep-api/internal/delivery/eventcore/policy_test.go
+++ b/services/aep-api/internal/delivery/eventcore/policy_test.go
@@ -76,6 +76,9 @@ func TestDecideAutoMerge(t *testing.T) {
 		{Number: 13, State: "open", Labels: []string{delivery.LabelAgentWork, delivery.LabelProvisionGate}},
 		// A ledger issue: in the milestone, but not agent work.
 		{Number: 14, State: "open", Labels: []string{"question"}},
+		// The validation issue: the run's own work, and deliberately WITHOUT the
+		// `aep` label (it must not sit in the working set).
+		{Number: 15, State: "open", Labels: []string{delivery.LabelValidationWork}},
 	}
 	cases := []struct {
 		name     string
@@ -89,6 +92,10 @@ func TestDecideAutoMerge(t *testing.T) {
 		{"a ledger issue is not agent work", []int{14}, false, nil},
 		{"partial match still merges", []int{99, 12}, true, []int{12}},
 		{"claiming nothing never merges", nil, false, nil},
+		// The validation cycle's pull request IS this run's work. Declining it —
+		// which is what reading `aep` alone did — strands the tests and the report
+		// unmerged, so the run can never read a verdict from them.
+		{"the validation issue is this run's work", []int{15}, true, []int{15}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/services/aep-api/internal/delivery/repository_cycle.go
+++ b/services/aep-api/internal/delivery/repository_cycle.go
@@ -75,6 +75,15 @@ type RunCycleRepository interface {
 	// phase enum on the run row.
 	Latest(ctx context.Context, orgID, runID string) (*RunCycle, error)
 
+	// GetByIDScoped returns the cycle only when it belongs to orgID, and (nil,
+	// nil) otherwise — the tenant fence, so a cross-org id reads as absent rather
+	// than forbidden and a probe learns nothing from the difference.
+	//
+	// This is the RUNNER's identity read: a dispatched pod names its cycle id on
+	// every callback (AEP_TASK_ID), and this resolves it to the project the
+	// callback may act on.
+	GetByIDScoped(ctx context.Context, orgID, id string) (*RunCycle, error)
+
 	// ListByRun returns a run's cycles oldest first — the cycle timeline.
 	ListByRun(ctx context.Context, orgID, runID string) ([]RunCycle, error)
 
@@ -185,6 +194,23 @@ func (r *runCycleRepository) Latest(ctx context.Context, orgID, runID string) (*
 	err := r.db.WithContext(ctx).
 		Where("org_id = ? AND run_id = ?", orgID, runID).
 		Order("created_at DESC").
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *runCycleRepository) GetByIDScoped(ctx context.Context, orgID, id string) (*RunCycle, error) {
+	var row RunCycle
+	// The org is part of the WHERE, not a check after the read: a cycle that
+	// belongs to another org must be indistinguishable from one that does not
+	// exist.
+	err := r.db.WithContext(ctx).
+		Where("org_id = ? AND id = ?", orgID, id).
 		First(&row).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil

--- a/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
+++ b/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
@@ -126,7 +126,7 @@ func TestRunCycleRepository_AppendDispatchAndFinish(t *testing.T) {
 	// The merge policy's matched set is the cycle's only record of what it
 	// worked; a verdict is written only when the pull request did NOT merge.
 	declined, err := cycles.NoteMergeDecision(ctx, cycle.ID, []int{7, 8},
-		delivery.CycleMergeDeclined, "no resolved issue is agent work in this milestone")
+		delivery.CycleMergeDeclined, "no resolved issue is this run's work in this milestone")
 	if err != nil || declined == nil {
 		t.Fatalf("NoteMergeDecision(declined) = (%+v, %v)", declined, err)
 	}
@@ -267,6 +267,67 @@ func TestRunCycleRepository_LatestAndTimeline(t *testing.T) {
 	// Another project's cycles survive.
 	if rows, err := cycles.ListByRun(ctx, "orga", other.ID); err != nil || len(rows) != 1 {
 		t.Fatalf("other project's timeline = (%d rows, %v), want 1", len(rows), err)
+	}
+}
+
+// TestRunCycleRepository_GetByIDScoped pins the RUNNER's identity read: a
+// dispatched pod names its cycle id on every callback (AEP_TASK_ID), and this is
+// how the platform resolves that id to a project it may act on.
+//
+// It also pins the decision that the read resolves CYCLES ONLY. An execution id
+// must miss — the rows left in that table are dependency-provisioning gates,
+// which run no agent and are not a callback identity — so a future "helpful"
+// fallback to executions would fail here rather than silently widen who can pass
+// as a runner.
+func TestRunCycleRepository_GetByIDScoped(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t)
+	runs := delivery.NewMilestoneRunRepository(db)
+	cycles := delivery.NewRunCycleRepository(db, nil)
+	execs := delivery.NewExecutionRepository(db, nil)
+	ctx := context.Background()
+
+	run := admitRun(t, runs, "orga", "proj", 7, "v7")
+	cycle := &delivery.RunCycle{
+		OrgID: run.OrgID, ProjectID: run.ProjectID, RunID: run.ID,
+		Kind: delivery.CycleKindValidation,
+	}
+	if err := cycles.Append(ctx, cycle); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	got, err := cycles.GetByIDScoped(ctx, "orga", cycle.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByIDScoped = (%+v, %v), want the cycle", got, err)
+	}
+	// The project is the whole point of the read: it is what the callback is then
+	// allowed to act on.
+	if got.ProjectID != "proj" || got.Kind != delivery.CycleKindValidation {
+		t.Errorf("GetByIDScoped = %+v; want project proj, kind validation", got)
+	}
+
+	// The tenant fence: another org's read MISSES rather than erroring, so a
+	// cross-tenant probe cannot tell "not yours" from "does not exist".
+	if got, err := cycles.GetByIDScoped(ctx, "orgb", cycle.ID); err != nil || got != nil {
+		t.Fatalf("GetByIDScoped(cross-org) = (%+v, %v), want (nil, nil)", got, err)
+	}
+
+	// An unknown id misses cleanly, never gorm.ErrRecordNotFound.
+	const absent = "3f4b9c1e-0000-4000-8000-000000000000"
+	if got, err := cycles.GetByIDScoped(ctx, "orga", absent); err != nil || got != nil {
+		t.Fatalf("GetByIDScoped(unknown) = (%+v, %v), want (nil, nil)", got, err)
+	}
+
+	// An EXECUTION id is not a runner identity. Same org, real row, still a miss.
+	admitted, exec, err := execs.TryAdmit(ctx, &delivery.Execution{
+		OrgID: "orga", ProjectID: "proj", Repo: "orga/proj", IssueNumber: 3,
+		Kind: "provision", Status: "queued",
+	})
+	if err != nil || !admitted || exec == nil {
+		t.Fatalf("TryAdmit(provision execution) = (%v, %+v, %v)", admitted, exec, err)
+	}
+	if got, err := cycles.GetByIDScoped(ctx, "orga", exec.ID); err != nil || got != nil {
+		t.Fatalf("GetByIDScoped(execution id) = (%+v, %v), want (nil, nil) — cycles only", got, err)
 	}
 }
 

--- a/services/aep-api/internal/delivery/validation/context.go
+++ b/services/aep-api/internal/delivery/validation/context.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 )
 
-// ErrExecutionNotFound means the runner's execution id does not resolve to a
-// task in the caller's org — the endpoint surfaces it as 404.
-var ErrExecutionNotFound = errors.New("validation: execution not found for org")
+// ErrCycleNotFound means the runner's cycle id does not resolve to a dispatched
+// cycle in the caller's org — the endpoint surfaces it as 404. A cycle belonging
+// to another org resolves the same way, so a cross-tenant probe cannot tell "not
+// yours" from "does not exist".
+var ErrCycleNotFound = errors.New("validation: cycle not found for org")
 
 // ComponentEndpoint is one deployed component's reachable URL, the runner's
 // e2e target.
@@ -43,11 +45,17 @@ type ValidationContextResponse struct {
 	CriteriaPath string              `json:"criteriaPath"`
 }
 
-// ExecutionLocator resolves a runner's execution id to its project, fenced by
-// the caller's org (the INT-6 tenant fence). delivery.ExecutionRepository's
+// CycleLocator resolves a runner's CYCLE id to its project, fenced by the
+// caller's org (the INT-6 tenant fence). delivery.RunCycleRepository's
 // GetByIDScoped satisfies the adapter wired at the composition root.
-type ExecutionLocator interface {
-	LookupExecutionProject(ctx context.Context, orgHandle, executionID string) (projectID string, found bool, err error)
+//
+// The cycle id is what a dispatched pod carries (AEP_TASK_ID) and what its bearer
+// token is bound to, so it is the only identity a runner callback can present.
+// It used to be resolved against the executions table, which the milestone
+// supervisor does not write — so every validation runner was told its own
+// dispatch did not exist.
+type CycleLocator interface {
+	LookupCycleProject(ctx context.Context, orgHandle, cycleID string) (projectID string, found bool, err error)
 }
 
 // EndpointResolver resolves a project's deployed component endpoint URLs (first
@@ -60,25 +68,29 @@ type EndpointResolver interface {
 
 // ContextService answers the runner's validation-context fetch.
 type ContextService struct {
-	execs     ExecutionLocator
+	cycles    CycleLocator
 	endpoints EndpointResolver
 }
 
 // NewContextService wires the validation-context service.
-func NewContextService(execs ExecutionLocator, endpoints EndpointResolver) *ContextService {
-	return &ContextService{execs: execs, endpoints: endpoints}
+func NewContextService(cycles CycleLocator, endpoints EndpointResolver) *ContextService {
+	return &ContextService{cycles: cycles, endpoints: endpoints}
 }
 
-// ValidationContext resolves the runtime inputs for a runner's execution: the
-// deployed endpoint URLs. orgHandle is the verified caller org (the auth layer
-// fences it against the execution).
-func (s *ContextService) ValidationContext(ctx context.Context, executionID, orgHandle string) (*ValidationContextResponse, error) {
-	projectID, found, err := s.execs.LookupExecutionProject(ctx, orgHandle, executionID)
+// ValidationContext resolves the runtime inputs for a runner's validation cycle:
+// the deployed endpoint URLs. orgHandle is the verified caller org (the auth layer
+// fences it against the cycle).
+//
+// Identity FIRST, then endpoints — and note that a failure here never reaches the
+// endpoint resolution below, so an unreachable deployment and an unresolvable
+// runner are entirely different failures with entirely different fixes.
+func (s *ContextService) ValidationContext(ctx context.Context, cycleID, orgHandle string) (*ValidationContextResponse, error) {
+	projectID, found, err := s.cycles.LookupCycleProject(ctx, orgHandle, cycleID)
 	if err != nil {
-		return nil, fmt.Errorf("validation context: resolve execution: %w", err)
+		return nil, fmt.Errorf("validation context: resolve cycle: %w", err)
 	}
 	if !found {
-		return nil, ErrExecutionNotFound
+		return nil, ErrCycleNotFound
 	}
 	eps, err := s.endpoints.ResolveEndpoints(ctx, orgHandle, projectID)
 	if err != nil {

--- a/services/aep-api/internal/delivery/validation/context_test.go
+++ b/services/aep-api/internal/delivery/validation/context_test.go
@@ -22,30 +22,56 @@ import (
 	"testing"
 )
 
-type fakeExecLocator struct {
-	projectID string
-	found     bool
+// The cycle the tests resolve, and an org that does not own it.
+const (
+	theCycle   = "cycle-1"
+	theOrg     = "org"
+	strangeOrg = "org-other"
+)
+
+// fakeCycleLocator answers only for the (org, cycle) pairs it holds, which is how
+// the repository behaves: the org is part of the WHERE, so another org's cycle is
+// indistinguishable from one that does not exist. A locator keyed on the cycle
+// alone would let a broken tenant fence pass.
+type fakeCycleLocator struct {
+	// projects maps org handle → cycle id → project.
+	projects map[string]map[string]string
+	asked    []string
 }
 
-func (f fakeExecLocator) LookupExecutionProject(_ context.Context, _, _ string) (string, bool, error) {
-	return f.projectID, f.found, nil
+func (f *fakeCycleLocator) LookupCycleProject(_ context.Context, orgHandle, cycleID string) (string, bool, error) {
+	f.asked = append(f.asked, orgHandle+"/"+cycleID)
+	projectID, ok := f.projects[orgHandle][cycleID]
+	return projectID, ok, nil
 }
 
-type fakeEndpoints struct{ eps []ComponentEndpoint }
+// locatorFor is a locator that resolves theCycle under theOrg and nothing else.
+func locatorFor(projectID string) *fakeCycleLocator {
+	return &fakeCycleLocator{projects: map[string]map[string]string{
+		theOrg: {theCycle: projectID},
+	}}
+}
 
-func (f fakeEndpoints) ResolveEndpoints(_ context.Context, _, _ string) ([]ComponentEndpoint, error) {
+type fakeEndpoints struct {
+	eps    []ComponentEndpoint
+	called bool
+}
+
+func (f *fakeEndpoints) ResolveEndpoints(_ context.Context, _, _ string) ([]ComponentEndpoint, error) {
+	f.called = true
 	return f.eps, nil
 }
 
 func TestValidationContext_ResolvesEndpoints(t *testing.T) {
+	locator := locatorFor("proj")
 	svc := NewContextService(
-		fakeExecLocator{projectID: "proj", found: true},
-		fakeEndpoints{eps: []ComponentEndpoint{
+		locator,
+		&fakeEndpoints{eps: []ComponentEndpoint{
 			{Component: "hello-web", URL: "https://web.example"},
 			{Component: "hello-api", URL: "https://api.example"},
 		}},
 	)
-	resp, err := svc.ValidationContext(context.Background(), "exec-1", "org")
+	resp, err := svc.ValidationContext(context.Background(), theCycle, theOrg)
 	if err != nil {
 		t.Fatalf("ValidationContext: %v", err)
 	}
@@ -57,15 +83,33 @@ func TestValidationContext_ResolvesEndpoints(t *testing.T) {
 	if resp.CriteriaPath != criteriaFilePath {
 		t.Errorf("criteriaPath = %q; want %q", resp.CriteriaPath, criteriaFilePath)
 	}
+	// The id the runner presents is a CYCLE id, resolved under the verified org.
+	// Looking it up anywhere else is the bug this replaces.
+	if len(locator.asked) != 1 || locator.asked[0] != theOrg+"/"+theCycle {
+		t.Errorf("locator asked %v; want one lookup of %q under %q", locator.asked, theCycle, theOrg)
+	}
 }
 
-func TestValidationContext_UnknownExecutionIs404(t *testing.T) {
-	svc := NewContextService(
-		fakeExecLocator{found: false}, // execution not in caller's org
-		fakeEndpoints{},
-	)
-	_, err := svc.ValidationContext(context.Background(), "exec-x", "org")
-	if !errors.Is(err, ErrExecutionNotFound) {
-		t.Fatalf("want ErrExecutionNotFound (→ 404), got %v", err)
+func TestValidationContext_UnknownCycleIs404(t *testing.T) {
+	svc := NewContextService(locatorFor("proj"), &fakeEndpoints{})
+	_, err := svc.ValidationContext(context.Background(), "cycle-nope", theOrg)
+	if !errors.Is(err, ErrCycleNotFound) {
+		t.Fatalf("want ErrCycleNotFound (→ 404), got %v", err)
+	}
+}
+
+// The tenant fence: another org naming a real cycle id gets the SAME answer as
+// one naming nothing, so a cross-tenant probe cannot tell them apart. And the
+// endpoint resolver must never run — identity is decided first.
+func TestValidationContext_AnotherOrgsCycleIs404AndResolvesNothing(t *testing.T) {
+	endpoints := &fakeEndpoints{}
+	svc := NewContextService(locatorFor("proj"), endpoints)
+
+	_, err := svc.ValidationContext(context.Background(), theCycle, strangeOrg)
+	if !errors.Is(err, ErrCycleNotFound) {
+		t.Fatalf("want ErrCycleNotFound for another org's cycle, got %v", err)
+	}
+	if endpoints.called {
+		t.Error("resolved endpoints for an unowned cycle — identity must gate the endpoint read")
 	}
 }

--- a/services/aep-api/internal/delivery/validation/credentials.go
+++ b/services/aep-api/internal/delivery/validation/credentials.go
@@ -55,30 +55,30 @@ type CredentialProvider interface {
 }
 
 // CredentialService answers the runner's test-credential request. It resolves
-// the runner's execution id to its project (org-fenced, reusing the
-// validation-context ExecutionLocator) so the provider gets a verified project,
-// then delegates to the provider. Unknown execution → ErrExecutionNotFound
-// (surfaced as 404), exactly like the context fetch.
+// the runner's cycle id to its project (org-fenced, reusing the
+// validation-context CycleLocator) so the provider gets a verified project, then
+// delegates to the provider. Unknown cycle → ErrCycleNotFound (surfaced as 404),
+// exactly like the context fetch.
 type CredentialService struct {
-	execs ExecutionLocator
-	creds CredentialProvider
+	cycles CycleLocator
+	creds  CredentialProvider
 }
 
 // NewCredentialService wires the credential service.
-func NewCredentialService(execs ExecutionLocator, creds CredentialProvider) *CredentialService {
-	return &CredentialService{execs: execs, creds: creds}
+func NewCredentialService(cycles CycleLocator, creds CredentialProvider) *CredentialService {
+	return &CredentialService{cycles: cycles, creds: creds}
 }
 
-// RequestCredentials resolves the runner's execution to its project (org-fenced)
-// and returns the provider's test account. orgHandle is the verified caller org
-// (the auth layer fences it against the execution).
-func (s *CredentialService) RequestCredentials(ctx context.Context, executionID, orgHandle string, req CredentialRequest) (*TestCredential, error) {
-	projectID, found, err := s.execs.LookupExecutionProject(ctx, orgHandle, executionID)
+// RequestCredentials resolves the runner's cycle to its project (org-fenced) and
+// returns the provider's test account. orgHandle is the verified caller org (the
+// auth layer fences it against the cycle).
+func (s *CredentialService) RequestCredentials(ctx context.Context, cycleID, orgHandle string, req CredentialRequest) (*TestCredential, error) {
+	projectID, found, err := s.cycles.LookupCycleProject(ctx, orgHandle, cycleID)
 	if err != nil {
-		return nil, fmt.Errorf("request credentials: resolve execution: %w", err)
+		return nil, fmt.Errorf("request credentials: resolve cycle: %w", err)
 	}
 	if !found {
-		return nil, ErrExecutionNotFound
+		return nil, ErrCycleNotFound
 	}
 	cred, err := s.creds.RequestCredentials(ctx, orgHandle, projectID, req)
 	if err != nil {

--- a/services/aep-api/internal/delivery/validation/credentials_test.go
+++ b/services/aep-api/internal/delivery/validation/credentials_test.go
@@ -39,9 +39,9 @@ func (f *fakeCredProvider) RequestCredentials(_ context.Context, _, projectID st
 
 func TestRequestCredentials_ResolvesProjectAndReturnsAccount(t *testing.T) {
 	prov := &fakeCredProvider{cred: TestCredential{Username: "admin", Password: "admin", Mock: true, Note: "mock"}}
-	svc := NewCredentialService(fakeExecLocator{projectID: "proj", found: true}, prov)
+	svc := NewCredentialService(locatorFor("proj"), prov)
 
-	got, err := svc.RequestCredentials(context.Background(), "exec-1", "org", CredentialRequest{Role: "admin"})
+	got, err := svc.RequestCredentials(context.Background(), theCycle, theOrg, CredentialRequest{Role: "admin"})
 	if err != nil {
 		t.Fatalf("RequestCredentials: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestRequestCredentials_ResolvesProjectAndReturnsAccount(t *testing.T) {
 		t.Errorf("credential = %+v; want mock admin/admin", got)
 	}
 	// The provider must be fenced to the resolved project, not handed the raw
-	// execution id or org — this is the tenant fence real provisioning relies on.
+	// cycle id or org — this is the tenant fence real provisioning relies on.
 	if prov.gotProject != "proj" {
 		t.Errorf("provider project = %q; want %q", prov.gotProject, "proj")
 	}
@@ -58,15 +58,30 @@ func TestRequestCredentials_ResolvesProjectAndReturnsAccount(t *testing.T) {
 	}
 }
 
-func TestRequestCredentials_UnknownExecutionIs404(t *testing.T) {
+func TestRequestCredentials_UnknownCycleIs404(t *testing.T) {
 	prov := &fakeCredProvider{}
-	svc := NewCredentialService(fakeExecLocator{found: false}, prov) // execution not in caller's org
+	svc := NewCredentialService(locatorFor("proj"), prov)
 
-	_, err := svc.RequestCredentials(context.Background(), "exec-x", "org", CredentialRequest{})
-	if !errors.Is(err, ErrExecutionNotFound) {
-		t.Fatalf("want ErrExecutionNotFound (→ 404), got %v", err)
+	_, err := svc.RequestCredentials(context.Background(), "cycle-nope", theOrg, CredentialRequest{})
+	if !errors.Is(err, ErrCycleNotFound) {
+		t.Fatalf("want ErrCycleNotFound (→ 404), got %v", err)
 	}
 	if prov.gotProject != "" {
-		t.Errorf("provider must not be called on unknown execution; got project %q", prov.gotProject)
+		t.Errorf("provider must not be called on an unknown cycle; got project %q", prov.gotProject)
+	}
+}
+
+// A credential is the most sensitive thing this surface hands out, so the tenant
+// fence is asserted here too and not only on the context read.
+func TestRequestCredentials_AnotherOrgsCycleIs404(t *testing.T) {
+	prov := &fakeCredProvider{}
+	svc := NewCredentialService(locatorFor("proj"), prov)
+
+	_, err := svc.RequestCredentials(context.Background(), theCycle, strangeOrg, CredentialRequest{})
+	if !errors.Is(err, ErrCycleNotFound) {
+		t.Fatalf("want ErrCycleNotFound for another org's cycle, got %v", err)
+	}
+	if prov.gotProject != "" {
+		t.Errorf("issued a credential for an unowned cycle; got project %q", prov.gotProject)
 	}
 }

--- a/services/aep-api/internal/delivery/validation/doc.go
+++ b/services/aep-api/internal/delivery/validation/doc.go
@@ -33,10 +33,18 @@
 //
 // This feature does the ISSUE side only. Its runtime inputs — deployed endpoint
 // URLs and test credentials — are never written into the (public) issue: the
-// runner fetches endpoints from the secure validation-context endpoint and
-// requests test credentials on demand (only when a criterion needs a login)
-// from the sibling test-credentials endpoint (credentials.go). Test credentials
-// are a v1 mock (admin/admin) until real user provisioning exists.
+// runner PREFLIGHTS the endpoints from the secure validation-context endpoint
+// before its agent starts, and the agent requests test credentials on demand
+// (only when a criterion needs a login) from the sibling test-credentials
+// endpoint (credentials.go). Test credentials are a v1 mock (admin/admin) until
+// real user provisioning exists.
+//
+// Both callbacks identify their caller by the run CYCLE the platform dispatched
+// (context.go's CycleLocator) — the id the pod carries as AEP_TASK_ID and the
+// subject its bearer is bound to. Resolving it anywhere else is not a detail: it
+// was resolved against the executions table, which the milestone supervisor does
+// not write, so every validation runner was told its own dispatch did not exist
+// and the endpoint resolution below never ran.
 //
 // Feature-edge allowlist: {gitrepo}. Design + criteria reads are consumer ports
 // (ports.go) satisfied by adapters at the composition root, so this package

--- a/services/aep-api/internal/delivery/validation/ports.go
+++ b/services/aep-api/internal/delivery/validation/ports.go
@@ -49,14 +49,15 @@ type CriteriaReader interface {
 }
 
 // ContextProvider is the internal validation-context endpoint's view of the
-// context service (*ContextService satisfies it). The org is the verified
-// caller's, bound into ctx by the internal runner-auth gate.
+// context service (*ContextService satisfies it). cycleID is the run cycle the
+// runner was dispatched for; the org is the verified caller's, bound into ctx by
+// the internal runner-auth gate.
 type ContextProvider interface {
-	ValidationContext(ctx context.Context, executionID, orgHandle string) (*ValidationContextResponse, error)
+	ValidationContext(ctx context.Context, cycleID, orgHandle string) (*ValidationContextResponse, error)
 }
 
 // CredentialRequester is the internal test-credentials endpoint's view of the
 // credential service (*CredentialService satisfies it).
 type CredentialRequester interface {
-	RequestCredentials(ctx context.Context, executionID, orgHandle string, req CredentialRequest) (*TestCredential, error)
+	RequestCredentials(ctx context.Context, cycleID, orgHandle string, req CredentialRequest) (*TestCredential, error)
 }

--- a/services/aep-api/internal/edge/internal.go
+++ b/services/aep-api/internal/edge/internal.go
@@ -83,29 +83,32 @@ func newInternalV1Handler(deps InternalDeps) http.Handler {
 }
 
 // runnerAuthGate is the internal surface's deny-by-default gate: every
-// operation must present a bearer the authorizer accepts for the execution id
-// named in the request, and the verified org is bound into the context. There
-// are deliberately NO carve-outs here. An operation whose request shape the
-// gate does not know is denied outright — adding an internal op means teaching
-// this gate its execution key first.
+// operation must present a bearer the authorizer accepts for the CYCLE id named
+// in the request, and the verified org is bound into the context. There are
+// deliberately NO carve-outs here. An operation whose request shape the gate does
+// not know is denied outright — adding an internal op means teaching this gate
+// where its cycle id lives first.
+//
+// The refresh operation still spells its parameter `executionId` on the wire; the
+// value is the dispatched cycle id, the same naming debt AEP_TASK_ID carries.
 func runnerAuthGate(authorizer *auth.RunnerAuthorizer) igen.StrictMiddlewareFunc {
 	return func(f igen.StrictHandlerFunc, operationID string) igen.StrictHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, request any) (any, error) {
 			if authorizer == nil {
 				return nil, errServiceUnavailable("runner auth not configured")
 			}
-			var executionID string
+			var cycleID string
 			switch req := request.(type) {
 			case igen.RunnerRefreshCredentialsRequestObject:
-				executionID = req.ExecutionID
+				cycleID = req.ExecutionID
 			case igen.RunnerValidationContextRequestObject:
-				executionID = req.ExecutionID
+				cycleID = req.CycleID
 			case igen.RunnerValidationCredentialsRequestObject:
-				executionID = req.ExecutionID
+				cycleID = req.CycleID
 			default:
 				return nil, errUnauthorized("unauthenticated internal operation: " + operationID)
 			}
-			caller, err := authorizer.Authorize(ctx, r.Header.Get("Authorization"), executionID)
+			caller, err := authorizer.Authorize(ctx, r.Header.Get("Authorization"), cycleID)
 			if err != nil {
 				return nil, mapRunnerAuthError(err)
 			}
@@ -166,10 +169,10 @@ func (s *internalServer) RunnerValidationContext(ctx context.Context, request ig
 		return nil, errServiceUnavailable("validation context not configured")
 	}
 	org := tenant.BoundOrgFromContext(ctx)
-	resp, err := s.deps.ValidationContext.ValidationContext(ctx, request.ExecutionID, org)
+	resp, err := s.deps.ValidationContext.ValidationContext(ctx, request.CycleID, org)
 	if err != nil {
-		if errors.Is(err, validation.ErrExecutionNotFound) {
-			return nil, errNotFound("no validation task for this execution")
+		if errors.Is(err, validation.ErrCycleNotFound) {
+			return nil, errNotFound("no validation cycle with this id")
 		}
 		return nil, errInternal("failed to resolve validation context")
 	}
@@ -215,10 +218,10 @@ func (s *internalServer) RunnerValidationCredentials(ctx context.Context, reques
 			Username: request.Body.Username,
 		}
 	}
-	resp, err := s.deps.ValidationCredentials.RequestCredentials(ctx, request.ExecutionID, org, req)
+	resp, err := s.deps.ValidationCredentials.RequestCredentials(ctx, request.CycleID, org, req)
 	if err != nil {
-		if errors.Is(err, validation.ErrExecutionNotFound) {
-			return nil, errNotFound("no validation task for this execution")
+		if errors.Is(err, validation.ErrCycleNotFound) {
+			return nil, errNotFound("no validation cycle with this id")
 		}
 		return nil, errInternal("failed to request test credentials")
 	}

--- a/services/aep-api/internal/edge/internal_surface_test.go
+++ b/services/aep-api/internal/edge/internal_surface_test.go
@@ -38,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wso2/aep/aep-api/internal/delivery/validation"
 	"github.com/wso2/aep/aep-api/internal/organization"
 	"github.com/wso2/aep/aep-api/internal/platform/auth"
 	"github.com/wso2/aep/aep-api/internal/platform/secrets"
@@ -57,7 +58,44 @@ func (f *fakeCredsRefresh) Refresh(_ context.Context, executionID, orgHandle str
 	}, nil
 }
 
+// fakeValidationContext records the cycle id and org the surface hands it, which
+// is what proves the path parameter reaches the service intact.
+type fakeValidationContext struct {
+	gotCycle, gotOrg string
+}
+
+func (f *fakeValidationContext) ValidationContext(_ context.Context, cycleID, orgHandle string) (*validation.ValidationContextResponse, error) {
+	f.gotCycle, f.gotOrg = cycleID, orgHandle
+	return &validation.ValidationContextResponse{
+		Endpoints:    []validation.ComponentEndpoint{{Component: "hello-webapp", URL: "https://hello.example"}},
+		CriteriaPath: "specs/validation/validation-criteria.json",
+	}, nil
+}
+
+type fakeValidationCreds struct {
+	gotCycle, gotOrg string
+}
+
+func (f *fakeValidationCreds) RequestCredentials(_ context.Context, cycleID, orgHandle string, _ validation.CredentialRequest) (*validation.TestCredential, error) {
+	f.gotCycle, f.gotOrg = cycleID, orgHandle
+	return &validation.TestCredential{Username: "admin", Password: "admin", Mock: true}, nil
+}
+
+type internalStack struct {
+	handler http.Handler
+	tokens  *auth.TaskTokenManager
+	refresh *fakeCredsRefresh
+	context *fakeValidationContext
+	creds   *fakeValidationCreds
+}
+
 func newInternalTestStack(t *testing.T) (http.Handler, *auth.TaskTokenManager, *fakeCredsRefresh) {
+	t.Helper()
+	s := newInternalStack(t)
+	return s.handler, s.tokens, s.refresh
+}
+
+func newInternalStack(t *testing.T) internalStack {
 	t.Helper()
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -70,14 +108,21 @@ func newInternalTestStack(t *testing.T) (http.Handler, *auth.TaskTokenManager, *
 	if err != nil {
 		t.Fatalf("NewTaskTokenManager: %v", err)
 	}
-	svc := &fakeCredsRefresh{}
-	h := NewHandler(AppParams{
+	stack := internalStack{
+		tokens:  mgr,
+		refresh: &fakeCredsRefresh{},
+		context: &fakeValidationContext{},
+		creds:   &fakeValidationCreds{},
+	}
+	stack.handler = NewHandler(AppParams{
 		InternalDeps: InternalDeps{
-			CredsRefresh: svc,
-			RunnerAuth:   auth.NewRunnerAuthorizer(mgr, nil, nil),
+			CredsRefresh:          stack.refresh,
+			RunnerAuth:            auth.NewRunnerAuthorizer(mgr, nil, nil),
+			ValidationContext:     stack.context,
+			ValidationCredentials: stack.creds,
 		},
 	})
-	return h, mgr, svc
+	return stack
 }
 
 func TestInternalSurface_RunnerRefresh_Lockstep(t *testing.T) {
@@ -115,6 +160,75 @@ func TestInternalSurface_RunnerRefresh_Lockstep(t *testing.T) {
 	if got, want := slices.Sorted(maps.Keys(identity)), []string{"Email", "Login", "Name"}; !slices.Equal(got, want) {
 		t.Fatalf("identity keys drifted (capitalized, runner lockstep): got %v want %v", got, want)
 	}
+}
+
+// The validation callbacks live under their own prefix, so the edge must MOUNT
+// that prefix — the inner mux registers the contract's full paths, and a prefix
+// missing from the outer mux 404s before any handler or auth gate runs. That is a
+// silent break the contract test cannot see, so it is asserted through real HTTP.
+func TestInternalSurface_ValidationCallbacksAreRoutedAndCycleKeyed(t *testing.T) {
+	t.Parallel()
+	s := newInternalStack(t)
+	const cycle = "9d90f001-67bb-4c51-a5f3-7fd808c06c36"
+
+	tok, err := s.tokens.Issue(cycle, "org-acme", "proj-1")
+	if err != nil {
+		t.Fatalf("issue task token: %v", err)
+	}
+
+	t.Run("context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/internal/v1/validation/"+cycle+"/context", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rec := httptest.NewRecorder()
+		s.handler.ServeHTTP(rec, req)
+
+		if rec.Code == 404 {
+			t.Fatalf("404 — the /internal/v1/validation/ prefix is not mounted on the edge mux")
+		}
+		if rec.Code != 200 {
+			t.Fatalf("want 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		// The CYCLE id must arrive intact, and the org must come from the verified
+		// token rather than anything in the request.
+		if s.context.gotCycle != cycle || s.context.gotOrg != "org-acme" {
+			t.Fatalf("service saw cycle=%q org=%q; want %q / org-acme", s.context.gotCycle, s.context.gotOrg, cycle)
+		}
+		if !strings.Contains(rec.Body.String(), "hello.example") {
+			t.Errorf("endpoints missing from the body: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("test-credentials", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/internal/v1/validation/"+cycle+"/test-credentials",
+			strings.NewReader(`{"role":"admin"}`))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		s.handler.ServeHTTP(rec, req)
+
+		if rec.Code == 404 {
+			t.Fatalf("404 — the /internal/v1/validation/ prefix is not mounted on the edge mux")
+		}
+		if rec.Code != 200 {
+			t.Fatalf("want 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if s.creds.gotCycle != cycle || s.creds.gotOrg != "org-acme" {
+			t.Fatalf("service saw cycle=%q org=%q; want %q / org-acme", s.creds.gotCycle, s.creds.gotOrg, cycle)
+		}
+	})
+
+	// The INT-6 fence covers the new prefix too: a bearer minted for a different
+	// cycle cannot read this one's endpoints or ask for its credentials.
+	t.Run("bearer bound to another cycle → 403", func(t *testing.T) {
+		other, _ := s.tokens.Issue("some-other-cycle", "org-acme", "proj-1")
+		req := httptest.NewRequest(http.MethodGet, "/internal/v1/validation/"+cycle+"/context", nil)
+		req.Header.Set("Authorization", "Bearer "+other)
+		rec := httptest.NewRecorder()
+		s.handler.ServeHTTP(rec, req)
+		if rec.Code != 403 {
+			t.Fatalf("want 403, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
 }
 
 func TestInternalSurface_AuthPosture(t *testing.T) {

--- a/services/aep-api/internal/edge/internal_test.go
+++ b/services/aep-api/internal/edge/internal_test.go
@@ -35,15 +35,20 @@ func TestInternalContract(t *testing.T) {
 
 	for _, want := range []string{
 		"runner-refresh-credentials",
-		// Runner S2S re-keyed from task to execution (tasks-github-native §9.2);
-		// the version root lives in `servers`, the path is server-relative.
+		// Token refresh is every runner's, not validation's, so it keeps its path.
+		// The id it names is the dispatched CYCLE — the parameter's spelling is the
+		// same wire-compat debt AEP_TASK_ID carries. The version root lives in
+		// `servers`, so the path is server-relative.
 		"/executions/{executionId}/credentials/refresh",
-		// Validation runner callbacks: deployed-endpoint fetch + on-demand
-		// test-credential request.
+		// Validation runner callbacks, grouped under the feature that owns them and
+		// keyed by the cycle id the runner actually carries. They used to sit under
+		// /executions/{executionId}, resolved against a table the milestone
+		// supervisor never writes — so every validation runner was told its own
+		// dispatch did not exist.
 		"runner-validation-context",
-		"/executions/{executionId}/validation-context",
+		"/validation/{cycleId}/context",
 		"runner-validation-credentials",
-		"/executions/{executionId}/test-credentials",
+		"/validation/{cycleId}/test-credentials",
 		"taskJWT",
 		"publisherCC",
 	} {

--- a/services/aep-api/internal/edge/surfaces.go
+++ b/services/aep-api/internal/edge/surfaces.go
@@ -35,8 +35,9 @@ import (
 //	───────────────────────────────────────────────────────────────────────────────────────────────────
 //	public         /api/v1              Thunder user JWT + org gate                handlers_*.go · tenant_gate.go
 //	               (jwt → orgensure)    (org from the verified token, never input)  ← packages/contracts/api/v1 (source of truth)
-//	internal S2S   /internal/v1/executions/  BFF Task-JWT or publisher-cc          internal.go · runnerAuthGate
-//	               (deny-by-default gate)    (dual-token verify + INT-6 fence)      ← packages/contracts/api/internal/v1 (non-public)
+//	internal S2S   /internal/v1/validation/, BFF Task-JWT or publisher-cc          internal.go · runnerAuthGate
+//	               /internal/v1/executions/  (dual-token verify + INT-6 fence,      ← packages/contracts/api/internal/v1 (non-public)
+//	               (deny-by-default gate)     both keyed to the run CYCLE id)
 //	internal MCP   /internal/v1/mcp     BFF-signed JWT, aud aep-api-mcp            dependencies/mcp_server.go ·
 //	               (POST, JSON-RPC)     (org from ocOrgId claim, never input)       auth.AgentsScopedVerifier (no spec — JSON-RPC)
 //	               /mcp/playground-token  NONE — flag-gated only                   dependencies/playground_token.go
@@ -118,10 +119,19 @@ func mountSurfaces(params AppParams) *http.ServeMux {
 	// Served contract-first from packages/contracts/api/internal/v1 (strict
 	// server in internal/igen), NOT wrapped by the /api/ user-JWT
 	// middleware. Every operation passes the deny-by-default runnerAuthGate
-	// (BFF Task-JWT or publisher-cc verified against the path execution id)
-	// and is never gateway-advertised. All runner callbacks are keyed to the
-	// execution id — tasks-github-native §9.2.
-	mux.Handle(internalV1+"/executions/", newInternalV1Handler(params.InternalDeps))
+	// (BFF Task-JWT or publisher-cc verified against the path id) and is never
+	// gateway-advertised. Every runner callback is keyed to the run CYCLE the
+	// platform dispatched the pod for — the id it carries as AEP_TASK_ID.
+	//
+	// TWO prefixes, ONE handler: the validation callbacks live under the feature
+	// that owns them, and token refresh keeps the `/executions/` prefix it was
+	// published under (the id it names is a cycle, the same wire-compat debt
+	// AEP_TASK_ID carries). Both must be mounted — the inner mux registers the
+	// contract's full paths, so a prefix that is not mounted here 404s before any
+	// handler or auth gate is reached.
+	internalHandler := newInternalV1Handler(params.InternalDeps)
+	mux.Handle(internalV1+"/executions/", internalHandler)
+	mux.Handle(internalV1+"/validation/", internalHandler)
 
 	// ── internal MCP discovery (POST /internal/v1/mcp) ───────────────────────
 	// A raw (non-Huma) JSON-RPC mount: the MCP server the agents service's

--- a/services/aep-api/internal/igen/igen_gen.go
+++ b/services/aep-api/internal/igen/igen_gen.go
@@ -99,12 +99,12 @@ type ServerInterface interface {
 	// Refresh an execution's git credentials (runner callback)
 	// (POST /executions/{executionId}/credentials/refresh)
 	RunnerRefreshCredentials(w http.ResponseWriter, r *http.Request, executionID string)
-	// Request test credentials for a validation run (runner callback)
-	// (POST /executions/{executionId}/test-credentials)
-	RunnerValidationCredentials(w http.ResponseWriter, r *http.Request, executionID string)
 	// Fetch a validation run's deployed endpoints (runner callback)
-	// (GET /executions/{executionId}/validation-context)
-	RunnerValidationContext(w http.ResponseWriter, r *http.Request, executionID string)
+	// (GET /validation/{cycleId}/context)
+	RunnerValidationContext(w http.ResponseWriter, r *http.Request, cycleID string)
+	// Request test credentials for a validation run (runner callback)
+	// (POST /validation/{cycleId}/test-credentials)
+	RunnerValidationCredentials(w http.ResponseWriter, r *http.Request, cycleID string)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -150,18 +150,18 @@ func (siw *ServerInterfaceWrapper) RunnerRefreshCredentials(w http.ResponseWrite
 	handler.ServeHTTP(w, r)
 }
 
-// RunnerValidationCredentials operation middleware
-func (siw *ServerInterfaceWrapper) RunnerValidationCredentials(w http.ResponseWriter, r *http.Request) {
+// RunnerValidationContext operation middleware
+func (siw *ServerInterfaceWrapper) RunnerValidationContext(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	_ = err
 
-	// ------------- Path parameter "executionId" -------------
-	var executionID string
+	// ------------- Path parameter "cycleId" -------------
+	var cycleID string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "executionId", r.PathValue("executionId"), &executionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	err = runtime.BindStyledParameterWithOptions("simple", "cycleId", r.PathValue("cycleId"), &cycleID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "executionId", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cycleId", Err: err})
 		return
 	}
 
@@ -174,7 +174,7 @@ func (siw *ServerInterfaceWrapper) RunnerValidationCredentials(w http.ResponseWr
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.RunnerValidationCredentials(w, r, executionID)
+		siw.Handler.RunnerValidationContext(w, r, cycleID)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -184,18 +184,18 @@ func (siw *ServerInterfaceWrapper) RunnerValidationCredentials(w http.ResponseWr
 	handler.ServeHTTP(w, r)
 }
 
-// RunnerValidationContext operation middleware
-func (siw *ServerInterfaceWrapper) RunnerValidationContext(w http.ResponseWriter, r *http.Request) {
+// RunnerValidationCredentials operation middleware
+func (siw *ServerInterfaceWrapper) RunnerValidationCredentials(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	_ = err
 
-	// ------------- Path parameter "executionId" -------------
-	var executionID string
+	// ------------- Path parameter "cycleId" -------------
+	var cycleID string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "executionId", r.PathValue("executionId"), &executionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	err = runtime.BindStyledParameterWithOptions("simple", "cycleId", r.PathValue("cycleId"), &cycleID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "executionId", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cycleId", Err: err})
 		return
 	}
 
@@ -208,7 +208,7 @@ func (siw *ServerInterfaceWrapper) RunnerValidationContext(w http.ResponseWriter
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.RunnerValidationContext(w, r, executionID)
+		siw.Handler.RunnerValidationCredentials(w, r, cycleID)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -339,8 +339,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	}
 
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/executions/{executionId}/credentials/refresh", wrapper.RunnerRefreshCredentials)
-	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/executions/{executionId}/test-credentials", wrapper.RunnerValidationCredentials)
-	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/executions/{executionId}/validation-context", wrapper.RunnerValidationContext)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/validation/{cycleId}/context", wrapper.RunnerValidationContext)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/validation/{cycleId}/test-credentials", wrapper.RunnerValidationCredentials)
 
 	return m
 }
@@ -384,48 +384,8 @@ func (response RunnerRefreshCredentialsdefaultJSONResponse) VisitRunnerRefreshCr
 	return err
 }
 
-type RunnerValidationCredentialsRequestObject struct {
-	ExecutionID string `json:"executionId"`
-	Body        *RunnerValidationCredentialsJSONRequestBody
-}
-
-type RunnerValidationCredentialsResponseObject interface {
-	VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error
-}
-
-type RunnerValidationCredentials200JSONResponse TestCredential
-
-func (response RunnerValidationCredentials200JSONResponse) VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
-type RunnerValidationCredentialsdefaultJSONResponse struct {
-	Body       Error
-	StatusCode int
-}
-
-func (response RunnerValidationCredentialsdefaultJSONResponse) VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error {
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(response.Body); err != nil {
-		return err
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(response.StatusCode)
-	_, err := buf.WriteTo(w)
-	return err
-}
-
 type RunnerValidationContextRequestObject struct {
-	ExecutionID string `json:"executionId"`
+	CycleID string `json:"cycleId"`
 }
 
 type RunnerValidationContextResponseObject interface {
@@ -463,17 +423,57 @@ func (response RunnerValidationContextdefaultJSONResponse) VisitRunnerValidation
 	return err
 }
 
+type RunnerValidationCredentialsRequestObject struct {
+	CycleID string `json:"cycleId"`
+	Body    *RunnerValidationCredentialsJSONRequestBody
+}
+
+type RunnerValidationCredentialsResponseObject interface {
+	VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error
+}
+
+type RunnerValidationCredentials200JSONResponse TestCredential
+
+func (response RunnerValidationCredentials200JSONResponse) VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type RunnerValidationCredentialsdefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response RunnerValidationCredentialsdefaultJSONResponse) VisitRunnerValidationCredentialsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response.Body); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// Refresh an execution's git credentials (runner callback)
 	// (POST /executions/{executionId}/credentials/refresh)
 	RunnerRefreshCredentials(ctx context.Context, request RunnerRefreshCredentialsRequestObject) (RunnerRefreshCredentialsResponseObject, error)
-	// Request test credentials for a validation run (runner callback)
-	// (POST /executions/{executionId}/test-credentials)
-	RunnerValidationCredentials(ctx context.Context, request RunnerValidationCredentialsRequestObject) (RunnerValidationCredentialsResponseObject, error)
 	// Fetch a validation run's deployed endpoints (runner callback)
-	// (GET /executions/{executionId}/validation-context)
+	// (GET /validation/{cycleId}/context)
 	RunnerValidationContext(ctx context.Context, request RunnerValidationContextRequestObject) (RunnerValidationContextResponseObject, error)
+	// Request test credentials for a validation run (runner callback)
+	// (POST /validation/{cycleId}/test-credentials)
+	RunnerValidationCredentials(ctx context.Context, request RunnerValidationCredentialsRequestObject) (RunnerValidationCredentialsResponseObject, error)
 }
 
 type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, request any) (any, error)
@@ -531,11 +531,37 @@ func (sh *strictHandler) RunnerRefreshCredentials(w http.ResponseWriter, r *http
 	}
 }
 
+// RunnerValidationContext operation middleware
+func (sh *strictHandler) RunnerValidationContext(w http.ResponseWriter, r *http.Request, cycleID string) {
+	var request RunnerValidationContextRequestObject
+
+	request.CycleID = cycleID
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RunnerValidationContext(ctx, request.(RunnerValidationContextRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RunnerValidationContext")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RunnerValidationContextResponseObject); ok {
+		if err := validResponse.VisitRunnerValidationContextResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // RunnerValidationCredentials operation middleware
-func (sh *strictHandler) RunnerValidationCredentials(w http.ResponseWriter, r *http.Request, executionID string) {
+func (sh *strictHandler) RunnerValidationCredentials(w http.ResponseWriter, r *http.Request, cycleID string) {
 	var request RunnerValidationCredentialsRequestObject
 
-	request.ExecutionID = executionID
+	request.CycleID = cycleID
 
 	var body RunnerValidationCredentialsJSONRequestBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -560,32 +586,6 @@ func (sh *strictHandler) RunnerValidationCredentials(w http.ResponseWriter, r *h
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(RunnerValidationCredentialsResponseObject); ok {
 		if err := validResponse.VisitRunnerValidationCredentialsResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// RunnerValidationContext operation middleware
-func (sh *strictHandler) RunnerValidationContext(w http.ResponseWriter, r *http.Request, executionID string) {
-	var request RunnerValidationContextRequestObject
-
-	request.ExecutionID = executionID
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.RunnerValidationContext(ctx, request.(RunnerValidationContextRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "RunnerValidationContext")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(RunnerValidationContextResponseObject); ok {
-		if err := validResponse.VisitRunnerValidationContextResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/services/aep-api/internal/platform/auth/runner.go
+++ b/services/aep-api/internal/platform/auth/runner.go
@@ -33,12 +33,15 @@ import (
 	"github.com/wso2/aep/aep-api/internal/platform/tenant"
 )
 
-// ExecutionOrgLookup returns the owning org handle of an execution. It is
-// injected (from the composition root) so this package — the auth layer —
-// never imports a feature package; it is needed only for the publisher-cc
-// branch, which is org-scoped and must confirm the path execution belongs to
-// the token's org.
-type ExecutionOrgLookup func(ctx context.Context, executionID string) (orgHandle string, err error)
+// CycleOrgLookup returns the owning org handle of a run cycle. It is injected
+// (from the composition root) so this package — the auth layer — never imports a
+// feature package; it is needed only for the publisher-cc branch, which is
+// org-scoped and must confirm the path cycle belongs to the token's org.
+//
+// The CYCLE is the runner's identity: every agent pod is launched by the
+// milestone supervisor, which carries the cycle id to the pod and binds it into
+// the bearer. A lookup that misses fails the request closed.
+type CycleOrgLookup func(ctx context.Context, cycleID string) (orgHandle string, err error)
 
 // RunnerAuthorizer verifies a runner-callback bearer and resolves the acting
 // org. It is the inbound half of the symmetric S2S identity model — the
@@ -48,7 +51,7 @@ type ExecutionOrgLookup func(ctx context.Context, executionID string) (orgHandle
 type RunnerAuthorizer struct {
 	taskTokens *TaskTokenManager
 	publisher  *PublisherTokenVerifier // may be nil (Task-JWT only)
-	execOrg    ExecutionOrgLookup
+	cycleOrg   CycleOrgLookup
 }
 
 // HTTPError is the neutral transport error the authorizer returns (401/403);
@@ -63,30 +66,30 @@ func (e *HTTPError) Error() string { return e.Message }
 
 // NewRunnerAuthorizer builds the authorizer. publisher may be nil (local dev
 // without the platform IDP) — then only BFF Task-JWTs are accepted.
-func NewRunnerAuthorizer(taskTokens *TaskTokenManager, publisher *PublisherTokenVerifier, execOrg ExecutionOrgLookup) *RunnerAuthorizer {
-	return &RunnerAuthorizer{taskTokens: taskTokens, publisher: publisher, execOrg: execOrg}
+func NewRunnerAuthorizer(taskTokens *TaskTokenManager, publisher *PublisherTokenVerifier, cycleOrg CycleOrgLookup) *RunnerAuthorizer {
+	return &RunnerAuthorizer{taskTokens: taskTokens, publisher: publisher, cycleOrg: cycleOrg}
 }
 
-// Authorize verifies authHeader for a runner callback scoped to executionID
-// and returns the verified caller. The BFF Task-JWT is tried first (BFF-signed
-// and execution-bound: the token's `taskId` claim — kept for wire compat, it
-// carries the execution id since the §9.2 re-key — MUST equal the path id, the
-// INT-6 fence); then the publisher-cc token (org-bound: the path execution
-// MUST belong to the token's org). Returns an *HTTPError on any failure; the
-// caller (the internal surface's auth gate) maps it onto its envelope.
-func (a *RunnerAuthorizer) Authorize(ctx context.Context, authHeader, executionID string) (tenant.Caller, error) {
+// Authorize verifies authHeader for a runner callback scoped to cycleID and
+// returns the verified caller. The BFF Task-JWT is tried first (BFF-signed and
+// cycle-bound: the token's `taskId` claim — kept for wire compat, it carries the
+// dispatched cycle id — MUST equal the path id, the INT-6 fence); then the
+// publisher-cc token (org-bound: the path cycle MUST belong to the token's org).
+// Returns an *HTTPError on any failure; the caller (the internal surface's auth
+// gate) maps it onto its envelope.
+func (a *RunnerAuthorizer) Authorize(ctx context.Context, authHeader, cycleID string) (tenant.Caller, error) {
 	const prefix = "Bearer "
 	if len(authHeader) <= len(prefix) || !strings.EqualFold(authHeader[:len(prefix)], prefix) {
 		return tenant.Caller{}, &HTTPError{Status: 401, Message: "bearer token required"}
 	}
 	tok := authHeader[len(prefix):]
 
-	// BFF Task-JWT first: signed by this BFF, execution-bound by the INT-6 fence.
+	// BFF Task-JWT first: signed by this BFF, cycle-bound by the INT-6 fence.
 	if a.taskTokens != nil {
 		if claims, err := a.taskTokens.Verify(tok); err == nil {
-			if claims.TaskID != executionID {
+			if claims.TaskID != cycleID {
 				slog.WarnContext(ctx, "runner callback: task bearer subject mismatch",
-					"execution", executionID, "claimTaskId", claims.TaskID)
+					"cycle", cycleID, "claimTaskId", claims.TaskID)
 				return tenant.Caller{}, &HTTPError{Status: 403, Message: "task bearer does not match path"}
 			}
 			return tenant.Caller{
@@ -98,21 +101,20 @@ func (a *RunnerAuthorizer) Authorize(ctx context.Context, authHeader, executionI
 	}
 
 	// Publisher client-credentials fallback: org-bound (the token's audience
-	// embeds the org). Confirm the path execution actually belongs to that org
-	// so an org-A token cannot read/refresh an org-B execution it merely names
-	// in the path.
+	// embeds the org). Confirm the path cycle actually belongs to that org so an
+	// org-A token cannot read/refresh an org-B cycle it merely names in the path.
 	if a.publisher != nil {
 		if claims, err := a.publisher.Verify(tok); err == nil {
-			execOrg, lerr := a.execOrg(ctx, executionID)
-			if lerr != nil || execOrg == "" {
-				slog.WarnContext(ctx, "runner callback: execution lookup failed",
-					"execution", executionID, "error", lerr)
-				return tenant.Caller{}, &HTTPError{Status: 403, Message: "execution not found"}
+			cycleOrg, lerr := a.cycleOrg(ctx, cycleID)
+			if lerr != nil || cycleOrg == "" {
+				slog.WarnContext(ctx, "runner callback: cycle lookup failed",
+					"cycle", cycleID, "error", lerr)
+				return tenant.Caller{}, &HTTPError{Status: 403, Message: "cycle not found"}
 			}
-			if execOrg != claims.OrgHandle {
+			if cycleOrg != claims.OrgHandle {
 				slog.WarnContext(ctx, "runner callback: publisher org mismatch",
-					"execution", executionID, "executionOrg", execOrg, "publisherOrg", claims.OrgHandle)
-				return tenant.Caller{}, &HTTPError{Status: 403, Message: "publisher token does not match execution org"}
+					"cycle", cycleID, "cycleOrg", cycleOrg, "publisherOrg", claims.OrgHandle)
+				return tenant.Caller{}, &HTTPError{Status: 403, Message: "publisher token does not match cycle org"}
 			}
 			return tenant.Caller{
 				Org:    tenant.OrgHandle(claims.OrgHandle),
@@ -121,6 +123,6 @@ func (a *RunnerAuthorizer) Authorize(ctx context.Context, authHeader, executionI
 		}
 	}
 
-	slog.WarnContext(ctx, "runner callback: bearer rejected by all verifiers", "execution", executionID)
+	slog.WarnContext(ctx, "runner callback: bearer rejected by all verifiers", "cycle", cycleID)
 	return tenant.Caller{}, &HTTPError{Status: 401, Message: "invalid bearer"}
 }


### PR DESCRIPTION
**Stacked behind #338, which merges first.** That PR made verdicts meaningful; this one makes the
validation cycle able to produce one at all. `validation-phase4` branches off `validation-phase3`, so
until #338 lands this PR's diff also carries its commits — everything described below is **only** the
new work, which is the single commit `014ab19e` (29 files).

Fixes #339

## Problem

A full flow on a fresh project reached validation, minted its issue correctly, dispatched the cycle
— and produced no verdict. Three independent defects, each fatal alone. The issue has the full
trace; in short:

1. **The runner's identity was resolved in a table nothing writes.** A pod names its cycle id on
   every callback (`AEP_TASK_ID`); the validation-context endpoint looked it up in `executions`,
   which the milestone supervisor never writes. 404 `"no validation task for this execution"`. A
   second, **latent** instance sat in `RunnerAuthorizer`'s publisher-cc branch, which would 403
   *every* runner's token refresh in cloud — coding cycles included.
2. **A validation PR could never merge.** Auto-merge accepts only PRs resolving an `aep`-labelled
   issue, and the validation issue deliberately carries `aep:validation`. Separately, the skill's
   `validation/issue-<N>` branch did not match the `aep/m<milestone#>-…` shape the platform keys a
   merged PR back to its run by, so the cycle never learned its own merge SHA.
3. **The console asked for the wrong version.** `ValidationPage` keyed on `deploy.version` (newest
   *succeeded* run), which during validation names nothing on a first version — so it rendered "No
   validation has run yet" beside a chip reading "Validating".

Reachability was a red herring throughout: `ValidationContext` resolves *who is calling* and only
then *where the app is*, so it died before `ResolveEndpoints` — the only code that yields the URL a
browser uses — ever ran.

## Why `execution` became `cycle` in so many places

This is the bulk of the diff, so it is worth being precise about what was renamed and why it is not
cosmetic.

An **execution** (`executions`) was the pre-milestone unit of agent work: one row per
`(repo, issue_number, kind)` behind an admission mutex. A **cycle** (`run_cycles`) is the
milestone-spine replacement — *"one dispatch within a MilestoneRun: the platform hands the coding
agent a milestone reference, the agent opens one PR, and the PR squash-merges."*

They are **the same concept in two eras**. `c6bf509d` moved the agent loop onto cycles and left
`executions` behind; its only surviving writer mints dependency-provisioning gates, which run no
agent and are therefore not a runner identity at all. So the rename is not a synonym swap — it is
pointing the runner-identity reads at the table that actually holds runners, and the old name had
become actively misleading: reviewers reading `ExecutionLocator` would reasonably conclude a runner
*has* an execution row.

There is exactly **one** agent-launch path in the system (`milestone_dispatch.go` → `launchAgent`,
`ExecutionID: in.correlationID` where `correlationID = req.CycleID`), so every pod that exists
carries a cycle id. Nothing alive stamps an execution id, which is what makes the narrow fix safe and
the fallback unnecessary.

What was renamed, and what deliberately was **not**:

| | before | after |
|---|---|---|
| validation port | `ExecutionLocator.LookupExecutionProject` | `CycleLocator.LookupCycleProject` |
| not-found error | `ErrExecutionNotFound` | `ErrCycleNotFound` |
| auth port | `ExecutionOrgLookup` → `executions` | `CycleOrgLookup` → `run_cycles` |
| validation paths | `/executions/{executionId}/validation-context`, `…/test-credentials` | `/validation/{cycleId}/context`, `/validation/{cycleId}/test-credentials` |
| **token refresh path** | `/executions/{executionId}/credentials/refresh` | **unchanged** |
| **`taskId` JWT claim** | carries the dispatched id | **unchanged** |

The two "unchanged" rows are the interesting ones. Token refresh is **not** a validation callback —
it is org-scoped and every runner uses it — so it keeps its published path and only its auth-layer
lookup moved. And the `taskId` claim keeps its name for wire compatibility: one documented naming
debt (the same one `k8s_job_dispatcher.go` already records for `AEP_TASK_ID`) is better than two
spellings in flight.

The new paths are grouped by the **feature that owns them** rather than by id space, which is why
`credentials/refresh` staying put is consistent rather than an inconsistency.

## What changed

**Identity (3 sites).** `RunCycleRepository.GetByIDScoped` is new — the twin of the existing
`MilestoneRunRepository`/`ExecutionRepository` reads, org in the `WHERE` so a cross-org id is
indistinguishable from a missing one. It **fails closed**: an execution id named in a path resolves
to nothing, because a provisioning gate is not a callback identity.

**The context fetch moved into the runner.** `oneshot.ts` fetches it in the validation branch before
the agent starts and exits non-zero on failure, so an agent never gets control with an unanswered
platform question. The skill reads `/tmp/validation-context.json` instead of curling — deliberately
not under `.aep/`, which the base skill forbids the agent from opening. A context naming **zero**
endpoints is treated as failure too: validation runs at deployed-green, so "no targets" is exactly
the state that previously started the guessing.

**Merge path.** `decideAutoMerge` now accepts the milestone's validation issue as this run's work.
Safe for the same reason it was excluded: `OpenNonGateWork` subtracts it either way, so closing it
moves no predicate — and it *needs* to close, since an open validation issue in a settled milestone
is what the reconcile sweep misreads as unworked. The skill's branch is now
`aep/m<milestone#>-validation`, with the milestone read off the issue (which is filed under it at
mint time).

**Console.** `ValidationPage` keys on `build.version` — the newest run's, the same run the chip
describes.

## Proof of execution

```
go test -short ./...                       all packages ok, 0 failures
go test ./internal/delivery/...            dbtests against real Postgres (testcontainers)
golangci-lint run ./...                    0 issues.
make deadcode-check                        deadcode: OK — no dead functions.
make license-check                         clean
runners/remote-worker  pnpm test           225 tests, 0 fail
runners/remote-worker  tsc --noEmit        clean
pnpm turbo lint typecheck                  clean (except a pre-existing gitignored chat_playground file)
```

Verified against the running platform after deploy:

```
GET /internal/v1/validation/{cycleId}/context          401   ← routed, auth gate reached
GET /internal/v1/executions/{id}/validation-context    404   ← old path gone
GET /healthz                                           200
```

**A bug this nearly shipped, and the test that now catches it.** The edge mounts the internal
handler by *prefix* (`mux.Handle(internalV1+"/executions/", …)`), so the new paths would have 404'd
at the mux — before any handler or auth gate — reproducing the original failure from a different
cause. Neither `go build` nor the contract test can see that. The mount was added, and the test was
verified by removing the mount again:

```
--- FAIL: TestInternalSurface_ValidationCallbacksAreRoutedAndCycleKeyed/context
    404 — the /internal/v1/validation/ prefix is not mounted on the edge mux
```

New tests, by what they pin:

```
internal/edge  TestInternalSurface_ValidationCallbacksAreRoutedAndCycleKeyed
  the /validation/ prefix is mounted (real HTTP through the whole edge)
  the cycle id reaches the service intact, org from the verified token
  a bearer bound to another cycle → 403                   (INT-6 fence on the new prefix)

internal/delivery  TestRunCycleRepository_GetByIDScoped
  resolves the cycle and its project
  another org's read misses, never errors                 (tenant fence)
  an EXECUTION id misses — same org, real row             (the fail-closed decision)

internal/delivery/validation
  context/credentials resolve through a cycle-keyed locator
  another org's cycle is 404 AND resolves no endpoints     (identity gates the endpoint read)

internal/delivery/eventcore  TestDecideAutoMerge
  the validation issue is this run's work                  (the PR that could never merge)

runners/remote-worker  validation_context.test.ts
  the URL targets the cycle-scoped validation path
  the platform's payload is written verbatim               (a field we don't model still reaches the skill)
  a 404 throws and writes nothing
  a context with no endpoints throws
  an unset AEP_PLATFORM_URL throws before any request

apps/console  ValidationPage.test.tsx
  a live run whose deploy.version is empty still finds its run
```

## Not yet done

The end-to-end run on a fresh project — preflight → correct endpoint (fetched, not guessed) →
`aep/m1-validation` branch → auto-merge → merge SHA on the cycle → verdict read from the report at
that commit. The fixes are deployed locally and the paths verified live, but no project has been
taken through the whole loop since. Screenshots to follow here.

`/code-review` has **not** been run on this branch yet (AGENTS.md asks for it before submitting).

## Deploy note

No workflow change, so a plain restart — **not** a drain. The runner image **must** be rebuilt
(`FORCE=1 make build-runner`): the skill is baked in, and an image carrying the old skill will call
the retired paths and push an unrecognised branch.

## Out of scope, named with evidence

- **The supervisor still takes 2h to notice a dead runner.** `awaitLanding` selects on
  cancel/conflict/merged/deadline and deliberately drains `workable`/`builds` as noise, so there is
  no channel to reuse. A death signal is a new workflow channel (drain) and races the PR webhook — a
  runner can open its PR and exit before the webhook lands, so "terminal Job, no PR" would abort a
  cycle that succeeded.
- **Log capture is terminal-only.** `captureCycleLogs` fires *"once its Job is terminal"*, so a
  deleted or evicted Job loses its log entirely. The preflight narrows this to deleted/evicted Jobs;
  a periodic upsert (PK is `(cycle_id, run_name)`) would close it.
- **An Envoy admin port is reachable from a runner pod** (`:9901`, serving `/config_dump` and
  `/clusters` — every project's routing config, to a workload container). RBAC held; the network did
  not. A `deployments/` NetworkPolicy or a localhost-bound admin listener; a data-plane change that
  deserves its own review.
- Retiring `executions` for the provisioning path, and the `taskId` claim name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
