### PR TITLE
fix(deps): bump brace-expansion past CVE-2026-69152

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aep",
   "version": "0.0.0",
   "private": true,
-  "description": "Agentic Engineer Platform — polyglot monorepo (root).",
+  "description": "Agentic Engineer Platform \u2014 polyglot monorepo (root).",
   "packageManager": "pnpm@10.12.1",
   "engines": {
     "node": ">=22"
@@ -29,7 +29,10 @@
   },
   "pnpm": {
     "overrides": {
-      "@tanstack/router-cli>chokidar": "^4.0.3"
+      "@tanstack/router-cli>chokidar": "^4.0.3",
+      "brace-expansion@^1.1.0": "1.1.18",
+      "brace-expansion@^2.0.0": "2.1.4",
+      "brace-expansion@^5.0.0": "5.0.9"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 overrides:
   '@tanstack/router-cli>chokidar': ^4.0.3
+  brace-expansion@^1.1.0: 1.1.18
+  brace-expansion@^2.0.0: 2.1.4
+  brace-expansion@^5.0.0: 5.0.9
 
 importers:
 
@@ -3146,15 +3149,15 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8608,16 +8611,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10264,15 +10267,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Add `pnpm.overrides` for `brace-expansion` majors 1 / 2 / 5 to fixed versions (`1.1.18`, `2.1.4`, `5.0.9`)
- Refresh `pnpm-lock.yaml` so minimatch transitive deps no longer resolve to vulnerable `1.1.15` / `2.1.1` / `5.0.6`

Fixes Trivy **HIGH CVE-2026-69152** (DoS bypass of CVE-2026-14257 mitigation) that fails overlay PR Build & Security Scan when agents/collab images clone this monorepo (seen on [wso2-enterprise/lab-app-factory#94](https://github.com/wso2-enterprise/lab-app-factory/pull/94)).

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] Lockfile has no `brace-expansion@1.1.15|2.1.1|5.0.6`
- [ ] CI green on this PR
- [ ] Re-run overlay #94 PR check (or bump OSS pin) after merge — Trivy should clear this CVE