### PR TITLE
Price per-model usage slices so multi-model runs stamp USD (#291)

### DIFF
--- a/runners/remote-worker/src/lib/progress/from-sdk.test.ts
+++ b/runners/remote-worker/src/lib/progress/from-sdk.test.ts
@@ -72,6 +72,78 @@ test("from-sdk: result usage with multiple models → model '' (mixed)", () => {
   assert.equal((events[0] as { usage: { model: string } }).usage.model, "");
 });
 
+test("from-sdk: result usage carries per-model slices for aep-api to price (#291)", () => {
+  const events = progressFromSdkMessage({
+    type: "result",
+    subtype: "success",
+    usage: {
+      input_tokens: 110,
+      output_tokens: 55,
+      cache_read_input_tokens: 1000,
+      cache_creation_input_tokens: 200,
+    },
+    modelUsage: {
+      "claude-sonnet-5": {
+        inputTokens: 100, outputTokens: 50,
+        cacheReadInputTokens: 1000, cacheCreationInputTokens: 200,
+        canonicalModel: "claude-sonnet-5",
+      },
+      "claude-haiku-4-5-20251001": {
+        inputTokens: 10, outputTokens: 5,
+        cacheReadInputTokens: 0, cacheCreationInputTokens: 0,
+        canonicalModel: "claude-haiku-4-5",
+      },
+    },
+  });
+  const usage = (events[0] as unknown as { usage: Record<string, unknown> }).usage;
+  // Mixed models: the single aggregate model stays "", but the split survives.
+  assert.equal(usage.model, "");
+  assert.deepEqual(usage.models, [
+    {
+      model: "claude-sonnet-5",
+      inputTokens: 100, outputTokens: 50,
+      cacheReadTokens: 1000, cacheCreationTokens: 200,
+    },
+    {
+      model: "claude-haiku-4-5",
+      inputTokens: 10, outputTokens: 5,
+      cacheReadTokens: 0, cacheCreationTokens: 0,
+    },
+  ]);
+});
+
+test("from-sdk: versioned modelUsage keys collapse onto their canonical model", () => {
+  const events = progressFromSdkMessage({
+    type: "result",
+    subtype: "success",
+    usage: { input_tokens: 30, output_tokens: 3, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    modelUsage: {
+      "claude-sonnet-5-20260101": { inputTokens: 10, outputTokens: 1, canonicalModel: "claude-sonnet-5" },
+      "claude-sonnet-5-20260201": { inputTokens: 20, outputTokens: 2, canonicalModel: "claude-sonnet-5" },
+    },
+  });
+  const usage = (events[0] as unknown as { usage: Record<string, unknown> }).usage;
+  // Two dated releases of ONE model are still a single-model run.
+  assert.equal(usage.model, "claude-sonnet-5");
+  assert.deepEqual(usage.models, [{
+    model: "claude-sonnet-5",
+    inputTokens: 30, outputTokens: 3,
+    cacheReadTokens: 0, cacheCreationTokens: 0,
+  }]);
+});
+
+test("from-sdk: zero-token modelUsage entries produce no slices and keep the single model", () => {
+  const events = progressFromSdkMessage({
+    type: "result",
+    subtype: "success",
+    usage: { input_tokens: 5, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    modelUsage: { "claude-sonnet-5": {} },
+  });
+  const usage = (events[0] as unknown as { usage: Record<string, unknown> }).usage;
+  assert.equal(usage.model, "claude-sonnet-5");
+  assert.equal("models" in usage, false);
+});
+
 test("from-sdk: result error → failure result with errors joined", () => {
   const events = progressFromSdkMessage({
     type: "result",

--- a/runners/remote-worker/src/lib/progress/from-sdk.ts
+++ b/runners/remote-worker/src/lib/progress/from-sdk.ts
@@ -28,7 +28,7 @@
 // outcome are two different messages). Building that state per run keeps it out
 // of module scope, so tests and concurrent runs cannot see each other's.
 
-import type { ProgressAttribution, ProgressEventInput, TurnUsage } from "./schema.js";
+import type { ProgressAttribution, ProgressEventInput, TurnModelUsage, TurnUsage } from "./schema.js";
 
 const MAX_SUMMARY = 200;
 
@@ -65,22 +65,45 @@ function num(v: unknown): number {
 }
 
 // usageFromResult reads the SDK result message's token usage (#291). Tokens
-// come from `usage` (snake_case SDK fields); the model comes from `modelUsage`,
-// a record keyed by model id — a single key is the run's model, anything else
-// (multi-model, or none) reports "" so aep-api treats it as unpriceable/mixed,
-// matching contracts.TokenUsage semantics. Returns undefined when the result
-// carried no usage at all (older SDKs / nothing to stamp).
+// come from `usage` (snake_case SDK fields); the per-model split comes from
+// `modelUsage`, a record keyed by model id whose entries carry camelCase token
+// counts and (on current SDKs) the `canonicalModel` alias. Versioned release
+// ids collapse onto their canonical model — two dated releases of one model
+// are still a single-model run. `model` names the run's one model, or "" when
+// several genuinely mixed (matching contracts.TokenUsage.Add); `models` keeps
+// the split either way, because aep-api prices each slice against its own rate
+// row — a real coding run regularly touches a second model (the SDK's small-
+// model helpers), and collapsing to "" made every such run unpriceable.
+// Returns undefined when the result carried no usage at all (older SDKs /
+// nothing to stamp).
 function usageFromResult(m: Record<string, unknown>): TurnUsage | undefined {
   const u = m.usage;
   if (!u || typeof u !== "object") return undefined;
   const usage = u as Record<string, unknown>;
 
-  let model = "";
+  const byModel = new Map<string, TurnModelUsage>();
   const mu = m.modelUsage;
   if (mu && typeof mu === "object") {
-    const models = Object.keys(mu as Record<string, unknown>);
-    if (models.length === 1) model = models[0];
+    for (const [key, val] of Object.entries(mu as Record<string, unknown>)) {
+      const entry = val && typeof val === "object" ? (val as Record<string, unknown>) : {};
+      const canonical = typeof entry.canonicalModel === "string" && entry.canonicalModel !== "" ? entry.canonicalModel : key;
+      const slice = byModel.get(canonical) ?? {
+        model: canonical, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0,
+      };
+      slice.inputTokens += num(entry.inputTokens);
+      slice.outputTokens += num(entry.outputTokens);
+      slice.cacheReadTokens += num(entry.cacheReadInputTokens);
+      slice.cacheCreationTokens += num(entry.cacheCreationInputTokens);
+      byModel.set(canonical, slice);
+    }
   }
+  // The aggregate model considers every entry (a zero-token entry still names
+  // the run's model); the slices carry only entries that spent something —
+  // aep-api's pricing has nothing to do with an all-zero slice.
+  const model = byModel.size === 1 ? [...byModel.keys()][0] : "";
+  const models = [...byModel.values()].filter(
+    (s) => s.inputTokens + s.outputTokens + s.cacheReadTokens + s.cacheCreationTokens > 0,
+  );
 
   return {
     inputTokens: num(usage.input_tokens),
@@ -88,6 +111,7 @@ function usageFromResult(m: Record<string, unknown>): TurnUsage | undefined {
     cacheReadTokens: num(usage.cache_read_input_tokens),
     cacheCreationTokens: num(usage.cache_creation_input_tokens),
     model,
+    ...(models.length > 0 ? { models } : {}),
   };
 }
 

--- a/runners/remote-worker/src/lib/progress/schema.ts
+++ b/runners/remote-worker/src/lib/progress/schema.ts
@@ -156,16 +156,32 @@ export interface LogEvent extends ProgressEnvelope {
   summary: string;
 }
 
+// TurnModelUsage is one model's slice of the run's usage, read off the SDK
+// result's per-model `modelUsage` record (#291). The model id is the SDK's
+// canonicalModel where it reports one (versioned release ids collapse onto the
+// alias aep-api's model_rates table is keyed by), else the record key.
+export interface TurnModelUsage {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
 // TurnUsage is the run's token usage off the SDK result (#291) — the cross-
-// runtime wire shape aep-api parses (usageFromLog → contracts.TokenUsage), so
-// the camelCase field names must match byte-for-byte. model is "" when the run
-// spanned multiple models (or the SDK reported none).
+// runtime wire shape aep-api parses (usageFromLog → contracts.CapturedUsage),
+// so the camelCase field names must match byte-for-byte. model is "" when the
+// run spanned multiple models (or the SDK reported none); `models` is the
+// per-model split that lets aep-api price a multi-model run — without it a
+// single blanked model id made the whole run unpriceable and the console fell
+// back to token counts.
 export interface TurnUsage {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreationTokens: number;
   model: string;
+  models?: TurnModelUsage[];
 }
 
 export interface ResultEvent extends ProgressEnvelope {

--- a/services/aep-api/internal/contracts/progress.go
+++ b/services/aep-api/internal/contracts/progress.go
@@ -101,8 +101,9 @@ type ProgressEvent struct {
 	Message     string `json:"message,omitempty"`
 
 	// result: the run's token usage (#249), present once the runner captures
-	// it from the SDK terminal message.
-	Usage *TokenUsage `json:"usage,omitempty"`
+	// it from the SDK terminal message. CapturedUsage carries the aggregate
+	// plus the per-model split the capture path prices (#291).
+	Usage *CapturedUsage `json:"usage,omitempty"`
 }
 
 // ProgressResponse is the envelope the progress reader returns per execution.

--- a/services/aep-api/internal/contracts/usage.go
+++ b/services/aep-api/internal/contracts/usage.go
@@ -59,6 +59,29 @@ func (u TokenUsage) Add(other TokenUsage) TokenUsage {
 	}
 }
 
+// CapturedUsage is the wire shape of a runner result event's `usage` (#291):
+// the folded aggregate every reader already consumed, plus the per-model split
+// the stamper prices. Models carries one entry per model that spent tokens
+// (canonical ids — the runner collapses versioned release ids), and is empty
+// on captures from runners that predate the split; the capture path then falls
+// back to pricing the aggregate by its single Model. The split exists because
+// a real coding run regularly touches a second model (the SDK's small-model
+// helpers), which blanks the aggregate Model under Add's agreement rule and
+// made every such run unpriceable.
+type CapturedUsage struct {
+	TokenUsage
+	Models []TokenUsage `json:"models,omitempty"`
+}
+
+// PricingSlices returns what the stamper should price: the per-model split
+// when the runner reported one, else the aggregate as a single slice.
+func (c CapturedUsage) PricingSlices() []TokenUsage {
+	if len(c.Models) > 0 {
+		return c.Models
+	}
+	return []TokenUsage{c.TokenUsage}
+}
+
 // StampedUsage is an aggregate of usage rows plus the sum of the USD stamped on
 // them at capture (#291). CostUsd is nil when NO contributing row carried a
 // stamp (SQL SUM(cost_usd) over all-null rows is NULL) — the console then shows

--- a/services/aep-api/internal/delivery/codingagent/cycle_usage_capture_test.go
+++ b/services/aep-api/internal/delivery/codingagent/cycle_usage_capture_test.go
@@ -49,7 +49,7 @@ func (f fakeOrgsForCycle) GetByName(context.Context, string) (*organization.Orga
 type fakeCycleRepo struct {
 	delivery.RunCycleRepository
 	dispatched  []delivery.RunCycle
-	recorded    map[string]contracts.TokenUsage
+	recorded    map[string]contracts.CapturedUsage
 	recordCalls int
 }
 
@@ -57,9 +57,9 @@ func (f *fakeCycleRepo) ListRecentDispatched(context.Context, time.Time) ([]deli
 	return f.dispatched, nil
 }
 
-func (f *fakeCycleRepo) RecordUsage(_ context.Context, id string, u contracts.TokenUsage) error {
+func (f *fakeCycleRepo) RecordUsage(_ context.Context, id string, u contracts.CapturedUsage) error {
 	if f.recorded == nil {
-		f.recorded = map[string]contracts.TokenUsage{}
+		f.recorded = map[string]contracts.CapturedUsage{}
 	}
 	f.recorded[id] = u
 	f.recordCalls++
@@ -143,11 +143,11 @@ func TestCaptureCycleLog_RecordsUsageOnTheCycle(t *testing.T) {
 	if !ok {
 		t.Fatalf("no usage recorded for the cycle; recorded = %+v", cycles.recorded)
 	}
-	want := contracts.TokenUsage{
+	want := contracts.CapturedUsage{TokenUsage: contracts.TokenUsage{
 		InputTokens: 1200, OutputTokens: 340, CacheReadTokens: 50000,
 		CacheCreationTokens: 700, Model: "claude-fable-5",
-	}
-	if got != want {
+	}}
+	if got.TokenUsage != want.TokenUsage || len(got.Models) != 0 {
 		t.Fatalf("recorded usage = %+v, want %+v", got, want)
 	}
 }

--- a/services/aep-api/internal/delivery/codingagent/fakes_test.go
+++ b/services/aep-api/internal/delivery/codingagent/fakes_test.go
@@ -150,7 +150,7 @@ func (f *fakeExecRepo) count() int {
 	return len(f.rows)
 }
 
-func (f *fakeExecRepo) RecordUsage(context.Context, string, contracts.TokenUsage) error { return nil }
+func (f *fakeExecRepo) RecordUsage(context.Context, string, contracts.CapturedUsage) error { return nil }
 
 func (f *fakeExecRepo) SumUsageByProjectPhase(context.Context, string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
 	return nil, nil, nil

--- a/services/aep-api/internal/delivery/codingagent/usage_capture.go
+++ b/services/aep-api/internal/delivery/codingagent/usage_capture.go
@@ -27,10 +27,11 @@ import (
 // usageFromLog extracts the run's token usage (#249) from the captured pod
 // log: the last runner NDJSON `result` event carrying a usage object wins
 // (there is one per run; "last" guards against a retried in-container agent).
-// nil when the log carries none — pre-capture runners, or a run that died
-// before its terminal message.
-func usageFromLog(text string) *contracts.TokenUsage {
-	var found *contracts.TokenUsage
+// The capture keeps the per-model split (#291) so RecordUsage can price each
+// model's slice against its own rate row. nil when the log carries none —
+// pre-capture runners, or a run that died before its terminal message.
+func usageFromLog(text string) *contracts.CapturedUsage {
+	var found *contracts.CapturedUsage
 	scanner := bufio.NewScanner(strings.NewReader(text))
 	// The runner's terminal `result` line carries the full usage JSON and can
 	// be large; size the buffer generously (16 MiB) so a long line is scanned,

--- a/services/aep-api/internal/delivery/codingagent/usage_capture_test.go
+++ b/services/aep-api/internal/delivery/codingagent/usage_capture_test.go
@@ -16,7 +16,11 @@
 
 package codingagent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/contracts"
+)
 
 func TestUsageFromLogReadsTheResultLine(t *testing.T) {
 	log := `2026-07-21T10:00:00.000000000Z {"schemaVersion":1,"ts":"t","seq":1,"kind":"phase","phase":"agent"}
@@ -40,6 +44,34 @@ func TestUsageFromLogLastResultWins(t *testing.T) {
 	u := usageFromLog(log)
 	if u == nil || u.InputTokens != 7 {
 		t.Fatalf("expected the last result's usage, got %+v", u)
+	}
+}
+
+func TestUsageFromLogKeepsThePerModelSplit(t *testing.T) {
+	log := `{"schemaVersion":1,"ts":"t","seq":1,"kind":"result","status":"success","usage":{"inputTokens":110,"outputTokens":55,"cacheReadTokens":1000,"cacheCreationTokens":200,"model":"","models":[{"inputTokens":100,"outputTokens":50,"cacheReadTokens":1000,"cacheCreationTokens":200,"model":"claude-sonnet-5"},{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheCreationTokens":0,"model":"claude-haiku-4-5"}]}}
+`
+	u := usageFromLog(log)
+	if u == nil {
+		t.Fatal("expected usage, got nil")
+	}
+	if u.Model != "" || u.InputTokens != 110 {
+		t.Fatalf("unexpected aggregate: %+v", u.TokenUsage)
+	}
+	want := []contracts.TokenUsage{
+		{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 1000, CacheCreationTokens: 200, Model: "claude-sonnet-5"},
+		{InputTokens: 10, OutputTokens: 5, Model: "claude-haiku-4-5"},
+	}
+	if len(u.Models) != len(want) || u.Models[0] != want[0] || u.Models[1] != want[1] {
+		t.Fatalf("models = %+v, want %+v", u.Models, want)
+	}
+	// PricingSlices prefers the split…
+	if got := u.PricingSlices(); len(got) != 2 || got[0].Model != "claude-sonnet-5" {
+		t.Fatalf("PricingSlices = %+v, want the per-model split", got)
+	}
+	// …and falls back to the aggregate for pre-split runners.
+	legacy := contracts.CapturedUsage{TokenUsage: contracts.TokenUsage{InputTokens: 7, Model: "claude-sonnet-5"}}
+	if got := legacy.PricingSlices(); len(got) != 1 || got[0].Model != "claude-sonnet-5" {
+		t.Fatalf("PricingSlices(legacy) = %+v, want the aggregate as one slice", got)
 	}
 }
 

--- a/services/aep-api/internal/delivery/repository_cycle.go
+++ b/services/aep-api/internal/delivery/repository_cycle.go
@@ -120,7 +120,8 @@ type RunCycleRepository interface {
 	DeleteByProject(ctx context.Context, orgID, projectID string) error
 
 	// RecordUsage stamps the cycle's captured token usage onto the row, and its
-	// write-time USD onto cost_usd (#291).
+	// write-time USD onto cost_usd (#291) — each per-model slice priced at its
+	// own rate row, so a multi-model run still stamps.
 	//
 	// It is the ONE mutator NOT guarded on the cycle being open, and that is the
 	// whole point: usage arrives from the terminal-log capture, and a cycle
@@ -128,7 +129,7 @@ type RunCycleRepository interface {
 	// before the watcher's next tick. Fencing this on ended_at IS NULL would
 	// discard nearly every capture. Idempotent by value: the capture re-derives
 	// the same figures from the same log, so a repeat write is a no-op in effect.
-	RecordUsage(ctx context.Context, id string, u contracts.TokenUsage) error
+	RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error
 
 	// SumUsageByProjectPhase rolls up captured CYCLE usage per project across an
 	// org, split into the build and validation SDLC phases (#291) — delivery's
@@ -286,7 +287,7 @@ func (r *runCycleRepository) DeleteByProject(ctx context.Context, orgID, project
 		Delete(&RunCycle{}).Error
 }
 
-func (r *runCycleRepository) RecordUsage(ctx context.Context, id string, u contracts.TokenUsage) error {
+func (r *runCycleRepository) RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error {
 	updates := map[string]any{
 		"input_tokens":          u.InputTokens,
 		"output_tokens":         u.OutputTokens,
@@ -295,15 +296,10 @@ func (r *runCycleRepository) RecordUsage(ctx context.Context, id string, u contr
 		"model_id":              u.Model,
 	}
 	// Stamp USD at capture from the rates in force now (#291): frozen on the row,
-	// never re-derived. Null when unpriceable (no rate row / no model).
+	// never re-derived. Null when unpriceable (any token-bearing slice without a
+	// rate row).
 	if r.stamper != nil {
-		updates["cost_usd"] = r.stamper.Cost(modelcost.Tokens{
-			ModelID:             u.Model,
-			InputTokens:         u.InputTokens,
-			OutputTokens:        u.OutputTokens,
-			CacheReadTokens:     u.CacheReadTokens,
-			CacheCreationTokens: u.CacheCreationTokens,
-		})
+		updates["cost_usd"] = stampCapturedCost(r.stamper, u)
 	}
 	// NOT applyOpen: see RecordUsage's contract — a closed cycle is exactly the
 	// case this has to serve.
@@ -311,6 +307,25 @@ func (r *runCycleRepository) RecordUsage(ctx context.Context, id string, u contr
 		Model(&RunCycle{}).
 		Where("id = ?", id).
 		Updates(updates).Error
+}
+
+// stampCapturedCost prices a capture for a row write (#291): the runner's
+// per-model split when present (each slice at its own rate, summed by
+// Stamper.SumCost's all-or-nothing rule), else the aggregate as one slice —
+// the pre-split runner shape, where a mixed run has model "" and stays null.
+func stampCapturedCost(stamper *modelcost.Stamper, u contracts.CapturedUsage) *float64 {
+	slices := u.PricingSlices()
+	ts := make([]modelcost.Tokens, 0, len(slices))
+	for _, s := range slices {
+		ts = append(ts, modelcost.Tokens{
+			ModelID:             s.Model,
+			InputTokens:         s.InputTokens,
+			OutputTokens:        s.OutputTokens,
+			CacheReadTokens:     s.CacheReadTokens,
+			CacheCreationTokens: s.CacheCreationTokens,
+		})
+	}
+	return stamper.SumCost(ts)
 }
 
 func (r *runCycleRepository) SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error) {

--- a/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
+++ b/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
@@ -380,21 +380,21 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 		InputTokens: 1_000_000, OutputTokens: 100_000, CacheReadTokens: 2_000_000,
 		Model: "model-a",
 	}
-	if err := cycles.RecordUsage(ctx, coding.ID, usage); err != nil {
+	if err := cycles.RecordUsage(ctx, coding.ID, contracts.CapturedUsage{TokenUsage: usage}); err != nil {
 		t.Fatalf("RecordUsage(closed coding cycle): %v", err)
 	}
 	// A second, smaller build-phase contributor so the rollup is proven to SUM
 	// rather than to return the last row it saw.
-	if err := cycles.RecordUsage(ctx, fix.ID, contracts.TokenUsage{
+	if err := cycles.RecordUsage(ctx, fix.ID, contracts.CapturedUsage{TokenUsage: contracts.TokenUsage{
 		InputTokens: 1_000_000, Model: "model-a", // $1.00
-	}); err != nil {
+	}}); err != nil {
 		t.Fatalf("RecordUsage(fix): %v", err)
 	}
 	// An UNPRICEABLE validation run: real tokens, a model with no rate row. Its
 	// cost must stay null while its tokens still count.
-	if err := cycles.RecordUsage(ctx, validation.ID, contracts.TokenUsage{
+	if err := cycles.RecordUsage(ctx, validation.ID, contracts.CapturedUsage{TokenUsage: contracts.TokenUsage{
 		InputTokens: 500_000, OutputTokens: 10_000, Model: "model-unknown",
-	}); err != nil {
+	}}); err != nil {
 		t.Fatalf("RecordUsage(validation): %v", err)
 	}
 
@@ -452,6 +452,87 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 	if b2, v2, err := cycles.SumUsageByProjectPhase(ctx, "other-org"); err != nil ||
 		len(b2) != 0 || len(v2) != 0 {
 		t.Fatalf("cross-org rollup = (%v, %v, %v), want empty", b2, v2, err)
+	}
+}
+
+// TestRunCycleRepository_RecordUsageStampsMultiModelSplit pins the fix for the
+// tokens-instead-of-dollars Usage chips: a real coding run regularly touches a
+// second model (the SDK's small-model helpers), which blanks the aggregate
+// model id — but the runner now ships the per-model split, and the stamp must
+// price each slice at its own rate and sum. A split containing a model with no
+// rate row still stamps null (all-or-nothing), never a partial figure.
+func TestRunCycleRepository_RecordUsageStampsMultiModelSplit(t *testing.T) {
+	t.Parallel()
+	db := dbtest.New(t)
+	runs := delivery.NewMilestoneRunRepository(db)
+	stamper := modelcost.NewStamper([]modelcost.ModelRate{
+		{ModelID: "model-a", InputPerMTok: 1, OutputPerMTok: 10, CacheReadPerMTok: 0.1},
+		{ModelID: "model-b", InputPerMTok: 2, OutputPerMTok: 20},
+	})
+	cycles := delivery.NewRunCycleRepository(db, stamper)
+	ctx := context.Background()
+
+	run := admitRun(t, runs, "orgm", "shop", 1, "v1")
+	appendCycle := func() *delivery.RunCycle {
+		t.Helper()
+		c := &delivery.RunCycle{OrgID: run.OrgID, ProjectID: run.ProjectID, RunID: run.ID, Kind: delivery.CycleKindCoding}
+		if err := cycles.Append(ctx, c); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		return c
+	}
+	mixed := appendCycle()
+	poisoned := appendCycle()
+
+	// model-a: 1M in + 100k out = $2.00; model-b: 500k in = $1.00 → $3.00. The
+	// aggregate model is "" (mixed), which used to make the whole cycle
+	// unpriceable.
+	if err := cycles.RecordUsage(ctx, mixed.ID, contracts.CapturedUsage{
+		TokenUsage: contracts.TokenUsage{InputTokens: 1_500_000, OutputTokens: 100_000, Model: ""},
+		Models: []contracts.TokenUsage{
+			{InputTokens: 1_000_000, OutputTokens: 100_000, Model: "model-a"},
+			{InputTokens: 500_000, Model: "model-b"},
+		},
+	}); err != nil {
+		t.Fatalf("RecordUsage(mixed): %v", err)
+	}
+	if err := cycles.RecordUsage(ctx, poisoned.ID, contracts.CapturedUsage{
+		TokenUsage: contracts.TokenUsage{InputTokens: 1_000_010, Model: ""},
+		Models: []contracts.TokenUsage{
+			{InputTokens: 1_000_000, Model: "model-a"},
+			{InputTokens: 10, Model: "model-unrated"},
+		},
+	}); err != nil {
+		t.Fatalf("RecordUsage(poisoned): %v", err)
+	}
+
+	timeline, err := cycles.ListByRun(ctx, "orgm", run.ID)
+	if err != nil {
+		t.Fatalf("ListByRun: %v", err)
+	}
+	byID := map[string]delivery.RunCycle{}
+	for _, c := range timeline {
+		byID[c.ID] = c
+	}
+	if got := byID[mixed.ID]; got.CostUsd == nil || *got.CostUsd != 3.00 {
+		t.Fatalf("mixed-model cost_usd = %v, want 3.00", got.CostUsd)
+	}
+	if got := byID[poisoned.ID]; got.CostUsd != nil {
+		t.Fatalf("cost_usd with an unrated slice = %v, want null", *got.CostUsd)
+	}
+
+	// The phase rollup sums the mixed cycle's stamp and keeps the aggregate
+	// tokens; the poisoned cycle contributes tokens but no dollars.
+	build, _, err := cycles.SumUsageByProjectPhase(ctx, "orgm")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	b := build["shop"]
+	if b.CostUsd == nil || *b.CostUsd != 3.00 {
+		t.Fatalf("build cost = %v, want 3.00", b.CostUsd)
+	}
+	if b.Tokens.InputTokens != 2_500_010 {
+		t.Fatalf("build input tokens = %d, want 2_500_010", b.Tokens.InputTokens)
 	}
 }
 

--- a/services/aep-api/internal/delivery/repository_execution.go
+++ b/services/aep-api/internal/delivery/repository_execution.go
@@ -117,11 +117,12 @@ type ExecutionRepository interface {
 	DistinctDeployedProjects(ctx context.Context) ([]DeployedProjectRef, error)
 
 	// RecordUsage stamps the run's captured token usage onto the row (#249),
-	// and its write-time USD onto cost_usd (#291). Unguarded by status — usage
-	// arrives from the final-log capture, which can land before or after the row
-	// goes terminal (coding successes end via the PR webhook). Last write wins;
-	// the capture is idempotent upstream.
-	RecordUsage(ctx context.Context, id string, u contracts.TokenUsage) error
+	// and its write-time USD onto cost_usd (#291) — each per-model slice priced
+	// at its own rate row, so a multi-model run still stamps. Unguarded by
+	// status — usage arrives from the final-log capture, which can land before
+	// or after the row goes terminal (coding successes end via the PR webhook).
+	// Last write wins; the capture is idempotent upstream.
+	RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error
 
 	// SumUsageByProjectPhase rolls up captured execution usage per project
 	// across an org (#291), split into the build and validation SDLC phases —
@@ -365,7 +366,7 @@ func (r *executionRepository) getByID(ctx context.Context, id string) (*Executio
 	return &e, nil
 }
 
-func (r *executionRepository) RecordUsage(ctx context.Context, id string, u contracts.TokenUsage) error {
+func (r *executionRepository) RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error {
 	updates := map[string]any{
 		"input_tokens":          u.InputTokens,
 		"output_tokens":         u.OutputTokens,
@@ -374,15 +375,10 @@ func (r *executionRepository) RecordUsage(ctx context.Context, id string, u cont
 		"model_id":              u.Model,
 	}
 	// Stamp USD at capture from the rates in force now (#291): frozen on the
-	// row, never re-derived. Null when unpriceable (no rate / no model).
+	// row, never re-derived. Null when unpriceable (any token-bearing slice
+	// without a rate row).
 	if r.stamper != nil {
-		updates["cost_usd"] = r.stamper.Cost(modelcost.Tokens{
-			ModelID:             u.Model,
-			InputTokens:         u.InputTokens,
-			OutputTokens:        u.OutputTokens,
-			CacheReadTokens:     u.CacheReadTokens,
-			CacheCreationTokens: u.CacheCreationTokens,
-		})
+		updates["cost_usd"] = stampCapturedCost(r.stamper, u)
 	}
 	return r.db.WithContext(ctx).
 		Model(&Execution{}).

--- a/services/aep-api/internal/migrate/model_rates.go
+++ b/services/aep-api/internal/migrate/model_rates.go
@@ -25,38 +25,57 @@ import (
 	"github.com/wso2/aep/aep-api/internal/platform/modelcost"
 )
 
-// RunModelRatesSeed seeds model_rates with the platform's active model at the
+// RunModelRatesSeed seeds model_rates with the platform's active models at the
 // rates in force today (#291, amended ADR-0011). The table is ops-managed
 // thereafter — a price change is an UPDATE, and because USD is stamped at
 // capture (never re-derived), that change only affects work captured after it.
 //
-// The seed is claude-sonnet-5 (the agents' model, deployments/AGENT_MODEL) at
-// its INTRODUCTORY rates, which are in force through 2026-08-31: input
-// $2.00/MTok, output $10.00/MTok, cache-read ~0.1x input ($0.20), cache-write
-// ~1.25x input ($2.50). The 2026-08-31 step-up to standard $3/$15 is the first
-// intended ops override — a live demonstration of why history must not reprice.
+// Two rows:
 //
-// Idempotent: seeds only when the model has no row, so an ops-adjusted rate is
-// never clobbered by a redeploy. AutoMigrate (BaseModels) creates the table
-// before this step runs.
+//   - claude-sonnet-5 (the agents' model, deployments/AGENT_MODEL) at its
+//     INTRODUCTORY rates, in force through 2026-08-31: input $2.00/MTok,
+//     output $10.00/MTok, cache-read ~0.1x input ($0.20), cache-write ~1.25x
+//     input ($2.50). The 2026-08-31 step-up to standard $3/$15 is the first
+//     intended ops override — a live demonstration of why history must not
+//     reprice.
+//   - claude-haiku-4-5 at standard rates ($1.00/$5.00, cache-read $0.10,
+//     cache-write $1.25). Nothing dispatches on haiku, but the Agent SDK's
+//     small-model helpers spend tokens on it inside coding runs, and pricing
+//     is all-or-nothing per capture (Stamper.SumCost) — without this row every
+//     run haiku touched would stamp null and show tokens instead of dollars.
+//
+// Idempotent per model: seeds only where the model has no row, so an
+// ops-adjusted rate is never clobbered by a redeploy. AutoMigrate (BaseModels)
+// creates the table before this step runs.
 func RunModelRatesSeed(ctx context.Context, db *gorm.DB) error {
-	seed := modelcost.ModelRate{
-		ModelID:           "claude-sonnet-5",
-		InputPerMTok:      2.00,
-		OutputPerMTok:     10.00,
-		CacheReadPerMTok:  0.20,
-		CacheWritePerMTok: 2.50,
+	seeds := []modelcost.ModelRate{
+		{
+			ModelID:           "claude-sonnet-5",
+			InputPerMTok:      2.00,
+			OutputPerMTok:     10.00,
+			CacheReadPerMTok:  0.20,
+			CacheWritePerMTok: 2.50,
+		},
+		{
+			ModelID:           "claude-haiku-4-5",
+			InputPerMTok:      1.00,
+			OutputPerMTok:     5.00,
+			CacheReadPerMTok:  0.10,
+			CacheWritePerMTok: 1.25,
+		},
 	}
-	var count int64
-	if err := db.WithContext(ctx).Model(&modelcost.ModelRate{}).
-		Where("model_id = ?", seed.ModelID).Count(&count).Error; err != nil {
-		return fmt.Errorf("model_rates seed: count %s: %w", seed.ModelID, err)
-	}
-	if count > 0 {
-		return nil // already seeded (or ops-adjusted) — never overwrite
-	}
-	if err := db.WithContext(ctx).Create(&seed).Error; err != nil {
-		return fmt.Errorf("model_rates seed: insert %s: %w", seed.ModelID, err)
+	for _, seed := range seeds {
+		var count int64
+		if err := db.WithContext(ctx).Model(&modelcost.ModelRate{}).
+			Where("model_id = ?", seed.ModelID).Count(&count).Error; err != nil {
+			return fmt.Errorf("model_rates seed: count %s: %w", seed.ModelID, err)
+		}
+		if count > 0 {
+			continue // already seeded (or ops-adjusted) — never overwrite
+		}
+		if err := db.WithContext(ctx).Create(&seed).Error; err != nil {
+			return fmt.Errorf("model_rates seed: insert %s: %w", seed.ModelID, err)
+		}
 	}
 	return nil
 }

--- a/services/aep-api/internal/platform/modelcost/modelcost.go
+++ b/services/aep-api/internal/platform/modelcost/modelcost.go
@@ -78,14 +78,51 @@ func NewStamper(rows []ModelRate) *Stamper {
 // only for any aggregate that includes the unstamped row. The historical
 // record is immutable: this is computed once, at capture, and never revisited.
 func (s *Stamper) Cost(t Tokens) *float64 {
-	rate, ok := s.rates[t.ModelID]
-	if !ok || t.ModelID == "" {
+	usd, ok := s.raw(t)
+	if !ok {
 		return nil
 	}
-	usd := (float64(t.InputTokens)*rate.InputPerMTok +
-		float64(t.OutputTokens)*rate.OutputPerMTok +
-		float64(t.CacheReadTokens)*rate.CacheReadPerMTok +
-		float64(t.CacheCreationTokens)*rate.CacheWritePerMTok) / 1e6
 	usd = math.Round(usd*100) / 100
 	return &usd
+}
+
+// SumCost prices a multi-model capture (#291): each slice at its own rate row,
+// summed unrounded and rounded to cents once — per-slice rounding would zero
+// out small contributors. All-or-nothing: a token-bearing slice the stamper
+// cannot price (unknown/empty model) makes the WHOLE stamp nil, because a
+// partial dollar figure silently under-reports spend, and null degrades to the
+// honest tokens-only display. Zero-token slices are ignored; no priceable
+// traffic at all is nil (nothing was spent, nothing to stamp).
+func (s *Stamper) SumCost(slices []Tokens) *float64 {
+	total := 0.0
+	priced := false
+	for _, t := range slices {
+		if t.InputTokens+t.OutputTokens+t.CacheReadTokens+t.CacheCreationTokens == 0 {
+			continue
+		}
+		usd, ok := s.raw(t)
+		if !ok {
+			return nil
+		}
+		total += usd
+		priced = true
+	}
+	if !priced {
+		return nil
+	}
+	total = math.Round(total*100) / 100
+	return &total
+}
+
+// raw is the unrounded USD for one record; ok is false when the model has no
+// rate row (or no id at all).
+func (s *Stamper) raw(t Tokens) (float64, bool) {
+	rate, ok := s.rates[t.ModelID]
+	if !ok || t.ModelID == "" {
+		return 0, false
+	}
+	return (float64(t.InputTokens)*rate.InputPerMTok +
+		float64(t.OutputTokens)*rate.OutputPerMTok +
+		float64(t.CacheReadTokens)*rate.CacheReadPerMTok +
+		float64(t.CacheCreationTokens)*rate.CacheWritePerMTok) / 1e6, true
 }

--- a/services/aep-api/internal/platform/modelcost/modelcost_test.go
+++ b/services/aep-api/internal/platform/modelcost/modelcost_test.go
@@ -81,3 +81,71 @@ func TestCostZeroTokensStampsZero(t *testing.T) {
 		t.Fatalf("cost = %v, want 0", got)
 	}
 }
+
+func multiModelStamper() *Stamper {
+	return NewStamper([]ModelRate{
+		{ModelID: "claude-sonnet-5", InputPerMTok: 2.00, OutputPerMTok: 10.00, CacheReadPerMTok: 0.20, CacheWritePerMTok: 2.50},
+		{ModelID: "claude-haiku-4-5", InputPerMTok: 1.00, OutputPerMTok: 5.00, CacheReadPerMTok: 0.10, CacheWritePerMTok: 1.25},
+	})
+}
+
+func TestSumCostPricesEachSliceAtItsOwnRate(t *testing.T) {
+	s := multiModelStamper()
+	// sonnet: 1M in + 100k out = $2 + $1 = $3.00; haiku: 1M in = $1.00.
+	got := s.SumCost([]Tokens{
+		{ModelID: "claude-sonnet-5", InputTokens: 1_000_000, OutputTokens: 100_000},
+		{ModelID: "claude-haiku-4-5", InputTokens: 1_000_000},
+	})
+	if got == nil || *got != 4.00 {
+		t.Fatalf("cost = %v, want 4.00", got)
+	}
+}
+
+func TestSumCostRoundsOnceOverTheSum(t *testing.T) {
+	s := multiModelStamper()
+	// Each slice alone is $0.004 (rounds to $0.00); the sum is $0.008, which
+	// must round to $0.01 — per-slice rounding would report a false zero.
+	got := s.SumCost([]Tokens{
+		{ModelID: "claude-sonnet-5", InputTokens: 2_000},
+		{ModelID: "claude-haiku-4-5", InputTokens: 4_000},
+	})
+	if got == nil || *got != 0.01 {
+		t.Fatalf("cost = %v, want 0.01", got)
+	}
+}
+
+func TestSumCostNilWhenAnyTokenBearingSliceUnpriceable(t *testing.T) {
+	s := multiModelStamper()
+	// One slice with no rate row poisons the whole stamp: a partial dollar
+	// figure would silently under-report the run's spend.
+	got := s.SumCost([]Tokens{
+		{ModelID: "claude-sonnet-5", InputTokens: 1_000_000},
+		{ModelID: "some-unknown-model", InputTokens: 10},
+	})
+	if got != nil {
+		t.Fatalf("cost = %v, want nil when a contributing slice has no rate", *got)
+	}
+}
+
+func TestSumCostIgnoresZeroTokenSlices(t *testing.T) {
+	s := multiModelStamper()
+	// A zero-token slice — even for an unknown model — contributed nothing and
+	// must not block pricing the real spend.
+	got := s.SumCost([]Tokens{
+		{ModelID: "claude-sonnet-5", InputTokens: 1_000_000},
+		{ModelID: "some-unknown-model"},
+	})
+	if got == nil || *got != 2.00 {
+		t.Fatalf("cost = %v, want 2.00", got)
+	}
+}
+
+func TestSumCostNilOnEmptyOrAllZero(t *testing.T) {
+	s := multiModelStamper()
+	if got := s.SumCost(nil); got != nil {
+		t.Fatalf("cost = %v, want nil for no slices", *got)
+	}
+	if got := s.SumCost([]Tokens{{ModelID: "claude-sonnet-5"}}); got != nil {
+		t.Fatalf("cost = %v, want nil for all-zero slices", *got)
+	}
+}

--- a/services/aep-api/internal/projects/project_service_test.go
+++ b/services/aep-api/internal/projects/project_service_test.go
@@ -112,7 +112,7 @@ func (f *fakeExecs) DistinctDeployedProjects(context.Context) ([]delivery.Deploy
 	return nil, nil
 }
 
-func (f *fakeExecs) RecordUsage(context.Context, string, contracts.TokenUsage) error { return nil }
+func (f *fakeExecs) RecordUsage(context.Context, string, contracts.CapturedUsage) error { return nil }
 
 func (f *fakeExecs) SumUsageByProjectPhase(context.Context, string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
 	return nil, nil, nil


### PR DESCRIPTION
## Problem

On Settings → Usage, the "Cost by phase" breakdown showed a dollar figure for Spec/design but only token counts for Build and Validation. The chips fall back to tokens when a phase's `cost_usd` is null — and every coding/validation cycle was stamping null.

Root cause: the runner's SDK translator kept a model id only when the result's `modelUsage` had exactly one key. Real coding runs regularly touch a second model (the Agent SDK's small-model helpers), so the aggregate model was blanked to `""`, the stamper had nothing to price against, and the whole run became unpriceable. Live DB evidence: all `run_cycles` rows carried `model_id = ''` with null `cost_usd`, while spec `agent_turns` (single configured model) priced fine.

## Fix

Carry the per-model split end to end and price each slice at its own rate:

- **runner** — `TurnUsage` gains a `models` list read from `modelUsage`, using the SDK's `canonicalModel` so versioned release ids (`claude-haiku-4-5-20251001`) collapse onto the alias `model_rates` is keyed by. Two dated releases of one model now count as a single-model run.
- **aep-api** — new `contracts.CapturedUsage` (aggregate + split) flows from `usageFromLog` into both `RecordUsage` paths. New `Stamper.SumCost` prices each slice at its own rate row, sums unrounded and rounds once, and is all-or-nothing: a token-bearing slice with no rate row keeps the stamp null rather than silently under-reporting. Captures from pre-split runners fall back to today's aggregate single-model pricing.
- **migrate** — seed `claude-haiku-4-5` ($1/$5, cache $0.10/$1.25) alongside `claude-sonnet-5`, so the helper-model slice prices instead of nulling every run it touches. Idempotent per model; ops-adjusted rates are never overwritten.

No console or contract-surface change: once cycles stamp, the existing chips render dollars.

## Notes

- Existing unstamped rows stay tokens-only (no backfill per #291; they captured `model_id=''`, so there is nothing to re-price them from).
- Needs the runner image rebuilt for the split to reach new cycles.

## Testing

- Runner: 341/341 (`node --test`), `tsc --noEmit` clean. New pins: per-model slices emitted, versioned→canonical collapse, zero-token entries keep the single model.
- aep-api: full `go test ./...` green, `go vet` clean, deadcode gate OK. New pins: `SumCost` per-slice pricing/rounding/all-or-nothing; dbtest stamping a mixed-model cycle at the summed rate and nulling on an unrated slice; capture keeping the split; seed idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
