### PR TITLE
fix(console): wireframe prototype toggle hidden in seeded collab rooms

### DIFF
--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -58,19 +58,24 @@ export function WireframePanel({
     return lastGoodLive.current;
   }, [dslPath, liveSource]);
 
-  const streaming = liveScene != null;
   const agentBusy = collab.peers.some((p) => p.kind === "agent");
+  // The doc is always the source while collab is up (rooms seeded with #86
+  // phase 4). Use live content whenever it exists, regardless of agent presence.
+  const hasLiveContent = liveScene != null;
+  // Streaming means the agent is ACTIVELY writing — show the "Drawing…" chip
+  // and update the scene in place. Seeded content alone doesn't count.
+  const streaming = hasLiveContent && agentBusy;
   // Committed fetch: the collab-less base path only (mirrors `usesCollab`
   // disabling the content query for markdown) — passing "" disables it. An
   // agent in the room also suppresses it: the doc WILL deliver the file, and
   // probing git for a not-yet-committed path just sprays retrying 404s.
   const { scene, isPending, isError } = useDerivedWireframe(
     projectName,
-    streaming || agentBusy ? "" : dslPath,
+    hasLiveContent || agentBusy ? "" : dslPath,
     sha,
   );
 
-  if (!streaming && agentBusy) {
+  if (!hasLiveContent && agentBusy) {
     // The committed fetch is suppressed while an agent is in the room (the
     // doc will deliver the file) — "drawing about to start", not a failure.
     return (
@@ -81,17 +86,17 @@ export function WireframePanel({
       </Box>
     );
   }
-  if (!streaming && isPending) {
+  if (!hasLiveContent && isPending) {
     return (
       <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
         <CircularProgress aria-label="Loading wireframe" />
       </Box>
     );
   }
-  if (!streaming && isError) {
+  if (!hasLiveContent && isError) {
     return <Alert severity="error">Failed to load {dslPath}.</Alert>;
   }
-  if (!streaming && !scene) {
+  if (!hasLiveContent && !scene) {
     return (
       <Typography variant="body2" color="text.secondary">
         This wireframe source could not be rendered.
@@ -105,10 +110,8 @@ export function WireframePanel({
   // (fillHeight) sets `flex: 1` on its own root inside the flex column.
   return (
     <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-      {streaming && agentBusy && (
-        // The chip means "actively being generated", not "rendered from the
-        // live doc" — the doc is ALWAYS the source while collab is up (rooms
-        // are seeded), so gate the chip on the agent actually being in the room.
+      {streaming && (
+        // The chip means "actively being generated" — agent in room AND writing.
         <Box
           sx={{
             px: 1.5,
@@ -122,7 +125,7 @@ export function WireframePanel({
           <Chip size="small" color="primary" variant="outlined" label="Drawing…" />
         </Box>
       )}
-      {streaming ? (
+      {hasLiveContent ? (
         <ExcalidrawView scene={liveScene!} fillHeight />
       ) : (
         <ExcalidrawView key={sha} scene={scene!} fillHeight />


### PR DESCRIPTION
## Summary

Fixed the Canvas|Prototype toggle that was always hidden in seeded collab rooms. The toggle is part of the wireframe prototype feature (PR #393) but had a logic bug preventing it from ever appearing.

## Root Cause

The `streaming` flag was true whenever the collab doc had ANY content, including seeded committed files. Since spec rooms are always seeded with committed files (#86 phase 4), the toggle would never appear in real rooms.

## The Fix

Changed `streaming` to require BOTH conditions:
- Live scene exists (collab doc has content)
- Agent is actively in the room

```javascript
// Before
const streaming = liveScene != null;

// After  
const streaming = liveScene != null && agentBusy;
```

This distinguishes "agent actively writing" from "seeded committed content".

## Verification

✅ Toggle button now visible in wireframe panel
✅ Canvas/Prototype mode switching works
✅ Screen navigation functional (back button, history dropdown)
✅ Prototype mode interactive - click-through navigation works

## Related

- Fixes incomplete feature from PR #393 (wireframe prototype mode)
- Issue #348: wireframe prototype mode (click-through user flows)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>