### PR TITLE
perf(release): stop building arm64 images under QEMU emulation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
     name: Build + push ${{ matrix.name }}
     if: ${{ inputs.component == 'platform' || inputs.component == 'all' }}
     runs-on: ubuntu-latest
+    # Generous because remote-worker is the outlier: it cannot cross-compile (see
+    # its Dockerfile) so its arm64 half stays emulated, and a cold build of it has
+    # been measured at 28 min. The ceiling is here to catch a wedged build rather
+    # than let it hold a runner slot for the GitHub 6h default, not to enforce a
+    # budget — raise it rather than trim it if a build legitimately grows.
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -85,8 +91,17 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ inputs.version }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:latest
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          # Registry cache rather than type=gha. The Actions cache is capped at
+          # 10 GB per repository and CI's own entries already fill it, so eight
+          # images x two platforms of mode=max layers were evicted by LRU between
+          # releases and every release rebuilt from scratch. GHCR has no such cap.
+          #
+          # Kept under a buildcache/ prefix so it is not a tag on the released
+          # package. mode=max caches the builder stages, which is where the time
+          # goes — and therefore publishes those intermediate layers, so no build
+          # stage may hold a secret.
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/buildcache/${{ matrix.name }}:main
+          cache-to: type=registry,ref=${{ env.IMAGE_PREFIX }}/buildcache/${{ matrix.name }}:main,mode=max
 
   # ─── Platform: package + push Helm charts ───────────────────────────────────
   package-push-charts:
@@ -94,6 +109,7 @@ jobs:
     if: ${{ inputs.component == 'platform' || inputs.component == 'all' }}
     needs: build-push-images
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
@@ -163,6 +179,7 @@ jobs:
     if: ${{ inputs.component == 'platform' || inputs.component == 'all' }}
     needs: package-push-charts
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -203,6 +220,7 @@ jobs:
     name: Build aep binary (${{ matrix.goos }}/${{ matrix.goarch }})
     if: ${{ inputs.component == 'ctl' || inputs.component == 'all' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -248,6 +266,7 @@ jobs:
     if: ${{ inputs.component == 'ctl' || inputs.component == 'all' }}
     needs: build-ctl-binaries
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -21,7 +21,16 @@
 # run here because src/generated/* is gitignored and absent from a fresh
 # checkout. corepack picks the pnpm version from the root `packageManager`
 # field once package.json is copied in.
-FROM node:22-alpine AS builder
+#
+# Pinned to BUILDPLATFORM: this stage emits `dist/` — JS, CSS and static assets,
+# none of it architecture-specific — so one native run serves BOTH published
+# platforms and buildx reuses the identical stage across them. Only the nginx
+# stage below is genuinely per-arch, and it takes nothing from here but `dist`.
+# Remove the pin and the entire toolchain (pnpm install, six workspace builds,
+# vite) runs under QEMU for the arm64 image at ~6x the cost — the vite build
+# alone ~7x. Native modules installed here resolve for the BUILDPLATFORM, which
+# is what we want: they execute at build time and never reach the runtime image.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 RUN corepack enable
 WORKDIR /repo

--- a/deployments/local-cluster-gateway-proxy/Dockerfile
+++ b/deployments/local-cluster-gateway-proxy/Dockerfile
@@ -14,13 +14,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.26-alpine AS builder
+# Pinned to BUILDPLATFORM and cross-compiling via GOARCH, so the arm64 image is
+# never compiled under QEMU — emulating the Go toolchain costs ~8x and buys
+# nothing, since CGO_ENABLED=0 cross-compiles to a static binary for any GOARCH.
+# See the fuller note in services/aep-api/Dockerfile.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/local-cluster-gateway-proxy .
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
+    go build -o bin/local-cluster-gateway-proxy .
 
 FROM alpine:3.21
 RUN addgroup -g 1000 appgroup && adduser -S -u 1000 -G appgroup appuser

--- a/docs/developer-guide/releasing.md
+++ b/docs/developer-guide/releasing.md
@@ -1,0 +1,65 @@
+# Developer guide — cutting a release
+
+Releases are cut by dispatching the **Release** workflow
+(`.github/workflows/release.yml`) by hand. Nothing releases on merge.
+
+## Inputs
+
+| Input | Meaning |
+|---|---|
+| `version` | No leading `v` — e.g. `0.6.0`. Becomes the image tag, the chart version, and the release tag. |
+| `component` | `platform` (images + charts), `ctl` (the `aep` CLI binaries), or `all`. |
+
+## What it produces
+
+**`platform`** — one multi-arch image per entry in the `build-push-images`
+matrix at `ghcr.io/wso2/aep/<name>:<version>` (and `:latest`); then the
+`bootstrap` and `platform` Helm charts, version-stamped and pushed to
+`oci://ghcr.io/wso2/aep/charts`; then a `platform/v<version>` GitHub release.
+
+**`ctl`** — `aep` binaries for five GOOS/GOARCH pairs, attached to a
+`ctl/v<version>` GitHub release.
+
+Images are built for `linux/amd64` and `linux/arm64`. Builder stages that can be
+architecture-independent are pinned to `$BUILDPLATFORM` so they run once,
+natively, instead of under QEMU — read the note in `services/aep-api/Dockerfile`
+before removing a pin. `remote-worker` is the notable exception: it installs a
+per-arch Go toolchain, Ballerina, and Playwright browsers, so its arm64 half
+genuinely is emulated and it is the slowest job in the release.
+
+Layer cache lives in GHCR under `ghcr.io/wso2/aep/buildcache/<image>` rather than
+the Actions cache, which is capped at 10 GB per repository and which CI's own
+entries already fill. It is `mode=max`, so intermediate build stages are
+published — **no build stage may hold a secret**.
+
+## Recovering a failed release
+
+**Re-run the failed jobs of the existing run rather than dispatching a fresh
+one.** A re-run keeps the original inputs, rebuilds only what broke, and leaves
+the images that already published alone.
+
+```bash
+gh run rerun <run-id> --repo wso2/labs-agentic-engineer --failed
+```
+
+Tags are overwritten, so re-running over a partially-published version is safe.
+
+Note that each matrix leg moves its own `:latest` as it finishes, so a release
+that fails partway can leave `latest` pointing at the new version for the images
+that got through and the previous one for the rest. Completing the release
+realigns them.
+
+### When the failure is not ours
+
+Two signatures mean GitHub Actions itself is degraded, not the build. Check
+[githubstatus.com](https://www.githubstatus.com) before investigating:
+
+- `Failed to resolve action download info. Error: Service Unavailable` — the
+  service that resolves `uses:` references is down; the job dies before its
+  first step.
+- `The job was not acquired by Runner of type hosted even after multiple
+  attempts` — no runner was ever assigned. The job shows zero steps and an empty
+  runner name, having sat queued for up to a couple of hours.
+
+Neither is fixable from this repository. Wait for the incident to clear, then
+re-run the failed jobs.

--- a/services/aep-api/Dockerfile
+++ b/services/aep-api/Dockerfile
@@ -14,16 +14,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.26-alpine AS builder
+# Pinned to BUILDPLATFORM and cross-compiling via GOARCH, so the arm64 image is
+# never compiled under QEMU. Removing the pin makes this the most expensive step
+# in the release: emulating the Go toolchain costs ~8x here (measured on a cold
+# release: ~19 min against ~2 min native) and buys nothing, because CGO_ENABLED=0
+# cross-compiles to a static binary for any GOARCH.
+#
+# TARGETARCH comes from buildx and is the arch being built for, so a local
+# single-arch build resolves it to the host's. BuildKit is required — the legacy
+# builder leaves $BUILDPLATFORM unset and fails to parse the empty --platform.
+# That was already true here because of the cache mounts below, and BuildKit has
+# been Docker's default since 23.0.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . .
 # Cache the Go module + build caches (BuildKit) so incremental rebuilds
-# reuse compiled packages instead of recompiling from scratch.
+# reuse compiled packages instead of recompiling from scratch. One shared mount
+# serves both target arches: Go's build cache is content-addressed and already
+# namespaces entries by GOARCH.
+ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux go build -o bin/aep-api ./cmd/aep-api
+    CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o bin/aep-api ./cmd/aep-api
 
 FROM alpine:3.21
 

--- a/tools/aepctl/Dockerfile.server
+++ b/tools/aepctl/Dockerfile.server
@@ -1,9 +1,15 @@
-FROM golang:1.26 AS builder
+# Pinned to BUILDPLATFORM and cross-compiling via GOARCH, so the arm64 image is
+# never compiled under QEMU (~8x slower — see the fuller note in
+# services/aep-api/Dockerfile). CGO_ENABLED=0 already produces the static binary
+# the distroless/static runtime below requires.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /aep-server ./cmd/aep-server/
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o /aep-server ./cmd/aep-server/
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /aep-server /aep-server


### PR DESCRIPTION
## Problem

We publish every platform image for two architectures, `linux/amd64` and `linux/arm64`, and we build both on a single amd64 GitHub runner. Docker handles the mismatch by running the arm64 build under QEMU emulation — which is correct, but slow, and in our case entirely avoidable.

None of our builder stages declared which architecture they should run on, so the arm64 half of every image was emulated. Attributing buildkit's per-step timings by platform on a cold release:

| Image / step | arm64 (emulated) | amd64 (native) | Ratio |
|---|---|---|---|
| `aep-api` Go compile | **1127s** | 140s | **8.1x** |
| `console` vite build | **410s** | 58s | **7.1x** |
| `console` all steps | 607s | 101s | 6.0x |

The four slowest jobs in a recent release: `aep-api` 19m12s, `aep-server` 14m15s, `console` 13m35s, `cluster-gateway-proxy` 6m46s. Most of that is emulation.

## Why it's avoidable

Emulation is only needed when a build step must *execute* as the target architecture. For four of our eight images, nothing does:

- **The three Go images** (`aep-api`, `aep-server`, `cluster-gateway-proxy`) already set `CGO_ENABLED=0`. Go cross-compiles to a static binary for any `GOARCH` — the compiler doesn't need to run on the architecture it's targeting.
- **`console`** builds a browser bundle. JS and CSS have no architecture at all, and the nginx runtime stage copies only `dist/` out of the builder.

So those four builder stages are pinned to `$BUILDPLATFORM` (i.e. "run natively on whatever the runner is") and the Go ones pass `GOARCH=$TARGETARCH` to select the output architecture. Runtime stages are left unpinned, so they still resolve per target platform and the published images remain genuinely multi-arch.

The other four images can't do this, and the PR deliberately leaves them alone:

| Image | Why its builder must run as the target architecture |
|---|---|
| `remote-worker` | Installs a per-arch Go toolchain, Ballerina, and Playwright browsers. |
| `aep-mcp-server` | Copies the builder's `node_modules` into the runtime image, so those deps must resolve for the target. |
| `agents`, `collab` | Single-stage — the runtime image *is* the build stage. |

`remote-worker` therefore becomes the slowest job in the release (~28 min). Making it native needs a per-arch matrix split onto `ubuntu-24.04-arm` plus a manifest merge; that's follow-up work, not this PR.

## Two supporting changes

**Layer cache moves to GHCR** (`ghcr.io/wso2/aep/buildcache/<image>`) instead of `type=gha`. Cross-compiling doesn't help much if the cache is empty every time, and it was: the GitHub Actions cache is capped at 10 GB per repository, CI's own entries already fill it, and eight images × two platforms of `mode=max` layers were being evicted by LRU between releases. GHCR has no such cap.

**`timeout-minutes` on all five release jobs**, which previously inherited GitHub's 6-hour default. Set at 45 for the image matrix so the ~28 min `remote-worker` build has real headroom — this is a wedged-build tripwire, not a budget.

## Verification

The Go builders were built for both architectures on an arm64 machine and the output inspected:

```
$ docker buildx build --platform linux/amd64 --target builder .   # services/aep-api
  -> GOARCH=amd64, ELF x86-64      48.7s
$ docker buildx build --platform linux/arm64 --target builder .
  -> GOARCH=arm64, ELF ARM aarch64 56.0s
```

Both produce the correct target architecture, and the timings are the proof that neither emulated: the same amd64 compile takes 1127s when emulated and ~140s natively.

```
$ docker buildx build --platform linux/amd64 --target builder -f apps/console/Dockerfile .
  #20 69.54 ✓ built in 52.84s      # vite, native — cf. 410s emulated
```

Also checked:
- `docker compose build aep-api local-cluster-gateway-proxy console` — the local dev path from `deployments/scripts/start.sh` — succeeds, and produces arm64 binaries on an arm64 host.
- `docker build` with no `--platform` resolves `TARGETARCH` to the host arch, so plain local builds are unaffected.
- `actionlint` clean; `make license-check` passes.

## Note for reviewers

Two things worth a deliberate look rather than a nod:

1. **BuildKit is now required for all four Dockerfiles.** The legacy builder leaves `$BUILDPLATFORM` unset and fails to parse the resulting empty `--platform`. `aep-api` and `console` already required BuildKit for their cache mounts, and BuildKit has been Docker's default since 23.0, but `Dockerfile.server` and `cluster-gateway-proxy` did not require it before this change.

2. **The registry cache is a mutable, trusted build input.** Anything holding `packages: write` on the org can write `buildcache/<image>:main`, and `mode=max` publishes intermediate build stages. No stage holds a secret today, and the `buildcache/` prefix keeps it off the released packages — but this is a real trust-boundary change and deserves an explicit accept-or-mitigate.

## Not in this PR

Deliberately left out to keep this reviewable as one change: a CI job that builds the images on PRs (today a Dockerfile break only surfaces when a release is cut), the `remote-worker` native-arm split, pinning third-party actions to commit SHAs, moving `:latest` so a partly-failed release can't leave it split across two versions, and CI cache hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
