### PR TITLE
Contract-first coding runs, design-time endpoint wiring, and the managed-API trait sync

### DIFF
--- a/packages/agent-stream/src/component-design-schema.ts
+++ b/packages/agent-stream/src/component-design-schema.ts
@@ -72,15 +72,36 @@ const EXTERNAL_ONLY_DEPENDENCY_FIELDS = [
   "specPath",
 ] as const;
 
-// The resolved consumer-side wiring for a platform-resource / external
-// dependency: byte-identical to one workload.yaml `dependencies.resources[]`
-// entry, so the coding agent copies it instead of transforming it. Both fields
-// are required WHEN the object is present — a half-stamped wiring (a ref with no
-// bindings, or bindings with no ref) would render an unusable workload entry.
-const dependencyWiringSchema = z.strictObject({
+// The resolved consumer-side wiring: ONE VARIANT PER workload.yaml
+// `dependencies:` sub-block, each byte-identical to one entry of its block so the
+// coding agent copies it instead of transforming it.
+//
+// A UNION rather than one object of optional fields, because that is what keeps
+// each block's all-or-nothing rule enforceable: a resource variant needs BOTH ref
+// and envBindings (a ref with no bindings renders an unusable resources[] entry),
+// and an endpoint variant needs the full target. Optional fields on one flat
+// object would accept every half-stamped combination.
+const resourceWiringSchema = z.strictObject({
   ref: z.string().min(1),
   envBindings: z.record(z.string(), z.string()),
 });
+
+// One `dependencies.endpoints[]` entry for a sibling component. `component` is
+// the SCOPED OC name (`<project>-<component>`) — the key OpenChoreo resolves the
+// binding by, and the field an agent left to guess gets wrong (it writes the
+// friendly name, the connection never resolves, and the consumer's ReleaseBinding
+// never reaches Ready).
+const endpointWiringSchema = z.strictObject({
+  component: z.string().min(1),
+  name: z.string().min(1),
+  visibility: z.string().min(1),
+  envBindings: z.record(z.string(), z.string()),
+});
+
+const dependencyWiringSchema = z.union([
+  resourceWiringSchema,
+  z.strictObject({ endpoint: endpointWiringSchema }),
+]);
 
 // One unified, kind-discriminated dependency edge — the successor to the legacy
 // per-kind `connections[]`. A single flat shape carries every kind's fields;
@@ -113,8 +134,8 @@ const dependencyObjectSchema = z.strictObject({
   // is marshalled verbatim into the OpenChoreo Resource spec.parameters, so a
   // number must survive as a JSON number for CRD validation to pass.
   parameters: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
-  // platform-resource / external: the platform-stamped consumer-side wiring
-  // (see contracts/component-design.ts `DependencyWiring`). ACCEPTED here rather
+  // component / platform-resource / external: the platform-stamped consumer-side
+  // wiring (see contracts/component-design.ts `DependencyWiring`). ACCEPTED here rather
   // than rejected as agent-authored — unlike status/reason, this one is
   // PERSISTED in design.json, and the design agent reads-edits-writes the file,
   // so a rejection rule would reject its own echo. Design save re-derives and

--- a/packages/agent-stream/src/contracts/component-design.ts
+++ b/packages/agent-stream/src/contracts/component-design.ts
@@ -164,31 +164,46 @@ export interface Dependency {
    */
   parameters?: Record<string, string | number | boolean>;
   /**
-   * platform-resource / external: the consumer-side wiring, PLATFORM-STAMPED at
-   * design save and re-derived on every save — never authored. See `DependencyWiring`.
+   * component / platform-resource / external: the consumer-side wiring,
+   * PLATFORM-STAMPED at design save and re-derived on every save — never
+   * authored. See `DependencyWiring`.
    */
   wiring?: DependencyWiring;
 }
 
 /**
- * The resolved consumer-side wiring for a `platform-resource` or `external`
- * dependency — everything the coding agent needs to reach it, and the only part
- * of the `workload.yaml` `dependencies:` block that is knowable without asking
- * the cluster. Its shape is byte-identical to one `dependencies.resources[]`
- * entry so the agent copies the object rather than transforming it.
+ * The resolved consumer-side wiring for a dependency — everything the coding
+ * agent needs to reach it, and the part of the `workload.yaml` `dependencies:`
+ * block that is knowable without asking the cluster.
  *
- * PLATFORM-STAMPED, never authored: the platform derives it at design save from
- * the dependency name plus the resource type's declared outputs, and OVERWRITES
- * it on every save. An agent-authored value is therefore corrected rather than
- * rejected — the design agent reads the design, edits and writes it back, so a
- * rejection rule would reject its own echo.
+ * ONE VARIANT PER `dependencies:` SUB-BLOCK, and each variant is byte-identical
+ * to one entry of its block, so the agent COPIES the object rather than
+ * transforming it:
+ *   - `{ ref, envBindings }`  → one `dependencies.resources[]` entry
+ *     (`platform-resource` / `external`)
+ *   - `{ endpoint }`          → one `dependencies.endpoints[]` entry
+ *     (`component` — a sibling in the same project)
+ *
+ * The variants are exclusive: a dependency resolves to a resource OR to an
+ * endpoint, never both, and the `kind` already says which. Keeping them as
+ * separate variants rather than one object of optional fields is what preserves
+ * each block's own all-or-nothing rule — a half-stamped entry renders a
+ * workload.yaml OpenChoreo silently ignores.
+ *
+ * PLATFORM-STAMPED, never authored: the platform derives it at design save and
+ * OVERWRITES it on every save. An agent-authored value is therefore corrected
+ * rather than rejected — the design agent reads the design, edits and writes it
+ * back, so a rejection rule would reject its own echo.
  *
  * Absent means "not derivable yet" — the resource type is unknown to the
  * cluster, or (for an external dep) no config keys are declared. It never means
  * "this dependency needs no wiring": a declared dependency with no `wiring` is a
  * platform fault the coding agent reports rather than works around.
  */
-export interface DependencyWiring {
+export type DependencyWiring = ResourceWiring | EndpointWiringVariant;
+
+/** The `platform-resource` / `external` variant — one `resources[]` entry. */
+export interface ResourceWiring {
   /** The OpenChoreo Resource name — the `dependencies.resources[].ref` value. */
   ref: string;
   /**
@@ -197,6 +212,44 @@ export interface DependencyWiring {
    * prefixed with the dependency name (`orders-db` + `host` → `ORDERS_DB_HOST`);
    * an external resource's are already namespaced by its own config schema, so
    * the env var IS the key.
+   */
+  envBindings: Record<string, string>;
+}
+
+/** The `component` variant — wraps one `endpoints[]` entry. */
+export interface EndpointWiringVariant {
+  endpoint: EndpointWiring;
+}
+
+/**
+ * One `dependencies.endpoints[]` entry pointing at a sibling component in the
+ * same project.
+ *
+ * Every field is a pure function of the design, which is why this is stamped here
+ * instead of resolved from the live cluster at dispatch time. That distinction is
+ * the entire point: the live endpoint catalog is only populated once a component
+ * has DEPLOYED, so on a first delivery — where siblings are coded in one cycle,
+ * before anything is running — the cluster could answer nothing and the agent was
+ * left to invent `component`. It invented the friendly name, OpenChoreo resolves
+ * endpoint dependencies by SCOPED name, and the consumer's ReleaseBinding sat at
+ * `Ready=False / ConnectionsPending` indefinitely while the platform reported
+ * "deploying".
+ */
+export interface EndpointWiring {
+  /**
+   * The provider's SCOPED OpenChoreo component name (`<project>-<component>`) —
+   * the key OpenChoreo resolves the binding by. NOT the friendly name the design
+   * declares as the dependency's `name`.
+   */
+  component: string;
+  /** The provider's workload endpoint name — its design's `endpoint.name`, default "http". */
+  name: string;
+  /** Reachability of the target endpoint; "project" for a same-project sibling. */
+  visibility: string;
+  /**
+   * Endpoint output → the env var OpenChoreo injects it as. One key, `address`,
+   * bound to the provider's base-URL variable (`todo-api` → `TODO_API_URL`) —
+   * the same name a browser app already reads from `window._env_`.
    */
   envBindings: Record<string, string>;
 }

--- a/packages/agent-stream/test/component-design-gate.test.ts
+++ b/packages/agent-stream/test/component-design-gate.test.ts
@@ -129,9 +129,21 @@ const wiredDep = (wiring: unknown) => ({
   wiring,
 });
 
+// The sibling endpoint the derivation stamps for a `component` dependency. Its
+// `component` is the SCOPED OpenChoreo name — the value an agent left to guess
+// gets wrong (it writes the friendly one, the connection never resolves, and the
+// consumer's ReleaseBinding never reaches Ready).
+const SIBLING_ENDPOINT = {
+  component: "todo-api99-todo-api",
+  name: "http",
+  visibility: "project",
+  envBindings: { address: "TODO_API_URL" },
+};
+
 for (const [name, wiring] of [
   ["the platform-stamped shape", { ref: "shop-orders-db", envBindings: { host: "ORDERS_DB_HOST", port: "ORDERS_DB_PORT" } }],
   ["no outputs bound yet", { ref: "shop-orders-db", envBindings: {} }],
+  ["the sibling endpoint variant", { endpoint: SIBLING_ENDPOINT }],
 ] as const) {
   test(`accepts dependency wiring: ${name}`, () => {
     assert.equal(checkComponentDesign(PATH, design({ dependencies: [wiredDep(wiring)] })), null);
@@ -146,6 +158,17 @@ for (const [name, wiring] of [
   ["envBindings not an object", { ref: "shop-orders-db", envBindings: "ORDERS_DB_HOST" }],
   ["env var not a string", { ref: "shop-orders-db", envBindings: { port: 5432 } }],
   ["unknown property", { ref: "shop-orders-db", envBindings: {}, values: { host: "db" } }],
+  // The endpoints[] variant is all-or-nothing too, and exclusive with the
+  // resources[] one — OpenChoreo silently ignores a partial entry.
+  ["endpoint not an object", { endpoint: "todo-api99-todo-api" }],
+  ["endpoint component missing", { endpoint: { ...SIBLING_ENDPOINT, component: undefined } }],
+  ["endpoint component empty", { endpoint: { ...SIBLING_ENDPOINT, component: "" } }],
+  ["endpoint name missing", { endpoint: { ...SIBLING_ENDPOINT, name: undefined } }],
+  ["endpoint visibility missing", { endpoint: { ...SIBLING_ENDPOINT, visibility: undefined } }],
+  ["endpoint envBindings missing", { endpoint: { ...SIBLING_ENDPOINT, envBindings: undefined } }],
+  ["endpoint env var not a string", { endpoint: { ...SIBLING_ENDPOINT, envBindings: { address: 8080 } } }],
+  ["endpoint unknown property", { endpoint: { ...SIBLING_ENDPOINT, project: "todo-api99" } }],
+  ["both variants at once", { ref: "shop-orders-db", envBindings: {}, endpoint: SIBLING_ENDPOINT }],
 ] as const) {
   test(`rejects malformed dependency wiring: ${name}`, () => {
     const problem = checkComponentDesign(PATH, design({ dependencies: [wiredDep(wiring)] }));

--- a/packages/contracts/schemas/component-design.schema.json
+++ b/packages/contracts/schemas/component-design.schema.json
@@ -150,27 +150,73 @@
             }
           },
           "wiring": {
-            "type": "object",
-            "properties": {
-              "ref": {
-                "type": "string",
-                "minLength": 1
-              },
-              "envBindings": {
+            "anyOf": [
+              {
                 "type": "object",
-                "propertyNames": {
-                  "type": "string"
+                "properties": {
+                  "ref": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "envBindings": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
                 },
-                "additionalProperties": {
-                  "type": "string"
-                }
+                "required": [
+                  "ref",
+                  "envBindings"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "object",
+                    "properties": {
+                      "component": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "visibility": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "envBindings": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "component",
+                      "name",
+                      "visibility",
+                      "envBindings"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ],
+                "additionalProperties": false
               }
-            },
-            "required": [
-              "ref",
-              "envBindings"
-            ],
-            "additionalProperties": false
+            ]
           }
         },
         "required": [

--- a/runners/AGENTS.md
+++ b/runners/AGENTS.md
@@ -58,6 +58,12 @@ edits (see `deployments/scripts/setup-k3d.sh`).
   belongs to the run and one naming a path, a file or an env var belongs to the
   contract. That tie-break lives here, not in the skill — it is authoring
   guidance, useless to the agent at runtime.
+  **`## Contract-first` carries the premise both of those rest on** — `specs/` is
+  fixed at design time and is what implementation targets, so no issue waits for
+  another's code. Keep it to the premise; the ordering rule is the run's and the
+  per-dependency lookup the contract's. A dependency declaration (`dependsOn`,
+  `Depends on #N`) is a **runtime** edge, and text reading it as a build order is
+  a defect.
   **The platform text is the trunk** — gate a region only when the ungated
   version would make a mode attempt something impossible, and prefer gating one
   side to writing two variants. A *paired* region is prose duplicated per mode

--- a/runners/remote-worker/plugin/skills/aep/SKILL.md
+++ b/runners/remote-worker/plugin/skills/aep/SKILL.md
@@ -51,25 +51,37 @@ When an issue's Scope names a stack convention ("use `modernc.org/sqlite`", "rea
 `window._env_.X_URL`"), the owning skill is authoritative — never re-derive a
 convention from training data when a loaded skill states it.
 
+## Contract-first
+
+`specs/` was authored at design time, before any issue existed: every component's
+`design.json`, and every service's `openapi.yaml`. It is the contract — what a
+service implements, and what its consumers are written against. **Implement to it;
+never edit it.** A service with no `openapi.yaml` has its issue's Scope and
+Acceptance criteria as its contract instead.
+
+That is what makes the work parallel. A consumer codes against its provider's
+committed `openapi.yaml`, never its code, so **no issue waits for another issue's
+code** — and a dependency an issue declares is a *runtime* edge, who calls whom
+once deployed, never a build order. Only two issues writing the same files
+serialise anything.
+
 ---
 
 # The run
 
 ## 1 · Start the cycle
 
-Settle **what you are working, and in what order**, before you write any file.
+Settle **what you are working, and what can run at once**, before you write any
+file.
 
 Done-ness is a **live fact, never a stored flag**: an issue is finished because
 the work landed. So derive the working set fresh before each pick — a run is
 long enough for the set to change under you, and re-checking is what lets new
-work join *this* run instead of the next one. Then order it **topologically** on
-the dependencies each issue declares and work it in that order: a dependent's
-code has to compile against its provider's, and you commit as you go.
+work join *this* run instead of the next one.
 
-- A dependency on something **not in your working set** (already finished, or no
-  issue exists for it) is **already satisfied** — ignore it.
-- **Ties, and any issue with no dependencies, sort by issue number ascending.**
-  Same for breaking a cycle if the declarations contain one.
+**Order is by issue number ascending, and nothing else** — every issue's contract
+is already fixed (**Contract-first**), so there is no build order to derive. What
+decides how much runs at once is file overlap: see **Fan-out to subagents**.
 
 <!-- mode:github -->
 **The set.** Ask the **issues API**, live, once per pick:
@@ -99,10 +111,11 @@ joins the working set on your next re-list.
 > you should work around it: treat the working set as empty and go to Finish —
 > never fall back to the search API, never guess issue numbers.
 
-**The order.** Issue bodies name their dependencies in **prose**, e.g.
-`Depends on #41`. **Nothing parses this platform-side — reading it is your
-job.** Fetch the bodies of your whole working set up front with
-`gh issue view <number> --json number,title,body,labels`.
+**The bodies.** Fetch the bodies of your whole working set up front with
+`gh issue view <number> --json number,title,body,labels` — you need them to plan
+the fan-out. A `Depends on #41` line records the **runtime** relationship the
+design declared. It is context, not a gate: it never means "work #41 first" and
+never means "wait for #41".
 <!-- /mode -->
 <!-- mode:local -->
 **The set.** List every `issues/<n>.md` under `issues/`. Each is markdown with
@@ -116,9 +129,9 @@ not merely because those components exist. Read each path from its `design.json`
 and look. Satisfied → leave the issue out of the working set. Missing, empty, or
 short of the Scope → it's in.
 
-**The order.** Each issue's `dependsOn` frontmatter array names the
-**components** its component depends on (component names, not issue numbers) —
-read it straight off the frontmatter, no prose parsing needed.
+**The declarations.** An issue's `dependsOn` frontmatter names the **components**
+its component consumes at runtime (component names, not issue numbers). That is a
+runtime relationship, not a build order — it never holds an issue back.
 <!-- /mode -->
 
 <!-- mode:github -->
@@ -179,8 +192,10 @@ it is how the platform maps your PR back to this run.
 
 For **each** issue in the ordered set:
 
-1. **Read it in full.** The issue is the spec — Scope, Acceptance criteria,
-   References.
+1. **Read it in full** — Scope, Acceptance criteria, References — **and the
+   contract under `specs/`**: its component's `design.json` and `openapi.yaml`,
+   plus the `openapi.yaml` of every component it consumes. The issue says what to
+   build; the contract fixes the shape.
 <!-- mode:github -->
    Read its comments too (`gh issue view <number> --comments`): a
    "Platform-resolved dependencies" comment carries dependency wiring you need.
@@ -206,23 +221,22 @@ For **each** issue in the ordered set:
 
 ### Fan-out to subagents
 
-You have the **Task** tool. Use it to work more than one issue at a time — but
-**you** decide what is safe to parallelise, and the bar is higher than "they
-don't conflict":
+You have the **Task** tool, and **fanning out is the default, not the exception** —
+a provider and its consumer may be built at the same time, by different subagents
+(**Contract-first**). Two tests, and they are the only two:
 
-- **Independent** in the ordering you derived — neither depends on the other,
-  directly or transitively — **and** their App Paths are disjoint (no shared
-  file, no shared module).
+- **Disjoint App Paths** — no file and no module written by both. Overlap is the
+  only reason to serialise; work those inline, in ascending order.
 - **Big enough to be worth a subagent.** A one-file change, a config tweak, a
   small fix issue: work those inline. Spawning a subagent for small work costs
   more than it saves and makes the run harder to follow.
-- If either test fails, work the issue inline, in order.
 
 **Subagents Edit/Write only. A subagent never runs `git` and never runs `gh`** —
 no commit, no push, no branch, no comment, no PR. Say so explicitly in every
 Task prompt, and give the subagent its issue's body, the App Paths it may touch,
-and the relevant stack skills' conventions. It reports what it changed; you
-inspect it.
+its component's contract and the `openapi.yaml` of every component it consumes
+(**Contract-first**), and the relevant stack skills' conventions. It reports what
+it changed; you inspect it.
 
 **You are the sole git writer.** When a subagent reports done, *you* stage those
 paths and commit them exactly as in step 3. **No worktrees** — one workspace.
@@ -373,9 +387,11 @@ actually runs on is its own default for `<DEP_NAME>_URL`.
 <!-- /mode -->
 
 **Contracts.** Find the contract before writing any client code: never guess at
-endpoint paths or request/response shapes, and never invent an operation. With no
-published contract, implement a minimal client against the injected address plus
-its `basePath` and nothing more.
+endpoint paths or request/response shapes, and never invent an operation. A
+`component` dependency's `openapi.yaml` is authoritative **whether or not that
+component has been written yet** — read the spec, never the provider's source.
+With no published contract, implement a minimal client against the injected
+address plus its `basePath` and nothing more.
 <!-- mode:github -->
 
 The comment's **Consumed API contracts** sections name the providers. For an
@@ -473,6 +489,14 @@ The platform contract the code itself must satisfy. Layout, libraries, the
 `Dockerfile` and the verify command belong to the stack skill, not here — and
 **where** a rule below lands in the tree is the stack skill's call too.
 
+- **Keep a `.gitignore` at the repo root, and keep it current** — one file for the
+  whole project, extended in the same change that introduces something it should
+  cover (build output, dependency directories, local env files; your stack skill
+  names its own). Never commit what belongs in it.
+- **A service implements its own `openapi.yaml` exactly** — same paths, schemas
+  and status codes. Its consumers are being written against that document, maybe
+  in this same run, so a path you "improve" is a break your own component cannot
+  show you.
 - **Code that is already there sets the conventions.** Read the files an issue
   touches before editing them and follow their structure, error handling and
   config names over what you would write on a blank page, unless one contradicts
@@ -547,6 +571,11 @@ output and what you tried, leave that issue unfinished, and hand both to
   only the `## Progress` section of an issue you touched is yours to write.
 - Delete or rewrite `.aep-playground/` (the playground's state dir).
 <!-- /mode -->
+- **Edit, add to, or delete anything under the repo-root `specs/`.** It is the
+  design-time contract and your consumers are reading it. If it is wrong, or
+  contradicts an issue, implement what the issue asks and say so in one line.
+- **Hold back or skip an issue because a component it depends on is not built
+  yet.** Code against the contract.
 - **Substitute your own technology for a declared dependency.** A
   `platform-resource` you have no `wiring` for is broken input, not
   a licence to pick your own database, cache or IDP — and a local file or an

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -488,10 +488,11 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 
 	// trait_sync is the single shared emitter that reconciles the
 	// `api-configuration` ClusterTrait on a Component CR + per-environment
-	// ReleaseBindings. Hooked from both the dispatch path (after
-	// CreateComponent) and the design-edit path (after
-	// `components/<name>/design.md` PUT). See
-	// docs/design/api-platform-integration.md §6 Phase 2.
+	// ReleaseBindings. The Component CR's trait shape is set independently of
+	// this, at component create (projects/component_service.go); what this
+	// emitter adds is the per-environment half, which needs a ReleaseBinding to
+	// exist and so cannot run before a build has deployed. Its trigger is the run
+	// supervisor at builds-green — see the NOTE above the watcher list.
 	traitSyncService := projects.NewTraitSyncService(componentClient, artifactStore)
 
 	// Thunder admin client + IDP service. Reads
@@ -688,11 +689,20 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// the component_tasks table to periodically reconcile the api-configuration
 	// ClusterTrait. That table is gone (tasks are GitHub issues), so the periodic
 	// watcher is dropped. The per-env traitEnvironmentConfigs (jwtAuth/CORS) are
-	// instead re-emitted on the ExecWatcher deploy path via traitDeployObserver
-	// (wired into the MultiDeployObserver fan-out below), which fires once a
-	// protected component — or a sibling SPA — deploys and its ReleaseBinding
-	// exists to carry the config. A component-enumerating reconcile backstop can
-	// be re-added over the OC component list if drift reappears.
+	// re-emitted from the run supervisor instead, when a cycle's builds go green
+	// (run.Deps.APITraits below). traitDeployObserver, wired into the
+	// MultiDeployObserver fan-out below, reaches the same emitter from the
+	// ExecWatcher deploy path and is kept for the paths that still mint
+	// `kind=build` execution rows — it is inert for anything the run loop builds,
+	// which is what left every protected API's gateway unauthenticated until the
+	// run-loop trigger was added.
+	//
+	// Both triggers are events, so neither covers drift: a ReleaseBinding
+	// recreated, a config stripped, or a transient OC failure during the write
+	// (the fan-out is best-effort and does not retry) stays broken until the next
+	// green cycle. The component-enumerating reconcile backstop over the OC
+	// component list — the sibling of runtimeconfig.NewWatcher below — is what
+	// would close that, and is still owed.
 
 	// Inbound JWT verifier — Thunder publishes the User JWT and Service JWT
 	// signing keys at JWKSURL. Lazy fetch on first request avoids compose
@@ -1235,6 +1245,12 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 			// its Job ref. It mints no execution row — the cycle record is the
 			// supervisor's own bookkeeping.
 			Dispatcher: codingExecutor,
+			// Managed-API gateway policy, converged at builds-green. This rail is
+			// where the trait sync has to hang now: it took over building from the
+			// ExecWatcher deploy path (which reached the same emitter through
+			// traitDeployObserver below) but writes no `kind=build` execution rows,
+			// so that observer no longer fires for anything this loop builds.
+			APITraits: traitSyncService,
 		})
 		watchers = append(watchers, run.NewWorkerWatcher(temporalRuntime, runActs))
 		slog.Info("run: temporal worker watcher registered", "hostPort", cfg.Temporal.HostPort)

--- a/services/aep-api/internal/app/tasks_adapters.go
+++ b/services/aep-api/internal/app/tasks_adapters.go
@@ -131,11 +131,11 @@ func (d designComponents) ComponentPaths(ctx context.Context, orgID, projectID s
 	return paths, nil
 }
 
-// DeclaredResources maps each design component to its App Path plus the OC
-// resource refs its design says it consumes — read off each dependency's
-// platform-stamped `wiring` (spec/derive_wiring.go). A dependency with no wiring
-// is skipped: it is not derivable yet, so no agent could have wired it.
-// Satisfies eventcore.DesignReader's conformance half.
+// DeclaredResources maps each design component to its App Path plus the wiring
+// its design says it consumes — resource refs and sibling endpoint targets, both
+// read off each dependency's platform-stamped `wiring` (spec/derive_wiring.go). A
+// dependency with no wiring is skipped: it is not derivable yet, so no agent could
+// have wired it. Satisfies eventcore.DesignReader's conformance half.
 func (d designComponents) DeclaredResources(ctx context.Context, orgID, projectID string) (map[string]eventcore.ComponentResources, error) {
 	design, err := d.store.ReadDesign(ctx, orgID, projectID)
 	if err != nil {
@@ -148,7 +148,11 @@ func (d designComponents) DeclaredResources(ctx context.Context, orgID, projectI
 	for _, c := range design.Components {
 		entry := eventcore.ComponentResources{AppPath: strings.Trim(c.AppPath, "/")}
 		for _, dep := range c.Dependencies {
-			if dep.Wiring != nil && dep.Wiring.Ref != "" {
+			switch {
+			case dep.Wiring == nil:
+			case dep.Wiring.Endpoint != nil && dep.Wiring.Endpoint.Component != "":
+				entry.EndpointTargets = append(entry.EndpointTargets, dep.Wiring.Endpoint.Component)
+			case dep.Wiring.Ref != "":
 				entry.Refs = append(entry.Refs, dep.Wiring.Ref)
 			}
 		}

--- a/services/aep-api/internal/clients/openchoreo/oc_names.go
+++ b/services/aep-api/internal/clients/openchoreo/oc_names.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
+	"github.com/wso2/aep/aep-api/internal/platform/ocname"
 )
 
 // unixMilliDigits is the width of the timestamp NewBuildRunName appends. Thirteen
@@ -58,19 +59,16 @@ func NewBuildRunName(projectName, componentName string) string {
 	return fmt.Sprintf("%s-%d", head, time.Now().UnixMilli())
 }
 
-// ScopedComponentName is the k8s metadata name OC uses for a component. OC
-// components across every project in an org share a single k8s namespace, so
-// two projects can't hold the same component name unless we disambiguate.
-// We prefix with the project name; the user's original name survives as the
-// display-name annotation.
+// ScopedComponentName is the k8s metadata name OC uses for a component.
+// Delegates to ocname.ScopedComponentName — the shared source of truth, because
+// spec stamps this same name into design.json at design save (see
+// spec/derive_wiring.go) and a byte of drift there costs a consumer's
+// ReleaseBinding its Ready condition.
 //
 // Callers must always pass the friendly component name (never a previously
-// scoped name) — call this exactly once, at the OC boundary.
+// scoped name) — scope exactly once.
 func ScopedComponentName(projectName, componentName string) string {
-	if projectName == "" {
-		return componentName
-	}
-	return projectName + "-" + componentName
+	return ocname.ScopedComponentName(projectName, componentName)
 }
 
 // FriendlyComponentName reverses ScopedComponentName using the owner project

--- a/services/aep-api/internal/contracts/dependency.go
+++ b/services/aep-api/internal/contracts/dependency.go
@@ -87,23 +87,60 @@ type Dependency struct {
 	// spec.parameters (numbers must stay JSON numbers for CRD validation).
 	ResourceType string         `json:"resourceType,omitempty"`
 	Parameters   map[string]any `json:"parameters,omitempty"`
-	// platform-resource / external: the platform-stamped consumer-side wiring.
-	// See DependencyWiring — derived at design save, overwritten on every save,
-	// never authored by an agent.
+	// component / platform-resource / external: the platform-stamped consumer-side
+	// wiring. See DependencyWiring — derived at design save, overwritten on every
+	// save, never authored by an agent.
 	Wiring *DependencyWiring `json:"wiring,omitempty"`
 }
 
-// DependencyWiring is the resolved consumer-side wiring for a platform-resource
-// or external dependency: the OC Resource name plus the output→env-var mapping
-// the coding agent copies into its component's workload.yaml. Its shape mirrors
-// ONE `dependencies.resources[]` entry exactly (provisioning's
-// workloadResourceDepYAML), so the agent copies rather than transforms.
+// DependencyWiring is the resolved consumer-side wiring for a dependency: what
+// the coding agent copies into its component's workload.yaml `dependencies:`
+// block. It carries ONE VARIANT PER sub-block of that block, and each variant
+// mirrors one entry of its sub-block exactly, so the agent copies rather than
+// transforms:
 //
-// It is knowable at design save because both halves are pure functions of the
-// design plus the resource type's DECLARED outputs — no binding, no gate, no
-// cluster state. Mirrors the agent-stream TS `DependencyWiring`.
+//   - Ref + EnvBindings → one `dependencies.resources[]` entry (provisioning's
+//     workloadResourceDepYAML), for kind platform-resource / external.
+//   - Endpoint          → one `dependencies.endpoints[]` entry (provisioning's
+//     workloadEndpointDepYAML), for kind component.
+//
+// The variants are EXCLUSIVE — a dependency resolves to a resource or to an
+// endpoint, never both, and Kind already says which. Go cannot express a union,
+// so both live on one struct and exactly-one is enforced by the write gates (the
+// zod union in agent-stream, agentfold.validateDependencyWiring here); the TS
+// contract states it as a real union type.
+//
+// Every variant is knowable at design save because every field is a pure function
+// of the design (plus, for a resource, the resource type's DECLARED outputs) — no
+// binding, no gate, no cluster state. Mirrors the agent-stream TS
+// `DependencyWiring`.
 type DependencyWiring struct {
-	Ref         string            `json:"ref"`
+	Ref         string            `json:"ref,omitempty"`
+	EnvBindings map[string]string `json:"envBindings,omitempty"`
+	Endpoint    *EndpointWiring   `json:"endpoint,omitempty"`
+}
+
+// EndpointWiring is one `dependencies.endpoints[]` entry: a sibling component's
+// endpoint in the same project.
+//
+// Component is the SCOPED OC component name (ocname.ScopedComponentName), because
+// that is the key OpenChoreo resolves an endpoint dependency by. Stamping it here
+// is what removed the ordering dependency that made this unknowable: the live
+// endpoint catalog only lists components that have DEPLOYED, so on a first
+// delivery — siblings coded in one cycle, nothing running yet — dispatch-time
+// resolution could answer nothing, and an agent left to guess wrote the FRIENDLY
+// name. OpenChoreo then matched no binding, and the consumer sat at
+// `Ready=False / ConnectionsPending` while the platform reported "deploying".
+//
+// Mirrors the agent-stream TS `EndpointWiring`.
+type EndpointWiring struct {
+	Component string `json:"component"`
+	Name      string `json:"name"`
+	// Visibility is the target endpoint's reachability — "project" for a
+	// same-project sibling.
+	Visibility string `json:"visibility"`
+	// EnvBindings maps the endpoint output to the env var OpenChoreo injects it
+	// as: one key, `address`, bound to ocname.ServiceURLEnvName(depName).
 	EnvBindings map[string]string `json:"envBindings"`
 }
 

--- a/services/aep-api/internal/delivery/eventcore/conformance.go
+++ b/services/aep-api/internal/delivery/eventcore/conformance.go
@@ -25,10 +25,19 @@ package eventcore
 // container filesystem for a component whose design named postgres-cnpg.
 //
 // So the platform checks it, deterministically, with no LLM involved: the design
-// says which OC resources a component consumes (each dependency's stamped
-// `wiring.ref`), the shipped workload.yaml says which it declared, and the
-// difference is a defect. Nothing about that comparison needs a model, a cluster
-// read or a heuristic.
+// says what a component consumes (each dependency's stamped `wiring`), the shipped
+// workload.yaml says what it declared, and the difference is a defect. Nothing
+// about that comparison needs a model, a cluster read or a heuristic.
+//
+// BOTH sub-blocks of `dependencies:` are checked, and the endpoints half is the
+// quieter defect of the two. A missing resource at least leaves data that does not
+// survive a restart; a sibling endpoint targeting the FRIENDLY component name
+// instead of the scoped one produces nothing observable at all — the release
+// renders, the pod runs, the app serves, and the sole symptom is a ReleaseBinding
+// parked at Ready=False with the connection unresolved, which surfaces only as a
+// project that reads "deploying" forever. Because the value is stamped in
+// design.json, the comparison is exact: presence is not enough, the target must be
+// the declared one.
 //
 // WHERE it runs is the merged-PR fan-out, which fits the policy this package
 // already follows (see decideAutoMerge): there is no verification before the
@@ -38,8 +47,8 @@ package eventcore
 // to cause.
 //
 // It NEVER fails the fan-out. A build that would have run still runs: a missing
-// resource declaration is a defect to fix, not a reason to withhold the build
-// output that tells the agent whether its code even compiles.
+// wiring declaration is a defect to fix, not a reason to withhold the build output
+// that tells the agent whether its code even compiles.
 
 import (
 	"context"
@@ -58,9 +67,11 @@ import (
 // App Path. The coding agent authors it there; OpenChoreo reads it from there.
 const workloadPath = "workload.yaml"
 
-// checkWiringConformance compares one component's design-declared resource refs
-// against the workload.yaml it shipped, and mints a fix issue naming whatever is
-// missing.
+// checkWiringConformance compares one component's design-declared wiring against
+// the workload.yaml it shipped, and mints a fix issue naming whatever is missing.
+//
+// BOTH `dependencies:` sub-blocks are checked, and the endpoints half is checked
+// for the VALUE, not just presence — see missingEndpointTargets.
 //
 // Every failure path is a logged no-op. The check is a safety net; a net that can
 // fail a merge fan-out is worse than the hole it covers.
@@ -75,7 +86,7 @@ func (e *Events) checkWiringConformance(ctx context.Context, run *delivery.Miles
 		return
 	}
 	want, ok := declared[component]
-	if !ok || len(want.Refs) == 0 {
+	if !ok || (len(want.Refs) == 0 && len(want.EndpointTargets) == 0) {
 		return // nothing declared ⇒ nothing to conform to
 	}
 
@@ -97,15 +108,21 @@ func (e *Events) checkWiringConformance(ctx context.Context, run *delivery.Miles
 		return
 	}
 
-	missing := missingResourceRefs(want.Refs, content)
-	if len(missing) == 0 {
-		return
+	if missing := missingResourceRefs(want.Refs, content); len(missing) > 0 {
+		slog.WarnContext(ctx, "eventcore: shipped workload.yaml is missing declared resources",
+			"project", run.ProjectID, "component", component, "missing", missing)
+		if _, err := e.mintUnwiredResourceIssue(ctx, run, component, path, missing); err != nil {
+			slog.WarnContext(ctx, "eventcore: mint unwired-resource issue failed",
+				"project", run.ProjectID, "component", component, "error", err)
+		}
 	}
-	slog.WarnContext(ctx, "eventcore: shipped workload.yaml is missing declared resources",
-		"project", run.ProjectID, "component", component, "missing", missing)
-	if _, err := e.mintUnwiredResourceIssue(ctx, run, component, path, missing); err != nil {
-		slog.WarnContext(ctx, "eventcore: mint unwired-resource issue failed",
-			"project", run.ProjectID, "component", component, "error", err)
+	if missing := missingEndpointTargets(want.EndpointTargets, content); len(missing) > 0 {
+		slog.WarnContext(ctx, "eventcore: shipped workload.yaml does not target the declared sibling endpoints",
+			"project", run.ProjectID, "component", component, "missing", missing)
+		if _, err := e.mintUnwiredEndpointIssue(ctx, run, component, path, missing); err != nil {
+			slog.WarnContext(ctx, "eventcore: mint unwired-endpoint issue failed",
+				"project", run.ProjectID, "component", component, "error", err)
+		}
 	}
 }
 
@@ -139,6 +156,44 @@ func missingResourceRefs(declaredRefs []string, workloadYAML string) []string {
 	return missing
 }
 
+// missingEndpointTargets returns the declared sibling endpoint targets absent from
+// the workload descriptor's `dependencies.endpoints[]`, sorted for a stable issue
+// body.
+//
+// This catches a WRONG value, not only a missing one, and that is the point: the
+// expected `component` is the SCOPED OC name, and an agent guessing writes the
+// friendly one. `todo-api` where `todo-api99-todo-api` was declared is a diff, so
+// it reports — where before it shipped, built, deployed and served, with the only
+// symptom a ReleaseBinding stuck at Ready=False and a project that read
+// "deploying" forever.
+//
+// An unparseable descriptor yields every target as missing, for the same reason
+// missingResourceRefs does: OpenChoreo cannot read the file either, so nothing in
+// it is wired, whatever the bytes intended.
+func missingEndpointTargets(declaredTargets []string, workloadYAML string) []string {
+	var doc struct {
+		Dependencies struct {
+			Endpoints []struct {
+				Component string `yaml:"component"`
+			} `yaml:"endpoints"`
+		} `yaml:"dependencies"`
+	}
+	shipped := map[string]bool{}
+	if err := yaml.Unmarshal([]byte(workloadYAML), &doc); err == nil {
+		for _, ep := range doc.Dependencies.Endpoints {
+			shipped[strings.TrimSpace(ep.Component)] = true
+		}
+	}
+	var missing []string
+	for _, target := range declaredTargets {
+		if !shipped[target] {
+			missing = append(missing, target)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
 // mintUnwiredResourceIssue files the fix issue for a component that shipped
 // without declaring resources its design consumes.
 //
@@ -165,5 +220,38 @@ func (e *Events) mintUnwiredResourceIssue(ctx context.Context, run *delivery.Mil
 		Labels:    []string{delivery.LabelAgentWork},
 		Milestone: &run.MilestoneNumber,
 		DedupeKey: fmt.Sprintf("aep unwired %s %s", component, strings.Join(missing, ",")),
+	})
+}
+
+// mintUnwiredEndpointIssue files the fix issue for a component whose shipped
+// workload.yaml does not target the sibling endpoints its design declares.
+//
+// The body leads with WHY nothing looks broken, because that is the trap: unlike a
+// missing resource, a wrong endpoint target still builds, deploys and serves. An
+// agent asked to "fix the deployment" would find a running pod, conclude the report
+// is stale, and close it. The one observable symptom — a ReleaseBinding parked at
+// Ready=False with the connection unresolved — is named explicitly so the agent can
+// confirm the defect rather than re-diagnose it.
+//
+// Same policy as the resource half: agent-work label so the next cycle picks it up,
+// dedupe on (component, targets) so a redelivered webhook files nothing new.
+func (e *Events) mintUnwiredEndpointIssue(ctx context.Context, run *delivery.MilestoneRun,
+	component, path string, missing []string) (int, error) {
+	list := "`" + strings.Join(missing, "`, `") + "`"
+	body := fmt.Sprintf(
+		"Component **%s** declares sibling-component dependencies in its design that its shipped `%s` does not target, so OpenChoreo resolves no address for them and injects no env var.\n\n"+
+			"Missing from `dependencies.endpoints`: %s\n\n"+
+			"**This does not look broken.** The component still builds, deploys and serves — the release renders fine without the address, so the only symptom is the component's ReleaseBinding sitting at `Ready=False` with `ConnectionsPending`, and the platform reporting the project as \"deploying\" indefinitely. Do not close this because the app is running.\n\n"+
+			"The usual cause is a `component:` value written as the FRIENDLY component name. OpenChoreo resolves an endpoint dependency by the SCOPED name (`<project>-<component>`), so the friendly name matches no binding, silently.\n\n"+
+			"Each entry is already resolved for you: read the `wiring.endpoint` object on that dependency in `specs/design/components/%s/design.json` and copy it into `%s` as one `dependencies.endpoints[]` entry verbatim — it is byte-identical to the entry that belongs there.\n\n"+
+			"Do not invent a component name or an env-var name, and do not remove the dependency from the design to make this pass.",
+		component, path, list, component, path)
+
+	return e.mint(ctx, run.OrgID, run.ProjectID, sourcecontrol.CreateIssueRequest{
+		Title:     fmt.Sprintf("Wire the declared sibling endpoints for %s", component),
+		Body:      body,
+		Labels:    []string{delivery.LabelAgentWork},
+		Milestone: &run.MilestoneNumber,
+		DedupeKey: fmt.Sprintf("aep unwired-endpoints %s %s", component, strings.Join(missing, ",")),
 	})
 }

--- a/services/aep-api/internal/delivery/eventcore/conformance_test.go
+++ b/services/aep-api/internal/delivery/eventcore/conformance_test.go
@@ -231,6 +231,148 @@ func TestMissingResourceRefs(t *testing.T) {
 	}
 }
 
+// --- sibling endpoint targets ------------------------------------------------
+
+// webappDesign is the shape the live bug had: a browser app whose design declares
+// a dependency on the API beside it, stamped with the SCOPED target OpenChoreo
+// resolves by.
+func webappDesign() fakeDesign {
+	return fakeDesign{declared: map[string]ComponentResources{
+		"todo-webapp": {AppPath: "todo-webapp", EndpointTargets: []string{"todo-api99-todo-api"}},
+	}}
+}
+
+// scopedEndpointWorkload targets the sibling correctly.
+const scopedEndpointWorkload = `apiVersion: openchoreo.dev/v1alpha1
+metadata:
+  name: todo-webapp
+dependencies:
+  endpoints:
+    - component: todo-api99-todo-api
+      name: http
+      visibility: project
+      envBindings:
+        address: TODO_API_URL
+`
+
+// friendlyEndpointWorkload is what actually shipped in asdlc-repos/todo-api99: a
+// well-formed entry naming the FRIENDLY component. OpenChoreo matched no binding.
+const friendlyEndpointWorkload = `apiVersion: openchoreo.dev/v1alpha1
+metadata:
+  name: todo-webapp
+dependencies:
+  endpoints:
+    - component: todo-api
+      name: http
+      visibility: project
+      envBindings:
+        address: TODO_API_URL
+`
+
+// THE second incident, and the one the resource check could never have caught: the
+// endpoint entry is PRESENT and well-formed, just pointed at a name OpenChoreo does
+// not resolve. Everything downstream succeeds — image, release, pod, HTTP 200 — so
+// only an exact comparison against the declared target finds it.
+func TestConformance_MintsWhenASiblingEndpointTargetsTheFriendlyName(t *testing.T) {
+	e, issues := conformanceEvents(webappDesign(),
+		fakeWorkloads{byPath: map[string]string{"todo-webapp/workload.yaml": friendlyEndpointWorkload}})
+
+	e.checkWiringConformance(context.Background(), conformanceRun(), "todo-webapp")
+
+	if len(issues.created) != 1 {
+		t.Fatalf("want one fix issue, got %d: %v", len(issues.created), mintedTitles(issues))
+	}
+	req := issues.created[0]
+	if want := "Wire the declared sibling endpoints for todo-webapp"; req.Title != want {
+		t.Errorf("title = %q, want %q", req.Title, want)
+	}
+	if !delivery.HasLabel(req.Labels, delivery.LabelAgentWork) {
+		t.Error("the issue must be agent work, or no cycle picks it up")
+	}
+	if req.Milestone == nil || *req.Milestone != 1 {
+		t.Error("the issue must join the run's milestone")
+	}
+	for _, want := range []string{
+		"todo-api99-todo-api", // names the target that should be there
+		"This does not look broken",
+		"Ready=False",               // the one observable symptom
+		"Do not close this",         // ... and do not dismiss it as stale
+		"SCOPED",                    // the actual cause
+		"wiring.endpoint",           // where the answer already is
+		"todo-webapp/workload.yaml", // where it goes
+		"do not remove the dependency from the design",
+	} {
+		if !strings.Contains(req.Body, want) {
+			t.Errorf("issue body missing %q:\n%s", want, req.Body)
+		}
+	}
+}
+
+// The correctly-targeted case must be silent, or the check is noise on every merge
+// of every project that has two components.
+func TestConformance_SilentWhenTheSiblingEndpointIsScoped(t *testing.T) {
+	e, issues := conformanceEvents(webappDesign(),
+		fakeWorkloads{byPath: map[string]string{"todo-webapp/workload.yaml": scopedEndpointWorkload}})
+
+	e.checkWiringConformance(context.Background(), conformanceRun(), "todo-webapp")
+
+	if len(issues.created) != 0 {
+		t.Errorf("a correctly-targeted sibling must mint nothing, got %v", mintedTitles(issues))
+	}
+}
+
+// The two halves are independent defects and each gets its own issue: they are
+// fixed in different blocks of the file, and their dedupe keys must not collide or
+// the second one to be found would be swallowed.
+func TestConformance_ReportsBothHalvesSeparately(t *testing.T) {
+	e, issues := conformanceEvents(
+		fakeDesign{declared: map[string]ComponentResources{
+			"todo-webapp": {
+				AppPath:         "todo-webapp",
+				Refs:            []string{"todo-webapp-todo-db"},
+				EndpointTargets: []string{"todo-api99-todo-api"},
+			},
+		}},
+		fakeWorkloads{byPath: map[string]string{"todo-webapp/workload.yaml": sqliteWorkload}})
+
+	e.checkWiringConformance(context.Background(), conformanceRun(), "todo-webapp")
+
+	if len(issues.created) != 2 {
+		t.Fatalf("want one issue per half, got %d: %v", len(issues.created), mintedTitles(issues))
+	}
+	if issues.created[0].DedupeKey == issues.created[1].DedupeKey {
+		t.Error("the two halves share a dedupe key — one would swallow the other")
+	}
+}
+
+// The target comparison itself. The wrong-value case is the one a presence-only
+// check gets wrong, and an unparseable descriptor must report everything missing:
+// OpenChoreo cannot read the file either, so nothing in it is wired.
+func TestMissingEndpointTargets(t *testing.T) {
+	declared := []string{"proj-api", "proj-worker"}
+	cases := map[string]struct {
+		yaml string
+		want []string
+	}{
+		"both targeted":     {"dependencies:\n  endpoints:\n    - component: proj-api\n    - component: proj-worker\n", nil},
+		"one targeted":      {"dependencies:\n  endpoints:\n    - component: proj-api\n", []string{"proj-worker"}},
+		"friendly names":    {"dependencies:\n  endpoints:\n    - component: api\n    - component: worker\n", []string{"proj-api", "proj-worker"}},
+		"no endpoints":      {"endpoints:\n  - name: http\n", []string{"proj-api", "proj-worker"}},
+		"empty endpoints":   {"dependencies:\n  endpoints: []\n", []string{"proj-api", "proj-worker"}},
+		"resources only":    {"dependencies:\n  resources:\n    - ref: proj-api\n", []string{"proj-api", "proj-worker"}},
+		"unparseable yaml":  {"dependencies: [oh no\n  endpoints:\n", []string{"proj-api", "proj-worker"}},
+		"target whitespace": {"dependencies:\n  endpoints:\n    - component: \"  proj-api  \"\n", []string{"proj-worker"}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := missingEndpointTargets(declared, tc.yaml)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("missing = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // A component that builds from the repo root reads workload.yaml at the root, not
 // at "/workload.yaml".
 func TestConformance_RootAppPathReadsRepoRoot(t *testing.T) {

--- a/services/aep-api/internal/delivery/eventcore/ports.go
+++ b/services/aep-api/internal/delivery/eventcore/ports.go
@@ -141,11 +141,23 @@ type RepoRef struct {
 }
 
 // ComponentResources is what the wiring-conformance check compares against: a
-// component's App Path (where its workload.yaml lives) and the OC resource refs
-// its design declares. Primitives only, so this package names no design entity.
+// component's App Path (where its workload.yaml lives) and the wiring its design
+// declares, one field per workload `dependencies:` sub-block. Primitives only, so
+// this package names no design entity.
 type ComponentResources struct {
 	AppPath string
-	Refs    []string
+	// Refs are the OC resource refs the design declares — the expected
+	// `dependencies.resources[].ref` values.
+	Refs []string
+	// EndpointTargets are the SCOPED provider component names the design declares
+	// — the expected `dependencies.endpoints[].component` values.
+	//
+	// Unlike Refs, these are checked for the value as well as the presence. A
+	// missing ref leaves the agent with nothing wired and something eventually
+	// notices; a WRONG endpoint target is the quiet one — it parses, renders,
+	// deploys and serves, and only the ReleaseBinding's Ready condition ever
+	// disagrees.
+	EndpointTargets []string
 }
 
 // WorkloadReader reads a file from the project repo at HEAD of the default
@@ -171,11 +183,12 @@ type DesignReader interface {
 	// therefore matches any change. Nil when the project has no design.
 	ComponentPaths(ctx context.Context, orgID, projectID string) (map[string]string, error)
 
-	// DeclaredResources returns, per component, the OC resource refs its design
-	// says it consumes — read off each dependency's platform-stamped `wiring`.
-	// A dependency with no wiring contributes nothing: it is not derivable yet,
-	// so the agent could not have wired it and it is not the agent's defect.
-	// Keyed by the component's design name, like ComponentPaths.
+	// DeclaredResources returns, per component, the wiring its design says it
+	// consumes — read off each dependency's platform-stamped `wiring`, resource
+	// refs and endpoint targets alike. A dependency with no wiring contributes
+	// nothing: it is not derivable yet, so the agent could not have wired it and
+	// it is not the agent's defect. Keyed by the component's design name, like
+	// ComponentPaths.
 	DeclaredResources(ctx context.Context, orgID, projectID string) (map[string]ComponentResources, error)
 }
 

--- a/services/aep-api/internal/delivery/run/activities.go
+++ b/services/aep-api/internal/delivery/run/activities.go
@@ -42,6 +42,7 @@ type Activities struct {
 	builds     BuildReader
 	validation ValidationCoordinator
 	dispatcher delivery.MilestoneDispatcher
+	apiTraits  APITraitSyncer
 }
 
 // Deps carries the activity adapters. runs/cycles/milestones are required; the
@@ -55,6 +56,7 @@ type Deps struct {
 	Builds     BuildReader
 	Validation ValidationCoordinator
 	Dispatcher delivery.MilestoneDispatcher
+	APITraits  APITraitSyncer
 }
 
 // NewActivities wires the activity adapters.
@@ -68,6 +70,7 @@ func NewActivities(d Deps) *Activities {
 		builds:     d.Builds,
 		validation: d.Validation,
 		dispatcher: d.Dispatcher,
+		apiTraits:  d.APITraits,
 	}
 }
 
@@ -336,6 +339,42 @@ func (a *Activities) PollCycleBuilds(ctx context.Context, in CycleBuildsInput) (
 		}
 	}
 	return out, nil
+}
+
+// ---- managed-API traits -----------------------------------------------------
+
+// ProjectRef names the project an activity acts on, for the activities whose
+// scope is the whole project rather than one milestone or one cycle.
+type ProjectRef struct {
+	OrgID     string `json:"orgId"`
+	ProjectID string `json:"projectId"`
+}
+
+// SyncAPITraits lands the per-environment `api-configuration` trait config on
+// every protected component's ReleaseBinding in the project.
+//
+// Called once per cycle at builds-green, which is the earliest point in a run
+// where the write target exists: OpenChoreo creates the ReleaseBinding from the
+// workload the build's last step generates, so before green there may be
+// nothing to patch. The supervisor observes green on a poll up to
+// buildPollInterval after the WorkflowRun actually completed, by which time the
+// deploy chain has long since produced the binding.
+//
+// Degrades to "nothing to do" when unwired, like the other optional
+// collaborators: a deployment with no trait emitter has no managed-API policy
+// to converge, which is a legitimate configuration rather than a failed run.
+func (a *Activities) SyncAPITraits(ctx context.Context, in ProjectRef) error {
+	if a.apiTraits == nil {
+		return nil
+	}
+	if err := a.apiTraits.SyncProjectAPITraits(ctx, in.OrgID, in.ProjectID); err != nil {
+		// Logged here as well as returned: Temporal retries this activity, and the
+		// per-attempt cause is otherwise only visible in workflow history.
+		slog.ErrorContext(ctx, "run: managed-API trait sync failed",
+			"orgID", in.OrgID, "projectID", in.ProjectID, "error", err)
+		return err
+	}
+	return nil
 }
 
 // ---- validation ------------------------------------------------------------

--- a/services/aep-api/internal/delivery/run/cycle.go
+++ b/services/aep-api/internal/delivery/run/cycle.go
@@ -118,7 +118,19 @@ func (l *loop) runCycle(ctx workflow.Context, kind string, anchorIssue int) (cyc
 		return cycleNone, err
 	}
 	l.st.Phase = delivery.RunPhaseBuilding
-	return l.awaitBuilds(ctx)
+	res, err = l.awaitBuilds(ctx)
+	if err != nil {
+		return cycleNone, err
+	}
+	if res == cycleGreen {
+		// Green is the first moment the managed-API trait config has somewhere to
+		// land: OpenChoreo builds the ReleaseBinding that carries it out of the
+		// workload the build's last step generates. Deliberately not on the red
+		// path — a component that did not build has no new binding to converge,
+		// and the fix cycle that follows will pass through here again.
+		l.syncAPITraits(ctx)
+	}
+	return res, nil
 }
 
 // dispatchUntilLanded spends the cycle's re-dispatch budget trying to land a

--- a/services/aep-api/internal/delivery/run/ports.go
+++ b/services/aep-api/internal/delivery/run/ports.go
@@ -151,3 +151,21 @@ type ValidationCoordinator interface {
 type Dispatcher interface {
 	Dispatch(ctx context.Context, req delivery.MilestoneDispatch) (jobRef string, err error)
 }
+
+// APITraitSyncer lands the per-environment `api-configuration` trait config —
+// the `jwtAuth` policy the gateway enforces and the sibling-SPA CORS allowlist
+// — on each protected component's ReleaseBinding. projects.TraitSyncService
+// satisfies it.
+//
+// Why the supervisor drives this at all: the config's write target is the
+// ReleaseBinding, which OpenChoreo creates only once a build has produced a
+// workload. The Component CR's trait SHAPE is set far earlier (at component
+// ensure, pre-build) and is what makes OpenChoreo render the RestApi; this is
+// the other half, and it cannot be written before the deploy chain has run.
+// Builds settling green is the first moment in the run where that is true.
+//
+// Idempotent and convergent: re-running it re-asserts the same desired state,
+// so a cycle that syncs twice costs a round trip and changes nothing.
+type APITraitSyncer interface {
+	SyncProjectAPITraits(ctx context.Context, orgID, projectID string) error
+}

--- a/services/aep-api/internal/delivery/run/workflow.go
+++ b/services/aep-api/internal/delivery/run/workflow.go
@@ -47,6 +47,13 @@ const (
 	// "the agent died" (including a Job that exited without opening a pull
 	// request) is a named failure class with a named budget.
 	cycleLandingTimeout = 2 * time.Hour
+
+	// traitSyncTimeout bounds the WHOLE managed-API trait sync including its
+	// retries. It is bounded rather than left to Temporal's unlimited default
+	// because the sync is a convergence step, not a step the version depends on:
+	// a cycle must not hang on it. See syncAPITraits for what happens when it
+	// runs out.
+	traitSyncTimeout = 5 * time.Minute
 )
 
 // RunInput starts a supervisor over one milestone. Everything in it is already
@@ -500,4 +507,42 @@ func dispatchActivityCtx(ctx workflow.Context) workflow.Context {
 		StartToCloseTimeout: activityTimeout,
 		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
 	})
+}
+
+// traitSyncActivityCtx retries the managed-API trait sync under an overall
+// deadline. Retries are wanted — the failures this sees are transient
+// OpenChoreo round trips, and the previous owner of this write dropped them
+// silently — but they are bounded, because no part of delivering the version
+// depends on the answer.
+func traitSyncActivityCtx(ctx workflow.Context) workflow.Context {
+	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout:    activityTimeout,
+		ScheduleToCloseTimeout: traitSyncTimeout,
+	})
+}
+
+// syncAPITraits converges the managed-API gateway policy for the project after
+// a cycle's builds go green.
+//
+// It NEVER fails the cycle. The reason is not that the write is unimportant —
+// an unset `jwtAuth` leaves a protected API's gateway passing every request
+// through unauthenticated — but that failing here would not undo it: the
+// component is already deployed and serving by the time this runs, so a red
+// cycle would add noise without removing exposure. Only convergence removes it,
+// which is why the outcome is logged loudly and left to be re-asserted.
+//
+// This is the interim trigger. It is coupled to THIS build rail, which is
+// exactly how its predecessor died — the trait sync used to hang off the
+// ExecWatcher's build terminal, and stopped firing the moment builds moved to
+// this loop and stopped writing the execution rows that watcher reads. A
+// rail-agnostic reconcile sweep is what makes the guarantee; this only makes it
+// prompt.
+func (l *loop) syncAPITraits(ctx workflow.Context) {
+	err := workflow.ExecuteActivity(traitSyncActivityCtx(ctx), (*Activities).SyncAPITraits,
+		ProjectRef{OrgID: l.in.OrgID, ProjectID: l.in.ProjectID}).Get(ctx, nil)
+	if err != nil {
+		workflow.GetLogger(ctx).Error(
+			"managed-API trait sync did not converge; protected APIs in this project may be serving unauthenticated",
+			"orgID", l.in.OrgID, "projectID", l.in.ProjectID, "error", err)
+	}
 }

--- a/services/aep-api/internal/delivery/run/workflow_test.go
+++ b/services/aep-api/internal/delivery/run/workflow_test.go
@@ -17,6 +17,7 @@
 package run
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -67,6 +68,9 @@ type harness struct {
 	states     []string
 	settle     SettleRunInput
 	verdicts   []string
+	// traitSyncs records every managed-API trait convergence the loop asked for,
+	// so a test can assert WHEN it fires rather than merely that it was wired.
+	traitSyncs []ProjectRef
 	// verdictWrites keeps the full payload so a test can assert on what was
 	// PERSISTED (verdict + issue), not merely on the verdict the run returned.
 	verdictWrites []SetValidationVerdictInput
@@ -97,6 +101,7 @@ func newHarness(t *testing.T) *harness {
 	h.env.RegisterActivity(acts.EnsureValidationIssue)
 	h.env.RegisterActivity(acts.ReadValidationVerdict)
 	h.env.RegisterActivity(acts.DispatchAgent)
+	h.env.RegisterActivity(acts.SyncAPITraits)
 
 	h.env.OnActivity(acts.SetRunState, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -142,6 +147,27 @@ func newHarness(t *testing.T) *harness {
 		}).Return("job-1", nil)
 
 	return h
+}
+
+// traitSyncIs pins what the managed-API convergence answers. Registered per
+// test rather than as a constructor default so a test can make it fail — the
+// harness consumes expectations in registration order, so an unlimited default
+// set in newHarness would swallow the override.
+func (h *harness) traitSyncIs(err error) {
+	h.set["traits"] = true
+	h.env.OnActivity(h.acts.SyncAPITraits, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			h.traitSyncs = append(h.traitSyncs, args.Get(1).(ProjectRef))
+		}).Return(err)
+}
+
+// traitSyncCount is the convergence tally, read safely.
+func (h *harness) traitSyncCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.traitSyncs)
 }
 
 // milestoneIs queues the cycle-boundary polls, in order. The last one repeats
@@ -201,6 +227,9 @@ func (h *harness) applyDefaults() {
 	}
 	if !h.set["milestone"] {
 		h.milestoneIs(MilestoneSnapshot{})
+	}
+	if !h.set["traits"] {
+		h.traitSyncIs(nil)
 	}
 }
 
@@ -334,6 +363,69 @@ func TestFixCycle_RedBuildBecomesTheNextCyclesWork(t *testing.T) {
 
 	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
 	require.Equal(t, []string{delivery.CycleKindCoding, delivery.CycleKindFix}, h.dispatchKinds())
+}
+
+// TestBuildsGreen_ConvergesTheManagedAPIGatewayPolicy pins the trigger this
+// loop now owns. The `api-configuration` trait's per-environment half — the
+// `jwtAuth` policy the gateway enforces — is written to the ReleaseBinding,
+// which OpenChoreo creates from the workload the build's last step generates.
+// Builds going green is therefore the first moment in a run where the write has
+// a target, and the loop must take it: nothing else on this rail does, which is
+// how protected APIs came to serve unauthenticated.
+func TestBuildsGreen_ConvergesTheManagedAPIGatewayPolicy(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(MilestoneSnapshot{Work: 1, Total: 1}, MilestoneSnapshot{})
+	h.merges(1)
+
+	h.run(delivery.RunOriginSpecBuild, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+	require.Equal(t, []ProjectRef{{OrgID: testOrg, ProjectID: testProject}}, h.traitSyncs,
+		"a green cycle converges the project's managed-API policy exactly once")
+}
+
+// TestRedBuild_ConvergesOnlyOnceItGoesGreen: a red cycle produced no new
+// ReleaseBinding, so there is nothing to converge and the loop must not spend a
+// round trip pretending otherwise. The fix cycle that follows passes through the
+// same green path and does the write then.
+func TestRedBuild_ConvergesOnlyOnceItGoesGreen(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(
+		MilestoneSnapshot{Work: 1, Total: 1},
+		MilestoneSnapshot{Work: 1, Total: 1},
+		MilestoneSnapshot{},
+	)
+	h.buildsAre(
+		CycleBuildState{Expected: 1, Settled: 1, Red: []string{"order-service"}},
+		CycleBuildState{Expected: 1, Settled: 1},
+	)
+	h.merges(2)
+
+	h.run(delivery.RunOriginSpecBuild, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+	require.Equal(t, 1, h.traitSyncCount(),
+		"only the green cycle converges; the red one had no binding to write to")
+}
+
+// TestTraitSyncFailure_DoesNotFailTheRun pins the deliberate asymmetry: the
+// convergence is retried under its own deadline, but its exhaustion is logged,
+// not fatal. Failing the cycle would not undo the exposure — the component is
+// already deployed and serving by the time this runs — so a red run would add
+// noise without removing it. Only a later convergence removes it.
+func TestTraitSyncFailure_DoesNotFailTheRun(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(MilestoneSnapshot{Work: 1, Total: 1}, MilestoneSnapshot{})
+	h.traitSyncIs(errors.New("openchoreo unreachable"))
+	h.merges(1)
+
+	h.run(delivery.RunOriginSpecBuild, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+	require.Positive(t, h.traitSyncCount(), "the convergence was attempted")
 }
 
 // TestConflictCycle_AnUnmergeablePRBecomesTheNextCyclesWork is the same shape

--- a/services/aep-api/internal/dependencies/provisioning/wiring.go
+++ b/services/aep-api/internal/dependencies/provisioning/wiring.go
@@ -274,15 +274,20 @@ func (s *Service) resolveDependenciesYAML(ctx context.Context, orgID, projectID 
 				Component:   target.Component,
 				Name:        target.Name,
 				Visibility:  "namespace",
-				EnvBindings: map[string]string{"address": orgServiceURLEnv(name)},
+				EnvBindings: map[string]string{spec.EndpointAddressOutput: orgServiceURLEnv(name)},
 			})
 			contractSections = append(contractSections, orgServiceContractSection(name, target))
 		}
 		// same-project component siblings (visibility project). The sibling's OC
-		// component name is `<project>-<logicalName>`; the env var keys on the
-		// LOGICAL dep name. Project is omitted (same project).
+		// component name is the SCOPED one; the env var keys on the LOGICAL dep
+		// name. Project is omitted (same project).
+		//
+		// Both values are now stamped into design.json at design save
+		// (spec/derive_wiring.go), so this path is no longer the only source for
+		// them — it re-states them for a reader of the issue thread, and still
+		// carries the consumed-contract guidance below, which is not derivable.
 		for _, depName := range comp.ComponentDependsOn() {
-			ocComponent := projectID + "-" + depName
+			ocComponent := ocname.ScopedComponentName(projectID, depName)
 			target, ok, rerr := s.providers.ResolveProjectEndpoint(ctx, orgID, projectID, ocComponent)
 			if rerr != nil {
 				return "", "", false, fmt.Errorf("resolve same-project component %q: %w", depName, rerr)
@@ -294,8 +299,8 @@ func (s *Service) resolveDependenciesYAML(ctx context.Context, orgID, projectID 
 			deps.Endpoints = append(deps.Endpoints, workloadEndpointDepYAML{
 				Component:   target.Component,
 				Name:        target.Name,
-				Visibility:  "project",
-				EnvBindings: map[string]string{"address": orgServiceURLEnv(depName)},
+				Visibility:  spec.EndpointVisibilityProject,
+				EnvBindings: map[string]string{spec.EndpointAddressOutput: orgServiceURLEnv(depName)},
 			})
 			contractSections = append(contractSections, localComponentContractSection(depName))
 		}
@@ -373,18 +378,10 @@ func externalSpecContractSection(depName, specPath string) string {
 	)
 }
 
-// orgServiceURLEnv mirrors endpoints.OrgServiceURLEnv: <UPPER_SNAKE>_URL (a local
-// copy keeps this feature's edge to dependencies/endpoints out). e.g.
-// "employee-api" → "EMPLOYEE_API_URL".
+// orgServiceURLEnv is <UPPER_SNAKE>_URL — the env var a consumer reads a
+// provider's base URL from. Delegates to ocname.ServiceURLEnvName so this comment
+// and the `address` binding spec stamps into design.json cannot drift apart.
+// e.g. "employee-api" → "EMPLOYEE_API_URL".
 func orgServiceURLEnv(name string) string {
-	return envVarName(name, "") + "URL"
-}
-
-// envVarName builds a valid C_IDENTIFIER env-var name from a dep name + output
-// name. Delegates to ocname.EnvVarName — the single source of truth shared
-// with runtimeconfig's window._env_ keys, so the pod env var and the SPA config
-// key for the same dep+output are byte-identical. "orders-db" + "host" →
-// "ORDERS_DB_HOST".
-func envVarName(depName, outName string) string {
-	return ocname.EnvVarName(depName, outName)
+	return ocname.ServiceURLEnvName(name)
 }

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
@@ -305,9 +305,9 @@ func Test_platformResourceDeps(t *testing.T) {
 // --- naming consistency ------------------------------------------------------
 
 // Test_outputKeyNaming_matchesWiringConvention pins the window._env_ key naming
-// to the SAME helper wiring.go injects pod env vars with (resources.EnvVarName —
-// the single source of truth). A guarding white-box test lives beside wiring.go
-// (provisioning) asserting its envVarName delegates to this same helper.
+// to the SAME helper wiring.go injects pod env vars with (ocname.EnvVarName — the
+// single source of truth every consumer now calls directly, so the browser's
+// window._env_ key and the pod env var for one dep+output cannot drift).
 func Test_outputKeyNaming_matchesWiringConvention(t *testing.T) {
 	t.Parallel()
 	cases := []struct{ dep, out, want string }{

--- a/services/aep-api/internal/platform/agentfold/designgate.go
+++ b/services/aep-api/internal/platform/agentfold/designgate.go
@@ -229,11 +229,17 @@ func validateDependency(i int, d any) *designProblem {
 	return nil
 }
 
-// validateDependencyWiring mirrors the zod dependencyWiringSchema.strictObject:
-// when present, `wiring` carries a non-empty `ref` plus an `envBindings` object
-// of string values, and nothing else. Both halves are required together — a ref
-// with no bindings (or bindings with no ref) renders an unusable workload.yaml
-// resource entry, which is worse than an absent wiring the agent reports.
+// validateDependencyWiring mirrors the zod dependencyWiringSchema union: when
+// present, `wiring` is EXACTLY ONE of two variants, each carrying only its own
+// keys —
+//
+//	{ref, envBindings}  — one workload dependencies.resources[] entry
+//	{endpoint}          — one workload dependencies.endpoints[] entry
+//
+// Every field of a variant is required together. A half-stamped wiring (a ref with
+// no bindings, an endpoint with no component) renders a workload.yaml entry
+// OpenChoreo silently ignores, which is worse than an absent wiring the agent
+// reports as a platform fault.
 func validateDependencyWiring(i int, raw any) *designProblem {
 	if raw == nil {
 		return nil // absent (optional) — not yet derivable
@@ -245,6 +251,18 @@ func validateDependencyWiring(i int, raw any) *designProblem {
 	if !ok {
 		return violation(": must be an object")
 	}
+	_, hasEndpoint := wiring["endpoint"]
+	if hasEndpoint {
+		// The variants are exclusive: one dependency resolves to a resource or to
+		// an endpoint, never both, so a mixed object is a defect and not a
+		// tolerable superset.
+		for k := range wiring {
+			if k != "endpoint" {
+				return violation(": %s cannot be combined with endpoint — a dependency wires to a resource or to an endpoint, not both", k)
+			}
+		}
+		return validateEndpointWiring(violation, wiring["endpoint"])
+	}
 	for k := range wiring {
 		if k != "ref" && k != "envBindings" {
 			return violation(": unknown property %s", k)
@@ -253,13 +271,42 @@ func validateDependencyWiring(i int, raw any) *designProblem {
 	if ref, ok := wiring["ref"].(string); !ok || ref == "" {
 		return violation(".ref: must be a non-empty string")
 	}
-	bindings, ok := wiring["envBindings"].(map[string]any)
+	return validateEnvBindings(violation, ".envBindings", wiring["envBindings"])
+}
+
+// validateEndpointWiring mirrors the zod endpointWiringSchema.strictObject: the
+// scoped provider component, its endpoint name, the target's visibility, and the
+// address binding — all required, nothing else.
+func validateEndpointWiring(violation func(string, ...any) *designProblem, raw any) *designProblem {
+	endpoint, ok := raw.(map[string]any)
 	if !ok {
-		return violation(".envBindings: must be an object")
+		return violation(".endpoint: must be an object")
+	}
+	for k := range endpoint {
+		switch k {
+		case "component", "name", "visibility", "envBindings":
+		default:
+			return violation(".endpoint: unknown property %s", k)
+		}
+	}
+	for _, field := range []string{"component", "name", "visibility"} {
+		if v, ok := endpoint[field].(string); !ok || v == "" {
+			return violation(".endpoint.%s: must be a non-empty string", field)
+		}
+	}
+	return validateEnvBindings(violation, ".endpoint.envBindings", endpoint["envBindings"])
+}
+
+// validateEnvBindings is the output→env-var map both variants carry: an object of
+// string values. Shared so the two variants cannot drift on what a binding is.
+func validateEnvBindings(violation func(string, ...any) *designProblem, path string, raw any) *designProblem {
+	bindings, ok := raw.(map[string]any)
+	if !ok {
+		return violation("%s: must be an object", path)
 	}
 	for k, v := range bindings {
 		if _, ok := v.(string); !ok {
-			return violation(".envBindings.%s: must be a string", k)
+			return violation("%s.%s: must be a string", path, k)
 		}
 	}
 	return nil

--- a/services/aep-api/internal/platform/agentfold/designgate_test.go
+++ b/services/aep-api/internal/platform/agentfold/designgate_test.go
@@ -209,6 +209,8 @@ func TestValidateComponentDesign_Wiring(t *testing.T) {
 	}{
 		{"platform-stamped shape", `{ "ref": "shop-orders-db", "envBindings": { "host": "ORDERS_DB_HOST", "port": "ORDERS_DB_PORT" } }`},
 		{"no outputs bound yet", `{ "ref": "shop-orders-db", "envBindings": {} }`},
+		// The endpoints[] variant: a sibling component's endpoint, scoped for OC.
+		{"sibling endpoint variant", `{ "endpoint": { "component": "todo-api99-todo-api", "name": "http", "visibility": "project", "envBindings": { "address": "TODO_API_URL" } } }`},
 	}
 	for _, tc := range accept {
 		t.Run("accept/"+tc.name, func(t *testing.T) {
@@ -229,6 +231,18 @@ func TestValidateComponentDesign_Wiring(t *testing.T) {
 		{"envBindings not an object", `{ "ref": "shop-orders-db", "envBindings": "ORDERS_DB_HOST" }`},
 		{"env var not a string", `{ "ref": "shop-orders-db", "envBindings": { "port": 5432 } }`},
 		{"unknown property", `{ "ref": "shop-orders-db", "envBindings": {}, "values": { "host": "db" } }`},
+		// The endpoints[] variant is all-or-nothing too, and exclusive with the
+		// resources[] one: a partial or mixed entry is silently ignored by
+		// OpenChoreo, which is the failure mode this whole field exists to end.
+		{"endpoint not an object", `{ "endpoint": "todo-api99-todo-api" }`},
+		{"endpoint component missing", `{ "endpoint": { "name": "http", "visibility": "project", "envBindings": { "address": "TODO_API_URL" } } }`},
+		{"endpoint component empty", `{ "endpoint": { "component": "", "name": "http", "visibility": "project", "envBindings": {} } }`},
+		{"endpoint name missing", `{ "endpoint": { "component": "todo-api99-todo-api", "visibility": "project", "envBindings": {} } }`},
+		{"endpoint visibility missing", `{ "endpoint": { "component": "todo-api99-todo-api", "name": "http", "envBindings": {} } }`},
+		{"endpoint envBindings missing", `{ "endpoint": { "component": "todo-api99-todo-api", "name": "http", "visibility": "project" } }`},
+		{"endpoint env var not a string", `{ "endpoint": { "component": "todo-api99-todo-api", "name": "http", "visibility": "project", "envBindings": { "address": 8080 } } }`},
+		{"endpoint unknown property", `{ "endpoint": { "component": "todo-api99-todo-api", "name": "http", "visibility": "project", "envBindings": {}, "project": "todo-api99" } }`},
+		{"both variants at once", `{ "ref": "shop-orders-db", "envBindings": {}, "endpoint": { "component": "todo-api99-todo-api", "name": "http", "visibility": "project", "envBindings": {} } }`},
 	}
 	for _, tc := range reject {
 		t.Run("reject/"+tc.name, func(t *testing.T) {

--- a/services/aep-api/internal/platform/designspec/component-design.schema.json
+++ b/services/aep-api/internal/platform/designspec/component-design.schema.json
@@ -150,27 +150,73 @@
             }
           },
           "wiring": {
-            "type": "object",
-            "properties": {
-              "ref": {
-                "type": "string",
-                "minLength": 1
-              },
-              "envBindings": {
+            "anyOf": [
+              {
                 "type": "object",
-                "propertyNames": {
-                  "type": "string"
+                "properties": {
+                  "ref": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "envBindings": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
                 },
-                "additionalProperties": {
-                  "type": "string"
-                }
+                "required": [
+                  "ref",
+                  "envBindings"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "object",
+                    "properties": {
+                      "component": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "visibility": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "envBindings": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "component",
+                      "name",
+                      "visibility",
+                      "envBindings"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ],
+                "additionalProperties": false
               }
-            },
-            "required": [
-              "ref",
-              "envBindings"
-            ],
-            "additionalProperties": false
+            ]
           }
         },
         "required": [

--- a/services/aep-api/internal/platform/ocname/naming.go
+++ b/services/aep-api/internal/platform/ocname/naming.go
@@ -14,9 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package ocname is the OpenChoreo resource-naming vocabulary: the Resource and
-// binding names AEP derives for a project's external and platform resources, and
-// the env-var names a consumer reads their outputs from.
+// Package ocname is the OpenChoreo naming vocabulary: the Resource and binding
+// names AEP derives for a project's external and platform resources, the scoped
+// component name OC identifies a component by, and the env-var names a consumer
+// reads their outputs from.
 //
 // It lives in the kernel rather than in the dependencies domain because TWO
 // domains derive the same names and must agree byte-for-byte: dependencies
@@ -103,6 +104,43 @@ func EnvVarName(depName, outName string) string {
 		}
 	}, joined)
 	return strings.ToUpper(mapped)
+}
+
+// ScopedComponentName is the k8s metadata name OC uses for a component. OC
+// components across every project in an org share a single k8s namespace, so two
+// projects cannot hold the same component name unless we disambiguate; the
+// project prefixes the name, and the user's original name survives as the
+// display-name annotation.
+//
+// It lives here, beside EnvVarName, for the same reason: THREE call sites derive
+// this name and must agree byte-for-byte — the OC client at the API boundary,
+// provisioning when it resolves a sibling's endpoint dependency, and spec when it
+// stamps that sibling's `component` into design.json at design save. The third is
+// what makes the shared home necessary: a sibling endpoint dependency that names
+// the FRIENDLY component resolves to nothing in OpenChoreo (the binding lookup is
+// by scoped name), so the consumer's ReleaseBinding never reaches Ready and the
+// platform reports "deploying" forever.
+//
+// Callers must always pass the friendly component name (never an already-scoped
+// name) — scope exactly once.
+func ScopedComponentName(projectName, componentName string) string {
+	if projectName == "" {
+		return componentName
+	}
+	return projectName + "-" + componentName
+}
+
+// ServiceURLEnvName is the env var a consumer reads a provider component's
+// resolved base URL from — the `envBindings.address` value on a workload
+// `dependencies.endpoints[]` entry. Keyed on the LOGICAL dependency name (never
+// the scoped component name), so the env var the coding agent codes against does
+// not change when the OC scoping rule does: "todo-api" → "TODO_API_URL".
+//
+// Shared for the same byte-for-byte reason as EnvVarName: provisioning binds this
+// name into the pod env, spec stamps it into design.json, and runtimeconfig emits
+// it as a window._env_ key for a browser app.
+func ServiceURLEnvName(depName string) string {
+	return EnvVarName(depName, "URL")
 }
 
 // ExternalResourceName is the per-project OC Resource name (== the Workload

--- a/services/aep-api/internal/platform/ocname/naming_test.go
+++ b/services/aep-api/internal/platform/ocname/naming_test.go
@@ -21,6 +21,40 @@ import (
 	"testing"
 )
 
+// TestScopedComponentName pins the sibling-endpoint `component` value against the
+// LIVE OpenChoreo lookup key. A friendly name here is the whole "deploying
+// forever" bug: OC resolves a workload endpoint dependency by scoped name, so
+// `todo-api` matched no ReleaseBinding and the consumer's Ready condition never
+// flipped.
+func TestScopedComponentName(t *testing.T) {
+	t.Parallel()
+
+	if got := ScopedComponentName("todo-api99", "todo-api"); got != "todo-api99-todo-api" {
+		t.Errorf("ScopedComponentName = %q, want todo-api99-todo-api", got)
+	}
+	// No project ⇒ nothing to disambiguate against; the name passes through.
+	if got := ScopedComponentName("", "todo-api"); got != "todo-api" {
+		t.Errorf("ScopedComponentName with no project = %q, want todo-api", got)
+	}
+}
+
+// TestServiceURLEnvName pins the `address` binding to the key a browser app's
+// window._env_ already carries, so the coding agent's workload.yaml and the SPA
+// config name the same variable.
+func TestServiceURLEnvName(t *testing.T) {
+	t.Parallel()
+
+	for dep, want := range map[string]string{
+		"todo-api":     "TODO_API_URL",
+		"orders":       "ORDERS_URL",
+		"employee-api": "EMPLOYEE_API_URL",
+	} {
+		if got := ServiceURLEnvName(dep); got != want {
+			t.Errorf("ServiceURLEnvName(%q) = %q, want %q", dep, got, want)
+		}
+	}
+}
+
 func TestExternalResourceNaming(t *testing.T) {
 	t.Parallel()
 

--- a/services/aep-api/internal/projects/trait_sync.go
+++ b/services/aep-api/internal/projects/trait_sync.go
@@ -41,14 +41,32 @@ type OrgPublisher interface {
 
 // TraitSyncService is the single shared emitter for `api-configuration`
 // trait state on a Component CR + its per-environment ReleaseBindings.
-// See docs/design/api-platform-integration.md section 6.
 //
-// Two write triggers call SyncComponentTraits:
-//  1. Dispatch path (`dispatch_service.go`): after CreateComponent so a
-//     newly-protected component lands with traits set immediately.
-//  2. Design edit path (`design_service.UpdateDesignFile`): after the
-//     user toggles `exposesAPI.auth` on `design.json` so the trait shape
-//     propagates without waiting for the next dispatch.
+// The two halves of that state are written at different times, because they
+// have different write targets:
+//
+//  1. The Component CR's trait SHAPE — which is what makes OpenChoreo render
+//     the RestApi at all — is set at component create by
+//     `component_service.go`, from the same `exposesAPI.auth` this service
+//     reads. That happens before the first build, and this service re-asserts
+//     it on every reconcile.
+//  2. The per-environment config — the `jwtAuth` policy the gateway enforces
+//     and the sibling-SPA CORS allowlist — lands on the ReleaseBinding, which
+//     OpenChoreo creates only once a build has produced a workload. It cannot
+//     be written before then; UpdateComponentTraitEnvironmentConfigs soft
+//     no-ops when the binding is absent.
+//
+// The trigger for (2) is `SyncProjectAPITraits`, called by the run
+// supervisor when a cycle's builds go green (`delivery/run`, activity
+// SyncAPITraits). That trigger is rail-coupled ON PURPOSE-FOR-NOW and it is
+// the known weak point: the previous trigger hung off the ExecWatcher's build
+// terminal and stopped firing — silently, for every project — when builds
+// moved to the Temporal run loop, which writes no `kind=build` execution rows
+// for that watcher to read. A missed write leaves a protected API's gateway
+// passing every request through unauthenticated, so a rail-agnostic reconcile
+// sweep over the component list is what should ultimately make the guarantee.
+// `traitDeployObserver` still routes the old ExecWatcher path here; it is
+// inert for anything the run loop builds.
 //
 // Concurrency: every call acquires a per-component mutex keyed by
 // `(orgID, projectID, componentName)`. We use a `sync.Map` of `*sync.Mutex`

--- a/services/aep-api/internal/spec/derive.go
+++ b/services/aep-api/internal/spec/derive.go
@@ -166,6 +166,15 @@ func snapshotDerived(c DesignComponent) derivedState {
 		if d.Wiring != nil {
 			v := *d.Wiring
 			v.EnvBindings = maps.Clone(d.Wiring.EnvBindings)
+			// The endpoints[] variant is a POINTER on the copied struct, so the
+			// shallow copy above still shares it. Clone it too, or a later
+			// in-place derivation mutates the "before" snapshot through it and the
+			// diff can never see an endpoint change.
+			if d.Wiring.Endpoint != nil {
+				ep := *d.Wiring.Endpoint
+				ep.EnvBindings = maps.Clone(d.Wiring.Endpoint.EnvBindings)
+				v.Endpoint = &ep
+			}
 			st.wiring[d.Name] = &v
 		}
 	}

--- a/services/aep-api/internal/spec/derive_wiring.go
+++ b/services/aep-api/internal/spec/derive_wiring.go
@@ -38,11 +38,34 @@ import "github.com/wso2/aep/aep-api/internal/platform/ocname"
 // So it is derived HERE, at design save, and committed into design.json next to
 // the dependency it belongs to — the same artifact, in the same tree, that the
 // agent already reads as its spec. No ordering, no audience, no idempotency
-// marker. What genuinely needs live resolution (a cross-project org-service
-// endpoint, a sibling's endpoint name) keeps its dispatch-time channel.
+// marker. Only a cross-project org-service endpoint still needs live resolution
+// (its project, component and visibility are another project's business) and
+// keeps its dispatch-time channel.
 //
-// Two kinds carry wiring, with two different output vocabularies:
+// A SIBLING'S ENDPOINT is derived here too, for exactly the same reason, and the
+// bug that proved it was worse than the SQLite one because it produced a value
+// that LOOKED right. Every field is a pure function of the design:
 //
+//	component   = ScopedComponentName(project, depName)     — deterministic
+//	name        = the sibling's own EndpointName()          — read from its design
+//	visibility  = "project"                                 — same project
+//	envBindings = {address: ServiceURLEnvName(depName)}     — pure string work
+//
+// It was nonetheless resolved from the LIVE endpoint catalog at dispatch, and that
+// catalog only lists components which have already DEPLOYED. On a first delivery,
+// where siblings are coded in one cycle before anything runs, it could answer
+// nothing — so the comment was never posted and the agent invented `component`. It
+// wrote the FRIENDLY name; OpenChoreo resolves endpoint dependencies by SCOPED
+// name, matched no binding, and left the consumer at `Ready=False /
+// ConnectionsPending`. Nothing crashed — the release still rendered and applied,
+// minus the address env var — so the only symptom was a project reporting
+// "deploying" forever. Deriving it here is what makes a first delivery work
+// without a second build to fix it up.
+//
+// Three kinds carry wiring, with three different output vocabularies:
+//
+//   - component — resolves to a sibling's ENDPOINT, not to resource outputs, so it
+//     carries the endpoints[] variant and one `address` binding.
 //   - platform-resource — outputs are generic (host, port, …), so the env var is
 //     prefixed with the dependency name. They come off the ClusterResourceType,
 //     which is why this derivation needs the catalog at all.
@@ -50,13 +73,14 @@ import "github.com/wso2/aep/aep-api/internal/platform/ocname"
 //     by the schema the design itself declares, so the env var IS the key and no
 //     catalog read is involved.
 //
-// Both mirror what provisioning's bindingEnvBindings does at wiring time, and
-// both route through ocname (the shared naming source of truth in the kernel) so
-// the pod env var, the SPA's window._env_ key and design.json cannot drift.
+// Each mirrors what provisioning emits at wiring time, and all route through
+// ocname (the shared naming source of truth in the kernel) so the pod env var, the
+// SPA's window._env_ key and design.json cannot drift.
 
 // deriveDependencyWiring stamps the resolved consumer-side wiring on every
-// platform-resource and external dependency in components, and mutates them in
-// place. projectID is the OC-Resource name prefix (the ref's project half).
+// component, platform-resource and external dependency in components, and mutates
+// them in place. projectID is the OC name prefix (the ref's and the scoped
+// component name's project half).
 //
 // It OVERWRITES an existing wiring rather than preserving it: the value is
 // derived, so a dependency rename, a config-key edit or a resource type gaining
@@ -66,26 +90,35 @@ import "github.com/wso2/aep/aep-api/internal/platform/ocname"
 //
 // A dependency it cannot derive wiring for has its wiring REMOVED, not left
 // stale: absent means "not derivable yet" (an unknown resourceType, an external
-// dep with no config keys), and a stale value is worse than none — the agent
-// would author a workload.yaml that binds env vars the binding never exposes.
-// The coding agent treats a declared-but-unwired dependency as a platform fault
-// and reports it, which is the loud failure the old silent path lacked.
+// dep with no config keys, a sibling the design does not declare), and a stale
+// value is worse than none — the agent would author a workload.yaml that binds env
+// vars the binding never exposes. The coding agent treats a declared-but-unwired
+// dependency as a platform fault and reports it, which is the loud failure the old
+// silent path lacked.
 func deriveDependencyWiring(components []DesignComponent, types map[string]CRTType, projectID string) {
+	// A sibling's endpoint name comes off the SIBLING's design, so index the set
+	// once before walking the dependencies that point into it.
+	endpointNames := make(map[string]string, len(components))
+	for _, c := range components {
+		endpointNames[c.Name] = c.EndpointName()
+	}
 	for i := range components {
 		deps := components[i].Dependencies
 		for j := range deps {
-			deps[j].Wiring = dependencyWiring(deps[j], types, projectID)
+			deps[j].Wiring = dependencyWiring(deps[j], types, projectID, endpointNames)
 		}
 	}
 }
 
 // dependencyWiring computes one dependency's wiring, or nil when it has none to
-// compute. Kinds other than platform-resource and external never carry one:
-// a component/org-service dependency resolves to an endpoint address, not to
-// resource outputs, and its wiring is the dispatch-time `endpoints:` half.
-func dependencyWiring(d Dependency, types map[string]CRTType, projectID string) *DependencyWiring {
+// compute. org-service is the one kind that never carries one: its project,
+// component and visibility belong to another project's design, so it stays on the
+// dispatch-time `endpoints:` channel that can actually resolve them.
+func dependencyWiring(d Dependency, types map[string]CRTType, projectID string, endpointNames map[string]string) *DependencyWiring {
 	var outputs []string
 	switch d.Kind {
+	case DependencyKindComponent:
+		return siblingEndpointWiring(d.Name, projectID, endpointNames)
 	case DependencyKindPlatformResource:
 		// A nil map (no catalog read) or an unknown resourceType yields no
 		// outputs — nothing to bind, so nothing is stamped.
@@ -121,6 +154,32 @@ func dependencyWiring(d Dependency, types map[string]CRTType, projectID string) 
 	return &DependencyWiring{Ref: ocname.ExternalResourceName(projectID, d.Name), EnvBindings: bindings}
 }
 
+// siblingEndpointWiring resolves a `component` dependency to one
+// `dependencies.endpoints[]` entry, or nil when the named sibling is not in this
+// design.
+//
+// An unknown sibling yields NO wiring rather than a guessed one. The endpoint name
+// is the sibling's to declare, and inventing "http" for a component that is not
+// there would stamp a confident value for a dependency the design cannot satisfy —
+// exactly the failure this derivation exists to end. Absent instead makes the
+// dangling dependency the coding agent's reportable platform fault.
+//
+// `project` is deliberately NOT set: it is omitted for a same-project target (see
+// provisioning's workloadEndpointDepYAML), and `component` alone is what
+// OpenChoreo resolves within the project.
+func siblingEndpointWiring(depName, projectID string, endpointNames map[string]string) *DependencyWiring {
+	endpoint, ok := endpointNames[depName]
+	if !ok || endpoint == "" {
+		return nil
+	}
+	return &DependencyWiring{Endpoint: &EndpointWiring{
+		Component:   ocname.ScopedComponentName(projectID, depName),
+		Name:        endpoint,
+		Visibility:  EndpointVisibilityProject,
+		EnvBindings: map[string]string{EndpointAddressOutput: ocname.ServiceURLEnvName(depName)},
+	}}
+}
+
 // dependencyWiringEqual reports whether two (possibly nil) wirings describe the
 // same value — the change detection that decides whether a component's
 // design.json is re-committed. Compared by value, not by pointer: the derivation
@@ -129,11 +188,29 @@ func dependencyWiringEqual(a, b *DependencyWiring) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.Ref != b.Ref || len(a.EnvBindings) != len(b.EnvBindings) {
+	if a.Ref != b.Ref || !envBindingsEqual(a.EnvBindings, b.EnvBindings) {
 		return false
 	}
-	for k, v := range a.EnvBindings {
-		if b.EnvBindings[k] != v {
+	return endpointWiringEqual(a.Endpoint, b.Endpoint)
+}
+
+// endpointWiringEqual compares the endpoints[] variant. Omitting it here would
+// re-commit every design.json on every save once the sibling variant exists (a
+// derived value the diff never looks at always reads as changed).
+func endpointWiringEqual(a, b *EndpointWiring) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Component == b.Component && a.Name == b.Name &&
+		a.Visibility == b.Visibility && envBindingsEqual(a.EnvBindings, b.EnvBindings)
+}
+
+func envBindingsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
 			return false
 		}
 	}

--- a/services/aep-api/internal/spec/derive_wiring_test.go
+++ b/services/aep-api/internal/spec/derive_wiring_test.go
@@ -83,6 +83,90 @@ func TestDeriveDependencyWiring_PlatformResourcePrefixesEveryOutput(t *testing.T
 	}
 }
 
+// todoProject is the two-component shape the sibling-endpoint bug was found in: a
+// browser app depending on the API beside it.
+func todoProject() []DesignComponent {
+	return []DesignComponent{
+		{Name: "todo-api"},
+		{Name: "todo-webapp", Dependencies: []Dependency{{
+			Kind: DependencyKindComponent, Name: "todo-api",
+		}}},
+	}
+}
+
+// THE regression pin, with the values taken from the live failure: project
+// `todo-api99`, a webapp depending on sibling `todo-api`. OpenChoreo resolves an
+// endpoint dependency by SCOPED component name, so the friendly `todo-api` the
+// agent invented matched no ReleaseBinding — `Ready` never flipped and the project
+// reported "deploying" indefinitely while serving fine.
+//
+// The expected values are literal, not re-derived: a test that called the same
+// helpers would keep passing if the naming convention changed under both sides.
+func TestDeriveDependencyWiring_SiblingEndpointIsScopedForOpenChoreo(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+
+	deriveDependencyWiring(comps, nil, "todo-api99") // no catalog: none is needed
+
+	w := wiringOf(t, comps, "todo-api")
+	if w == nil || w.Endpoint == nil {
+		t.Fatal("no endpoint wiring stamped for a sibling-component dependency")
+	}
+	if want := "todo-api99-todo-api"; w.Endpoint.Component != want {
+		t.Errorf("component = %q, want %q — the SCOPED name OpenChoreo resolves by", w.Endpoint.Component, want)
+	}
+	if w.Endpoint.Component == "todo-api" {
+		t.Error("stamped the friendly name: this is the exact value that never resolves")
+	}
+	if want := "http"; w.Endpoint.Name != want {
+		t.Errorf("name = %q, want %q", w.Endpoint.Name, want)
+	}
+	if want := "project"; w.Endpoint.Visibility != want {
+		t.Errorf("visibility = %q, want %q", w.Endpoint.Visibility, want)
+	}
+	if want := "TODO_API_URL"; w.Endpoint.EnvBindings["address"] != want {
+		t.Errorf("envBindings[address] = %q, want %q", w.Endpoint.EnvBindings["address"], want)
+	}
+	if len(w.Endpoint.EnvBindings) != 1 {
+		t.Errorf("envBindings has %d entries, want exactly 1 (address)", len(w.Endpoint.EnvBindings))
+	}
+	// The variants are exclusive — a resources[] half here would render a
+	// workload.yaml entry OpenChoreo ignores, and the write gates reject the mix.
+	if w.Ref != "" || w.EnvBindings != nil {
+		t.Errorf("endpoint wiring also carried the resource variant: ref=%q envBindings=%v", w.Ref, w.EnvBindings)
+	}
+}
+
+// The endpoint name belongs to the PROVIDER, and it is in the provider's own
+// design — which is what makes the whole value derivable without the cluster. A
+// derivation that hardcoded "http" would silently mis-wire every component that
+// named its endpoint anything else.
+func TestDeriveDependencyWiring_SiblingEndpointUsesTheProvidersDeclaredName(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+	comps[0].Endpoint = &ComponentEndpoint{Name: "rest"}
+
+	deriveDependencyWiring(comps, nil, "todo-api99")
+
+	if got := wiringOf(t, comps, "todo-api").Endpoint.Name; got != "rest" {
+		t.Errorf("name = %q, want %q (the provider's declared endpoint name)", got, "rest")
+	}
+}
+
+// The address env var keys on the LOGICAL dependency name, never the scoped
+// component name: it is the variable the coding agent writes into its source, and a
+// browser app already reads the identical key from window._env_.
+func TestDeriveDependencyWiring_SiblingAddressEnvIgnoresScoping(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+
+	deriveDependencyWiring(comps, nil, "some-very-different-project")
+
+	if got := wiringOf(t, comps, "todo-api").Endpoint.EnvBindings["address"]; got != "TODO_API_URL" {
+		t.Errorf("envBindings[address] = %q, want TODO_API_URL regardless of the project", got)
+	}
+}
+
 // An external resource's outputs are its OWN config keys, already namespaced by
 // the schema the design declares — prefixing them would rename the very keys the
 // architect authored and the build drawer collects.
@@ -127,8 +211,13 @@ func TestDeriveDependencyWiring_UnderivableStampsNothing(t *testing.T) {
 		"no catalog read at all":               {platformDep("todo-db", "postgres-cnpg"), nil},
 		"type declares no outputs":             {platformDep("thing", "opaque"), map[string]CRTType{"opaque": {}}},
 		"external with no config keys":         {Dependency{Kind: DependencyKindExternal, Name: "weather"}, nil},
-		"sibling component":                    {Dependency{Kind: DependencyKindComponent, Name: "todo-api"}, postgresType()},
-		"cross-project org service":            {Dependency{Kind: DependencyKindOrgService, Name: "billing"}, postgresType()},
+		// A sibling the design does not declare: the endpoint name is the
+		// PROVIDER's to declare, so there is nothing to derive. Guessing "http"
+		// would stamp a confident value for a dependency the design cannot satisfy.
+		"sibling absent from the design": {Dependency{Kind: DependencyKindComponent, Name: "todo-api"}, postgresType()},
+		// org-service stays on the dispatch-time channel: its project, component
+		// and visibility live in ANOTHER project's design, which this one cannot read.
+		"cross-project org service": {Dependency{Kind: DependencyKindOrgService, Name: "billing"}, postgresType()},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -278,5 +367,67 @@ func TestSnapshotDerived_IsNotAliasedByALaterDerivation(t *testing.T) {
 
 	if before.wiring["todo-db"].EnvBindings["host"] != "TODO_DB_HOST" {
 		t.Error("snapshot aliased the live envBindings map")
+	}
+}
+
+// The endpoints[] variant hangs off a POINTER, so the shallow struct copy shares
+// it. Left aliased, the "before" snapshot would mutate along with the live value
+// and an endpoint change could never be committed.
+func TestSnapshotDerived_DoesNotAliasTheEndpointVariant(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+	deriveDependencyWiring(comps, nil, "todo-api99")
+	before := snapshotDerived(comps[1])
+
+	live := comps[1].Dependencies[0].Wiring.Endpoint
+	live.Component = "MUTATED"
+	live.EnvBindings["address"] = "MUTATED"
+
+	snap := before.wiring["todo-api"].Endpoint
+	if snap.Component != "todo-api99-todo-api" {
+		t.Errorf("snapshot aliased the live endpoint struct: component = %q", snap.Component)
+	}
+	if snap.EnvBindings["address"] != "TODO_API_URL" {
+		t.Errorf("snapshot aliased the live endpoint envBindings: %q", snap.EnvBindings["address"])
+	}
+}
+
+// Change detection has to look INSIDE the endpoint variant. If it did not, a
+// project rename would move every scoped component name while the diff reported no
+// change — so the corrected wiring would never be committed and every consumer in
+// the project would keep the stale, unresolvable target.
+func TestDerivedStateEqual_CatchesEndpointVariantChanges(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+	deriveDependencyWiring(comps, nil, "todo-api99")
+	first := snapshotDerived(comps[1])
+
+	deriveDependencyWiring(comps, nil, "todo-api99")
+	if !derivedStateEqual(first, snapshotDerived(comps[1])) {
+		t.Error("re-deriving the same endpoint reported a change — every save would commit")
+	}
+
+	deriveDependencyWiring(comps, nil, "renamed-project")
+	if derivedStateEqual(first, snapshotDerived(comps[1])) {
+		t.Error("a changed scoped component name went undetected — the fix would never be committed")
+	}
+}
+
+// A sibling dependency that stops being derivable must LOSE its wiring: a stale
+// scoped name pointing at a component the design no longer declares is exactly the
+// confidently-wrong value this derivation exists to stop producing.
+func TestDeriveDependencyWiring_RemovesEndpointWhenTheSiblingGoes(t *testing.T) {
+	t.Parallel()
+	comps := todoProject()
+	deriveDependencyWiring(comps, nil, "todo-api99")
+	if wiringOf(t, comps, "todo-api") == nil {
+		t.Fatal("precondition: the sibling wiring should have been stamped")
+	}
+
+	// The provider is removed from the design; the consumer still names it.
+	deriveDependencyWiring(comps[1:], nil, "todo-api99")
+
+	if w := wiringOf(t, comps[1:], "todo-api"); w != nil {
+		t.Errorf("wiring = %+v, want nil once the sibling is gone from the design", w)
 	}
 }

--- a/services/aep-api/internal/spec/design.go
+++ b/services/aep-api/internal/spec/design.go
@@ -77,6 +77,17 @@ type DesignComponent struct {
 // declares no explicit endpoint.
 const DefaultEndpointName = "http"
 
+const (
+	// EndpointVisibilityProject is the reachability of a same-project sibling's
+	// endpoint — the `visibility` on a workload `dependencies.endpoints[]` entry
+	// pointing at one.
+	EndpointVisibilityProject = "project"
+	// EndpointAddressOutput is the single output an endpoint dependency exposes:
+	// the provider's resolved base URL. It is the `envBindings` KEY on an
+	// endpoints[] entry (the value is the env var it lands in).
+	EndpointAddressOutput = "address"
+)
+
 // ComponentEndpoint is the component's single network endpoint as declared in
 // design.json. Only Name is carried: it is the SINGLE SOURCE OF TRUTH for the
 // endpoint name shared between the coding agent's workload.yaml
@@ -160,10 +171,15 @@ type Dependency = contracts.Dependency
 // resolution set (see Dependency.Candidates). Wire shape in the contracts leaf.
 type DependencyCandidate = contracts.DependencyCandidate
 
-// DependencyWiring is the platform-stamped consumer-side wiring for a
+// DependencyWiring is the platform-stamped consumer-side wiring for a component /
 // platform-resource / external dependency (see derive_wiring.go). Wire shape in
 // the contracts leaf.
 type DependencyWiring = contracts.DependencyWiring
+
+// EndpointWiring is the `endpoints[]` variant of a dependency's wiring — a
+// sibling component's endpoint (see derive_wiring.go). Wire shape in the
+// contracts leaf.
+type EndpointWiring = contracts.EndpointWiring
 
 // ConfigKey is one env-var key a component reads at runtime. Wire shape in the
 // contracts leaf (re-exported here).

--- a/services/aep-api/internal/spec/design_json.go
+++ b/services/aep-api/internal/spec/design_json.go
@@ -126,8 +126,23 @@ type dependencyJSON struct {
 
 // dependencyWiringJSON is the on-disk shape of a dependency's `wiring` object.
 // Mirrors DependencyWiring; its own field order is the emitted key order.
+//
+// Every field is omitempty because the shape is a two-variant union (see
+// DependencyWiring): the resources[] variant must not emit a null `endpoint`, and
+// the endpoints[] variant must not emit an empty `ref` — either would fail the
+// write gates, which require each variant to carry exactly its own keys.
 type dependencyWiringJSON struct {
-	Ref         string            `json:"ref"`
+	Ref         string              `json:"ref,omitempty"`
+	EnvBindings map[string]string   `json:"envBindings,omitempty"`
+	Endpoint    *endpointWiringJSON `json:"endpoint,omitempty"`
+}
+
+// endpointWiringJSON is the on-disk shape of the `wiring.endpoint` object — one
+// workload `dependencies.endpoints[]` entry. Mirrors EndpointWiring.
+type endpointWiringJSON struct {
+	Component   string            `json:"component"`
+	Name        string            `json:"name"`
+	Visibility  string            `json:"visibility"`
 	EnvBindings map[string]string `json:"envBindings"`
 }
 
@@ -326,18 +341,41 @@ func marshalComponentDesignJSON(dir string, comp DesignComponent) ([]byte, error
 // and the coding agent is back to having nothing to copy), and dropping it on READ
 // makes each derivation see no prior value, so the change detection reports a diff
 // and commits on every single save.
+//
+// Both VARIANTS ride the same rule. The endpoints[] half is the one whose loss is
+// invisible: a missing `ref` leaves the agent with nothing to write, but a missing
+// `endpoint` leaves it free to guess a plausible sibling name, and a wrong one
+// deploys and serves without ever reaching Ready.
 func toJSONWiring(in *DependencyWiring) *dependencyWiringJSON {
 	if in == nil {
 		return nil
 	}
-	return &dependencyWiringJSON{Ref: in.Ref, EnvBindings: in.EnvBindings}
+	out := &dependencyWiringJSON{Ref: in.Ref, EnvBindings: in.EnvBindings}
+	if in.Endpoint != nil {
+		out.Endpoint = &endpointWiringJSON{
+			Component:   in.Endpoint.Component,
+			Name:        in.Endpoint.Name,
+			Visibility:  in.Endpoint.Visibility,
+			EnvBindings: in.Endpoint.EnvBindings,
+		}
+	}
+	return out
 }
 
 func toModelWiring(in *dependencyWiringJSON) *DependencyWiring {
 	if in == nil {
 		return nil
 	}
-	return &DependencyWiring{Ref: in.Ref, EnvBindings: in.EnvBindings}
+	out := &DependencyWiring{Ref: in.Ref, EnvBindings: in.EnvBindings}
+	if in.Endpoint != nil {
+		out.Endpoint = &EndpointWiring{
+			Component:   in.Endpoint.Component,
+			Name:        in.Endpoint.Name,
+			Visibility:  in.Endpoint.Visibility,
+			EnvBindings: in.Endpoint.EnvBindings,
+		}
+	}
+	return out
 }
 
 // toJSONDeps converts the unified model back to on-disk dependency entries.

--- a/services/aep-api/internal/spec/design_json_test.go
+++ b/services/aep-api/internal/spec/design_json_test.go
@@ -689,3 +689,52 @@ func TestComponentDesignJSON_CarriesPlatformStampedWiring(t *testing.T) {
 		}
 	}
 }
+
+// The endpoints[] variant has to survive the same round trip, and its loss is the
+// one that hides: a missing `ref` leaves the coding agent with nothing to write,
+// but a missing `endpoint` leaves it free to invent a plausible sibling name — and
+// the wrong one builds, deploys and serves while its ReleaseBinding never reaches
+// Ready.
+func TestComponentDesignJSON_CarriesTheSiblingEndpointWiring(t *testing.T) {
+	comp := DesignComponent{
+		Name: "todo-webapp", ComponentType: "web-application", Version: "0.1.0",
+		Language: "TypeScript", Buildpack: "docker", AppPath: "todo-webapp",
+		Dependencies: []Dependency{{
+			Kind: DependencyKindComponent, Name: "todo-api",
+			Wiring: &DependencyWiring{Endpoint: &EndpointWiring{
+				Component:   "todo-api99-todo-api",
+				Name:        "http",
+				Visibility:  "project",
+				EnvBindings: map[string]string{"address": "TODO_API_URL"},
+			}},
+		}},
+	}
+
+	out, err := marshalComponentDesignJSON("todo-webapp", comp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"endpoint"`, `"component": "todo-api99-todo-api"`, `"visibility": "project"`, `"address": "TODO_API_URL"`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("write dropped %s:\n%s", want, out)
+		}
+	}
+	// The variants are exclusive on the wire too: an empty `ref` alongside the
+	// endpoint is a mixed object, which both write gates reject.
+	if strings.Contains(string(out), `"ref"`) {
+		t.Errorf("endpoint-variant wiring emitted an empty ref — the write gates reject the mix:\n%s", out)
+	}
+
+	back, err := parseComponentDesignJSON("todo-webapp", string(out))
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	got := back.Dependencies[0].Wiring
+	if got == nil || got.Endpoint == nil {
+		t.Fatalf("read dropped the endpoint wiring: %+v", got)
+	}
+	if got.Endpoint.Component != "todo-api99-todo-api" || got.Endpoint.Name != "http" ||
+		got.Endpoint.Visibility != "project" || got.Endpoint.EnvBindings["address"] != "TODO_API_URL" {
+		t.Errorf("round-trip changed the endpoint wiring: %+v", got.Endpoint)
+	}
+}

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -17,7 +17,8 @@ per-env values (API URLs, OIDC config, flags) arrive at request time in
 
 1. **Scaffold** per Layout.
 2. **Implement** — `src/env.ts` first (every other module reads config through
-   it), then `src/api.ts`, then pages. Every rule under Constraints is a runtime
+   it), then generate `src/generated/` from each dependency's OpenAPI contract,
+   then `src/api.ts`, then pages. Every rule under Constraints is a runtime
    failure if broken, not a style preference.
 3. **Verify** — from the app path:
    ```bash
@@ -71,6 +72,17 @@ by the same static config as plain JS.
 **Never `exposesAPI`.** That toggle is for backends only; a web-app expresses
 auth through its auth dependency instead.
 
+**Contract-first client, never hand-rolled shapes.** Every dependency has a
+committed OpenAPI contract: `specs/design/components/<component-name>/openapi.yaml`
+for a `component`-kind dependency, or
+`specs/design/components/<this-app>/dependencies/<dep-name>.openapi.yaml` for an
+`external`-kind one — project-root paths, sibling to this app's own folder.
+Generate types from it and call through `openapi-fetch`'s typed client (Layout);
+don't hand-write request/response shapes, they drift from the real contract the
+moment it changes. Commit `src/generated/` — the per-component Docker build's
+context is this app's own folder alone, so unlike a monorepo-wide `gen` step
+there is no later stage that can reach the sibling spec to regenerate it.
+
 ## Layout
 
 ```
@@ -83,7 +95,8 @@ auth through its auth dependency instead.
 │   ├── main.tsx
 │   ├── App.tsx
 │   ├── env.ts            # typed window._env_ shim
-│   ├── api.ts            # fetch helpers
+│   ├── generated/        # openapi-typescript output, one file per dependency — commit, never hand-edit
+│   ├── api.ts            # openapi-fetch client(s), typed against generated/
 │   ├── auth.ts           # only with an auth dependency — see thunder-authentication
 │   └── pages/
 ├── nginx/
@@ -129,16 +142,38 @@ if (!window._env_) {
 export const env: Env = window._env_;
 ```
 
+`src/generated/<component-name>.ts` — one run per dependency, before writing
+`api.ts`. `openapi-typescript` is a devDependency (codegen only, no runtime
+footprint); `openapi-fetch` is a regular dependency (it ships in the bundle):
+
+```bash
+npx openapi-typescript ../specs/design/components/<component-name>/openapi.yaml \
+  -o src/generated/<component-name>.ts
+```
+
+(`external`-kind dependency: point at
+`../specs/design/components/<this-app>/dependencies/<dep-name>.openapi.yaml`
+instead.) Re-run and commit the diff whenever the upstream spec changes.
+
 `src/api.ts` — resolve the upstream URL at module top level, so a missing key
-throws at load rather than at the first click:
+throws at load rather than at the first click; the client is typed end-to-end
+against the generated file, so a path or method typo is a compile error, not a
+runtime 404:
 
 ```ts
+import createClient from "openapi-fetch";
+import type { paths } from "./generated/todo-api";
 import { env } from "./env";
 
-const BASE_URL = env.API_BASE_URL; // or env.TODO_API_URL for a specific upstream
+const BASE_URL = env.TODO_API_URL; // or env.API_BASE_URL for the primary upstream
 if (!BASE_URL) {
-  throw new Error("API_BASE_URL not set in window._env_");
+  throw new Error("TODO_API_URL not set in window._env_");
 }
+
+export const todoApi = createClient<paths>({ baseUrl: BASE_URL });
+
+// call sites use the typed client directly, e.g.:
+// const { data, error } = await todoApi.GET("/todos");
 ```
 
 `nginx/default.conf` — pure static:
@@ -191,3 +226,5 @@ configurations:
 |---|---|---|
 | SPA throws on load: `window._env_ not set` | `/env-config.js` failed to load — path wrong, 404, or the `<script>` was `defer`/`async` | Make the tag synchronous in `<head>`, BEFORE the bundle's `<script type="module">`. |
 | `nginx: [emerg] host not found in upstream "thunder-service..."` at pod start | Legacy `/oidc/` proxy block in `nginx/default.conf` | Delete the block. The browser posts cross-origin. |
+| Types in `src/generated/*` don't match the live service | Upstream `openapi.yaml` changed since last generation | Re-run the `openapi-typescript` command and commit the diff. |
+| Docker build succeeds but ships stale/hand-written shapes, or fails `ENOENT ../specs/...` | `src/generated/` wasn't committed — the per-component build context is this app's folder alone, `specs/` isn't reachable from it | Generate and commit `src/generated/` before PR; never rely on a build-time regen step. |


### PR DESCRIPTION
Four commits on `coding-agent`, in three themes (33 files, +1472/-219).

## Contract-first is the methodology, not an ordering problem

The `aep` skill told the coding agent to work its issue set in **topological order** because "a dependent's code has to compile against its provider's". That is not how this platform works: `specs/` is authored at design time, so a consumer codes against its provider's committed `openapi.yaml` and never against its code. The rule was serialising work with no reason to be serial.

`## Contract-first` now states the premise once, and the rest follows:

- **Order is issue number ascending.** There is no build order to derive.
- **A declared dependency (`Depends on #N`, `dependsOn`) is a runtime edge** — who calls whom once deployed — never a build order.
- **Fan-out to subagents is the default**, not a judged exception. Disjoint App Paths is the only real test, so a provider and its consumer are built at the same time.
- A `component` dependency's contract is authoritative **whether or not that component has been written yet**; a service implements its own `openapi.yaml` exactly, because consumers are being written against it concurrently; `specs/` is off-limits to a coding run.

`skills/react-webapp` follows the same line on the client side: generate `src/generated/` from each dependency's committed contract via `openapi-typescript`, call it through `openapi-fetch`, and commit the output (a component's Docker context is its own folder, so nothing downstream can regenerate it).

## A sibling endpoint's wiring is derived at design save

Every field of a `component` dependency's endpoint wiring is a pure function of the design — scoped provider name, the sibling's endpoint name, `project` visibility, one `address` binding on `<DEP_NAME>_URL` — but it was resolved from the **live endpoint catalog at dispatch**, which only lists components that have already deployed. On a first delivery nothing has, so no wiring was posted and the agent authored `component` itself, writing the **friendly** name where OpenChoreo resolves by the **scoped** one. Nothing crashed: the release rendered and applied minus the address env var, and the consumer sat at `Ready=False / ConnectionsPending` with the project reporting "deploying" forever.

It is now stamped into `design.json` at save. `DependencyWiring` becomes a two-variant union — one `dependencies.resources[]` entry or one `dependencies.endpoints[]` entry, never a mix — enforced identically by the zod schema, the JSON schema and the Go design gate. `ScopedComponentName` and `ServiceURLEnvName` move into `ocname`, so the three call sites that must agree byte-for-byte (OC client, provisioning, spec) derive them from one place. Wiring conformance gains `EndpointTargets` and compares the **value**, not just presence: a missing ref leaves nothing wired and something eventually notices, while a wrong endpoint target parses, renders, deploys and serves.

## The managed-API trait sync fires again

The per-environment half of `api-configuration` (the `jwtAuth` policy the gateway enforces, plus the sibling-SPA CORS allowlist) hung off the ExecWatcher's build terminal, which reads `kind=build` execution rows. The run loop took over building and writes none, so the sync stopped firing — silently, for every project — leaving every protected API's gateway passing requests through unauthenticated.

It now hangs on the rail that builds: a `SyncAPITraits` activity the cycle calls at builds-green, bounded by a 5-minute `ScheduleToCloseTimeout` so a convergence step cannot hang a cycle, and non-fatal by design (the component is already deployed and serving by then, so failing the cycle would add noise without removing exposure). Both triggers are events, so drift is still uncovered; the component-enumerating reconcile backstop is recorded as owed, beside the `runtimeconfig` watcher it would mirror.

## Verification

Run in this working tree, at `62aefc91`:

- **`make test` — green**, exit 0: turbo 28/28 packages (remote-worker 235/235) plus every Go module.
- **`skill_compose` 44/44**, which is what guards the composed skill: no mode markers leak, `## The code` / `## Dependencies` / `` `workload.yaml` `` stay byte-identical across both composed modes, and the paired-region cap holds (no new mode regions were added).
- **Composed local-mode skill checked by hand** — `## Contract-first`, the ascending-order rule, the fan-out default, the `.gitignore` rule and the `dependsOn` framing all present; zero unstripped markers.
- **Live local plane** (k3d + compose): `aep-api` `/healthz` 200 with the new `skills/` library inside the image (`/app/skills/react-webapp/SKILL.md` carries the contract-first client section) and the new trait-sync diagnostic in the running binary; `agents` rebuilt, `/healthz` `{"status":"ok"}`; the live `ClusterWorkflow/aep-coding-agent` carries the `/aep-dev/plugin` hostPath overlay, so a dispatched run reads this skill text.

**Not proven here:** no end-to-end delivery was run against this build, so the endpoint-wiring fix is covered by unit + conformance tests and the naming argument, not by a fresh project reaching `Ready=True`. The trait-sync trigger likewise has workflow-test coverage but no live cycle. `/code-review` has not been run over the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
