### PR TITLE
Make aep-api and console safe at multiple replicas

### DIFF
--- a/apps/console/src/features/agent-chat/api/turns.ts
+++ b/apps/console/src/features/agent-chat/api/turns.ts
@@ -144,6 +144,22 @@ export async function getTurn(
   return data;
 }
 
+/** Thrown when the turn-stream attach HTTP call fails. `status` lets callers
+ *  discriminate a pre-stream 404 (buffer not on this replica / not yet minted)
+ *  from other failures. */
+export class TurnStreamAttachError extends Error {
+  readonly status: number;
+  constructor(status: number, message = "Failed to attach to the turn stream") {
+    super(message);
+    this.name = "TurnStreamAttachError";
+    this.status = status;
+  }
+}
+
+export function isTurnStreamNotFound(err: unknown): boolean {
+  return err instanceof TurnStreamAttachError && err.status === 404;
+}
+
 /**
  * Open the turn's SSE stream as a raw byte stream (replay from `from`, then
  * live tail). The caller iterates it with @aep/agent-stream's parseSseStream.
@@ -154,7 +170,7 @@ export async function openTurnStream(
   from: number,
   signal: AbortSignal,
 ): Promise<ReadableStream<Uint8Array>> {
-  const { data, error } = await client.GET(
+  const { data, error, response } = await client.GET(
     "/projects/{projectName}/turns/{turnId}/stream",
     {
       params: { path: { projectName, turnId }, query: { from } },
@@ -162,6 +178,8 @@ export async function openTurnStream(
       signal,
     },
   );
-  if (error || !data) throw new Error("Failed to attach to the turn stream");
+  if (error || !data) {
+    throw new TurnStreamAttachError(response?.status ?? 0);
+  }
   return data as ReadableStream<Uint8Array>;
 }

--- a/apps/console/src/features/agent-chat/runTurn.test.ts
+++ b/apps/console/src/features/agent-chat/runTurn.test.ts
@@ -16,16 +16,22 @@
  * under the License.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StreamPart } from "@aep/agent-stream";
 
 // --- api/turns.js: openTurnStream/getTurn are the only calls runTurn makes.
+// Pass through TurnStreamAttachError / isTurnStreamNotFound so attach tests
+// exercise the real discriminator.
 const mockOpenTurnStream = vi.fn();
 const mockGetTurn = vi.fn();
-vi.mock("./api/turns.js", () => ({
-  openTurnStream: (...args: unknown[]) => mockOpenTurnStream(...args),
-  getTurn: (...args: unknown[]) => mockGetTurn(...args),
-}));
+vi.mock("./api/turns.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api/turns.js")>();
+  return {
+    ...actual,
+    openTurnStream: (...args: unknown[]) => mockOpenTurnStream(...args),
+    getTurn: (...args: unknown[]) => mockGetTurn(...args),
+  };
+});
 
 // --- @aep/agent-stream: parseSseStream is mocked to yield the parts a test
 // queues, bypassing real SSE byte parsing (irrelevant to this unit).
@@ -48,11 +54,14 @@ vi.mock("./chatStore.js", () => ({
   appendAssistantText: vi.fn(),
   addMessage: vi.fn(),
   upsertToolMessage: vi.fn(),
+  upsertQuestionMessage: vi.fn(),
   setTurnStatus: vi.fn(),
   notifyTurnEnd: (key: string, status: string) => notified.push({ key, status }),
 }));
 
 import { attachAndFoldTurn } from "./runTurn";
+import { TurnStreamAttachError } from "./api/turns.js";
+import { addMessage } from "./chatStore.js";
 
 const KEY = "aep.chat.v1.acme.proj1";
 
@@ -62,6 +71,10 @@ describe("attachAndFoldTurn — turn-end notification (#252 Task 5)", () => {
     queuedParts = [];
     notified.length = 0;
     mockOpenTurnStream.mockResolvedValue(new ReadableStream());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("notifies turn-end with 'completed' on a turn-committed terminal frame", async () => {
@@ -97,5 +110,59 @@ describe("attachAndFoldTurn — turn-end notification (#252 Task 5)", () => {
     await attachAndFoldTurn(KEY, "proj1", "t1", ac.signal);
     expect(notified).toEqual([]);
     expect(mockGetTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachAndFoldTurn — pre-stream 404 re-attach (#3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queuedParts = [];
+    notified.length = 0;
+    mockOpenTurnStream.mockResolvedValue(new ReadableStream());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries openTurnStream on a pre-stream 404, then folds the stream (no Turn failed)", async () => {
+    vi.useFakeTimers();
+    const attachErr = new TurnStreamAttachError(404);
+    mockOpenTurnStream
+      .mockRejectedValueOnce(attachErr)
+      .mockResolvedValueOnce(new ReadableStream());
+    queuedParts = [{ type: "turn-committed" } as StreamPart];
+    mockGetTurn.mockResolvedValue({ status: "running" });
+
+    const done = attachAndFoldTurn(KEY, "proj1", "t1", new AbortController().signal);
+    await vi.runAllTimersAsync();
+    await done;
+
+    expect(mockOpenTurnStream).toHaveBeenCalledTimes(2);
+    expect(notified).toEqual([{ key: KEY, status: "completed" }]);
+    expect(addMessage).not.toHaveBeenCalledWith(
+      KEY,
+      expect.objectContaining({ role: "error" }),
+    );
+  });
+
+  it("falls through to getTurn when a pre-stream 404's turn is already completed", async () => {
+    vi.useFakeTimers();
+    const attachErr = new TurnStreamAttachError(404);
+    mockOpenTurnStream.mockRejectedValue(attachErr);
+    mockGetTurn.mockResolvedValue({ status: "completed" });
+
+    const done = attachAndFoldTurn(KEY, "proj1", "t1", new AbortController().signal);
+    await vi.runAllTimersAsync();
+    await done;
+
+    expect(notified).toEqual([{ key: KEY, status: "completed" }]);
+  });
+
+  it("re-throws non-404 attach failures (still surfaces Turn failed upstream)", async () => {
+    mockOpenTurnStream.mockRejectedValue(new Error("Failed to attach to the turn stream")); // no status
+    await expect(
+      attachAndFoldTurn(KEY, "proj1", "t1", new AbortController().signal),
+    ).rejects.toThrow(/Failed to attach/);
   });
 });

--- a/apps/console/src/features/agent-chat/runTurn.ts
+++ b/apps/console/src/features/agent-chat/runTurn.ts
@@ -50,17 +50,45 @@ function attachBackoffMs(attempt: number): number {
 async function sleep(ms: number, signal: AbortSignal): Promise<void> {
   if (ms <= 0) return;
   await new Promise<void>((resolve, reject) => {
-    const t = setTimeout(resolve, ms);
     const onAbort = () => {
       clearTimeout(t);
+      signal.removeEventListener("abort", onAbort);
       reject(new DOMException("Aborted", "AbortError"));
     };
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
     if (signal.aborted) {
       onAbort();
       return;
     }
-    signal.addEventListener("abort", onAbort, { once: true });
+    signal.addEventListener("abort", onAbort);
   });
+}
+
+function settleFromTurnStatus(
+  chatKey: string,
+  turnId: string,
+  status: { status?: string; message?: string } | null | undefined,
+  onCommitted?: () => void,
+): boolean {
+  if (status?.status === "completed") {
+    setTurnStatus(chatKey, turnId, "completed");
+    notifyTurnEnd(chatKey, "completed");
+    onCommitted?.();
+    return true;
+  }
+  if (status?.status === "failed") {
+    setTurnStatus(chatKey, turnId, "failed");
+    notifyTurnEnd(chatKey, "failed");
+    addMessage(chatKey, {
+      role: "error",
+      content: status.message ?? "The agent turn failed.",
+    });
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -245,19 +273,7 @@ export async function attachAndFoldTurn(
         }
         // Turn may already be terminal on another replica — settle via getTurn.
         const status = await getTurn(projectName, turnId);
-        if (status?.status === "completed") {
-          setTurnStatus(chatKey, turnId, "completed");
-          notifyTurnEnd(chatKey, "completed");
-          onCommitted?.();
-          return;
-        }
-        if (status?.status === "failed") {
-          setTurnStatus(chatKey, turnId, "failed");
-          notifyTurnEnd(chatKey, "failed");
-          addMessage(chatKey, {
-            role: "error",
-            content: status.message ?? "The agent turn failed.",
-          });
+        if (settleFromTurnStatus(chatKey, turnId, status, onCommitted)) {
           return;
         }
         await sleep(attachBackoffMs(attempt), signal);
@@ -281,16 +297,5 @@ export async function attachAndFoldTurn(
   // (and is itself a "terminal frame arrived" for turn-end purposes: the
   // fallback poll IS how this turn's end is observed here).
   const status = await getTurn(projectName, turnId);
-  if (status?.status === "completed") {
-    setTurnStatus(chatKey, turnId, "completed");
-    notifyTurnEnd(chatKey, "completed");
-    onCommitted?.();
-  } else if (status?.status === "failed") {
-    setTurnStatus(chatKey, turnId, "failed");
-    notifyTurnEnd(chatKey, "failed");
-    addMessage(chatKey, {
-      role: "error",
-      content: status.message ?? "The agent turn failed.",
-    });
-  }
+  settleFromTurnStatus(chatKey, turnId, status, onCommitted);
 }

--- a/apps/console/src/features/agent-chat/runTurn.ts
+++ b/apps/console/src/features/agent-chat/runTurn.ts
@@ -36,9 +36,32 @@ import {
   notifyTurnEnd,
 } from "./chatStore.js";
 import { extractStreamingQuestions, isQuestionTool, parseQuestionsInput } from "./questionCards.js";
-import { getTurn, openTurnStream } from "./api/turns.js";
+import { getTurn, isTurnStreamNotFound, openTurnStream } from "./api/turns.js";
 
 const FILE_TOOLS = new Set(["addFile", "editFile", "removeFile"]);
+
+const ATTACH_404_MAX_ATTEMPTS = 8;
+const ATTACH_404_BASE_MS = 250; // 250, 500, 1000, ... capped
+
+function attachBackoffMs(attempt: number): number {
+  return Math.min(ATTACH_404_BASE_MS * 2 ** attempt, 4000);
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 /**
  * Attach to a running turn's stream and fold it to its terminal. Resolves
@@ -206,17 +229,50 @@ export async function attachAndFoldTurn(
   };
 
   try {
-    const body = await openTurnStream(projectName, turnId, 0, signal);
-    for await (const part of parseSseStream(body)) {
-      if (signal.aborted) return;
-      fold(part);
+    let attempt = 0;
+    for (;;) {
+      try {
+        const body = await openTurnStream(projectName, turnId, 0, signal);
+        for await (const part of parseSseStream(body)) {
+          if (signal.aborted) return;
+          fold(part);
+        }
+        break; // stream ended cleanly (terminal or severed)
+      } catch (err) {
+        if (signal.aborted) return; // unmount/navigation — not a failure
+        if (!isTurnStreamNotFound(err) || attempt >= ATTACH_404_MAX_ATTEMPTS - 1) {
+          throw err;
+        }
+        // Turn may already be terminal on another replica — settle via getTurn.
+        const status = await getTurn(projectName, turnId);
+        if (status?.status === "completed") {
+          setTurnStatus(chatKey, turnId, "completed");
+          notifyTurnEnd(chatKey, "completed");
+          onCommitted?.();
+          return;
+        }
+        if (status?.status === "failed") {
+          setTurnStatus(chatKey, turnId, "failed");
+          notifyTurnEnd(chatKey, "failed");
+          addMessage(chatKey, {
+            role: "error",
+            content: status.message ?? "The agent turn failed.",
+          });
+          return;
+        }
+        await sleep(attachBackoffMs(attempt), signal);
+        attempt += 1;
+      }
     }
   } catch (err) {
-    if (signal.aborted) return; // unmount/navigation — not a failure
+    // sleep / openTurnStream may reject AbortError after the inner catch's
+    // aborted check — treat detach as success, matching prior semantics.
+    if (signal.aborted) return;
     throw err;
   } finally {
-    // Stream over (terminal, severed, or aborted): nothing further can flip a
-    // streaming card, so settle any question prefix into its final state.
+    // Stream over (terminal, severed, aborted, or settled via pre-stream
+    // getTurn): nothing further can flip a streaming card. Do NOT finalize
+    // inside the per-attempt catch — that would settle question cards mid-turn.
     finalizeStreamingQuestions();
   }
 

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher.go
@@ -175,9 +175,7 @@ func (w *ExecWatcher) reconcile(ctx context.Context, row *delivery.Execution, ru
 			exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run))
 			if err != nil {
 				slog.WarnContext(ctx, "exec watcher: finish coding failed", "execution", row.ID, "error", err)
-				return
-			}
-			if exec == nil {
+			} else if exec == nil {
 				return // lost the race — another replica already finished
 			}
 			w.notifier.Notify(row.Repo, row.IssueNumber)
@@ -219,9 +217,7 @@ func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.E
 		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run))
 		if err != nil {
 			slog.WarnContext(ctx, "exec watcher: finish build failed", "execution", row.ID, "error", err)
-			return
-		}
-		if exec == nil {
+		} else if exec == nil {
 			return // lost the race — another replica already finished
 		}
 		w.notifier.Notify(row.Repo, row.IssueNumber)
@@ -233,9 +229,7 @@ func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.E
 		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), buildAuthRetryExceededReason)
 		if err != nil {
 			slog.WarnContext(ctx, "exec watcher: finish build auth-exhausted", "execution", row.ID, "error", err)
-			return
-		}
-		if exec == nil {
+		} else if exec == nil {
 			return // lost the race — another replica already finished
 		}
 		slog.WarnContext(ctx, "exec watcher: build git-auth retry budget exhausted", "execution", row.ID, "attempts", attempt, "budget", w.authBudget)

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher.go
@@ -216,8 +216,14 @@ func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.E
 	if !authFailure || w.buildRetrier == nil {
 		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run))
 		if err != nil {
+			// Notify is cheap/idempotent; do NOT notifyBuildTerminal — the row
+			// stays running and the next tick retries Finish. Reporting terminal
+			// on a DB blip spends budget / mints a fix issue prematurely.
 			slog.WarnContext(ctx, "exec watcher: finish build failed", "execution", row.ID, "error", err)
-		} else if exec == nil {
+			w.notifier.Notify(row.Repo, row.IssueNumber)
+			return
+		}
+		if exec == nil {
 			return // lost the race — another replica already finished
 		}
 		w.notifier.Notify(row.Repo, row.IssueNumber)
@@ -229,7 +235,10 @@ func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.E
 		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), buildAuthRetryExceededReason)
 		if err != nil {
 			slog.WarnContext(ctx, "exec watcher: finish build auth-exhausted", "execution", row.ID, "error", err)
-		} else if exec == nil {
+			w.notifier.Notify(row.Repo, row.IssueNumber)
+			return
+		}
+		if exec == nil {
 			return // lost the race — another replica already finished
 		}
 		slog.WarnContext(ctx, "exec watcher: build git-auth retry budget exhausted", "execution", row.ID, "attempts", attempt, "budget", w.authBudget)

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher.go
@@ -172,17 +172,26 @@ func (w *ExecWatcher) reconcile(ctx context.Context, row *delivery.Execution, ru
 	case string(taskmeta.KindCoding):
 		if !succeeded {
 			// A failed coding run — the PR will never open; Finish failed.
-			if _, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run)); err != nil {
+			exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run))
+			if err != nil {
 				slog.WarnContext(ctx, "exec watcher: finish coding failed", "execution", row.ID, "error", err)
+				return
+			}
+			if exec == nil {
+				return // lost the race — another replica already finished
 			}
 			w.notifier.Notify(row.Repo, row.IssueNumber)
 		}
 		// A succeeded coding run rides the pull_request-opened webhook — no action.
 	case string(taskmeta.KindBuild):
 		if succeeded {
-			if _, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecSucceeded), ""); err != nil {
+			exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecSucceeded), "")
+			if err != nil {
 				slog.WarnContext(ctx, "exec watcher: finish build succeeded", "execution", row.ID, "error", err)
 				return
+			}
+			if exec == nil {
+				return // lost the race — another replica already finished
 			}
 			if w.deployObserver != nil {
 				// The component deployed — grant any pending cross-project access
@@ -207,8 +216,13 @@ func (w *ExecWatcher) reconcile(ctx context.Context, row *delivery.Execution, ru
 func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.Execution, run *gen.WorkflowRun) {
 	_, authFailure := classifyBuildRun(run)
 	if !authFailure || w.buildRetrier == nil {
-		if _, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run)); err != nil {
+		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), workflowReason(run))
+		if err != nil {
 			slog.WarnContext(ctx, "exec watcher: finish build failed", "execution", row.ID, "error", err)
+			return
+		}
+		if exec == nil {
+			return // lost the race — another replica already finished
 		}
 		w.notifier.Notify(row.Repo, row.IssueNumber)
 		w.notifyBuildTerminal(ctx, row, false, workflowReason(run))
@@ -216,11 +230,15 @@ func (w *ExecWatcher) reconcileBuildFailure(ctx context.Context, row *delivery.E
 	}
 	attempt := parseBuildAuthRetryAttempt(row.Reason)
 	if attempt >= w.authBudget {
-		if _, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), buildAuthRetryExceededReason); err != nil {
+		exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), buildAuthRetryExceededReason)
+		if err != nil {
 			slog.WarnContext(ctx, "exec watcher: finish build auth-exhausted", "execution", row.ID, "error", err)
-		} else {
-			slog.WarnContext(ctx, "exec watcher: build git-auth retry budget exhausted", "execution", row.ID, "attempts", attempt, "budget", w.authBudget)
+			return
 		}
+		if exec == nil {
+			return // lost the race — another replica already finished
+		}
+		slog.WarnContext(ctx, "exec watcher: build git-auth retry budget exhausted", "execution", row.ID, "attempts", attempt, "budget", w.authBudget)
 		w.notifier.Notify(row.Repo, row.IssueNumber)
 		w.notifyBuildTerminal(ctx, row, false, buildAuthRetryExceededReason)
 		return

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
@@ -237,6 +237,114 @@ func TestExecWatcher_BuildSuccess_FinishLoserSkipsObserver(t *testing.T) {
 	}
 }
 
+// TestExecWatcher_CodingFailure_FinishLoserSkipsNotify: reconcile twice on the
+// same failed coding run — the second Finish is a loser and must not Notify.
+func TestExecWatcher_CodingFailure_FinishLoserSkipsNotify(t *testing.T) {
+	coding := &delivery.Execution{ID: "c1", OrgID: "acme", Repo: "acme/widgets", IssueNumber: 7,
+		Kind: string(taskmeta.KindCoding), Status: string(taskmeta.ExecRunning), RunName: "wf-1"}
+	repo := newFakeExecRepo(coding)
+	failed := &gen.WorkflowRun{Name: "wf-1", Completed: true, Status: openchoreo.ReasonWorkflowFailed}
+	hub := delivery.NewTaskStreamHub()
+	ch, cancel := hub.Subscribe(coding.Repo, coding.IssueNumber)
+	defer cancel()
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"wf-1": failed}), repo, nil, 0).
+		WithTaskNotifier(hub)
+
+	ctx := context.Background()
+	if err := w.Sweep(ctx); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("winner must Notify")
+	}
+	w.reconcile(ctx, coding, failed)
+	select {
+	case <-ch:
+		t.Fatal("Finish loser must not Notify")
+	default:
+	}
+}
+
+// TestExecWatcher_BuildPlainFailure_FinishLoserSkipsNotifyAndObserver: reconcile
+// twice on the same plain-failed build — the second Finish is a loser and must
+// not Notify or re-fire OnBuildTerminal.
+func TestExecWatcher_BuildPlainFailure_FinishLoserSkipsNotifyAndObserver(t *testing.T) {
+	row := runningBuild("b1", "run-1", "")
+	repo := newFakeExecRepo(row)
+	failed := plainFailedRun("run-1")
+	hub := delivery.NewTaskStreamHub()
+	ch, cancel := hub.Subscribe(row.Repo, row.IssueNumber)
+	defer cancel()
+	obs := &countingBuildObserver{}
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"run-1": failed}), repo, nil, 0).
+		WithBuildRetrier(&fakeRetrier{}, 3).
+		WithTaskNotifier(hub).
+		WithBuildObserver(obs)
+
+	ctx := context.Background()
+	if err := w.Sweep(ctx); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("winner must Notify")
+	}
+	if obs.n != 1 {
+		t.Fatalf("winner must notify observer once, got %d", obs.n)
+	}
+	w.reconcile(ctx, row, failed)
+	select {
+	case <-ch:
+		t.Fatal("Finish loser must not Notify")
+	default:
+	}
+	if obs.n != 1 {
+		t.Fatalf("Finish loser must not re-fire OnBuildTerminal, got %d", obs.n)
+	}
+}
+
+// TestExecWatcher_BuildAuthBudgetExhausted_FinishLoserSkipsNotifyAndObserver:
+// reconcile twice after auth-retry budget is spent — the second Finish is a
+// loser and must not Notify or re-fire OnBuildTerminal.
+func TestExecWatcher_BuildAuthBudgetExhausted_FinishLoserSkipsNotifyAndObserver(t *testing.T) {
+	row := runningBuild("b1", "run-3", "build_auth_retry:3")
+	repo := newFakeExecRepo(row)
+	failed := authFailedRun("run-3")
+	hub := delivery.NewTaskStreamHub()
+	ch, cancel := hub.Subscribe(row.Repo, row.IssueNumber)
+	defer cancel()
+	obs := &countingBuildObserver{}
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"run-3": failed}), repo, nil, 0).
+		WithBuildRetrier(&fakeRetrier{newRun: "run-4"}, 3).
+		WithTaskNotifier(hub).
+		WithBuildObserver(obs)
+
+	ctx := context.Background()
+	if err := w.Sweep(ctx); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("winner must Notify")
+	}
+	if obs.n != 1 {
+		t.Fatalf("winner must notify observer once, got %d", obs.n)
+	}
+	w.reconcile(ctx, row, failed)
+	select {
+	case <-ch:
+		t.Fatal("Finish loser must not Notify")
+	default:
+	}
+	if obs.n != 1 {
+		t.Fatalf("Finish loser must not re-fire OnBuildTerminal, got %d", obs.n)
+	}
+}
+
 // TestJobWatcher_FinishFailed_LoserSkipsNotify: finishFailed twice on the same
 // row — the second Finish loses and must not Notify the task-stream hub.
 func TestJobWatcher_FinishFailed_LoserSkipsNotify(t *testing.T) {

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
@@ -345,6 +345,58 @@ func TestExecWatcher_BuildAuthBudgetExhausted_FinishLoserSkipsNotifyAndObserver(
 	}
 }
 
+// TestExecWatcher_BuildPlainFailure_FinishErrorSkipsObserver: a Finish DB
+// error must Notify (idempotent) but must NOT call OnBuildTerminal — the row
+// stays running for the next tick.
+func TestExecWatcher_BuildPlainFailure_FinishErrorSkipsObserver(t *testing.T) {
+	row := runningBuild("b1", "run-1", "")
+	repo := newFakeExecRepo(row)
+	repo.finishErr = errors.New("db blip")
+	failed := plainFailedRun("run-1")
+	hub := delivery.NewTaskStreamHub()
+	ch, cancel := hub.Subscribe(row.Repo, row.IssueNumber)
+	defer cancel()
+	obs := &countingBuildObserver{}
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"run-1": failed}), repo, nil, 0).
+		WithBuildRetrier(&fakeRetrier{}, 3).
+		WithTaskNotifier(hub).
+		WithBuildObserver(obs)
+
+	w.reconcile(context.Background(), row, failed)
+	select {
+	case <-ch:
+	default:
+		t.Fatal("Finish DB error must still Notify")
+	}
+	if obs.n != 0 {
+		t.Fatalf("Finish DB error must not OnBuildTerminal, got %d", obs.n)
+	}
+	if got := repo.get("b1"); got.Status != string(taskmeta.ExecRunning) {
+		t.Fatalf("row must stay running after Finish error, got %q", got.Status)
+	}
+}
+
+// TestExecWatcher_BuildAuthBudgetExhausted_FinishErrorSkipsObserver: same
+// Finish-error contract on the auth-budget-exhausted branch.
+func TestExecWatcher_BuildAuthBudgetExhausted_FinishErrorSkipsObserver(t *testing.T) {
+	row := runningBuild("b1", "run-3", "build_auth_retry:3")
+	repo := newFakeExecRepo(row)
+	repo.finishErr = errors.New("db blip")
+	failed := authFailedRun("run-3")
+	obs := &countingBuildObserver{}
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"run-3": failed}), repo, nil, 0).
+		WithBuildRetrier(&fakeRetrier{newRun: "run-4"}, 3).
+		WithBuildObserver(obs)
+
+	w.reconcile(context.Background(), row, failed)
+	if obs.n != 0 {
+		t.Fatalf("Finish DB error must not OnBuildTerminal, got %d", obs.n)
+	}
+	if got := repo.get("b1"); got.Status != string(taskmeta.ExecRunning) {
+		t.Fatalf("row must stay running after Finish error, got %q", got.Status)
+	}
+}
+
 // TestJobWatcher_FinishFailed_LoserSkipsNotify: finishFailed twice on the same
 // row — the second Finish loses and must not Notify the task-stream hub.
 func TestJobWatcher_FinishFailed_LoserSkipsNotify(t *testing.T) {

--- a/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
+++ b/services/aep-api/internal/delivery/codingagent/exec_watcher_test.go
@@ -202,3 +202,65 @@ func TestExecWatcher_CodingFailure_FinishesFailed_SuccessRidesPRWebhook(t *testi
 		t.Errorf("failed coding run must Finish failed (no PR will open), got %q", got.Status)
 	}
 }
+
+// countingBuildObserver counts OnBuildTerminal deliveries so a Finish loser can
+// be shown not to re-fire terminal side effects.
+type countingBuildObserver struct{ n int }
+
+func (c *countingBuildObserver) OnBuildTerminal(context.Context, delivery.BuildTerminal) error {
+	c.n++
+	return nil
+}
+
+// TestExecWatcher_BuildSuccess_FinishLoserSkipsObserver: reconcile twice on the
+// same completed build — the second Finish is a loser ((nil, nil)) and must not
+// call OnBuildTerminal again.
+func TestExecWatcher_BuildSuccess_FinishLoserSkipsObserver(t *testing.T) {
+	row := runningBuild("b1", "run-1", "")
+	repo := newFakeExecRepo(row)
+	ok := &gen.WorkflowRun{Name: "run-1", Completed: true, Status: openchoreo.ReasonWorkflowSucceeded}
+	obs := &countingBuildObserver{}
+	w := NewExecWatcher(ocRuns(map[string]*gen.WorkflowRun{"run-1": ok}), repo, nil, 0).
+		WithBuildObserver(obs)
+
+	ctx := context.Background()
+	if err := w.Sweep(ctx); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	if obs.n != 1 {
+		t.Fatalf("winner must notify observer once, got %d", obs.n)
+	}
+	// Row is terminal; Sweep no longer lists it. Drive reconcile directly for the loser path.
+	w.reconcile(ctx, row, ok)
+	if obs.n != 1 {
+		t.Fatalf("Finish loser must not re-fire OnBuildTerminal, got %d", obs.n)
+	}
+}
+
+// TestJobWatcher_FinishFailed_LoserSkipsNotify: finishFailed twice on the same
+// row — the second Finish loses and must not Notify the task-stream hub.
+func TestJobWatcher_FinishFailed_LoserSkipsNotify(t *testing.T) {
+	row := &delivery.Execution{
+		ID: "c1", Repo: "acme/widgets", IssueNumber: 7,
+		Kind: string(taskmeta.KindCoding), Status: string(taskmeta.ExecRunning),
+	}
+	repo := newFakeExecRepo(row)
+	hub := delivery.NewTaskStreamHub()
+	ch, cancel := hub.Subscribe(row.Repo, row.IssueNumber)
+	defer cancel()
+	w := &JobWatcher{execRows: repo, notifier: hub}
+
+	ctx := context.Background()
+	w.finishFailed(ctx, row, "job_failed")
+	select {
+	case <-ch:
+	default:
+		t.Fatal("winner must Notify")
+	}
+	w.finishFailed(ctx, row, "job_failed")
+	select {
+	case <-ch:
+		t.Fatal("Finish loser must not Notify")
+	default:
+	}
+}

--- a/services/aep-api/internal/delivery/codingagent/fakes_test.go
+++ b/services/aep-api/internal/delivery/codingagent/fakes_test.go
@@ -118,8 +118,9 @@ func (f *fakeRetrier) count() int { f.mu.Lock(); defer f.mu.Unlock(); return len
 // tests, and a panic would mask an unexpected call regression, so they no-op
 // instead of panicking to keep the fake honest about "not exercised here".
 type fakeExecRepo struct {
-	mu   sync.Mutex
-	rows map[string]*delivery.Execution
+	mu        sync.Mutex
+	rows      map[string]*delivery.Execution
+	finishErr error // when set, Finish returns this error without mutating the row
 }
 
 func newFakeExecRepo(rows ...*delivery.Execution) *fakeExecRepo {
@@ -183,6 +184,9 @@ func (f *fakeExecRepo) StartWithRun(_ context.Context, id, runName string) (*del
 func (f *fakeExecRepo) Finish(_ context.Context, id, status, reason string) (*delivery.Execution, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.finishErr != nil {
+		return nil, f.finishErr
+	}
 	r := f.rows[id]
 	if r == nil || !taskmeta.ExecutionStatus(r.Status).IsActive() {
 		return nil, nil

--- a/services/aep-api/internal/delivery/codingagent/watcher.go
+++ b/services/aep-api/internal/delivery/codingagent/watcher.go
@@ -277,9 +277,13 @@ func (w *JobWatcher) checkOne(ctx context.Context, row *delivery.Execution) {
 }
 
 func (w *JobWatcher) finishFailed(ctx context.Context, row *delivery.Execution, reason string) {
-	if _, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), reason); err != nil {
+	exec, err := w.execRows.Finish(ctx, row.ID, string(taskmeta.ExecFailed), reason)
+	if err != nil {
 		slog.ErrorContext(ctx, "codingagent.JobWatcher: finish failed", "execution", row.ID, "reason", reason, "error", err)
 		return
+	}
+	if exec == nil {
+		return // lost the race — another replica already finished
 	}
 	slog.InfoContext(ctx, "codingagent.JobWatcher: coding execution failed", "execution", row.ID, "reason", reason)
 	w.notifier.Notify(row.Repo, row.IssueNumber)

--- a/services/aep-api/internal/dependencies/ports.go
+++ b/services/aep-api/internal/dependencies/ports.go
@@ -45,7 +45,8 @@ type SecretWriter interface {
 // consumers (external_values.go / resources_service.go, git-rm'd). Phase 6
 // rebuilt the value/param surface in internal/feature/provisioning on our
 // GitHub-native aep:provision funnel; the completion port it uses there is
-// "close the provision issue + Funnel.Reevaluate", not a component_tasks
+// "close the provision issue" (consumer release via gate-close webhook +
+// eventcore sweep), not a component_tasks
 // projector. The org-level external-resource catalog (list/delete + the
 // consumer scan for the in-use delete guard) also lives there now: the
 // provisioning ExternalRTCatalog port, backed by resources.ExternalResourceCatalog

--- a/services/aep-api/internal/dependencies/provisioning/build_provision_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/build_provision_test.go
@@ -38,10 +38,9 @@ import (
 func TestProvisionForBuild_ByKind(t *testing.T) {
 	issues := newFakeIssues(nil) // no gates yet — EnsureProvisionIssues mints them
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	ext := &fakeExtProv{}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
 		{Component: "orders", Dependency: "stripe", Kind: "external-config",
@@ -105,10 +104,9 @@ func TestProvisionForBuild_UsesMintedGateDespiteListRace(t *testing.T) {
 	issues := newFakeIssues(nil)
 	issues.raceNewIssues = true // just-minted gates are invisible to ListIssues (the race)
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	ext := &fakeExtProv{}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
 		{Component: "orders", Dependency: "stripe", Kind: "external-config",
@@ -142,7 +140,7 @@ func TestProvisionForBuild_ExternalAuthorFailureContinues(t *testing.T) {
 	execs := &fakeExecStore{}
 	ext := &fakeExtProv{authorErr: fmt.Errorf("author boom")}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, ext, plat, &fakeBindings{})
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
 		{Component: "orders", Dependency: "stripe", Kind: "external-config",
@@ -174,7 +172,7 @@ func TestProvisionForBuild_OrgServiceUnapprovedIsNoop(t *testing.T) {
 	issues := newFakeIssues(nil)
 	ext := &fakeExtProv{}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, &fakeExecStore{}, &fakeReeval{},
+	svc := newTestService(issues, &fakeExecStore{},
 		fakeDesign{comps: []spec.DesignComponent{{Name: "web"}}}, ext, plat, &fakeBindings{})
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
@@ -205,7 +203,6 @@ func TestProvisionForBuild_OrgServiceApprovedStartsVisibility(t *testing.T) {
 	svc := NewService(Deps{
 		Issues: issues,
 		Execs:  &fakeExecStore{},
-		Reeval: &fakeReeval{},
 		Design: fakeDesign{comps: []spec.DesignComponent{consumer}},
 		Repos:  fakeRepos{},
 		Access: access,
@@ -249,14 +246,13 @@ func TestProvisionForBuild_OrgServiceApprovedStartsVisibility(t *testing.T) {
 func TestProvisionForBuild_SettlesReadyGateNotInInputs(t *testing.T) {
 	issues := newFakeIssues(nil)
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	ext := &fakeExtProv{}
 	plat := &fakePlatProv{}
 	// orders-db (platform-resource) is already Ready in OC but NOT in the drawer inputs.
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{
 		ocname.ExternalResourceBindingName("proj", "orders-db", "development"): readyBinding("host", "port"),
 	}}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, ext, plat, bindings)
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, ext, plat, bindings)
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
 		{Component: "orders", Dependency: "stripe", Kind: "external-config",
@@ -296,7 +292,7 @@ func TestProvisionForBuild_SkipsNotReadyGateNotInInputs(t *testing.T) {
 	issues := newFakeIssues(nil)
 	execs := &fakeExecStore{}
 	// orders-db has NO binding (never provisioned) → Status reports not-ready.
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
 		{Component: "orders", Dependency: "stripe", Kind: "external-config",
@@ -323,7 +319,7 @@ func TestSettleReadyGate_NoOpenGate(t *testing.T) {
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{
 		ocname.ExternalResourceBindingName("proj", "orders-db", "development"): readyBinding(),
 	}}
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
 
 	if err := svc.completeReadyGate(context.Background(), "acme", "proj", "orders-db", "orders"); err != nil {
 		t.Fatalf("no open gate must be a no-op, got %v", err)
@@ -348,7 +344,7 @@ func TestProvisionForBuild_EmptyInputsDoesNotMint(t *testing.T) {
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{
 		ocname.ExternalResourceBindingName("proj", "orders-db", "development"): readyBinding(),
 	}}
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
 
 	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, nil)
 	if err != nil {

--- a/services/aep-api/internal/dependencies/provisioning/doc.go
+++ b/services/aep-api/internal/dependencies/provisioning/doc.go
@@ -27,22 +27,21 @@
 //     per project). The consumer coding task holds until each derives deployed.
 //   - ValueService — external value collection: split values by the registered
 //     schema, write secrets to SM-API + author the OC external Resource model,
-//     then Finish the provision Execution + close the issue + Reevaluate
+//     then Finish the provision Execution + close the issue
 //     (external readyWhen:${true} → completion is synchronous).
 //   - ResourceService — platform-resource provisioning: author the OC Resource +
 //     binding (async) and admit a running provision Execution; the readiness
 //     watcher observes the binding's native Ready condition out-of-band.
 //   - ResourceWatcher — the resource-readiness watcher (cloned from the exec
 //     watcher): on the binding going Ready it Finishes the provision Execution
-//     (→ deployed), closes the issue with the binding reference, and Reevaluates
-//     so gated consumer tasks dispatch. A 30-minute stale bound fails a stuck run.
+//     (→ deployed) and closes the issue with the binding reference. A 30-minute
+//     stale bound fails a stuck run.
 //   - StatusService — the masked status read (outputs by name only — secrets
 //     live only in SM-API / the OC-rendered Secret, never in a response).
 //
 // The no-secrets invariant holds throughout: secret VALUES go only to SM-API /
 // OpenBao; issue bodies, comments, and API responses carry only names / paths /
 // references. This package coordinates provisioners (dependencies/resources) +
-// GitHub issues (gitrepo); every other collaborator (executions store, funnel
-// Reevaluate, design read, repo lookup) is a narrow local port wired in the
-// composition root.
+// GitHub issues (gitrepo); every other collaborator (executions store, design
+// read, repo lookup) is a narrow local port wired in the composition root.
 package provisioning

--- a/services/aep-api/internal/dependencies/provisioning/org_service_visibility.go
+++ b/services/aep-api/internal/dependencies/provisioning/org_service_visibility.go
@@ -138,7 +138,7 @@ func (s *Service) triggerProviderBuild(ctx context.Context, orgID, providerProje
 // org-service visibility gate so it derives StatusDeployed and the consumer's
 // held coding task dispatches — the grant-cascade tail (issue #164, Task 4). It
 // mirrors SaveValues' tail (admit → StartWithRun → completeProvisionRow, which
-// closes the gate + reevaluates the funnel). Best-effort throughout: a missing
+// closes the gate). Best-effort throughout: a missing
 // gate (an interactive-flow rider) or any step failure is logged and swallowed
 // so the deploy cascade never fails over it.
 func (s *Service) resolveConsumerVisibilityGate(ctx context.Context, orgID, consumerProjectID, dep string) {

--- a/services/aep-api/internal/dependencies/provisioning/org_service_visibility_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/org_service_visibility_test.go
@@ -95,7 +95,6 @@ func newVisibilityService(t *testing.T) (*Service, visibilitySpies) {
 	svc := NewService(Deps{
 		Issues: issues,
 		Execs:  &fakeExecStore{},
-		Reeval: &fakeReeval{},
 		Design: fakeDesign{comps: []spec.DesignComponent{consumer}},
 		Repos:  fakeRepos{},
 		Access: access,
@@ -164,7 +163,7 @@ func TestStartOrgServiceVisibility_Idempotent(t *testing.T) {
 }
 
 // The grant cascade completes a provision run on the consumer visibility gate so
-// it derives deployed, closes the gate, and reevaluates the funnel.
+// it derives deployed and closes the gate.
 func TestGrantByProviderComponent_ResolvesConsumerVisibilityGate(t *testing.T) {
 	svc, spies := newVisibilityService(t)
 	ctx := context.Background()
@@ -174,10 +173,6 @@ func TestGrantByProviderComponent_ResolvesConsumerVisibilityGate(t *testing.T) {
 	if err := svc.StartOrgServiceVisibility(ctx, "acme", "shop", "billing"); err != nil {
 		t.Fatalf("StartOrgServiceVisibility: %v", err)
 	}
-	// Re-point the design + repo the grant tail reads: the CONSUMER gate lives in
-	// project "shop" (fakeRepos returns a single repo "o/r" + acme/warehouse, which
-	// is fine — findProvisionIssue reads the consumer issue list).
-	reeval := svc.reeval.(*fakeReeval)
 	execs := svc.execs.(*fakeExecStore)
 
 	// The consumer gate issue number (the org-service-visibility gate).
@@ -204,12 +199,9 @@ func TestGrantByProviderComponent_ResolvesConsumerVisibilityGate(t *testing.T) {
 	if r.Component != "billing" {
 		t.Fatalf("provision run must be keyed by the org-service dep name, got %q", r.Component)
 	}
-	// The gate issue closed and the funnel reevaluated (held consumer dispatches).
+	// The gate issue closed (held consumer dispatches via gate-close webhook + sweep).
 	if _, closed := spies.issues.closed[consumerGate]; !closed {
 		t.Fatalf("consumer visibility gate must be closed on grant")
-	}
-	if reeval.calls == 0 {
-		t.Fatalf("grant cascade must reevaluate the funnel")
 	}
 	// The rider flipped to granted.
 	if spies.access.rows[0].Status != dependencies.AccessRequestStatusGranted {

--- a/services/aep-api/internal/dependencies/provisioning/ports.go
+++ b/services/aep-api/internal/dependencies/provisioning/ports.go
@@ -56,13 +56,6 @@ type ExecutionStore interface {
 	ListActive(ctx context.Context) ([]delivery.Execution, error)
 }
 
-// Reevaluator releases consumer coding tasks whose provision dependency just
-// reached deployed (the same unhold hook build success uses). *execution.Funnel
-// satisfies it.
-type Reevaluator interface {
-	Reevaluate(ctx context.Context) error
-}
-
 // DesignReader reads a project's authored design components at HEAD. It returns
 // ONLY models-typed data so this package needs no artifacts feature edge — the
 // composition root adapts artifacts.ArtifactStore. (Minting runs right after

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
@@ -161,10 +161,6 @@ func (f *fakeExecStore) ListActive(_ context.Context) ([]delivery.Execution, err
 	return out, nil
 }
 
-type fakeReeval struct{ calls int }
-
-func (f *fakeReeval) Reevaluate(context.Context) error { f.calls++; return nil }
-
 type fakeDesign struct {
 	comps []spec.DesignComponent
 	err   error
@@ -432,11 +428,10 @@ func designWithDeps() []spec.DesignComponent {
 	}}
 }
 
-func newTestService(issues *fakeIssues, execs *fakeExecStore, reeval Reevaluator, design DesignReader, ext *fakeExtProv, plat *fakePlatProv, bindings *fakeBindings) *Service {
+func newTestService(issues *fakeIssues, execs *fakeExecStore, design DesignReader, ext *fakeExtProv, plat *fakePlatProv, bindings *fakeBindings) *Service {
 	return NewService(Deps{
 		Issues:   issues,
 		Execs:    execs,
-		Reeval:   reeval,
 		Design:   design,
 		Repos:    fakeRepos{},
 		ExtProv:  ext,
@@ -449,7 +444,7 @@ func newTestService(issues *fakeIssues, execs *fakeExecStore, reeval Reevaluator
 
 func TestEnsureProvisionIssues_MintsPerDepDeduped(t *testing.T) {
 	issues := newFakeIssues(nil)
-	svc := newTestService(issues, &fakeExecStore{}, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, &fakeExecStore{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 
 	gateByDep, err := svc.EnsureProvisionIssues(context.Background(), "org", "proj", "v1-1", 0)
 	if err != nil {
@@ -507,7 +502,7 @@ func TestEnsureProvisionIssues_MintsPerDepDeduped(t *testing.T) {
 // agent work.
 func TestEnsureProvisionIssues_AssignsTheMilestoneAtCreation(t *testing.T) {
 	issues := newFakeIssues(nil)
-	svc := newTestService(issues, &fakeExecStore{}, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, &fakeExecStore{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 
 	if _, err := svc.EnsureProvisionIssues(context.Background(), "org", "proj", "v4", 7); err != nil {
 		t.Fatalf("EnsureProvisionIssues: %v", err)
@@ -529,12 +524,11 @@ func TestSaveValues_ProvisionsAndClosesGate(t *testing.T) {
 	gate := provisionGateIssue(10, "stripe")
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	ext := &fakeExtProv{}
 	// Secret-vs-plain classification comes from the project's committed design
 	// (dep.Config), never a catalog: SaveValues reads the design to split
 	// api_key → secret, region → plain (see designWithDeps).
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, ext, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, ext, &fakePlatProv{}, &fakeBindings{})
 
 	err := svc.SaveValues(context.Background(), "org", "org", "proj", "stripe", map[string]map[string]string{
 		"development": {"api_key": "sk_live_x", "region": "us"},
@@ -554,12 +548,9 @@ func TestSaveValues_ProvisionsAndClosesGate(t *testing.T) {
 	if _, leaked := ev.Plain["api_key"]; leaked {
 		t.Fatalf("secret api_key leaked into the plain map")
 	}
-	// The gate issue is closed and the funnel re-evaluated (consumers release).
+	// The gate issue is closed (consumers release via gate-close webhook + sweep).
 	if _, closed := issues.closed[10]; !closed {
 		t.Fatalf("gate issue must be closed after external provisioning")
-	}
-	if reeval.calls != 1 {
-		t.Fatalf("Reevaluate must be called once, got %d", reeval.calls)
 	}
 	// The provision Execution derives deployed (succeeded provision run).
 	if r := latestProvisionRow(execs); r == nil || r.Status != string(taskmeta.ExecSucceeded) {
@@ -575,9 +566,8 @@ func TestProvision_PlatformIsAsync_LeftRunning(t *testing.T) {
 	gate := provisionGateIssue(11, "orders-db")
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, plat, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, plat, &fakeBindings{})
 
 	if err := svc.Provision(context.Background(), "org", "proj", "orders-db", nil, nil); err != nil {
 		t.Fatalf("Provision: %v", err)
@@ -601,19 +591,15 @@ func TestProvision_PlatformIsAsync_LeftRunning(t *testing.T) {
 	if _, closed := issues.closed[11]; closed {
 		t.Fatalf("gate issue must stay open until the binding is ready")
 	}
-	if reeval.calls != 0 {
-		t.Fatalf("no reevaluate before readiness, got %d", reeval.calls)
-	}
 }
 
 func TestResourceWatcher_ReadyClosesGateAndReleases(t *testing.T) {
 	gate := provisionGateIssue(11, "orders-db")
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	execs := &fakeExecStore{}
-	reeval := &fakeReeval{}
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{}}
 	plat := &fakePlatProv{}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, plat, bindings)
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, plat, bindings)
 
 	// Provision (async) → running row pinned to the binding.
 	if err := svc.Provision(context.Background(), "org", "proj", "orders-db", nil, nil); err != nil {
@@ -643,9 +629,6 @@ func TestResourceWatcher_ReadyClosesGateAndReleases(t *testing.T) {
 	if _, closed := issues.closed[11]; !closed {
 		t.Fatalf("gate issue must be closed once the binding is ready")
 	}
-	if reeval.calls != 1 {
-		t.Fatalf("Reevaluate must fire once on readiness, got %d", reeval.calls)
-	}
 }
 
 func TestResourceWatcher_StaleFails(t *testing.T) {
@@ -653,7 +636,7 @@ func TestResourceWatcher_StaleFails(t *testing.T) {
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	execs := &fakeExecStore{}
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{"o-orders-db-development": {}}}
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, bindings)
 	if err := svc.Provision(context.Background(), "org", "proj", "orders-db", nil, nil); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -672,7 +655,7 @@ func TestStatus_MasksOutputsToNames(t *testing.T) {
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{
 		"proj-orders-db-development": readyBinding("host", "port"),
 	}}
-	svc := newTestService(newFakeIssues(nil), &fakeExecStore{}, &fakeReeval{}, fakeDesign{}, &fakeExtProv{}, &fakePlatProv{}, bindings)
+	svc := newTestService(newFakeIssues(nil), &fakeExecStore{}, fakeDesign{}, &fakeExtProv{}, &fakePlatProv{}, bindings)
 	st, err := svc.Status(context.Background(), "org", "proj", "orders-db", "")
 	if err != nil {
 		t.Fatalf("Status: %v", err)
@@ -882,7 +865,7 @@ func TestDeprovisionProject_TearsDownResources(t *testing.T) {
 
 func TestSaveValues_WrongKind400(t *testing.T) {
 	// stripe is external; asking to provision it as a platform resource is wrong-kind.
-	svc := newTestService(newFakeIssues(nil), &fakeExecStore{}, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(newFakeIssues(nil), &fakeExecStore{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 	err := svc.Provision(context.Background(), "org", "proj", "stripe", nil, nil)
 	if err == nil || !strings.Contains(err.Error(), dependencies.ErrDepWrongKind.Error()) {
 		t.Fatalf("provisioning an external dep as a resource must be wrong-kind, got %v", err)
@@ -929,7 +912,7 @@ func contains(ss []string, want string) bool {
 // provisioner must never be called.
 func TestSaveValues_DesignReadErrorFails(t *testing.T) {
 	ext := &fakeExtProv{}
-	svc := newTestService(newFakeIssues(nil), &fakeExecStore{}, &fakeReeval{},
+	svc := newTestService(newFakeIssues(nil), &fakeExecStore{},
 		fakeDesign{err: fmt.Errorf("boom")}, ext, &fakePlatProv{}, &fakeBindings{})
 
 	err := svc.SaveValues(context.Background(), "org", "org", "proj", "stripe",
@@ -959,7 +942,7 @@ func TestSaveValues_UnionSecretAcrossComponents(t *testing.T) {
 			{Kind: spec.DependencyKindExternal, Name: "stripe", Config: []spec.ConfigKey{{Key: "api_key", Secret: true}}}, // secret
 		}},
 	}
-	svc := newTestService(newFakeIssues([]sourcecontrol.IssueInfo{gate}), &fakeExecStore{}, &fakeReeval{},
+	svc := newTestService(newFakeIssues([]sourcecontrol.IssueInfo{gate}), &fakeExecStore{},
 		fakeDesign{comps: comps}, ext, &fakePlatProv{}, &fakeBindings{})
 
 	if err := svc.SaveValues(context.Background(), "org", "org", "proj", "stripe",
@@ -986,7 +969,7 @@ func TestSaveValues_UnionSecretAcrossComponents(t *testing.T) {
 func TestSaveValues_AuthorsDefinitionFromDesign(t *testing.T) {
 	gate := provisionGateIssue(10, "stripe")
 	ext := &fakeExtProv{}
-	svc := newTestService(newFakeIssues([]sourcecontrol.IssueInfo{gate}), &fakeExecStore{}, &fakeReeval{},
+	svc := newTestService(newFakeIssues([]sourcecontrol.IssueInfo{gate}), &fakeExecStore{},
 		fakeDesign{comps: designWithDeps()}, ext, &fakePlatProv{}, &fakeBindings{}) // empty catalog
 
 	if err := svc.SaveValues(context.Background(), "org", "org", "proj", "stripe",
@@ -1008,22 +991,18 @@ func TestSaveValues_AuthorsDefinitionFromDesign(t *testing.T) {
 
 // TestCompleteProvisionRow_FinishLoserSkipsCloseIssue: when Finish returns
 // (nil, nil) because the row is already terminal, the loser must not CloseIssue
-// (or re-evaluate) — another replica already won.
+// — another replica already won.
 func TestCompleteProvisionRow_FinishLoserSkipsCloseIssue(t *testing.T) {
 	gate := provisionGateIssue(10, "stripe")
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	row := &delivery.Execution{ID: "e1", Status: string(taskmeta.ExecSucceeded)} // already terminal
 	execs := &fakeExecStore{rows: []*delivery.Execution{row}}
-	reeval := &fakeReeval{}
-	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 
 	svc.completeProvisionRow(context.Background(), "org", "proj", "stripe", 10, "e1", "ref")
 
 	if _, closed := issues.closed[10]; closed {
 		t.Fatalf("loser must not CloseIssue")
-	}
-	if reeval.calls != 0 {
-		t.Fatalf("loser must not Reevaluate, got %d calls", reeval.calls)
 	}
 }
 
@@ -1034,7 +1013,7 @@ func TestFailProvisionRow_FinishLoserSkipsComment(t *testing.T) {
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
 	row := &delivery.Execution{ID: "e1", Status: string(taskmeta.ExecFailed)} // already terminal
 	execs := &fakeExecStore{rows: []*delivery.Execution{row}}
-	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+	svc := newTestService(issues, execs, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
 
 	svc.failProvisionRow(context.Background(), "org", "proj", 10, "e1", "boom")
 

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
@@ -141,6 +141,9 @@ func (f *fakeExecStore) StartWithRun(_ context.Context, id, runName string) (*de
 func (f *fakeExecStore) Finish(_ context.Context, id, status, reason string) (*delivery.Execution, error) {
 	for _, r := range f.rows {
 		if r.ID == id {
+			if !taskmeta.ExecutionStatus(r.Status).IsActive() {
+				return nil, nil // loser — already terminal
+			}
 			r.Status = status
 			r.Reason = reason
 			return r, nil
@@ -1000,5 +1003,42 @@ func TestSaveValues_AuthorsDefinitionFromDesign(t *testing.T) {
 	}
 	if !secret["api_key"] || secret["region"] {
 		t.Fatalf("authored config must reflect the design schema; got %v", secret)
+	}
+}
+
+// TestCompleteProvisionRow_FinishLoserSkipsCloseIssue: when Finish returns
+// (nil, nil) because the row is already terminal, the loser must not CloseIssue
+// (or re-evaluate) — another replica already won.
+func TestCompleteProvisionRow_FinishLoserSkipsCloseIssue(t *testing.T) {
+	gate := provisionGateIssue(10, "stripe")
+	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
+	row := &delivery.Execution{ID: "e1", Status: string(taskmeta.ExecSucceeded)} // already terminal
+	execs := &fakeExecStore{rows: []*delivery.Execution{row}}
+	reeval := &fakeReeval{}
+	svc := newTestService(issues, execs, reeval, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+
+	svc.completeProvisionRow(context.Background(), "org", "proj", "stripe", 10, "e1", "ref")
+
+	if _, closed := issues.closed[10]; closed {
+		t.Fatalf("loser must not CloseIssue")
+	}
+	if reeval.calls != 0 {
+		t.Fatalf("loser must not Reevaluate, got %d calls", reeval.calls)
+	}
+}
+
+// TestFailProvisionRow_FinishLoserSkipsComment: same race on the failure path —
+// a pre-terminal row means Finish lost, so the gate must not get a failed comment.
+func TestFailProvisionRow_FinishLoserSkipsComment(t *testing.T) {
+	gate := provisionGateIssue(10, "stripe")
+	issues := newFakeIssues([]sourcecontrol.IssueInfo{gate})
+	row := &delivery.Execution{ID: "e1", Status: string(taskmeta.ExecFailed)} // already terminal
+	execs := &fakeExecStore{rows: []*delivery.Execution{row}}
+	svc := newTestService(issues, execs, &fakeReeval{}, fakeDesign{comps: designWithDeps()}, &fakeExtProv{}, &fakePlatProv{}, &fakeBindings{})
+
+	svc.failProvisionRow(context.Background(), "org", "proj", 10, "e1", "boom")
+
+	if comments := issues.comments[10]; len(comments) != 0 {
+		t.Fatalf("loser must not CommentIssue, got %v", comments)
 	}
 }

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_test.go
@@ -618,7 +618,7 @@ func TestResourceWatcher_ReadyClosesGateAndReleases(t *testing.T) {
 		t.Fatalf("run must stay running while binding not ready, got %s", r.Status)
 	}
 
-	// Binding goes Ready → watcher finishes the run, closes the gate, reevaluates.
+	// Binding goes Ready → watcher finishes the run, closes the gate (webhook + sweep release consumers).
 	bindings.byName["o-orders-db-development"] = readyBinding("host", "port")
 	if err := w.Sweep(context.Background()); err != nil {
 		t.Fatalf("Sweep (ready): %v", err)

--- a/services/aep-api/internal/dependencies/provisioning/service.go
+++ b/services/aep-api/internal/dependencies/provisioning/service.go
@@ -41,7 +41,6 @@ const defaultEnv = openchoreo.DevEnvironmentName
 type Service struct {
 	issues    IssueClient
 	execs     ExecutionStore
-	reeval    Reevaluator
 	design    DesignReader
 	repos     RepoLocator
 	rtCatalog ExternalRTCatalog
@@ -79,14 +78,12 @@ func (s *Service) SetOrgPublishMarker(m OrgPublishMarker) { s.orgPublish = m }
 // org-service visibility flow. Nil is a documented best-effort no-op (logged).
 func (s *Service) SetProviderBuildTrigger(t ProviderBuildTrigger) { s.providerBuild = t }
 
-// Deps is the provisioning service's collaborator set. reeval / projects /
-// access / providers may be nil (a nil reeval skips the release nudge — the
-// sweep heals it; a nil projects skips the cross-project consumer scan; nil
-// access / providers disable the access-request surface).
+// Deps is the provisioning service's collaborator set. projects / access /
+// providers may be nil (a nil projects skips the cross-project consumer scan;
+// nil access / providers disable the access-request surface).
 type Deps struct {
 	Issues    IssueClient
 	Execs     ExecutionStore
-	Reeval    Reevaluator
 	Design    DesignReader
 	Repos     RepoLocator
 	RTCatalog ExternalRTCatalog
@@ -103,7 +100,6 @@ func NewService(d Deps) *Service {
 	return &Service{
 		issues:    d.Issues,
 		execs:     d.Execs,
-		reeval:    d.Reeval,
 		design:    d.Design,
 		repos:     d.Repos,
 		rtCatalog: d.RTCatalog,
@@ -199,10 +195,10 @@ func (s *Service) admitProvisionRow(ctx context.Context, orgID, projectID, repo,
 	return row, admitted, err
 }
 
-// completeProvisionRow finishes a provision Execution succeeded, closes the gate
-// issue with a no-secrets reference, and re-evaluates the funnel so consumer tasks
-// gated on this dependency dispatch. Used by the synchronous external path and
-// the readiness watcher.
+// completeProvisionRow finishes a provision Execution succeeded and closes the
+// gate issue with a no-secrets reference. Consumer tasks gated on this
+// dependency release via the gate-issue-close webhook and the eventcore sweep.
+// Used by the synchronous external path and the readiness watcher.
 //
 // depName is the dependency this gate held, carried for the log line and (on the
 // watcher path) read off the execution row's Component.
@@ -226,11 +222,6 @@ func (s *Service) completeProvisionRow(ctx context.Context, orgID, projectID, de
 	comment := "✅ Provisioned. " + reference + "\n\nClosing — dependent tasks will dispatch automatically."
 	if err := s.issues.CloseIssue(ctx, orgID, projectID, issueNumber, comment); err != nil {
 		slog.WarnContext(ctx, "provisioning: close gate issue failed", "issue", issueNumber, "error", err)
-	}
-	if s.reeval != nil {
-		if err := s.reeval.Reevaluate(ctx); err != nil {
-			slog.WarnContext(ctx, "provisioning: reevaluate after provision failed", "error", err)
-		}
 	}
 }
 

--- a/services/aep-api/internal/dependencies/provisioning/service.go
+++ b/services/aep-api/internal/dependencies/provisioning/service.go
@@ -215,9 +215,13 @@ func (s *Service) admitProvisionRow(ctx context.Context, orgID, projectID, repo,
 // (wiring.go), where the dispatch predicate guarantees both a resolved design and
 // a non-empty audience.
 func (s *Service) completeProvisionRow(ctx context.Context, orgID, projectID, depName string, issueNumber int, execID, reference string) {
-	if _, err := s.execs.Finish(ctx, execID, string(taskmeta.ExecSucceeded), reference); err != nil {
+	exec, err := s.execs.Finish(ctx, execID, string(taskmeta.ExecSucceeded), reference)
+	if err != nil {
 		slog.WarnContext(ctx, "provisioning: finish provision run failed", "execution", execID, "error", err)
 		return
+	}
+	if exec == nil {
+		return // lost the race — another replica already finished
 	}
 	comment := "✅ Provisioned. " + reference + "\n\nClosing — dependent tasks will dispatch automatically."
 	if err := s.issues.CloseIssue(ctx, orgID, projectID, issueNumber, comment); err != nil {
@@ -242,8 +246,12 @@ func (s *Service) failProvisionRow(ctx context.Context, orgID, projectID string,
 	// terminal must always succeed, so it runs on a cancellation-free context
 	// (values — the user JWT for the issue comment — are preserved).
 	ctx = context.WithoutCancel(ctx)
-	if _, err := s.execs.Finish(ctx, execID, string(taskmeta.ExecFailed), reason); err != nil {
+	exec, err := s.execs.Finish(ctx, execID, string(taskmeta.ExecFailed), reason)
+	if err != nil {
 		slog.WarnContext(ctx, "provisioning: finish provision run (failed) failed", "execution", execID, "error", err)
+	}
+	if exec == nil && err == nil {
+		return // lost the race — another replica already finished
 	}
 	if issueNumber > 0 {
 		if err := s.issues.CommentIssue(ctx, orgID, projectID, issueNumber, "⚠️ Provisioning failed: "+reason); err != nil {

--- a/services/aep-api/internal/dependencies/provisioning/wiring_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/wiring_test.go
@@ -69,7 +69,7 @@ func publishFor(t *testing.T, seed []sourcecontrol.IssueInfo, design []spec.Desi
 	t.Helper()
 	issues := newFakeIssues(append([]sourcecontrol.IssueInfo{provisionGateIssue(11, "orders-db")}, seed...))
 	svc := NewService(Deps{
-		Issues: issues, Execs: &fakeExecStore{}, Reeval: &fakeReeval{},
+		Issues: issues, Execs: &fakeExecStore{},
 		Design: fakeDesign{comps: design}, Repos: fakeRepos{},
 		ExtProv: &fakeExtProv{}, PlatProv: &fakePlatProv{},
 		Bindings: &fakeBindings{}, Providers: providers,
@@ -132,7 +132,7 @@ func TestWiring_GateResolutionPostsNothing(t *testing.T) {
 		codingIssue(21, "Implement web", "open"),
 	})
 	bindings := &fakeBindings{byName: map[string]*openchoreo.ResourceReleaseBinding{}}
-	svc := newTestService(issues, &fakeExecStore{}, &fakeReeval{}, fakeDesign{comps: wiringDesign()},
+	svc := newTestService(issues, &fakeExecStore{}, fakeDesign{comps: wiringDesign()},
 		&fakeExtProv{}, &fakePlatProv{}, bindings)
 
 	if err := svc.Provision(context.Background(), "org", "proj", "orders-db", nil, nil); err != nil {
@@ -240,7 +240,7 @@ func TestWiring_IdempotentAcrossDispatches(t *testing.T) {
 		codingIssue(21, "Implement web", "open"),
 	})
 	svc := NewService(Deps{
-		Issues: issues, Execs: &fakeExecStore{}, Reeval: &fakeReeval{},
+		Issues: issues, Execs: &fakeExecStore{},
 		Design: fakeDesign{comps: wiringDesign()}, Repos: fakeRepos{},
 		ExtProv: &fakeExtProv{}, PlatProv: &fakePlatProv{},
 		Bindings: &fakeBindings{}, Providers: siblingResolved(),
@@ -272,7 +272,7 @@ func TestWiring_PartialPostIsUnmarkedAndSupersededLater(t *testing.T) {
 	issues := newFakeIssues([]sourcecontrol.IssueInfo{codingIssue(21, "Implement web", "open")})
 	providers := siblingResolved() // employee-api absent from nsVisible → unresolved
 	deps := Deps{
-		Issues: issues, Execs: &fakeExecStore{}, Reeval: &fakeReeval{},
+		Issues: issues, Execs: &fakeExecStore{},
 		Design: fakeDesign{comps: design}, Repos: fakeRepos{},
 		ExtProv: &fakeExtProv{}, PlatProv: &fakePlatProv{},
 		Bindings: &fakeBindings{}, Providers: providers,

--- a/services/aep-api/internal/migrate/executions.go
+++ b/services/aep-api/internal/migrate/executions.go
@@ -37,24 +37,35 @@ import (
 // on one component whose fix spans others). For coding/ops rows component is
 // constant per Task, so including it is a no-op for their one-active-per-Task
 // semantics. The pre-fan-out index keyed only (repo, issue_number, kind) is
-// dropped first so an already-migrated DB is upgraded in place.
+// superseded by CREATE-then-DROP so an already-migrated DB is upgraded in place
+// without leaving the mutex unenforced.
 //
-// Idempotent: the DROP/CREATE IF (NOT) EXISTS pair is a no-op on re-run, and the
+// Idempotent: the CREATE/DROP IF (NOT) EXISTS pair is a no-op on re-run, and the
 // step no-ops entirely if the table is not present yet.
 func RunExecutions(ctx context.Context, db *gorm.DB) error {
 	if !hasTable(db, "executions") {
 		return nil
 	}
-	// Drop the legacy component-less admission index (if present) so the widened
-	// key below replaces it in place on an already-migrated database.
-	if err := db.WithContext(ctx).Exec(`DROP INDEX IF EXISTS ux_executions_admission`).Error; err != nil {
-		return fmt.Errorf("drop legacy executions admission index: %w", err)
-	}
-	if err := db.WithContext(ctx).Exec(`
-		CREATE UNIQUE INDEX IF NOT EXISTS ux_executions_admission_component
-		ON executions (repo, issue_number, kind, component)
-		WHERE status IN ('queued', 'running')`).Error; err != nil {
+	stmts := ExecutionsAdmissionStatements()
+	// CREATE-then-DROP (not the reverse): dropping first leaves the admission
+	// mutex unenforced for the width of the migration — the window a second
+	// replica can double-admit into. Same rationale as RunMilestoneRuns.
+	if err := db.WithContext(ctx).Exec(stmts[0]).Error; err != nil {
 		return fmt.Errorf("executions admission-mutex index: %w", err)
 	}
+	if err := db.WithContext(ctx).Exec(stmts[1]).Error; err != nil {
+		return fmt.Errorf("drop legacy executions admission index: %w", err)
+	}
 	return nil
+}
+
+// ExecutionsAdmissionStatements is the ordered DDL RunExecutions applies.
+// CREATE precedes DROP so the admission mutex is never unenforced during upgrade.
+func ExecutionsAdmissionStatements() []string {
+	return []string{
+		`CREATE UNIQUE INDEX IF NOT EXISTS ux_executions_admission_component
+		ON executions (repo, issue_number, kind, component)
+		WHERE status IN ('queued', 'running')`,
+		`DROP INDEX IF EXISTS ux_executions_admission`,
+	}
 }

--- a/services/aep-api/internal/migrate/executions.go
+++ b/services/aep-api/internal/migrate/executions.go
@@ -49,7 +49,8 @@ func RunExecutions(ctx context.Context, db *gorm.DB) error {
 	stmts := ExecutionsAdmissionStatements()
 	// CREATE-then-DROP (not the reverse): dropping first leaves the admission
 	// mutex unenforced for the width of the migration — the window a second
-	// replica can double-admit into. Same rationale as RunMilestoneRuns.
+	// replica can double-admit into. Follows the CREATE-then-DROP ordering
+	// documented on RunMilestoneRuns.
 	if err := db.WithContext(ctx).Exec(stmts[0]).Error; err != nil {
 		return fmt.Errorf("executions admission-mutex index: %w", err)
 	}

--- a/services/aep-api/internal/migrate/executions_reorder_test.go
+++ b/services/aep-api/internal/migrate/executions_reorder_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package migrate_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
+	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/migrate"
+	"github.com/wso2/aep/aep-api/internal/platform/dbtest"
+)
+
+// CREATE must precede DROP so the admission mutex is never unenforced during
+// the upgrade — same rationale as RunMilestoneRuns.
+func TestExecutionsAdmissionStatements_CreateThenDrop(t *testing.T) {
+	t.Parallel()
+	stmts := migrate.ExecutionsAdmissionStatements()
+	if len(stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(stmts))
+	}
+	if !strings.Contains(strings.ToUpper(stmts[0]), "CREATE") {
+		t.Fatalf("first statement must CREATE the new index, got: %s", stmts[0])
+	}
+	if !strings.Contains(strings.ToUpper(stmts[1]), "DROP") {
+		t.Fatalf("second statement must DROP the legacy index, got: %s", stmts[1])
+	}
+	if strings.Contains(strings.ToUpper(stmts[0]), "DROP") {
+		t.Fatalf("first statement must not DROP: %s", stmts[0])
+	}
+}
+
+// After upgrading a DB that only has the legacy admission index, only the
+// component-keyed index remains and a second active admit for the same key
+// is refused.
+func TestRunExecutions_LegacyIndexUpgrade_AdmissionHeld(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t)
+	ctx := context.Background()
+
+	if err := db.Exec(`DROP INDEX IF EXISTS ux_executions_admission_component`).Error; err != nil {
+		t.Fatalf("drop new index: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE UNIQUE INDEX ux_executions_admission
+		ON executions (repo, issue_number, kind)
+		WHERE status IN ('queued', 'running')`).Error; err != nil {
+		t.Fatalf("create legacy index: %v", err)
+	}
+
+	if err := migrate.RunExecutions(ctx, db); err != nil {
+		t.Fatalf("RunExecutions: %v", err)
+	}
+
+	var hasNew, hasLegacy bool
+	if err := db.Raw(`SELECT EXISTS (
+		SELECT 1 FROM pg_indexes WHERE indexname = 'ux_executions_admission_component')`).
+		Scan(&hasNew).Error; err != nil {
+		t.Fatalf("check new index: %v", err)
+	}
+	if err := db.Raw(`SELECT EXISTS (
+		SELECT 1 FROM pg_indexes WHERE indexname = 'ux_executions_admission')`).
+		Scan(&hasLegacy).Error; err != nil {
+		t.Fatalf("check legacy index: %v", err)
+	}
+	if !hasNew {
+		t.Fatal("want ux_executions_admission_component after upgrade")
+	}
+	if hasLegacy {
+		t.Fatal("legacy ux_executions_admission must be dropped after upgrade")
+	}
+
+	repo := delivery.NewExecutionRepository(db, nil)
+	first := &delivery.Execution{
+		OrgID:       "orga",
+		ProjectID:   "proj",
+		Repo:        "acme/repo",
+		IssueNumber: 42,
+		Kind:        string(taskmeta.KindCoding),
+		Component:   "web",
+	}
+	ok, _, err := repo.TryAdmit(ctx, first)
+	if err != nil || !ok {
+		t.Fatalf("TryAdmit(first) = (%v, %v), want admitted", ok, err)
+	}
+	second := &delivery.Execution{
+		OrgID:       "orga",
+		ProjectID:   "proj",
+		Repo:        "acme/repo",
+		IssueNumber: 42,
+		Kind:        string(taskmeta.KindCoding),
+		Component:   "web",
+	}
+	ok, _, err = repo.TryAdmit(ctx, second)
+	if err != nil {
+		t.Fatalf("TryAdmit(second): %v", err)
+	}
+	if ok {
+		t.Fatal("TryAdmit(second) admitted — component admission mutex not enforced")
+	}
+}

--- a/services/aep-api/internal/migrate/executions_reorder_test.go
+++ b/services/aep-api/internal/migrate/executions_reorder_test.go
@@ -18,33 +18,16 @@ package migrate_test
 
 import (
 	"context"
-	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
 	"github.com/wso2/aep/aep-api/internal/delivery"
 	"github.com/wso2/aep/aep-api/internal/migrate"
 	"github.com/wso2/aep/aep-api/internal/platform/dbtest"
 )
-
-// CREATE must precede DROP so the admission mutex is never unenforced during
-// the upgrade — same rationale as RunMilestoneRuns.
-func TestExecutionsAdmissionStatements_CreateThenDrop(t *testing.T) {
-	t.Parallel()
-	stmts := migrate.ExecutionsAdmissionStatements()
-	if len(stmts) != 2 {
-		t.Fatalf("got %d statements, want 2", len(stmts))
-	}
-	if !strings.Contains(strings.ToUpper(stmts[0]), "CREATE") {
-		t.Fatalf("first statement must CREATE the new index, got: %s", stmts[0])
-	}
-	if !strings.Contains(strings.ToUpper(stmts[1]), "DROP") {
-		t.Fatalf("second statement must DROP the legacy index, got: %s", stmts[1])
-	}
-	if strings.Contains(strings.ToUpper(stmts[0]), "DROP") {
-		t.Fatalf("first statement must not DROP: %s", stmts[0])
-	}
-}
 
 // After upgrading a DB that only has the legacy admission index, only the
 // component-keyed index remains and a second active admit for the same key
@@ -113,5 +96,77 @@ func TestRunExecutions_LegacyIndexUpgrade_AdmissionHeld(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("TryAdmit(second) admitted — component admission mutex not enforced")
+	}
+}
+
+// Concurrent TryAdmit during the CREATE→DROP upgrade window must never
+// double-admit. A sleep between the two statements widens the window so the
+// race is observable; CREATE-then-DROP keeps a covering unique index for the
+// whole gap (DROP-then-CREATE would leave none).
+func TestRunExecutions_CreateThenDrop_NoDoubleAdmitUnderConcurrentTryAdmit(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t)
+	ctx := context.Background()
+
+	if err := db.Exec(`DROP INDEX IF EXISTS ux_executions_admission_component`).Error; err != nil {
+		t.Fatalf("drop new index: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE UNIQUE INDEX ux_executions_admission
+		ON executions (repo, issue_number, kind)
+		WHERE status IN ('queued', 'running')`).Error; err != nil {
+		t.Fatalf("create legacy index: %v", err)
+	}
+
+	stmts := migrate.ExecutionsAdmissionStatements()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := db.WithContext(ctx).Exec(stmts[0]).Error; err != nil {
+			t.Errorf("CREATE: %v", err)
+			return
+		}
+		time.Sleep(200 * time.Millisecond) // widen CREATE→DROP window
+		if err := db.WithContext(ctx).Exec(stmts[1]).Error; err != nil {
+			t.Errorf("DROP: %v", err)
+		}
+	}()
+
+	repo := delivery.NewExecutionRepository(db, nil)
+	var admits atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				e := &delivery.Execution{
+					OrgID:       "orga",
+					ProjectID:   "proj",
+					Repo:        "acme/race",
+					IssueNumber: 99,
+					Kind:        string(taskmeta.KindCoding),
+					Component:   "web",
+				}
+				ok, _, err := repo.TryAdmit(ctx, e)
+				if err != nil {
+					continue // unique violations / transient — keep spinning
+				}
+				if ok {
+					admits.Add(1)
+				}
+			}
+		}()
+	}
+	<-done
+	wg.Wait()
+
+	if n := admits.Load(); n != 1 {
+		t.Fatalf("admits during CREATE-then-DROP window = %d, want exactly 1", n)
 	}
 }

--- a/services/aep-api/internal/migrate/run_all.go
+++ b/services/aep-api/internal/migrate/run_all.go
@@ -176,5 +176,5 @@ func Steps(db *gorm.DB, deploymentTier string, credKey []byte) []database.Step {
 // those blocks are preserved on the steps in Steps. Fails fast on the first
 // error, naming the offending step. credKey must be 32 bytes for phase12.
 func RunAll(ctx context.Context, db *gorm.DB, deploymentTier string, credKey []byte) error {
-	return database.Run(ctx, Steps(db, deploymentTier, credKey))
+	return database.Run(ctx, db, Steps(db, deploymentTier, credKey))
 }

--- a/services/aep-api/internal/platform/database/runner.go
+++ b/services/aep-api/internal/platform/database/runner.go
@@ -37,6 +37,11 @@ import (
 // manage their own lifetimes and ignore it.
 const StepTimeout = 30 * time.Second
 
+// migrationLockKey serializes boot schema migrations across aep-api replicas.
+// Session-scoped (not xact): Run is not a single transaction. Distinct from
+// validatorLockKey (0x76616c696461746f) in platform/secrets.
+const migrationLockKey int64 = 0x6165702d6d696772 // "aep-migr" bytes
+
 // Step is one ordered schema migration, reduced to a name and a run func so the
 // runner needs no knowledge of what it does.
 type Step struct {
@@ -62,7 +67,30 @@ func CtxStep(name string, db *gorm.DB, fn func(context.Context, *gorm.DB) error)
 // Run applies every step in the ORDER GIVEN — the order is the caller's
 // invariant, never re-derived here (it is load-bearing and non-obvious; see
 // internal/migrate). Fails fast, naming the offending step.
-func Run(ctx context.Context, steps []Step) error {
+//
+// Concurrent callers (multi-replica boot) are serialized with a session-scoped
+// Postgres advisory lock held on a dedicated connection for the whole loop.
+func Run(ctx context.Context, db *gorm.DB, steps []Step) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("migration lock: underlying sql.DB: %w", err)
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("migration lock: conn: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrationLockKey); err != nil {
+		return fmt.Errorf("migration lock: acquire: %w", err)
+	}
+	defer func() {
+		// Unlock on the same session even if ctx is cancelled.
+		if _, uerr := conn.ExecContext(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock($1)`, migrationLockKey); uerr != nil {
+			slog.Error("migration lock: unlock failed", "error", uerr)
+		}
+	}()
+
 	for _, s := range steps {
 		if err := s.Run(ctx); err != nil {
 			return fmt.Errorf("%s migration: %w", s.Name, err)

--- a/services/aep-api/internal/platform/database/runner.go
+++ b/services/aep-api/internal/platform/database/runner.go
@@ -81,6 +81,12 @@ func Run(ctx context.Context, db *gorm.DB, steps []Step) error {
 	}
 	defer conn.Close()
 
+	slog.Info("waiting for migration lock", "key", migrationLockKey)
+	// Bound the wait so a wedged peer surfaces as a named error instead of an
+	// unexplained boot hang (Kubernetes would otherwise restart into the same queue).
+	if _, err := conn.ExecContext(ctx, `SET lock_timeout = '60s'`); err != nil {
+		return fmt.Errorf("migration lock: set lock_timeout: %w", err)
+	}
 	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrationLockKey); err != nil {
 		return fmt.Errorf("migration lock: acquire: %w", err)
 	}

--- a/services/aep-api/internal/platform/database/runner_dbtest_test.go
+++ b/services/aep-api/internal/platform/database/runner_dbtest_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package database_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/platform/database"
+	"github.com/wso2/aep/aep-api/internal/platform/dbtest"
+)
+
+// Two concurrent Run calls against one DB must serialize: the loser's first
+// step must not start until the winner's last step has finished.
+func TestRun_SerializesConcurrentCallersWithAdvisoryLock(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t) // already migrated; we only exercise the lock wrapper
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	step := func(ctx context.Context) error {
+		cur := concurrent.Add(1)
+		for {
+			old := maxConcurrent.Load()
+			if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+		concurrent.Add(-1)
+		return nil
+	}
+	steps := []database.Step{{Name: "probe", Run: step}}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- database.Run(context.Background(), db, steps)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+	if maxConcurrent.Load() != 1 {
+		t.Fatalf("max concurrent steps = %d, want 1 (advisory lock must serialize)", maxConcurrent.Load())
+	}
+}

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -487,7 +487,8 @@ func (s *Service) AttachTurn(ctx context.Context, orgID, projectID, turnID strin
 	sub, err := s.broker.Subscribe(turnID, from)
 	if errors.Is(err, ErrTurnNotBuffered) {
 		// Known turn, expired (or other-replica) buffer → 404 pre-stream; the
-		// FE falls back to the status GET.
+		// console retries attach with backoff and settles via the status GET when
+		// the turn is already terminal.
 		return nil, ErrTurnNotFound
 	}
 	if err != nil {

--- a/services/aep-api/internal/spec/turn_stream.go
+++ b/services/aep-api/internal/spec/turn_stream.go
@@ -21,8 +21,9 @@ package spec
 // payload as it taps the agents stream, attachers replay from an index and
 // live-tail, and ONE terminal event closes the turn. The buffer is
 // deliberately not durable (replica affinity, D17) and is dropped
-// turnBufferRetention after the terminal event — an attach after that 404s
-// and the FE falls back to the status GET.
+// turnBufferRetention after the terminal event — an attach after that 404s;
+// the console retries attach with backoff and settles via the status GET when
+// the turn is already terminal.
 
 import (
 	"errors"


### PR DESCRIPTION
## Why this exists

Today several paths in `aep-api` and the console assume a **single** API pod. When two pods run behind the same load balancer, users can see:

1. A design/agent turn show **“Turn failed”** even though it is still running (stream attach hit the other pod’s in-memory buffer → 404).
2. Pods **crash-loop on boot** when both apply schema migrations at once, and a short window where two provision runs can be admitted for the same work.
3. **Duplicate** gate-issue comments / budget bumps when two pods race to finish the same execution row.
4. Dead wiring left after PR #332: a `Reevaluator` port that is never set, so it never runs.

This PR fixes those four problems in code. It does **not** change replica counts in cloud; that stays a later deploy step.

## What changed

### 1. Console: retry turn-stream attach on 404

The turn narration buffer lives **in memory on one pod**. A browser that lands on another pod gets HTTP 404 before any SSE bytes. Previously that became a hard “Turn failed”. Now the client treats 404 as “try again with backoff”, and if the turn already finished it settles via the status GET.

```mermaid
sequenceDiagram
  participant UI as Console
  participant A as aep-api pod A<br/>(has buffer)
  participant B as aep-api pod B<br/>(no buffer)

  UI->>B: GET .../turns/{id}/stream
  B-->>UI: 404 (no local buffer)
  Note over UI: backoff, then retry
  UI->>B: GET .../turns/{id} (status)
  alt turn already completed/failed
    B-->>UI: terminal status
    Note over UI: settle bubble, stop retrying
  else still running
    UI->>A: GET .../turns/{id}/stream (retry may hit A)
    A-->>UI: 200 SSE (replay from index 0)
  end
```

### 2. Boot migrations: one lock, safer index swap

Two pods booting together used to run DDL concurrently. Migrations now take a **session-scoped Postgres advisory lock** so only one `database.Run` proceeds at a time. Separately, the executions admission index is created **before** the legacy index is dropped (same pattern as milestone runs), so there is never a window with no unique constraint.

```mermaid
flowchart LR
  subgraph before [Before]
    D1[DROP legacy index] --> Gap[No admission mutex] --> C1[CREATE new index]
  end
  subgraph after [After]
    C2[CREATE new index] --> D2[DROP legacy index]
  end
```

```mermaid
sequenceDiagram
  participant P1 as Pod 1 boot
  participant P2 as Pod 2 boot
  participant PG as Postgres

  P1->>PG: pg_advisory_lock(migration)
  P2->>PG: pg_advisory_lock(migration)
  Note over P2: blocks until P1 unlocks
  P1->>PG: RunAll migrations
  P1->>PG: pg_advisory_unlock
  P2->>PG: acquires lock, RunAll (idempotent)
```

### 3. Finish race: only the winner runs side effects

`Execution.Finish` is already conditional (`UPDATE … WHERE status IN (queued, running)`). The loser gets `(nil, nil)`. Call sites were ignoring that and still posting “✅ Provisioned” / “⚠️ failed” comments or notifying the build event plane. They now return immediately on a nil execution.

```mermaid
sequenceDiagram
  participant W1 as Watcher on pod 1
  participant W2 as Watcher on pod 2
  participant DB as executions row
  participant GH as GitHub issue

  W1->>DB: Finish(succeeded)
  DB-->>W1: row (winner)
  W2->>DB: Finish(succeeded)
  DB-->>W2: nil, nil (loser)
  W1->>GH: CloseIssue("✅ Provisioned…")
  Note over W2: skip CloseIssue / notifyBuildTerminal
```

### 4. Remove dead `Reevaluator` port

After PR #332 deleted the execution funnel, provisioning still had a `Reevaluator` dependency that `app.go` never wired. This PR deletes the interface, field, nil-guarded call, and test fakes.

#### Assumption for #332 authors — please veto at review if wrong

The instant “re-check blocked tasks now” nudge that port existed for is **superseded by the gate-issue-close webhook + the 60s `eventcore` sweep**. If that nudge must stay, say so and we will restore a real wiring instead of deleting the port.

## Out of scope (intentionally)

- Changing cloud `replicas:` (deploy later)
- Persisting turn-stream parts in Postgres (durable follow-up behind the 404 retry)
- Log-capture `ON CONFLICT` handling (deferred with the coding-agent job work)
- Advisory lock on the eventcore sweep (accepted 2× GitHub API cost at two replicas)

## Test plan

Local only (no cloud / no browser E2E in this PR):

- [x] `make test` / `make lint` / `make typecheck`
- [x] `services/aep-api` `make deadcode-check` (`Reevaluator` fully gone)
- [x] Console unit: turn-stream 404 retry + terminal settle + non-404 still throws
- [x] Integration / unit race proofs:

```
--- PASS: TestRun_SerializesConcurrentCallersWithAdvisoryLock
--- PASS: TestExecutionsAdmissionStatements_CreateThenDrop
--- PASS: TestRunExecutions_LegacyIndexUpgrade_AdmissionHeld
--- PASS: TestCompleteProvisionRow_FinishLoserSkipsCloseIssue
--- PASS: TestFailProvisionRow_FinishLoserSkipsComment
--- PASS: TestExecWatcher_BuildSuccess_FinishLoserSkipsObserver
--- PASS: TestExecWatcher_CodingFailure_FinishLoserSkipsNotify
--- PASS: TestExecWatcher_BuildPlainFailure_FinishLoserSkipsNotifyAndObserver
--- PASS: TestExecWatcher_BuildAuthBudgetExhausted_FinishLoserSkipsNotifyAndObserver
--- PASS: TestJobWatcher_FinishFailed_LoserSkipsNotify
```

- [x] Two-axis `/code-review` against `aep-rewrite` (Standards: no hard violations; Spec: missing loser tests then filled; no cancelled items built)
- [ ] Browser E2E (`agent-browser`) — **not run**; needs a live multi-replica (or sticky-buffer miss) environment. Planned with the cloud `replicas: 2` checks later.