### PR TITLE
fix(aep-api): trait sync write order and stale-write retry

### DIFF
--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -600,38 +600,42 @@ func (c *componentClient) DeleteComponent(ctx context.Context, orgName, projectN
 // slice to clear traits.
 func (c *componentClient) UpdateComponentTraits(ctx context.Context, orgName, projectName, componentName string, traits []ComponentTrait) error {
 	scopedComp := ScopedComponentName(projectName, componentName)
-	getResp, err := c.oc.GetComponentWithResponse(ctx, orgName, scopedComp)
-	if err != nil {
-		return fmt.Errorf("failed to get component for traits update: %w", err)
-	}
-	if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
-		return handleErrorResponse(getResp.StatusCode(), ErrorResponses{
-			JSON401: getResp.JSON401,
-			JSON403: getResp.JSON403,
-			JSON404: getResp.JSON404,
-			JSON500: getResp.JSON500,
-		})
-	}
-	comp := *getResp.JSON200
-	if comp.Spec == nil {
-		comp.Spec = &ocgen.ComponentSpec{}
-	}
-	comp.Spec.Traits = componentTraitsToGen(traits)
+	// GET and PUT both inside the retried closure: a retry has to re-read, or
+	// it replays the same stale resourceVersion. See stale_write.go.
+	return retryStaleWrite(ctx, "component/"+scopedComp+" spec.traits", func(ctx context.Context) error {
+		getResp, err := c.oc.GetComponentWithResponse(ctx, orgName, scopedComp)
+		if err != nil {
+			return fmt.Errorf("failed to get component for traits update: %w", err)
+		}
+		if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+			return handleErrorResponse(getResp.StatusCode(), ErrorResponses{
+				JSON401: getResp.JSON401,
+				JSON403: getResp.JSON403,
+				JSON404: getResp.JSON404,
+				JSON500: getResp.JSON500,
+			})
+		}
+		comp := *getResp.JSON200
+		if comp.Spec == nil {
+			comp.Spec = &ocgen.ComponentSpec{}
+		}
+		comp.Spec.Traits = componentTraitsToGen(traits)
 
-	updResp, err := c.oc.UpdateComponentWithResponse(ctx, orgName, ocgen.ComponentNameParam(scopedComp), ocgen.UpdateComponentJSONRequestBody(comp))
-	if err != nil {
-		return fmt.Errorf("failed to update component traits: %w", err)
-	}
-	if updResp.StatusCode() != http.StatusOK && updResp.StatusCode() != http.StatusCreated {
-		return handleErrorResponse(updResp.StatusCode(), ErrorResponses{
-			JSON400: updResp.JSON400,
-			JSON401: updResp.JSON401,
-			JSON403: updResp.JSON403,
-			JSON404: updResp.JSON404,
-			JSON500: updResp.JSON500,
-		})
-	}
-	return nil
+		updResp, err := c.oc.UpdateComponentWithResponse(ctx, orgName, ocgen.ComponentNameParam(scopedComp), ocgen.UpdateComponentJSONRequestBody(comp))
+		if err != nil {
+			return fmt.Errorf("failed to update component traits: %w", err)
+		}
+		if updResp.StatusCode() != http.StatusOK && updResp.StatusCode() != http.StatusCreated {
+			return handleErrorResponse(updResp.StatusCode(), ErrorResponses{
+				JSON400: updResp.JSON400,
+				JSON401: updResp.JSON401,
+				JSON403: updResp.JSON403,
+				JSON404: updResp.JSON404,
+				JSON500: updResp.JSON500,
+			})
+		}
+		return nil
+	})
 }
 
 // UpdateComponentTraitEnvironmentConfigs iterates the Component's
@@ -664,39 +668,69 @@ func (c *componentClient) UpdateComponentTraitEnvironmentConfigs(ctx context.Con
 		return nil
 	}
 
+	// The list supplies the RB NAMES only. Each write re-GETs its binding
+	// inside the retried closure, because OC's Component controller rewrites
+	// `spec.releaseName` on the very bindings we are patching — a trait change
+	// on the Component produces a new ComponentRelease, and that rewrite lands
+	// in the window between a list and a PUT. See stale_write.go.
 	for _, rb := range rbs {
-		if rb.Spec == nil {
-			rb.Spec = &ocgen.ReleaseBindingSpec{}
+		name := rb.Metadata.Name
+		if err := retryStaleWrite(ctx, "releasebinding/"+name+" spec.traitEnvironmentConfigs", func(ctx context.Context) error {
+			return c.putTraitEnvironmentConfigs(ctx, orgName, name, configs)
+		}); err != nil {
+			return err
 		}
-		// Merge: preserve any pre-existing instance keys we don't touch.
-		var merged map[string]interface{}
-		if rb.Spec.TraitEnvironmentConfigs != nil {
-			merged = *rb.Spec.TraitEnvironmentConfigs
-		} else {
-			merged = map[string]interface{}{}
-		}
-		for inst, params := range configs {
-			if len(params) == 0 {
-				delete(merged, inst)
-				continue
-			}
-			merged[inst] = cloneParameterMap(params)
-		}
-		rb.Spec.TraitEnvironmentConfigs = &merged
+	}
+	return nil
+}
 
