### PR TITLE
fix(console): show the wireframe view switch in seeded collab rooms

### DIFF
--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -48,6 +48,7 @@ vi.mock("../api/useDerivedDesign", () => ({
 }));
 
 const DSL_PATH = "specs/design/components/shop-webapp/wireframes.dsl";
+const OTHER_DSL_PATH = "specs/design/components/admin-webapp/wireframes.dsl";
 
 function makeCollab(ytext: Y.Text | null, agent = true): CollabSpec {
   return {
@@ -156,6 +157,35 @@ describe("WireframePanel streaming", () => {
     renderPanel(makeCollab(null, false));
     expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
   });
+
+  it("keeps a held scene with its own file — one component's wireframe never stands in for another's", () => {
+    // Committed read resolves with nothing to render (not an error), so the
+    // fallback below is the honest "nothing here", never component A's scene.
+    mockDerived.mockReturnValue({ scene: null, isPending: false, isError: false });
+    const doc = new Y.Doc();
+    const a = doc.getText(DSL_PATH);
+    a.insert(0, 'screen Catalog "A"\n  heading "Browse"\n');
+    // Component B's doc holds text that does not compile.
+    const b = doc.getText(OTHER_DSL_PATH);
+    b.insert(0, "garbage {{{");
+    const collab = {
+      peers: [],
+      getFileText: (p: string) => (p === DSL_PATH ? a : p === OTHER_DSL_PATH ? b : null),
+    } as unknown as CollabSpec;
+
+    const { rerender } = render(
+      <WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={collab} />,
+    );
+    expect(Number(screen.getByTestId("excalidraw").dataset.elements)).toBeGreaterThan(0);
+
+    // The panel is not remounted on selection change (SpecView renders it
+    // unkeyed), so the held scene must not leak across the path switch.
+    rerender(
+      <WireframePanel projectName="p" dslPath={OTHER_DSL_PATH} files={[]} collab={collab} />,
+    );
+    expect(screen.queryByTestId("excalidraw")).not.toBeInTheDocument();
+    expect(screen.getByText(/could not be rendered/i)).toBeInTheDocument();
+  });
 });
 
 describe("WireframePanel prototype toggle", () => {
@@ -171,6 +201,54 @@ describe("WireframePanel prototype toggle", () => {
     expect(screen.getByTestId("prototype")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /canvas/i }));
     expect(screen.getByTestId("excalidraw")).toBeInTheDocument();
+  });
+
+  // The state every real user is in: collab connected, the room seeded with the
+  // committed .dsl (#86 phase 4), no turn running. Every test above this block
+  // passed a null Y.Text — i.e. collab OFFLINE — which is why #348 shipped: the
+  // seeded room was never exercised, and there the switch never appeared.
+  describe("in a seeded room between turns (no agent)", () => {
+    function seededCollab() {
+      const doc = new Y.Doc();
+      const ytext = doc.getText(DSL_PATH);
+      ytext.insert(0, 'screen Catalog "Seeded committed content"\n  heading "Browse"\n');
+      return makeCollab(ytext, false);
+    }
+
+    it("shows the view switch", () => {
+      // The committed fetch is disabled in this state, so it reports pending
+      // with no scene — the switch must not depend on it.
+      mockDerived.mockReturnValue({ scene: null, isPending: true, isError: false });
+      mockDerivedPrototype.mockReturnValue({ model: null, isPending: true, isError: false });
+      renderPanel(seededCollab());
+
+      expect(screen.getByRole("button", { name: /prototype/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /canvas/i })).toBeInTheDocument();
+      expect(screen.queryByText("Drawing…")).not.toBeInTheDocument();
+    });
+
+    it("renders the prototype from the LIVE doc, not the committed copy", () => {
+      // Committed read is disabled here and answers with nothing; the prototype
+      // must still compile off the doc, or Canvas and Prototype would disagree
+      // about the same file right after a turn ends.
+      mockDerived.mockReturnValue({ scene: null, isPending: true, isError: false });
+      mockDerivedPrototype.mockReturnValue({ model: null, isPending: true, isError: false });
+      renderPanel(seededCollab());
+
+      fireEvent.click(screen.getByRole("button", { name: /prototype/i }));
+      const proto = screen.getByTestId("prototype");
+      expect(proto).toBeInTheDocument();
+      expect(Number(proto.dataset.screens)).toBeGreaterThan(0);
+    });
+
+    it("does not spin or error on the suppressed committed read", () => {
+      mockDerived.mockReturnValue({ scene: null, isPending: false, isError: true });
+      renderPanel(seededCollab());
+
+      expect(screen.queryByLabelText("Loading wireframe")).not.toBeInTheDocument();
+      expect(screen.queryByText(/failed to load/i)).not.toBeInTheDocument();
+      expect(Number(screen.getByTestId("excalidraw").dataset.elements)).toBeGreaterThan(0);
+    });
   });
 
   it("hides the toggle while the agent is drawing", () => {

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -29,6 +29,7 @@ import {
 import { ExcalidrawView, PrototypeView } from "@aep/ui-excalidraw-view";
 import { useDerivedPrototype, useDerivedWireframe } from "../api/useDerivedDesign";
 import { deriveWireframeScene } from "../derive/deriveWireframe";
+import { derivePrototypeModel } from "../derive/derivePrototype";
 import type { SpecFileEntry } from "../api/mapping";
 import type { CollabSpec } from "../collab/useCollabSpec";
 import { useYTextString } from "../collab/useYTextString";
@@ -60,38 +61,57 @@ export function WireframePanel({
   // The writer flushes on line boundaries, so the live text is whole lines —
   // but a mid-stream compile can still fail (e.g. a screen header typed ahead
   // of its body). Hold the last GOOD scene so a bad intermediate never blanks
-  // the already-drawn screens.
-  const lastGoodLive = useRef<string | null>(null);
+  // the already-drawn screens. The held scene is tagged with the file it came
+  // from: SpecView renders this panel unkeyed, so the ref survives a move to
+  // another component, and untagged it would let component A's last good render
+  // stand in for component B's uncompilable source.
+  const lastGoodLive = useRef<{ path: string; scene: string } | null>(null);
   const liveScene = useMemo(() => {
     if (typeof liveSource !== "string" || liveSource.trim().length === 0) return null;
     const compiled = deriveWireframeScene(dslPath, liveSource);
-    if (compiled) lastGoodLive.current = compiled;
-    return lastGoodLive.current;
+    if (compiled) lastGoodLive.current = { path: dslPath, scene: compiled };
+    return lastGoodLive.current?.path === dslPath ? lastGoodLive.current.scene : null;
   }, [dslPath, liveSource]);
 
-  const streaming = liveScene != null;
+  // Two independent facts, deliberately NOT one flag:
+  //   hasLiveContent — the doc has something renderable, so the doc is the
+  //     source (the design.md rule above) and the committed states are moot.
+  //   agentBusy      — a turn is running.
+  // Rooms are seeded with every committed spec file, so live content says
+  // nothing about whether a turn is running; folding them together is what
+  // used to keep the view switch permanently hidden (#348).
+  const hasLiveContent = liveScene != null;
   const agentBusy = collab.peers.some((p) => p.kind === "agent");
+
   // Committed fetch: the collab-less base path only (mirrors `usesCollab`
   // disabling the content query for markdown) — passing "" disables it. An
   // agent in the room also suppresses it: the doc WILL deliver the file, and
   // probing git for a not-yet-committed path just sprays retrying 404s.
-  const { scene, isPending, isError } = useDerivedWireframe(
-    projectName,
-    streaming || agentBusy ? "" : dslPath,
-    sha,
+  // Canvas and prototype read the SAME path so the shared query key (see
+  // useDerivedDesign) means switching modes never refetches.
+  const committedPath = hasLiveContent || agentBusy ? "" : dslPath;
+  const { scene, isPending, isError } = useDerivedWireframe(projectName, committedPath, sha);
+  const { model: committedPrototype, isPending: committedPrototypePending } =
+    useDerivedPrototype(projectName, committedPath, sha);
+
+  // The prototype rides the same source as the canvas, or the two views would
+  // disagree about one file: after a turn ends the doc holds the new DSL while
+  // the committed read still answers with the pre-turn copy. derivePrototypeModel
+  // is pure, so the live model is just a compile of the text we already have.
+  const livePrototype = useMemo(
+    () =>
+      typeof liveSource === "string" && liveSource.trim().length > 0
+        ? derivePrototypeModel(dslPath, liveSource)
+        : null,
+    [dslPath, liveSource],
   );
+  const prototypeModel = hasLiveContent ? livePrototype : committedPrototype;
+  // A disabled query reports `isPending`, so only the committed path can pend.
+  const prototypePending = !hasLiveContent && committedPrototypePending;
 
-  // The toggle (and prototype derivation) only makes sense on a settled,
-  // committed render — the streaming/agent-busy paths above return early
-  // before this ever renders. Called unconditionally to keep hooks order
-  // stable; the "" path convention disables the query while unsettled.
-  const settled = !streaming && !agentBusy;
-  const {
-    model: prototypeModel,
-    isPending: prototypePending,
-  } = useDerivedPrototype(projectName, settled ? dslPath : "", sha);
-
-  if (!streaming && agentBusy) {
+  // These four states all belong to the committed read, so they only speak when
+  // the doc has nothing to render.
+  if (!hasLiveContent && agentBusy) {
     // The committed fetch is suppressed while an agent is in the room (the
     // doc will deliver the file) — "drawing about to start", not a failure.
     return (
@@ -102,17 +122,17 @@ export function WireframePanel({
       </Box>
     );
   }
-  if (!streaming && isPending) {
+  if (!hasLiveContent && isPending) {
     return (
       <Box sx={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
         <CircularProgress aria-label="Loading wireframe" />
       </Box>
     );
   }
-  if (!streaming && isError) {
+  if (!hasLiveContent && isError) {
     return <Alert severity="error">Failed to load {dslPath}.</Alert>;
   }
-  if (!streaming && !scene) {
+  if (!hasLiveContent && !scene) {
     return (
       <Typography variant="body2" color="text.secondary">
         This wireframe source could not be rendered.
@@ -120,9 +140,10 @@ export function WireframePanel({
     );
   }
 
-  // The toggle only makes sense once we've settled on a committed scene — the
-  // streaming/agent-busy/pending/error branches above all return before here.
-  const showToggle = settled && scene != null;
+  // Settled means no turn is running — a seeded room with no agent IS settled,
+  // which is the state every user browsing between turns is actually in. By
+  // here we know something is renderable: the live scene, or the committed one.
+  const showToggle = !agentBusy;
 
   // A compact segmented control (Oxygen's ToggleButtonGroup, restyled as a
   // pill) rather than the default chunky outlined pair — reads as a native
@@ -169,16 +190,16 @@ export function WireframePanel({
   // just the switch — since there's no PrototypeView toolbar to join.
   const showOwnHeader = showToggle && !(mode === "prototype" && prototypeModel && !prototypePending);
 
-  // While streaming, ONE mounted canvas takes successive scenes through
-  // ExcalidrawView's updateScene path (no `key`, no remount per line). The
-  // committed render keeps the remount-by-sha behavior. ExcalidrawView
+  // On the live branch ONE mounted canvas takes successive scenes through
+  // ExcalidrawView's updateScene path (no `key`, no remount per flushed line).
+  // The committed render keeps the remount-by-sha behavior. ExcalidrawView
   // (fillHeight) sets `flex: 1` on its own root inside the flex column.
   return (
     <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-      {streaming && agentBusy && (
+      {agentBusy && hasLiveContent && (
         // The chip means "actively being generated", not "rendered from the
         // live doc" — the doc is ALWAYS the source while collab is up (rooms
-        // are seeded), so gate the chip on the agent actually being in the room.
+        // are seeded), so it MUST key on the peer, not on the live text.
         <Box
           sx={{
             px: 1.5,
@@ -219,7 +240,7 @@ export function WireframePanel({
             This wireframe could not be rendered as a prototype.
           </Typography>
         )
-      ) : streaming ? (
+      ) : hasLiveContent ? (
         <ExcalidrawView scene={liveScene!} fillHeight />
       ) : (
         <ExcalidrawView key={sha} scene={scene!} fillHeight />


### PR DESCRIPTION
## The bug

The `Canvas | Prototype` switch from #393 never appeared for any real project. Reported against an existing project's Spec page; reproduced.

## Root cause

`streaming` was one flag doing three unrelated jobs:

```ts
const streaming = liveScene != null;
//  1. "the doc is my render source"        ← about WHERE content comes from
//  2. "an agent is drawing"                ← about WHETHER A TURN IS RUNNING
//  3. "skip the committed read's states"
```

Spec rooms are seeded with **every** committed spec file (#86 phase 4), so job 1 is true whenever collab is up. That made job 2 true as well, so `settled = !streaming && !agentBusy` was permanently `false` and `showToggle = settled && scene != null` never fired.

The two facts were never the same fact, so the fix splits them rather than patching the boolean:

```ts
const hasLiveContent = liveScene != null;                        // the doc is the source
const agentBusy = collab.peers.some((p) => p.kind === "agent");  // a turn is running
const showToggle = !agentBusy;                                   // a seeded room IS settled
```

`showToggle` needs no `&& scene != null` — the four committed-read guards above it already establish that something is renderable. Those guards now key on `hasLiveContent`, so a suppressed or failing committed read can no longer blank a perfectly good live scene, and the render keeps preferring the doc (the `design.md` rule documented in the file).

## Two more defects found in the same function

**Canvas and Prototype disagreed about one file.** Canvas followed the doc; Prototype always read the committed blob. Right after a turn ends the doc holds the new DSL while the committed read still answers with the pre-turn copy — same file, two answers. Both now compile from the same source. `derivePrototypeModel` is pure, so the live model needs no fetch, and both views share one committed path so switching modes never refetches (the shared cache key noted in `useDerivedDesign`).

**`lastGoodLive` bled across components.** The ref was untagged and `SpecView` renders this panel unkeyed, so moving to a component whose live DSL did not compile showed the *previous* component's wireframe. The held scene now carries its own path.

## Why this shipped invisible

Every pre-existing toggle test passed a `null` `Y.Text` — collab **offline**. The connected + seeded + agentless room, which is the only state a user browsing between turns is ever in, was never exercised. Three new cases cover it.

## Proof

**Tests pin the bug** — the 3 new cases fail against the pre-fix component and pass after; the 10 existing cases pass in both directions:

```
### new tests vs the ORIGINAL (unfixed) component ###
  × keeps a held scene with its own file — one component's wireframe never stands in for another's
  × shows the view switch
  × renders the prototype from the LIVE doc, not the committed copy
  Tests  3 failed | 10 passed (13)

### after the fix ###
  Tests  13 passed (13)
```

`make test` fully green (turbo + all Go modules); `tsc --noEmit` clean.

**Verified live**, against a container whose image sha matches the build and which actually restarted (`--force-recreate`):

Observed in the browser: the switch renders, `Canvas` draws the wireframes, and `Prototype` opens the interactive single-screen view with its screen picker.

The environment was confirmed to be in the *bug state*, not the collab-offline path that masks it: `requirements.md` was fetched over HTTP while `wireframes.dsl` **never was**, yet the wireframe rendered — so the doc drove the render, `hasLiveContent` was true, and the pre-fix code would have hidden the switch.

```
resource entries:
  …/files/specs/requirements/requirements.md   ← fetched
  …/wireframes.dsl                             ← NEVER fetched (came from the collab doc)
```

## Supersedes

Closes #398 (based before #393 landed, 48 commits behind `main`, and a provable no-op — every branch of its diff is byte-identical to the original). Also supersedes `fix/wireframe-prototype-toggle-visibility`, whose one-line `streaming = liveScene != null && agentBusy` restores the switch but regresses the `isError`/`isPending` states and renders the stale committed copy after a turn ends.

Fixes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

