### PR TITLE
fix(console): chown /var/lib/nginx for non-root alpine nginx

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -91,8 +91,14 @@ COPY --from=builder --chown=10001:10001 /repo/apps/console/dist /usr/share/nginx
 COPY --chown=10001:10001 apps/console/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
+# Alpine's packaged nginx (and any `apk upgrade nginx` in cloud overlays) defaults
+# temp paths to /var/lib/nginx/tmp/*, owned by the distro `nginx` user. UID 10001
+# must own that tree or boot fails with:
+#   mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
+# Official nginx image temps under /var/cache/nginx — chown both.
 RUN chown -R 10001:10001 /var/cache/nginx && \
     chown -R 10001:10001 /var/log/nginx && \
+    chown -R 10001:10001 /var/lib/nginx && \
     chown -R 10001:10001 /etc/nginx && \
     chown -R 10001:10001 /usr/share/nginx/html
 


### PR DESCRIPTION
## Summary
- Console pods in wso2cloud dev CrashLoop with `mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)`.
- Root cause: Alpine's packaged nginx (pulled by the cloud overlay's `apk upgrade nginx` for Trivy) defaults temp paths to `/var/lib/nginx/tmp`, which the image never chown'd for UID 10001. Official `nginx:*-alpine` temps under `/var/cache/nginx` (already chown'd), so this only surfaces after the overlay upgrade.
- Chown `/var/lib/nginx` alongside the existing cache/log/etc paths.

## Test plan
- [x] Reproduced failure locally after `apk upgrade nginx` as UID 10001
- [x] Confirmed `chown -R 10001:10001 /var/lib/nginx` allows creating `/var/lib/nginx/tmp/client_body`
- [ ] Overlay Dockerfile gets the same chown (companion PR) and console image is rebuilt/redeployed
- [ ] `kubectl -n dp-wso2cloud-app-factory-development-bad5f211 logs deploy/app-factory-console-…` shows nginx listening; no CrashLoopBackOff