-		updResp, uerr := c.oc.UpdateReleaseBindingWithResponse(ctx, orgName, ocgen.ReleaseBindingNameParam(rb.Metadata.Name), ocgen.UpdateReleaseBindingJSONRequestBody(rb))
-		if uerr != nil {
-			return fmt.Errorf("failed to update release binding %s trait env config: %w", rb.Metadata.Name, uerr)
+// putTraitEnvironmentConfigs is one read-modify-write attempt against a single
+// ReleaseBinding: re-read it, merge the desired trait-instance configs into
+// `spec.traitEnvironmentConfigs`, write it back. Instances absent from
+// `configs` are preserved; an instance mapped to an empty value is deleted.
+func (c *componentClient) putTraitEnvironmentConfigs(ctx context.Context, orgName, bindingName string, configs map[string]map[string]interface{}) error {
+	getResp, err := c.oc.GetReleaseBindingWithResponse(ctx, orgName, ocgen.ReleaseBindingNameParam(bindingName))
+	if err != nil {
+		return fmt.Errorf("failed to get release binding %s for trait env config update: %w", bindingName, err)
+	}
+	if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+		return handleErrorResponse(getResp.StatusCode(), ErrorResponses{
+			JSON401: getResp.JSON401,
+			JSON403: getResp.JSON403,
+			JSON404: getResp.JSON404,
+			JSON500: getResp.JSON500,
+		})
+	}
+	rb := *getResp.JSON200
+	if rb.Spec == nil {
+		rb.Spec = &ocgen.ReleaseBindingSpec{}
+	}
+	// Merge: preserve any pre-existing instance keys we don't touch.
+	merged := map[string]interface{}{}
+	if rb.Spec.TraitEnvironmentConfigs != nil {
+		merged = *rb.Spec.TraitEnvironmentConfigs
+	}
+	for inst, params := range configs {
+		if len(params) == 0 {
+			delete(merged, inst)
+			continue
 		}
-		if updResp.StatusCode() != http.StatusOK && updResp.StatusCode() != http.StatusCreated {
-			return handleErrorResponse(updResp.StatusCode(), ErrorResponses{
-				JSON400: updResp.JSON400,
-				JSON401: updResp.JSON401,
-				JSON403: updResp.JSON403,
-				JSON404: updResp.JSON404,
-				JSON500: updResp.JSON500,
-			})
-		}
+		merged[inst] = cloneParameterMap(params)
+	}
+	rb.Spec.TraitEnvironmentConfigs = &merged
+
+	updResp, uerr := c.oc.UpdateReleaseBindingWithResponse(ctx, orgName, ocgen.ReleaseBindingNameParam(bindingName), ocgen.UpdateReleaseBindingJSONRequestBody(rb))
+	if uerr != nil {
+		return fmt.Errorf("failed to update release binding %s trait env config: %w", bindingName, uerr)
+	}
+	if updResp.StatusCode() != http.StatusOK && updResp.StatusCode() != http.StatusCreated {
+		return handleErrorResponse(updResp.StatusCode(), ErrorResponses{
+			JSON400: updResp.JSON400,
+			JSON401: updResp.JSON401,
+			JSON403: updResp.JSON403,
+			JSON404: updResp.JSON404,
+			JSON500: updResp.JSON500,
+		})
 	}
 	return nil
 }

