### PR TITLE
feat(skills): /start asks once, then writes the PRD

### DIFF
--- a/skills/grilling/SKILL.md
+++ b/skills/grilling/SKILL.md
@@ -18,7 +18,7 @@ you cannot proceed safely" restraint does not apply.
 Each form ends your turn; the user's answers arrive as the next message.
 
 - **`ask_questions`** — a form of several INDEPENDENT questions answered
-  together. Keep a form to 1–3 questions.
+  together. Up to 8 per form — a ceiling, not a target.
 - **`ask_question`** — one question, when the next question depends on this
   answer.
 
@@ -47,3 +47,7 @@ suggestions.
   `*assumed*` where it lands in the artifact.
 - **Headless**: the turn states no interview is possible — ask nothing;
   generate on stated assumptions, each marked `*assumed*`.
+
+How many forms an interview may spend is the calling skill's rule, not this
+one's — some flows allow exactly one. Obey it; converging early is always
+allowed, asking again never is.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: Use when kicking off a project from its idea — the /start flow that interviews the user section by section and writes the PRD at specs/requirements/prd.md; also the flow for re-running /start on a project that already has a PRD.
+description: Use when kicking off a project from its idea — the /start flow that interviews the user in a single round of questions and writes the PRD at specs/requirements/prd.md; also the flow for re-running /start on a project that already has a PRD.
 metadata:
   aep:
     kind: platform
@@ -12,7 +12,8 @@ metadata:
 A user arrives with one sentence and leaves with a PRD the rest of the flow can
 build on. The interview is a **coverage walk**: the PRD's own sections are the
 plan, you visit every one, and nothing lands in the document that was neither
-asked about nor visibly assumed.
+asked about nor visibly assumed. You visit them all before you ask anything —
+**`/start` asks exactly once**.
 
 ## The idea comes to you
 
@@ -20,11 +21,12 @@ The user's idea is attached to this instruction when the project captured one.
 Read it as the brief — it is what the user actually asked for, in their words.
 It is not a file: it is attached or it is absent. When absent, open with one
 `ask_question`: "What are you building?" — a few concrete example options,
-free text welcome. The answer is the brief.
+free text welcome. The answer is the brief. Getting the brief is not the
+interview: it is the only thing that may precede the one form below.
 
 ## The coverage walk
 
-Interview section by section, in the PRD's own order:
+Walk the PRD's own sections, in its own order:
 
 1. **Problem** — who hurts, how, today.
 2. **Actors** — who uses the system, at product altitude.
@@ -33,18 +35,30 @@ Interview section by section, in the PRD's own order:
 5. **Phasing** — what ships first; a thin vertical slice makes the best MVP.
 6. **Out of scope** — what this project is explicitly not.
 
-For each section, in this order:
+The walk is **planning, not turns**: you take it silently, in full, before the
+user sees a single question. For each section:
 
 - **Consult the organization skill first.** A question its defaults answer is
   never asked — record the default as a plain Product Decision instead. A
-  section fully covered by defaults and the brief asks nothing.
-- **Ask ONE `ask_questions` form** (the `grilling` skill owns the question
-  mechanics) with the 1–3 questions whose answers change the document. Skip
-  questions the brief already answers.
+  section fully covered by defaults and the brief needs nothing.
+- **Note the questions whose answers would change the document**, and only
+  those. Skip what the brief already answers.
 
-The walk is complete when every section has been visited — covered by the
-brief, by org defaults, by a form, or by the skip valve below. Depth is opt-in:
-after generating, the user can go deeper in chat on any feature.
+## Ask once
+
+Then ask **ONE `ask_questions` form** — the `grilling` skill owns the question
+mechanics — carrying the questions the walk noted, and write the PRD from the
+answers. There is no second form: the next thing the user sees after answering
+is their document.
+
+- **The bar, not the budget.** Ask only what changes the PRD. Three questions
+  is a good form; padding one out to the cap is an interrogation.
+- **More questions than a form holds** → ask those whose answers change the
+  document most, and treat every one left behind exactly as the skip valve
+  does: your recommended answer, tagged `*assumed*`.
+
+Depth is opt-in: after generating, the user can go deeper in chat on any
+feature.
 
 ## The skip valve
 
