### PR TITLE
fix(delivery): the merge policy reads the milestone's open issues unfiltered

### DIFF
--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -115,15 +115,23 @@ vi.mock("../../projects/api/queries", () => ({
 }));
 
 vi.mock("../../builds/api/queries", () => ({
-  // Models the real hook's `enabled: Boolean(tag)`: with no tag the query never
-  // runs and there is no data. A mock that answered regardless of tag would hide
-  // the bug where this page asked for a version the status did not have yet.
+  // Models two things the real hook does, both of which a laxer mock would hide:
+  // `enabled: Boolean(tag)` (no tag → the query never runs, so no data), and
+  // per-version scoping (list-build-runs answers with THAT version's runs). The
+  // run under test belongs to the newest version, so asking for any other tag
+  // finds nothing — which is what makes "asked for the wrong version" visible.
   useBuildRuns: (_project: string, tag: string | undefined) => ({
     isPending: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-    data: tag ? { tag, milestoneNumber: 1, runs: mockRun ? [mockRun] : [] } : undefined,
+    data: tag
+      ? {
+          tag,
+          milestoneNumber: 1,
+          runs: mockRun && tag === mockBuildVersion ? [mockRun] : [],
+        }
+      : undefined,
   }),
 }));
 

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -168,6 +168,12 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   no-op. Gates (`aep:provision` + `aep:dep/<slug>`, minted by `dependencies/provisioning`) and the
   validation issue (`aep:validation`) deliberately do NOT carry `aep` — a gate is a dispatch hold and the
   validation issue is a phase of the run, and neither may hold the settle predicate open.
+  The corollary, and the trap: a read that NARROWS on `aep` cannot see either of them. So a decision that
+  must weigh them (the auto-merge policy, which merges the validation cycle's pull request) reads the
+  milestone's open issues UNFILTERED and decides on the labels itself. `?labels=` on the REST issues
+  endpoint is AND, so there is no filter that returns both populations anyway — and a label predicate split
+  across the fetch and the decision is one rule in two places, which is how the validation cycle's pull
+  request once ended up declined as "not this run's work".
 - **Milestone assignment rides issue creation.** A plan costs `1+N` content-generating requests against
   GitHub's 80-per-minute ceiling: one milestone create plus one issue create per Task. Never
   create-then-PATCH, and never a label pre-create per issue (`sourcecontrol` memoises the ensure).

--- a/services/aep-api/internal/delivery/eventcore/events.go
+++ b/services/aep-api/internal/delivery/eventcore/events.go
@@ -217,7 +217,7 @@ func (e *Events) OnPullRequest(ctx context.Context, _, _ string, payload []byte)
 	}
 
 	refs := parseResolvesRefs(p.PullRequest.Body)
-	work, err := e.p.Issues.ListMilestoneIssues(ctx, owner.orgID, owner.projectID, milestoneWorkFilter(owner.run.MilestoneNumber))
+	work, err := e.p.Issues.ListMilestoneIssues(ctx, owner.orgID, owner.projectID, milestoneOpenIssuesFilter(owner.run.MilestoneNumber))
 	if err != nil {
 		return err
 	}

--- a/services/aep-api/internal/delivery/eventcore/events_test.go
+++ b/services/aep-api/internal/delivery/eventcore/events_test.go
@@ -155,6 +155,35 @@ func TestPullRequestOpened_MergesWhenItResolvesMilestoneWork(t *testing.T) {
 	}
 }
 
+// The validation cycle's pull request must merge too, and this asserts it through
+// the REAL fetch rather than against a hand-built issue list. decideAutoMerge
+// accepting `aep:validation` is not enough on its own: the fetch used to narrow
+// on `aep`, so the validation issue never reached the policy and every validation
+// pull request was declined with "no resolved issue is this run's work" — a green
+// agent, a report in the branch, and a run that sat at its landing deadline until
+// a human merged by hand. The policy_test cases cannot see that, because they
+// call the pure function with the population already in hand.
+func TestPullRequestOpened_MergesTheValidationCyclesPullRequest(t *testing.T) {
+	h := newHarness(t, aRun("run-1", 7, delivery.RunStateRunning))
+	h.cycles.latest = aCycle("cycle-1", "run-1")
+	// The milestone as it really stands when validation runs: the coding work is
+	// closed, so all that is left open is the validation issue.
+	h.issues.withValidationIssue(7, 3)
+
+	if err := h.deliver(t, "pull_request", prBody("opened", "aep/m7-validation", "Resolves #3", 4, false, false, "")); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.merger.merged) != 1 || h.merger.merged[0] != 4 {
+		t.Fatalf("the validation cycle's PR must be squash-merged, got %v (decline reason: %q)",
+			h.merger.merged, h.cycles.latest.MergeReason)
+	}
+	// Without the matched set the merge closes #3 and nothing records that this
+	// cycle is what worked it.
+	if len(h.cycles.decisions) != 1 || h.cycles.decisions[0] != "cycle-1::[3]" {
+		t.Fatalf("the cycle must record the validation issue as its resolved set, got %v", h.cycles.decisions)
+	}
+}
+
 // A draft is the agent saying it is not finished, but the cycle still records
 // WHICH pull request it is parked behind: without it, a cycle waiting on a draft
 // is indistinguishable from one whose agent never opened a pull request, and the