--- a/services/aep-api/internal/clients/openchoreo/component_client_traits_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client_traits_test.go
@@ -1,0 +1,279 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// UNIT tier for the two trait write paths, driven end-to-end through the REAL
+// generated client against a stand-in openchoreo-api. These reproduce the
+// production failure that shipped a protected API with no jwtAuth policy: the
+// BFF's own Component write makes OC's controller rewrite the ReleaseBinding,
+// and the BFF's next write — the one carrying jwtAuth — died on the resulting
+// conflict-as-500 with no retry.
+
+// fakeOC records every request and serves a mutable ReleaseBinding + Component.
+// `failPUTs` makes the first N writes to a path fail the way openchoreo-api
+// reports a lost optimistic-concurrency race: HTTP 500, generic body.
+type fakeOC struct {
+	mu sync.Mutex
+	t  *testing.T
+
+	// rbTraitConfigs is the server-side state of spec.traitEnvironmentConfigs.
+	rbTraitConfigs map[string]interface{}
+	// rbReleaseName flips on each GET to model the controller rewriting the
+	// binding underneath us; the BFF must not carry a stale copy forward.
+	rbReleaseName string
+
+	failPUTs int
+	getCount int
+	putCount int
+	// putBodies is the traitEnvironmentConfigs seen on each accepted PUT.
+	putBodies []map[string]interface{}
+}
+
+func (f *fakeOC) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		// List bindings for a component — discovery only; returns names.
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releasebindings"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []any{f.releaseBinding()},
+			})
+
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releasebindings/"):
+			f.getCount++
+			// The controller moved the binding on to a new release since the
+			// last read: a caller that reused an older copy would write this
+			// field back to its stale value.
+			f.rbReleaseName = "release-rev-" + string(rune('a'+f.getCount))
+			_ = json.NewEncoder(w).Encode(f.releaseBinding())
+
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/releasebindings/"):
+			f.putCount++
+			if f.failPUTs > 0 {
+				f.failPUTs--
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Internal server error"})
+				return
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				f.t.Fatalf("decode PUT body: %v", err)
+			}
+			spec, _ := body["spec"].(map[string]any)
+			cfgs, _ := spec["traitEnvironmentConfigs"].(map[string]interface{})
+			// A PUT must be built from the newest read, so the releaseName it
+			// echoes back has to be the one the last GET served.
+			if got, _ := spec["releaseName"].(string); got != f.rbReleaseName {
+				f.t.Errorf("PUT carried releaseName %q, want the freshly-read %q — the write did not re-read", got, f.rbReleaseName)
+			}
+			f.rbTraitConfigs = cfgs
+			f.putBodies = append(f.putBodies, cfgs)
+			_ = json.NewEncoder(w).Encode(f.releaseBinding())
+
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/components/"):
+			f.getCount++
+			_ = json.NewEncoder(w).Encode(f.component())
+
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/components/"):
+			f.putCount++
+			if f.failPUTs > 0 {
+				f.failPUTs--
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Internal server error"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(f.component())
+
+		default:
+			f.t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	})
+}
+
+func (f *fakeOC) releaseBinding() map[string]any {
+	spec := map[string]any{
+		"environment": "development",
+		"owner":       map[string]any{"componentName": "proj-api", "projectName": "proj"},
+		"releaseName": f.rbReleaseName,
+	}
+	if f.rbTraitConfigs != nil {
+		spec["traitEnvironmentConfigs"] = f.rbTraitConfigs
+	}
+	return map[string]any{
+		"metadata": map[string]any{"name": "proj-api-development"},
+		"spec":     spec,
+	}
+}
+
+func (f *fakeOC) component() map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{"name": "proj-api"},
+		"spec": map[string]any{
+			"componentType": map[string]any{"kind": "ClusterComponentType", "name": "service"},
+			"owner":         map[string]any{"projectName": "proj"},
+		},
+	}
+}
+
+func newFakeOCClient(t *testing.T, f *fakeOC) (ComponentClient, func()) {
+	t.Helper()
+	f.t = t
+	f.rbReleaseName = "release-rev-0"
+	srv := httptest.NewServer(f.handler())
+	return NewComponentClient(Config{BaseURL: srv.URL}), srv.Close
+}
+
+// TestUpdateComponentTraitEnvironmentConfigs_RetriesConflictAs500 — THE
+// regression. In production this write lost a race with OC's Component
+// controller, returned 500, and was never retried, so jwtAuth never reached the
+// gateway and every request to a protected API passed through unauthenticated.
+func TestUpdateComponentTraitEnvironmentConfigs_RetriesConflictAs500(t *testing.T) {
+	noStaleWriteBackoff(t)
+	f := &fakeOC{failPUTs: 2}
+	c, closeSrv := newFakeOCClient(t, f)
+	defer closeSrv()
+
+	want := map[string]map[string]interface{}{
+		"api-http": {"jwtAuth": map[string]interface{}{"enabled": true}},
+	}
+	if err := c.UpdateComponentTraitEnvironmentConfigs(context.Background(), "org", "proj", "api", want); err != nil {
+		t.Fatalf("UpdateComponentTraitEnvironmentConfigs should survive two conflicts: %v", err)
+	}
+	if f.putCount != 3 {
+		t.Errorf("want 3 PUT attempts (2 conflicts + success), got %d", f.putCount)
+	}
+	got, ok := f.rbTraitConfigs["api-http"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("jwtAuth config never landed; server state = %#v", f.rbTraitConfigs)
+	}
+	jwt, _ := got["jwtAuth"].(map[string]interface{})
+	if jwt == nil || jwt["enabled"] != true {
+		t.Errorf("want jwtAuth.enabled=true on the binding, got %#v", got)
+	}
+}
+
+// TestUpdateComponentTraitEnvironmentConfigs_MergePreservesOtherInstances — the
+// write owns only the instances it names. A sibling trait's config (here the
+// auto-RCA rule's mandatory notification channel) must survive, or clearing one
+// trait's config would break another trait's render.
+func TestUpdateComponentTraitEnvironmentConfigs_MergePreservesOtherInstances(t *testing.T) {
+	noStaleWriteBackoff(t)
+	f := &fakeOC{rbTraitConfigs: map[string]interface{}{
+		"api-auto-rca-error": map[string]interface{}{"enabled": true},
+	}}
+	c, closeSrv := newFakeOCClient(t, f)
+	defer closeSrv()
+
+	err := c.UpdateComponentTraitEnvironmentConfigs(context.Background(), "org", "proj", "api",
+		map[string]map[string]interface{}{"api-http": {"jwtAuth": map[string]interface{}{"enabled": true}}})
+	if err != nil {
+		t.Fatalf("UpdateComponentTraitEnvironmentConfigs: %v", err)
+	}
+	if _, ok := f.rbTraitConfigs["api-auto-rca-error"]; !ok {
+		t.Errorf("untouched instance was clobbered; got keys %v", mapKeys(f.rbTraitConfigs))
+	}
+	if _, ok := f.rbTraitConfigs["api-http"]; !ok {
+		t.Errorf("named instance not written; got keys %v", mapKeys(f.rbTraitConfigs))
+	}
+}
+
+// TestUpdateComponentTraitEnvironmentConfigs_EmptyValueDeletes — a tombstone
+// removes just its own key.
+func TestUpdateComponentTraitEnvironmentConfigs_EmptyValueDeletes(t *testing.T) {
+	noStaleWriteBackoff(t)
+	f := &fakeOC{rbTraitConfigs: map[string]interface{}{
+		"api-http":           map[string]interface{}{"jwtAuth": map[string]interface{}{"enabled": true}},
+		"api-auto-rca-error": map[string]interface{}{"enabled": true},
+	}}
+	c, closeSrv := newFakeOCClient(t, f)
+	defer closeSrv()
+
+	err := c.UpdateComponentTraitEnvironmentConfigs(context.Background(), "org", "proj", "api",
+		map[string]map[string]interface{}{"api-http": nil})
+	if err != nil {
+		t.Fatalf("UpdateComponentTraitEnvironmentConfigs: %v", err)
+	}
+	if _, ok := f.rbTraitConfigs["api-http"]; ok {
+		t.Errorf("tombstoned instance still present: %v", mapKeys(f.rbTraitConfigs))
+	}
+	if _, ok := f.rbTraitConfigs["api-auto-rca-error"]; !ok {
+		t.Errorf("tombstone removed the wrong key: %v", mapKeys(f.rbTraitConfigs))
+	}
+}
+
+// TestUpdateComponentTraits_RetriesConflictAs500 — the Component half of the
+// same hazard: this write is the one that PROVOKES the controller rewrite, so it
+// races too.
+func TestUpdateComponentTraits_RetriesConflictAs500(t *testing.T) {
+	noStaleWriteBackoff(t)
+	f := &fakeOC{failPUTs: 1}
+	c, closeSrv := newFakeOCClient(t, f)
+	defer closeSrv()
+
+	traits := []ComponentTrait{{InstanceName: "api-http", Kind: "ClusterTrait", Name: "api-configuration"}}
+	if err := c.UpdateComponentTraits(context.Background(), "org", "proj", "api", traits); err != nil {
+		t.Fatalf("UpdateComponentTraits should survive one conflict: %v", err)
+	}
+	if f.putCount != 2 {
+		t.Errorf("want 2 PUT attempts, got %d", f.putCount)
+	}
+	if f.getCount != 2 {
+		t.Errorf("each attempt must re-GET the component; want 2 GETs, got %d", f.getCount)
+	}
+}
+
+// TestUpdateComponentTraitEnvironmentConfigs_NoBindingsIsSoftNoOp — before the
+// first build there is nothing to patch; that is not an error.
+func TestUpdateComponentTraitEnvironmentConfigs_NoBindingsIsSoftNoOp(t *testing.T) {
+	noStaleWriteBackoff(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/releasebindings") {
+			t.Fatalf("no write may be attempted when no binding exists; got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	err := c.UpdateComponentTraitEnvironmentConfigs(context.Background(), "org", "proj", "api",
+		map[string]map[string]interface{}{"api-http": {"jwtAuth": map[string]interface{}{"enabled": true}}})
+	if err != nil {
+		t.Fatalf("absent binding must be a soft no-op, got %v", err)
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/services/aep-api/internal/clients/openchoreo/stale_write.go
+++ b/services/aep-api/internal/clients/openchoreo/stale_write.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+// OpenChoreo exposes no PATCH for its CRs — every field-level edit is a
+// read-modify-write over the whole object (GET, mutate one field, PUT). Those
+// edits race OC's own controllers, which write the same objects continuously,
+// and the loser gets k8s' optimistic-concurrency error. openchoreo-api reports
+// it as a GENERIC HTTP 500: the cause appears only in openchoreo-api's log,
+// never in the response body.
+//
+//	openchoreo-api  INFO   UpdateReleaseBinding called
+//	openchoreo-api  ERROR  Failed to update release binding CR
+//	  error="Operation cannot be fulfilled on releasebindings.openchoreo.dev
+//	         \"…-workout-api-development\": the object has been modified;
+//	         please apply your changes to the latest version and try again"
+//	openchoreo-api  ACCESS-LOG  PUT /api/v1/…/releasebindings/…  status=500
+//
+// The stale resourceVersion is openchoreo-api's own, not ours — the wire types
+// here carry no resourceVersion at all (see gen.ObjectMeta), so openchoreo-api
+// re-reads the CR per request and applies our body onto it. Two consequences:
+//
+//   - The 500 is genuinely transient. The same request re-issued a moment later
+//     picks up a fresh server-side read and succeeds. But nothing retried it:
+//     the HTTP transport deliberately excludes 500 from its retryable set for
+//     non-idempotent methods (buildRetryConfig → TransientHTTPErrorCodes),
+//     because blindly replaying an arbitrary PUT/POST is not safe in general.
+//     Retrying has to be an opt-in by a caller that knows its write IS
+//     idempotent — which is what this helper is.
+//   - We re-read anyway, inside the retried closure. Not for the
+//     resourceVersion, but because the MERGE is ours: these writes preserve map
+//     keys they don't own (other traits' env configs), and a merge computed
+//     from a stale read would silently clobber a key a concurrent writer just
+//     added. `write` must therefore do its own read on every invocation.
+//
+// The BFF cannot tell a conflict-as-500 from a genuine fault, so retryStaleWrite
+// treats BOTH 409 and 500 as retryable. That is safe for the callers here
+// because each is an idempotent converge-to-desired-state reconcile: re-running
+// it re-reads and re-applies the same desired subset, so a retry after a
+// partially-visible failure can only reach the same end state. Do NOT reach for
+// this helper from a create/append path, where a retried write is not the same
+// as one write.
+const staleWriteAttempts = 4
+
+// staleWriteBackoff is the pause before attempt N+1 (index 0 ⇒ before the first
+// retry). Short by design: the conflict window is one controller reconcile, and
+// OC settles in milliseconds. Overridden to zero in tests.
+var staleWriteBackoff = []time.Duration{
+	50 * time.Millisecond,
+	200 * time.Millisecond,
+	600 * time.Millisecond,
+}
+
+// retryStaleWrite runs an idempotent read-modify-write reconcile, retrying when
+// the write loses an optimistic-concurrency race against an OpenChoreo
+// controller.
+//
+// `write` MUST perform its own read on every invocation — retrying a closure
+// that captured the object from an earlier read re-sends the same stale
+// resourceVersion and can never succeed. `target` names what is being written,
+// for the exhaustion log.
+func retryStaleWrite(ctx context.Context, target string, write func(context.Context) error) error {
+	var err error
+	for attempt := 0; attempt < staleWriteAttempts; attempt++ {
+		if attempt > 0 {
+			slog.DebugContext(ctx, "openchoreo: retrying stale read-modify-write",
+				"target", target, "attempt", attempt+1, "error", err)
+			if waitErr := sleepCtx(ctx, staleWriteBackoff[min(attempt-1, len(staleWriteBackoff)-1)]); waitErr != nil {
+				return waitErr
+			}
+		}
+		err = write(ctx)
+		if err == nil {
+			return nil
+		}
+		if !isStaleWriteError(err) {
+			return err
+		}
+	}
+	slog.WarnContext(ctx, "openchoreo: read-modify-write still conflicting after retries",
+		"target", target, "attempts", staleWriteAttempts, "error", err)
+	return err
+}
+
+// isStaleWriteError reports whether err is worth a re-read-and-retry. 500 is in
+// the set because openchoreo-api flattens the k8s conflict onto it (see the
+// package comment above); if OC ever starts returning a true 409 for that case,
+// dropping ErrInternalServerError here narrows the retry without breaking it.
+func isStaleWriteError(err error) bool {
+	return errors.Is(err, ErrConflict) || errors.Is(err, ErrInternalServerError)
+}
+
+// sleepCtx waits for d, or returns early with the context's error if the
+// caller is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/stale_write_test.go
+++ b/services/aep-api/internal/clients/openchoreo/stale_write_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// UNIT tier for the read-modify-write retry that guards every GET-then-PUT
+// against an OpenChoreo CR. The scenario it exists for: OC's Component
+// controller rewrites `ReleaseBinding.spec.releaseName` in the window between
+// our read and our write, k8s rejects the stale resourceVersion, and
+// openchoreo-api reports that conflict as a bare 500.
+
+// noStaleWriteBackoff removes the sleeps for the duration of a test so the
+// retry loop runs at memory speed.
+func noStaleWriteBackoff(t *testing.T) {
+	t.Helper()
+	orig := staleWriteBackoff
+	staleWriteBackoff = []time.Duration{0}
+	t.Cleanup(func() { staleWriteBackoff = orig })
+}
+
+// TestRetryStaleWrite_RetriesConflictSurfacedAs500 — the regression that let a
+// protected API deploy with no jwtAuth: openchoreo-api maps the k8s conflict
+// onto ErrInternalServerError, so the retry MUST treat 500 as retryable or the
+// write is lost on the first race.
+func TestRetryStaleWrite_RetriesConflictSurfacedAs500(t *testing.T) {
+	noStaleWriteBackoff(t)
+	attempts := 0
+	err := retryStaleWrite(context.Background(), "releasebinding/x", func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return fmt.Errorf("%w: Internal server error", ErrInternalServerError)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryStaleWrite should have converged, got %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("want 3 attempts (2 conflicts then success), got %d", attempts)
+	}
+}
+
+// TestRetryStaleWrite_RetriesTrueConflict — if OC ever starts returning a real
+// 409 for the same case, the retry still covers it.
+func TestRetryStaleWrite_RetriesTrueConflict(t *testing.T) {
+	noStaleWriteBackoff(t)
+	attempts := 0
+	err := retryStaleWrite(context.Background(), "component/x", func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return fmt.Errorf("%w: the object has been modified", ErrConflict)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryStaleWrite: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("want 2 attempts, got %d", attempts)
+	}
+}
+
+// TestRetryStaleWrite_SucceedsFirstTry — the happy path costs exactly one call;
+// the helper must not add a speculative retry.
+func TestRetryStaleWrite_SucceedsFirstTry(t *testing.T) {
+	noStaleWriteBackoff(t)
+	attempts := 0
+	if err := retryStaleWrite(context.Background(), "x", func(context.Context) error {
+		attempts++
+		return nil
+	}); err != nil {
+		t.Fatalf("retryStaleWrite: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("want 1 attempt, got %d", attempts)
+	}
+}
+
+// TestRetryStaleWrite_NonRetryableFailsFast — a 400/403/404 is a real rejection,
+// not a race. Retrying it would only multiply the latency of a doomed write.
+func TestRetryStaleWrite_NonRetryableFailsFast(t *testing.T) {
+	noStaleWriteBackoff(t)
+	for _, sentinel := range []error{ErrBadRequest, ErrForbidden, ErrNotFound, ErrUnauthorized} {
+		attempts := 0
+		err := retryStaleWrite(context.Background(), "x", func(context.Context) error {
+			attempts++
+			return fmt.Errorf("%w: nope", sentinel)
+		})
+		if !errors.Is(err, sentinel) {
+			t.Errorf("want %v preserved, got %v", sentinel, err)
+		}
+		if attempts != 1 {
+			t.Errorf("%v should not be retried; got %d attempts", sentinel, attempts)
+		}
+	}
+}
+
+// TestRetryStaleWrite_ExhaustsAndReturnsLastError — a permanently conflicting
+// object gives up after the bounded attempt count and surfaces the cause, so
+// the caller (and Temporal, above it) sees a failure rather than a false success.
+func TestRetryStaleWrite_ExhaustsAndReturnsLastError(t *testing.T) {
+	noStaleWriteBackoff(t)
+	attempts := 0
+	err := retryStaleWrite(context.Background(), "x", func(context.Context) error {
+		attempts++
+		return fmt.Errorf("%w: Internal server error", ErrInternalServerError)
+	})
+	if !errors.Is(err, ErrInternalServerError) {
+		t.Errorf("want ErrInternalServerError after exhaustion, got %v", err)
+	}
+	if attempts != staleWriteAttempts {
+		t.Errorf("want %d attempts, got %d", staleWriteAttempts, attempts)
+	}
+}
+
+// TestRetryStaleWrite_HonorsCancellation — a cancelled context stops the loop at
+// the backoff instead of burning the remaining attempts.
+func TestRetryStaleWrite_HonorsCancellation(t *testing.T) {
+	orig := staleWriteBackoff
+	staleWriteBackoff = []time.Duration{time.Hour}
+	t.Cleanup(func() { staleWriteBackoff = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	err := retryStaleWrite(ctx, "x", func(context.Context) error {
+		attempts++
+		cancel()
+		return fmt.Errorf("%w: Internal server error", ErrInternalServerError)
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want context.Canceled, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("want the loop to stop at the first backoff; got %d attempts", attempts)
+	}
+}

--- a/services/aep-api/internal/projects/trait_sync.go
+++ b/services/aep-api/internal/projects/trait_sync.go
@@ -18,6 +18,7 @@ package projects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -56,6 +57,13 @@ type OrgPublisher interface {
 //     be written before then; UpdateComponentTraitEnvironmentConfigs soft
 //     no-ops when the binding is absent.
 //
+// Because the two halves land on different objects, the WRITE ORDER is part of
+// the contract: a trait attached without its per-environment config fails the
+// whole ReleaseBinding render. SyncComponentTraits therefore writes config
+// upserts → trait shape → config tombstones, and each write re-reads under
+// retry (openchoreo.retryStaleWrite) because OC's own controllers rewrite the
+// objects we patch. The full account of both hazards is at the two write sites.
+//
 // The trigger for (2) is `SyncProjectAPITraits`, called by the run
 // supervisor when a cycle's builds go green (`delivery/run`, activity
 // SyncAPITraits). That trigger is rail-coupled ON PURPOSE-FOR-NOW and it is
@@ -65,8 +73,10 @@ type OrgPublisher interface {
 // for that watcher to read. A missed write leaves a protected API's gateway
 // passing every request through unauthenticated, so a rail-agnostic reconcile
 // sweep over the component list is what should ultimately make the guarantee.
-// `traitDeployObserver` still routes the old ExecWatcher path here; it is
-// inert for anything the run loop builds.
+// Until then the failure is at least LOUD and retried: SyncProjectAPITraits
+// returns its per-component failures, so the activity fails and Temporal
+// re-runs the sweep. `traitDeployObserver` still routes the old ExecWatcher
+// path here; it is inert for anything the run loop builds.
 //
 // Concurrency: every call acquires a per-component mutex keyed by
 // `(orgID, projectID, componentName)`. We use a `sync.Map` of `*sync.Mutex`
@@ -244,6 +254,30 @@ func (s *TraitSyncService) SyncComponentTraits(ctx context.Context, orgID, proje
 		}
 	}
 
+	// Write order matters, because the two halves land on different objects and
+	// either write can fail on its own. A trait instance attached to the
+	// Component whose per-environment config is MISSING doesn't degrade
+	// gracefully — it fails the whole ReleaseBinding render, taking every other
+	// trait on that binding down with it. observability-alert-rule is the live
+	// example: its schema rejects a rule with no notification channel, and the
+	// channel is supplied by the env config, so trait-shape-first briefly (or,
+	// if the second write fails, permanently) leaves the binding unrenderable:
+	//
+	//	Failed to render resources: trait observability-alert-rule/…-auto-rca-error
+	//	validation failed: A notification channel is mandatory for alert rules
+	//
+	// So: never a trait without its config, and never a config stripped from
+	// under a still-attached trait. Upserts go first, the trait shape second,
+	// and removals last. Each phase is skipped when its set is empty, so the
+	// common enabled path is still two writes.
+	upserts, removals := splitTraitConfigs(configs)
+
+	if len(upserts) > 0 {
+		if err := s.componentClient.UpdateComponentTraitEnvironmentConfigs(ctx, orgID, projectID, componentName, upserts); err != nil {
+			return fmt.Errorf("trait_sync: update trait env configs: %w", err)
+		}
+	}
+
 	// Patch the Component CR's spec.traits. Skip when there's nothing to
 	// change — but the OC client's GET-then-PUT is harmless so we always
 	// fire to avoid bookkeeping drift between in-process state and OC.
@@ -251,13 +285,15 @@ func (s *TraitSyncService) SyncComponentTraits(ctx context.Context, orgID, proje
 		return fmt.Errorf("trait_sync: update component traits: %w", err)
 	}
 
-	// Patch every existing ReleaseBinding's traitEnvironmentConfigs. The
-	// OC client returns a soft no-op when none exist yet (first-deploy
-	// race) — that's expected and the dispatch path creates the RB with
-	// the right env config in place via the Component's autoDeploy
+	// Tombstones: the instance is off the Component now, so its stale env
+	// config can go. The OC client returns a soft no-op when no ReleaseBinding
+	// exists yet (first-deploy race) — expected, and the dispatch path creates
+	// the RB with the right env config in place via the Component's autoDeploy
 	// reconcile.
-	if err := s.componentClient.UpdateComponentTraitEnvironmentConfigs(ctx, orgID, projectID, componentName, configs); err != nil {
-		return fmt.Errorf("trait_sync: update trait env configs: %w", err)
+	if len(removals) > 0 {
+		if err := s.componentClient.UpdateComponentTraitEnvironmentConfigs(ctx, orgID, projectID, componentName, removals); err != nil {
+			return fmt.Errorf("trait_sync: clear trait env configs: %w", err)
+		}
 	}
 
 	slog.InfoContext(ctx, "trait_sync: reconciled",
@@ -327,9 +363,15 @@ func (s *TraitSyncService) DeleteComponentCascade(ctx context.Context, orgID, pr
 //     so a fresh deploy provisions the default error→RCA alert-rule trait
 //     immediately, instead of waiting for the next reconcile-watcher sweep.
 //
-// Idempotent + best-effort: a failure on one component logs and continues
-// to the next. Returns nil unless reading design itself fails (no design ⇒
-// nothing to reconcile, returns nil).
+// Idempotent: a failure on one component logs and continues to the next, so one
+// bad component can't stop the rest of the project from converging. The
+// failures are then JOINED and RETURNED — they are not swallowed. That matters
+// because this is the only trigger: the caller is the Temporal SyncAPITraits
+// activity, and returning the error is what makes Temporal retry the sweep. A
+// dropped write here leaves a protected API's gateway passing every request
+// through unauthenticated, which is not a "log it and move on" outcome.
+//
+// No design ⇒ nothing to reconcile, returns nil.
 func (s *TraitSyncService) SyncProjectAPITraits(ctx context.Context, orgID, projectID string) error {
 	if s == nil {
 		return nil
@@ -347,6 +389,7 @@ func (s *TraitSyncService) SyncProjectAPITraits(ctx context.Context, orgID, proj
 	if design == nil {
 		return nil
 	}
+	var failures []error
 	for _, c := range design.Components {
 		if c.ComponentType != spec.ComponentTypeService {
 			continue
@@ -368,9 +411,10 @@ func (s *TraitSyncService) SyncProjectAPITraits(ctx context.Context, orgID, proj
 				"componentName", k8sName,
 				"error", err,
 			)
+			failures = append(failures, fmt.Errorf("component %q: %w", k8sName, err))
 		}
 	}
-	return nil
+	return errors.Join(failures...)
 }
 
 // siblingSPAOrigins returns the external SPA origins for every web-app
@@ -454,6 +498,29 @@ func (s *TraitSyncService) lockFor(orgID, projectID, componentName string) *sync
 }
 
 // -- Pure helpers ------------------------------------------------------------
+
+// splitTraitConfigs partitions a desired trait-env-config map into the
+// instances being written (`upserts`) and the instances being tombstoned
+// (`removals` — the empty/nil values that mean "delete this key"). Callers use
+// the split to order the two writes around the Component's trait-shape write;
+// see SyncComponentTraits. Both maps are nil when their side is empty, so
+// `len(...) > 0` is the phase gate.
+func splitTraitConfigs(configs map[string]map[string]interface{}) (upserts, removals map[string]map[string]interface{}) {
+	for inst, params := range configs {
+		if len(params) == 0 {
+			if removals == nil {
+				removals = map[string]map[string]interface{}{}
+			}
+			removals[inst] = nil
+			continue
+		}
+		if upserts == nil {
+			upserts = map[string]map[string]interface{}{}
+		}
+		upserts[inst] = params
+	}
+	return upserts, removals
+}
 
 // APIConfigurationInstanceName returns the canonical trait instance name for
 // the component's managed endpoint. Mirrors the POC manifests' naming

--- a/services/aep-api/internal/projects/trait_sync_project_test.go
+++ b/services/aep-api/internal/projects/trait_sync_project_test.go
@@ -214,7 +214,7 @@ func traitCORSFor(t *testing.T, oc *mocks.ComponentClientMock, component string)
 	return nil
 }
 
-func TestSyncProjectAPITraits_PerComponentErrorDoesNotAbort(t *testing.T) {
+func TestSyncProjectAPITraits_PerComponentErrorContinuesThenSurfaces(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	files := map[string]string{
@@ -231,10 +231,20 @@ func TestSyncProjectAPITraits_PerComponentErrorDoesNotAbort(t *testing.T) {
 	}
 	svc := NewTraitSyncService(oc, traitStoreWith(files))
 
-	// api-a's SyncComponentTraits errors; the loop logs and continues, so
-	// api-b is still attempted and the project-level call returns nil.
-	if err := svc.SyncProjectAPITraits(ctx, "acme", "proj"); err != nil {
-		t.Fatalf("per-component failure must be best-effort; got %v", err)
+	// api-a's SyncComponentTraits errors; the loop continues so api-b still
+	// converges — but the failure is then RETURNED, not swallowed. That return
+	// is what fails the Temporal SyncAPITraits activity and gets the sweep
+	// retried; swallowing it left protected APIs serving unauthenticated
+	// traffic with nothing but a WARN to show for it.
+	err := svc.SyncProjectAPITraits(ctx, "acme", "proj")
+	if err == nil {
+		t.Fatal("a dropped trait write must surface to the caller, got nil")
+	}
+	if !strings.Contains(err.Error(), "api-a") {
+		t.Errorf("error should name the failing component: %v", err)
+	}
+	if strings.Contains(err.Error(), "api-b") {
+		t.Errorf("api-b succeeded and must not appear in the error: %v", err)
 	}
 	if n := len(oc.UpdateComponentTraitsCalls()); n != 2 {
 		t.Errorf("both enabled services must be attempted even after one errors; got %d", n)

--- a/services/aep-api/internal/projects/trait_sync_write_order_test.go
+++ b/services/aep-api/internal/projects/trait_sync_write_order_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo/mocks"
+	"github.com/wso2/aep/aep-api/internal/spec"
+)
+
+// UNIT tier for the ORDER of the two trait writes. The two halves of trait state
+// live on different objects (Component.spec.traits, ReleaseBinding.spec
+// .traitEnvironmentConfigs) and either write can fail alone, so the order
+// decides what a half-applied sync leaves behind. A trait attached WITHOUT its
+// per-environment config is not a partial success: it fails the whole binding's
+// render, which is how one dropped write took down an entire project's
+// deployment —
+//
+//	Failed to render resources: trait observability-alert-rule/…-auto-rca-error
+//	validation failed: A notification channel is mandatory for alert rules
+
+// orderRecordingOC records the sequence of trait writes so a test can assert
+// which object was written first. `configWrites` captures each env-config call's
+// payload in order.
+type orderRecordingOC struct {
+	*mocks.ComponentClientMock
+	order        []string
+	configWrites []map[string]map[string]interface{}
+}
+
+func newOrderRecordingOC() *orderRecordingOC {
+	rec := &orderRecordingOC{ComponentClientMock: &mocks.ComponentClientMock{}}
+	rec.ListDeploymentsFunc = nil
+	rec.UpdateComponentTraitsFunc = func(context.Context, string, string, string, []openchoreo.ComponentTrait) error {
+		rec.order = append(rec.order, "traits")
+		return nil
+	}
+	rec.UpdateComponentTraitEnvironmentConfigsFunc = func(_ context.Context, _, _, _ string, configs map[string]map[string]interface{}) error {
+		rec.order = append(rec.order, "configs")
+		rec.configWrites = append(rec.configWrites, configs)
+		return nil
+	}
+	return rec
+}
+
+// TestSyncComponentTraits_ConfigBeforeTraitShape — a protected component's
+// jwtAuth + auto-RCA config must be on the binding BEFORE the traits that
+// require it are attached to the Component.
+func TestSyncComponentTraits_ConfigBeforeTraitShape(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{
+		spec.DesignRootFile:          traitRootMd(),
+		"components/api/design.json": endUserServiceMd("api"),
+	}
+	oc := newOrderRecordingOC()
+	svc := NewTraitSyncService(oc, traitStoreWith(files))
+
+	if err := svc.SyncComponentTraits(context.Background(), "acme", "proj", "api"); err != nil {
+		t.Fatalf("SyncComponentTraits: %v", err)
+	}
+	if len(oc.order) != 2 {
+		t.Fatalf("want exactly 2 writes for an enabled component, got %v", oc.order)
+	}
+	if oc.order[0] != "configs" || oc.order[1] != "traits" {
+		t.Errorf("upserts must precede the trait shape; got %v", oc.order)
+	}
+	// The one config write must carry BOTH traits' configs — they share the
+	// write, so splitting them would reintroduce the stranded-trait window.
+	cfg := oc.configWrites[0]
+	if _, ok := cfg["api-http"]; !ok {
+		t.Errorf("api-configuration config missing from the upsert; got %v", keysOfAny(cfg))
+	}
+	if _, ok := cfg["api-auto-rca-error"]; !ok {
+		t.Errorf("auto-RCA config missing from the upsert; got %v", keysOfAny(cfg))
+	}
+}
+
+// TestSyncComponentTraits_TraitShapeBeforeTombstone — going the other way, the
+// instance must leave the Component before its config is stripped, so a config
+// is never pulled out from under an attached trait.
+func TestSyncComponentTraits_TraitShapeBeforeTombstone(t *testing.T) {
+	t.Parallel()
+	// A web-application: no exposesAPI (api-configuration tombstoned) and not a
+	// service (auto-RCA does not apply), so nothing wants a config and the only
+	// config write is the removal.
+	files := map[string]string{
+		spec.DesignRootFile:          traitRootMd(),
+		"components/web/design.json": webAppMd("web"),
+	}
+	oc := newOrderRecordingOC()
+	svc := NewTraitSyncService(oc, traitStoreWith(files))
+
+	if err := svc.SyncComponentTraits(context.Background(), "acme", "proj", "web"); err != nil {
+		t.Fatalf("SyncComponentTraits: %v", err)
+	}
+	if len(oc.order) != 2 {
+		t.Fatalf("want 2 writes (trait shape then tombstone), got %v", oc.order)
+	}
+	if oc.order[0] != "traits" || oc.order[1] != "configs" {
+		t.Errorf("tombstones must follow the trait shape; got %v", oc.order)
+	}
+	if got := oc.configWrites[0]["web-http"]; got != nil {
+		t.Errorf("want a nil tombstone for web-http, got %#v", got)
+	}
+}
+
+// TestSyncComponentTraits_ConfigFailureLeavesTraitUnattached — the invariant the
+// ordering buys: when the config write fails, the sync aborts BEFORE attaching
+// the trait, so the binding stays renderable and the next sweep can converge.
+// Previously the trait went on first and a failed config write left the whole
+// ReleaseBinding permanently unrenderable.
+func TestSyncComponentTraits_ConfigFailureLeavesTraitUnattached(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{
+		spec.DesignRootFile:          traitRootMd(),
+		"components/api/design.json": endUserServiceMd("api"),
+	}
+	oc := newOrderRecordingOC()
+	oc.UpdateComponentTraitEnvironmentConfigsFunc = func(context.Context, string, string, string, map[string]map[string]interface{}) error {
+		return errors.New("oc: conflict surfaced as 500")
+	}
+	svc := NewTraitSyncService(oc, traitStoreWith(files))
+
+	err := svc.SyncComponentTraits(context.Background(), "acme", "proj", "api")
+	if err == nil {
+		t.Fatal("want the config-write failure to surface")
+	}
+	if !strings.Contains(err.Error(), "update trait env configs") {
+		t.Errorf("error should name the failing write: %v", err)
+	}
+	if n := len(oc.UpdateComponentTraitsCalls()); n != 0 {
+		t.Errorf("trait shape must NOT be attached when its config failed to land; got %d calls", n)
+	}
+}
+
+// TestSplitTraitConfigs — the partition the write order is built on.
+func TestSplitTraitConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mixed", func(t *testing.T) {
+		t.Parallel()
+		up, rm := splitTraitConfigs(map[string]map[string]interface{}{
+			"keep":  {"jwtAuth": map[string]interface{}{"enabled": true}},
+			"drop":  nil,
+			"empty": {},
+		})
+		if len(up) != 1 || up["keep"] == nil {
+			t.Errorf("upserts = %v, want just 'keep'", keysOfAny(up))
+		}
+		if len(rm) != 2 {
+			t.Errorf("removals = %v, want 'drop' and 'empty'", keysOfAny(rm))
+		}
+		if rm["drop"] != nil || rm["empty"] != nil {
+			t.Error("removals must map to nil so the client deletes the key")
+		}
+	})
+
+	t.Run("nil input yields two nil maps so both phases are skipped", func(t *testing.T) {
+		t.Parallel()
+		up, rm := splitTraitConfigs(nil)
+		if up != nil || rm != nil {
+			t.Errorf("want both nil, got upserts=%v removals=%v", up, rm)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes two critical hazards in component trait syncing that could leave ReleaseBindings permanently unrenderable:

1. **Write order invariant**: Trait state spans two objects (Component.spec.traits and ReleaseBinding.spec.traitEnvironmentConfigs). If a config write fails after traits are attached, the binding becomes unrenderable. Now enforces: upserts → trait shape → tombstones.

2. **Stale-write retry**: OpenChoreo's controllers continuously rewrite the ReleaseBindings we patch. A GET-then-PUT loses the race against the controller, and openchoreo-api reports the k8s conflict as HTTP 500. Added `retryStaleWrite()` helper that retries the entire read-modify-write cycle with exponential backoff.

3. **Error surfacing**: Previously `SyncProjectAPITraits` silently swallowed per-component failures. Now returns the joined error so Temporal retries the sweep on failure, ensuring no dropped trait writes.

## Test coverage

- `TestSyncComponentTraits_ConfigBeforeTraitShape`: Config upserts precede trait shape
- `TestSyncComponentTraits_TraitShapeBeforeTombstone`: Trait shape precedes config tombstones  
- `TestSyncComponentTraits_ConfigFailureLeavesTraitUnattached`: Failed config write aborts before trait attach
- `TestSplitTraitConfigs`: Partition upserts and removals correctly
- `TestSyncProjectAPITraits_PerComponentErrorContinuesThenSurfaces`: Per-component errors are logged, loop continues, but error is returned

All tests green locally; no regressions in existing suites.

Co-authored-by: Claude Haiku 4.5 <noreply@anthropic.com>