### PR TITLE
feat(agents): assemble conversation Postgres URL from discrete DB_* envs

### DIFF
--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -37,9 +37,17 @@ AGENT_JWT_SECRET=dev-agents-m2m-secret
 # this service never writes it.
 WORKSPACE_MOUNT_ROOT=/workspaces
 
-# ConversationStore: Postgres when DATABASE_URL is set, else in-memory. Threads
-# embed inlined snapshots, so a TTL sweep on updated_at reclaims stored rows.
+# ConversationStore: Postgres when a URL resolves, else in-memory. Precedence:
+# DATABASE_URL (verbatim, local dev) > discrete DB_* (platform release-binding).
+# When both are set, DATABASE_URL wins. Omit DB_SSLMODE to leave sslmode out of
+# the assembled URL. Incomplete discrete fields → in-memory store.
 DATABASE_URL=postgres://aep:aep@localhost:5432/aep?sslmode=disable
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=aep
+# DB_PASSWORD=aep
+# DB_NAME=aep
+# DB_SSLMODE=disable
 CONVERSATIONS_TTL_MS=604800000
 CONVERSATIONS_SWEEP_MS=3600000
 

--- a/services/agents/AGENTS.md
+++ b/services/agents/AGENTS.md
@@ -69,8 +69,12 @@ off the stream. The plan tool contract (inputs, results, error codes, the
 - **M2M gate is always on**: set `AGENT_JWT_JWKS_URL` (RS256) **or**
   `AGENT_JWT_SECRET` (HS256) — the server refuses to boot with neither. `aud`
   defaults to `agents-service` (`AGENT_JWT_AUDIENCE`); `AGENT_JWT_ISSUER` optional.
-- **Store**: Postgres when `DATABASE_URL` is set (idempotent bootstrap + TTL
-  sweep, `CONVERSATIONS_TTL_MS` / `CONVERSATIONS_SWEEP_MS`), else in-memory.
+- **Store**: Postgres when a connection URL resolves — `DATABASE_URL` verbatim
+  (local dev) or discrete `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` /
+  `DB_NAME` (+ optional `DB_SSLMODE`) assembled like aep-api (platform
+  release-binding); `DATABASE_URL` wins when both are set. Incomplete discrete
+  fields → in-memory. Idempotent bootstrap + TTL sweep
+  (`CONVERSATIONS_TTL_MS` / `CONVERSATIONS_SWEEP_MS`).
 - Keep-alives every `AGENT_KEEPALIVE_MS` (default 15s) while a turn streams.
 - Callers (e.g. the `@aep/playground` CLI) read `ANTHROPIC_API_KEY` themselves and
   send it (plus an HS256 M2M token) as headers — the service holds no key.

--- a/services/agents/src/main.ts
+++ b/services/agents/src/main.ts
@@ -51,7 +51,7 @@ function buildAuthConfig(): AgentsAuthConfig {
 
 async function buildStore(): Promise<ConversationStore> {
   if (!config.database.url) {
-    process.stdout.write("@aep/agents: no DATABASE_URL — using the in-memory conversation store\n");
+    process.stdout.write("@aep/agents: no Postgres URL — using the in-memory conversation store\n");
     return new InMemoryConversationStore();
   }
   const pool = new pg.Pool({ connectionString: config.database.url });

--- a/services/agents/src/shared/config.ts
+++ b/services/agents/src/shared/config.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { resolveDatabaseUrl } from "./database-url.js";
 import { loadDotenv, intEnv, boolEnv } from "./env.js";
 
 // Load the nearest .env BEFORE reading process.env, so AGENT_MODEL /
@@ -85,11 +86,12 @@ export const config = {
     secret: process.env.AGENT_JWT_SECRET || undefined,
   },
 
-  // ConversationStore selection: Postgres when DATABASE_URL is set, else the
-  // in-memory store (tests/evals). Threads embed inlined file snapshots, so
-  // stored rows have real size — a TTL sweep on updated_at reclaims them.
+  // ConversationStore selection: Postgres when a URL resolves (DATABASE_URL or
+  // discrete DB_*), else the in-memory store (tests/evals). Threads embed
+  // inlined file snapshots, so stored rows have real size — a TTL sweep on
+  // updated_at reclaims them.
   database: {
-    url: process.env.DATABASE_URL || undefined,
+    url: resolveDatabaseUrl(),
     conversationsTtlMs: intEnv(process.env.CONVERSATIONS_TTL_MS, 7 * DAY_MS),
     conversationsSweepMs: intEnv(process.env.CONVERSATIONS_SWEEP_MS, 60 * 60 * 1000),
   },

--- a/services/agents/src/shared/database-url.ts
+++ b/services/agents/src/shared/database-url.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { intEnv } from "./env.js";
+
+/** Discrete Postgres fields from release binding (platform shape). */
+export interface DatabaseDiscreteConfig {
+  host: string;
+  port: number; // default 5432 when assembling
+  user: string;
+  password: string;
+  name: string;
+  sslMode?: string; // only when DB_SSLMODE set
+}
+
+const DEFAULT_PORT = 5432;
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/**
+ * Resolve the Postgres connection string for ConversationStore.
+ * Precedence: DATABASE_URL (verbatim) > assembled discrete DB_*.
+ * Returns undefined when neither path yields a URL → in-memory store.
+ */
+export function resolveDatabaseUrl(env: typeof process.env = process.env): string | undefined {
+  const databaseUrl = nonEmpty(env.DATABASE_URL);
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+  const discrete = readDiscreteDatabaseConfig(env);
+  return discrete ? assembleDatabaseUrl(discrete) : undefined;
+}
+
+/**
+ * Build postgres:// URL from discrete fields. Omits sslmode query param when
+ * sslMode is undefined/empty (matches aep-api databaseURL).
+ */
+export function assembleDatabaseUrl(discrete: DatabaseDiscreteConfig): string {
+  const userinfo = `${encodeURIComponent(discrete.user)}:${encodeURIComponent(discrete.password)}`;
+  const base = `postgres://${userinfo}@${discrete.host}:${discrete.port}/${discrete.name}`;
+  if (!discrete.sslMode) {
+    return base;
+  }
+  return `${base}?sslmode=${encodeURIComponent(discrete.sslMode)}`;
+}
+
+/**
+ * Read discrete fields from env. Returns null when DATABASE_URL is set or when
+ * the discrete set is incomplete (no partial assembly).
+ */
+export function readDiscreteDatabaseConfig(
+  env: typeof process.env = process.env,
+): DatabaseDiscreteConfig | null {
+  if (nonEmpty(env.DATABASE_URL)) {
+    return null;
+  }
+
+  const host = nonEmpty(env.DB_HOST);
+  const user = nonEmpty(env.DB_USER);
+  const password = nonEmpty(env.DB_PASSWORD);
+  const name = nonEmpty(env.DB_NAME);
+
+  if (!host || !user || !password || !name) {
+    return null;
+  }
+
+  const port = intEnv(env.DB_PORT, DEFAULT_PORT);
+  const sslMode = nonEmpty(env.DB_SSLMODE);
+
+  return {
+    host,
+    port,
+    user,
+    password,
+    name,
+    ...(sslMode ? { sslMode } : {}),
+  };
+}

--- a/services/agents/test/database-url.test.ts
+++ b/services/agents/test/database-url.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assembleDatabaseUrl,
+  readDiscreteDatabaseConfig,
+  resolveDatabaseUrl,
+} from "../src/shared/database-url.js";
+
+test("DATABASE_URL wins over discrete", () => {
+  const env = {
+    DATABASE_URL: "postgres://u:p@h:5432/db",
+    DB_HOST: "other",
+    DB_USER: "u",
+    DB_PASSWORD: "p",
+    DB_NAME: "db",
+  };
+  assert.equal(resolveDatabaseUrl(env), "postgres://u:p@h:5432/db");
+});
+
+test("assembles discrete without sslmode when unset", () => {
+  const url = assembleDatabaseUrl({
+    host: "db.example",
+    port: 5432,
+    user: "app_factory_db_user",
+    password: "s3cret",
+    name: "app_factory_db",
+  });
+  assert.equal(
+    url,
+    "postgres://app_factory_db_user:s3cret@db.example:5432/app_factory_db",
+  );
+  assert.ok(!url.includes("sslmode"));
+});
+
+test("includes sslmode only when set", () => {
+  const url = assembleDatabaseUrl({
+    host: "h",
+    port: 5432,
+    user: "u",
+    password: "p",
+    name: "n",
+    sslMode: "disable",
+  });
+  assert.ok(url.includes("sslmode=disable"));
+});
+
+test("percent-encodes password special characters", () => {
+  const url = assembleDatabaseUrl({
+    host: "h",
+    port: 5432,
+    user: "u",
+    password: "a@b:c/d",
+    name: "n",
+  });
+  assert.ok(url.includes(encodeURIComponent("a@b:c/d")));
+  assert.ok(!url.includes("@b:c"));
+});
+
+test("incomplete discrete returns undefined (in-memory path)", () => {
+  assert.equal(resolveDatabaseUrl({ DB_HOST: "h" }), undefined);
+  assert.equal(readDiscreteDatabaseConfig({ DB_HOST: "h" }), null);
+});


### PR DESCRIPTION
## Summary
- Add `resolveDatabaseUrl()`, `assembleDatabaseUrl()`, and `readDiscreteDatabaseConfig()` in `services/agents/src/shared/database-url.ts`, mirroring aep-api's discrete Postgres URL assembly.
- Wire `config.database.url` through `resolveDatabaseUrl()` so cloud release-bindings can supply `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` (+ optional `DB_SSLMODE`) without `DATABASE_URL`.
- Precedence: `DATABASE_URL` verbatim > discrete assembly > in-memory store. Password percent-encoded in userinfo; `sslmode` query param omitted when `DB_SSLMODE` unset.

## Test plan
- [x] `pnpm --filter @aep/agents test -- test/database-url.test.ts` — 5/5 pass (precedence, sslmode, password encoding, incomplete discrete)
- [x] `pnpm --filter @aep/agents test` — 194/194 pass
- [x] Updated `.env.example` and `AGENTS.md` document precedence