--- a/services/aep-api/internal/delivery/eventcore/fakes_test.go
+++ b/services/aep-api/internal/delivery/eventcore/fakes_test.go
@@ -217,6 +217,17 @@ func (f *fakeIssues) withWork(milestone int, numbers ...int) *fakeIssues {
 	return f
 }
 
+// withValidationIssue puts the milestone's open VALIDATION issue in it, labelled
+// the way the minter files it: `aep:validation` and nothing else. The absent
+// `aep` label is the point — it keeps the issue out of the dispatch working set,
+// and any read that narrows on `aep` cannot see this issue at all.
+func (f *fakeIssues) withValidationIssue(milestone, number int) *fakeIssues {
+	f.byMilestone[milestone] = append(f.byMilestone[milestone], sourcecontrol.IssueInfo{
+		Number: number, State: "open", Labels: []string{delivery.LabelValidationWork},
+	})
+	return f
+}
+
 // withCounts gives a milestone its open-issue populations: gates, working set
 // ("aep", non-gate, non-validation) and grand total. work and total are stated
 // separately on purpose — the gap between them is the ledger, the population

--- a/services/aep-api/internal/delivery/eventcore/merge.go
+++ b/services/aep-api/internal/delivery/eventcore/merge.go
@@ -25,15 +25,26 @@ import (
 	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
 )
 