@@ -70,7 +84,8 @@ guess it.
 rewrite: append new stories with fresh numbers (story numbers are permanent),
 update only the sections the change touches, and leave the user's hand-edits
 alone. Regenerate from scratch only when the user explicitly asks, and confirm
-before overwriting.
+before overwriting. One form here too — a scoped change earns fewer questions
+than a cold start, never more.
 
 ## Where this stops
 


### PR DESCRIPTION
## What

`/start` now takes its coverage walk **silently**, then asks **exactly one**
`ask_questions` form, then writes the PRD.

Before, the walk did two jobs at once: planning what the PRD needs, and
structuring the turns. Six PRD sections meant up to six question forms, so a
user answered, waited, answered again — an interrogation for a document they
had already described in a sentence.

The walk itself is unchanged and still complete. What changed is that it no
longer dictates turn structure:

- Visit every section, consult the org skill's defaults first, and note only
  the questions whose answers would change the document.
- Then one form carrying those questions. There is no second form — the next
  thing the user sees after answering is their document. The rule holds on a
  re-run too.
- More questions than a form holds → ask the ones that change the document
  most; the rest fall through to the existing skip-valve semantics (the
  recommended answer, tagged `*assumed*` where it lands, visible for the user
  to overturn in chat afterwards).

Nothing is asked to fill slots: the "changes the artifact" bar stands, and
three questions is a good form.

`skills/grilling` stays pure mechanics. Its per-form guidance said 1–3
questions against a platform cap of 8 (`askQuestionsInputSchema`), so it now
states the real ceiling and hands round-count to the calling skill. `amend`
keeps its per-open-question walk untouched.

## Files

- `skills/start/SKILL.md` — the walk becomes planning; one form; ask-once rule.
- `skills/grilling/SKILL.md` — real per-form ceiling (8); round-count belongs
  to the caller.

## Proof of execution — read this before approving

**This change was not eval-verified, and I want that on the record rather than
buried.** It is a prompt-only change (two `SKILL.md` files, no code), so
`lint` / `typecheck` / `license-check` have nothing to say about it. The only
meaningful proof is an `evals/spec-agents` run, which was not re-run here.

Two things a reviewer should weigh:

1. **The requirements scenario's sim user only answers what it is asked.** In
   `scenarios/requirements/lunch-coordinator.yaml`, 5 of the 7 `mustCover`
   items are absent from the brief (Google-workspace sign-in, per-person cost
   totals, payment out of scope, Slack notifications, mobile-browser support).
   They are reachable in one form of up to 8 questions — but that is an
   argument, not a measurement.

2. **The existing baseline cannot settle it.** The most recent local review
   (`lunch-coordinator`, 2026-08-05, pre-change) scored requirements
   REVIEW (63) with the rubric judge at 25% — but 4 of 6 rubric items read
   `(no judgment returned)`. That is the judge failing to return, not the
   agent failing to cover, so there is no trustworthy before-side to compare
   a re-run against.

That same baseline also shows a known rubric blind spot worth flagging,
because this change makes it more likely rather than less: the agent wrote
"SSO through Thunder, the platform IDP (org default)" and the judge scored it
both as a missed item and as an invention, because the rubric wants "Google
Workspace" and cannot see that a settled org default answered the question.
This PR leans harder on org defaults, so expect more of that signal — it is
rubric noise, not agent regression. Repairing the judge is deliberately left
out of scope here.

## Branch note

Branched from `bfd4aafd`; `upstream/main` has since moved ahead. The only
skills change upstream is `skills/wireframes/SKILL.md`, which does not overlap
these files — merges clean, not rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