-// milestoneWorkFilter reads a milestone's OPEN agent-work issues — the
-// population the merge predicate is decided against. Gates and ledger issues
-// are excluded by the label filter, closed ones by the state filter, and pull
-// requests by the host.
-func milestoneWorkFilter(milestoneNumber int) sourcecontrol.MilestoneIssuesFilter {
+// milestoneOpenIssuesFilter reads a milestone's OPEN issues — the whole
+// population the merge predicate is decided against. Closed issues are excluded
+// by the state filter and pull requests by the host; NO label filter is applied,
+// because which labels count as this run's work is decideAutoMerge's decision
+// alone, made against the labels it can see.
+//
+// Narrowing here by label is what broke validation auto-merge: the fetch asked
+// for `aep` only, so the milestone's validation issue — labelled `aep:validation`
+// and nothing else — was gone before the policy could accept it, and every
+// validation pull request was declined with "no resolved issue is this run's
+// work". Two copies of one predicate, and the hidden copy won.
+//
+// Adding the validation label to this filter would not fix it either: REST
+// `?labels=a,b` is AND (see githubhost.ListMilestoneIssues), so asking for both
+// demands an issue carrying both and matches nothing. The fetch stays wide and
+// the policy stays the only place labels are read.
+func milestoneOpenIssuesFilter(milestoneNumber int) sourcecontrol.MilestoneIssuesFilter {
 	return sourcecontrol.MilestoneIssuesFilter{
 		Number: milestoneNumber,
 		State:  "open",
-		Labels: []string{delivery.LabelAgentWork},
 	}
 }
 

--- a/services/aep-api/internal/delivery/eventcore/service_test.go
+++ b/services/aep-api/internal/delivery/eventcore/service_test.go
@@ -153,14 +153,22 @@ func TestService_AutoMergeIssuesTheSquashMergeOnce(t *testing.T) {
 	if got := h.countRequests(http.MethodPut, "/repos/acme/widgets/pulls/42/merge"); got != 1 {
 		t.Fatalf("the merge must be issued exactly once across a delivery and its redelivery, got %d", got)
 	}
-	// The milestone read must be scoped — milestone number, open state, agent
-	// work — or the predicate would be decided against the wrong population.
+	// The milestone read must be scoped to the milestone and to open issues, or
+	// the predicate would be decided against the wrong population.
 	for _, r := range h.stub.Requests() {
 		if r.Method == http.MethodGet && r.Path == "/repos/acme/widgets/issues" {
-			for _, want := range []string{"milestone=7", "state=open", "labels=aep"} {
+			for _, want := range []string{"milestone=7", "state=open"} {
 				if !strings.Contains(r.Query, want) {
 					t.Fatalf("milestone read query %q must carry %q", r.Query, want)
 				}
+			}
+			// And it must NOT narrow by label. This endpoint's `labels` is AND, so
+			// any value here excludes some population the policy accepts — it used
+			// to send `labels=aep`, which hid the milestone's `aep:validation` issue
+			// and left every validation pull request unmerged. The label decision
+			// belongs to decideAutoMerge, over the labels this read returns.
+			if strings.Contains(r.Query, "labels=") {
+				t.Fatalf("milestone read query %q must not narrow by label — that decision is the policy's", r.Query)
 			}
 			break
 		}

--- a/services/aep-api/internal/delivery/eventcore/service_test.go
+++ b/services/aep-api/internal/delivery/eventcore/service_test.go
@@ -155,8 +155,10 @@ func TestService_AutoMergeIssuesTheSquashMergeOnce(t *testing.T) {
 	}
 	// The milestone read must be scoped to the milestone and to open issues, or
 	// the predicate would be decided against the wrong population.
+	milestoneRead := false
 	for _, r := range h.stub.Requests() {
 		if r.Method == http.MethodGet && r.Path == "/repos/acme/widgets/issues" {
+			milestoneRead = true
 			for _, want := range []string{"milestone=7", "state=open"} {
 				if !strings.Contains(r.Query, want) {
 					t.Fatalf("milestone read query %q must carry %q", r.Query, want)
@@ -172,6 +174,13 @@ func TestService_AutoMergeIssuesTheSquashMergeOnce(t *testing.T) {
 			}
 			break
 		}
+	}
+	// Nothing above fails when the read never happened — the loop simply matches
+	// no request and every assertion inside it is skipped. So a read that moved to
+	// another path would leave the label guard, which is the whole reason these
+	// assertions exist, silently testing nothing.
+	if !milestoneRead {
+		t.Fatal("the merge policy must read the milestone's issues; no such request was made")
 	}
 }
 


### PR DESCRIPTION
Fixes #341

> **Scope note.** This branch sits on top of unmerged validation-phase work, so the commit list and diff
> carry those changes too. **The change this PR is about is one commit** —
> `refactor(validation): Update milestone issue filters to ensure validation issues are included in
> auto-merge decisions` — touching six files under `services/aep-api/internal/delivery/eventcore/` plus one
> README. Review that commit; the rest belongs to the base PRs.

## The bug

A validation cycle completes — the agent runs the acceptance tests, writes `tests/validation/report.json`,
opens its pull request — and the pull request is never merged. The run then waits at its landing deadline
for a merge commit that never arrives, because the verdict is read from the report **at the validation
cycle's merge SHA**. Left alone it settles `failed` / `redispatch-budget`. A human merging by hand was the
only way a run reached a verdict.

The cycle record from the real failing run names the cause exactly:

```
kind          | validation
branch        | aep/m1-validation
pr_number     | 4
merge_sha     |
resolves      |
merge_verdict | declined
merge_reason  | no resolved issue is this run's work in this milestone
```

The pull request *did* claim its issue (`Resolves #3`). `resolves` is empty because it records the
**matched** set — and nothing matched.

## Root cause: one predicate in two places

`decideAutoMerge` accepts an issue carrying **either** `aep` or `aep:validation`. The fetch feeding it
narrowed server-side first:

```go
Labels: []string{delivery.LabelAgentWork},   // `aep` only
```

The validation issue is deliberately labelled `aep:validation` **and nothing else** — that absence of `aep`
is what keeps it out of the dispatch working set so it cannot hold the settle predicate open. The same
absence hid it from this fetch, so it never reached the policy that was written to accept it.

One label decision has two opposite consequences, and only the first one had been thought through.

## The fix

The fetch drops its label filter and reads the milestone's open issues; `decideAutoMerge` remains the only
place labels are read.

```go
func milestoneOpenIssuesFilter(milestoneNumber int) sourcecontrol.MilestoneIssuesFilter {
	return sourcecontrol.MilestoneIssuesFilter{
		Number: milestoneNumber,
		State:  "open",
	}
}
```

Renamed, because it no longer returns "work" — the population is the milestone's open issues, and deciding
which of them is work is the policy's job.

This is also what the three other milestone-issue readers already do. `build/milestone_plan.go` states it
outright: *"no label filter, because a milestone's leftovers are exactly everything still open in it."* The
merge path was the outlier.

### Why not simply extend the label list

GitHub's REST `?labels=` is **AND**. Probed against the affected repo's milestone:

| query | result |
|---|---|
| *(no label filter)* | `#1 [aep]`, `#3 [aep:validation, dedupe:…]` |
| `?labels=aep` | `#1` |
| `?labels=aep:validation` | `#3` |
| `?labels=aep,aep:validation` | **(empty)** |

Strictly worse than the bug: the fetch returns nothing and *every* pull request declines with the same
message, coding cycles included. What makes this counter-intuitive is that the dispatch predicate counts
the same issues over **GraphQL**, whose `labels:` argument is a **union**. Two APIs over one resource,
opposite rules — the client warns about it inline at `githubhost.ListMilestoneIssues`.

### Why not stamp `aep` on the validation issue instead

This was tried and measured, not assumed: every seeded validation issue in the test suite was given both
labels and all 62 packages were run. Nothing broke, so it is a genuine alternative — the working set is a
set difference `(A ∪ E) \ E`, which cancels an issue carrying both, and a committed fixture in
`TestDispatchable` already pins exactly that case.

It was not chosen for four reasons:

- **It fixes the instance, not the class.** The split-predicate shape survives, so the next phase label the
  platform invents hits the same wall with the same misleading decline reason.
- **It needs a backfill.** Only newly minted issues would carry the label; every already-open validation
  issue keeps failing. This fix works on existing repos immediately.
- **It moves four defensive checks to load-bearing.** Today both the missing `aep` and the present
  `aep:validation` exclude the issue. Adding `aep` leaves one signal — and the most important consumer of
  it, the coding agent's working-set rule, is prose in `SKILL.md`, not code.
- **It makes the label unreadable alone.** `aep` is defined as "this issue is agent work"; stamping it on
  an issue that by definition is not makes a human's `label:aep` query wrong.

Adding `aep` for some *other* reason is still safe on top of this — it just isn't what fixes the merge.

## Tests

`TestPullRequestOpened_MergesTheValidationCyclesPullRequest` drives a validation pull request through the
**real handler graph and the real fetch**, with the milestone holding only the validation issue, labelled
the way the minter files it.

The existing `policy_test` cases could not have caught this: they call the pure function with the
population already in hand, which is precisely the half that was correct. The new test's fake honours the
endpoint's AND semantics, so the filter is exercised rather than assumed.

Verified it reproduces the production failure — reinstating the label filter makes it fail with the exact
string from the cycle record above:

```
--- FAIL: TestPullRequestOpened_MergesTheValidationCyclesPullRequest
    the validation cycle's PR must be squash-merged, got []
    (decline reason: "no resolved issue is this run's work in this milestone")
```

`TestService_AutoMergeIssuesTheSquashMergeOnce` asserted `labels=aep` on the wire — an assertion that was
actively pinning the bug in place. It now asserts the opposite: the query must carry `milestone=` and
`state=open`, and must **not** carry `labels=`.

## Docs

The `delivery` README invariant explaining why gates and the validation issue omit `aep` now carries the
corollary that was missing — that a read narrowing on `aep` cannot see either of them, so a decision that
must weigh them reads unfiltered and decides on the labels itself.

## Verification

- `go test -short ./...` — 62 packages, 0 failures
- `golangci-lint run ./internal/delivery/...` — 0 issues
- `make deadcode-check` — OK
- `make license-check` — clean
- Deployed to the local stack (`aep-api` rebuilt, `/healthz` 200)

The rest of the chain was already proven by the run above: once #4 was merged by hand, the
`aep/m1-validation` branch was recognised as agent work, the cycle recorded its merge SHA, and the run
reached `succeeded` with `validation_verdict = passed`. Auto-merge was the last broken link.

`make lint` additionally reports two pre-existing errors in `services/agents/chat_playground/**/env-config.js`
— untracked and gitignored (`.gitignore:30`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
