### PR TITLE
fix(validation): a skipped verdict belongs to no cycle

### DIFF
--- a/apps/console/src/mocks/fixtures/validation.ts
+++ b/apps/console/src/mocks/fixtures/validation.ts
@@ -411,7 +411,16 @@ const VALIDATION_IN_FLIGHT: RunCycleView = {
   createdAt: "2026-07-10T09:45:00Z",
 };
 
+// The two counters the server DERIVES from the cycle ledger — the supervisor bumps
+// them as it appends cycles, so a fixture that states them by hand states them
+// wrong the moment its cycle list changes. Counting instead is what keeps every
+// scenario self-consistent: `skipped` has one cycle and no validation, `none` has
+// two coding cycles and no validation, and neither can drift again.
+//
+// The rest of the budgets stay literal: they are spend against ceilings, which no
+// cycle list implies.
 function run(over: Partial<MilestoneRunView>): MilestoneRunView {
+  const cycles = over.cycles ?? [CODING_1];
   return {
     id: "run-v1-1",
     milestoneNumber: 1,
@@ -419,15 +428,15 @@ function run(over: Partial<MilestoneRunView>): MilestoneRunView {
     origin: "spec-build",
     state: "succeeded",
     budgets: {
-      cyclesTotal: 2,
+      cyclesTotal: cycles.length,
       cycleCeiling: 8,
       fixCycles: 0,
       conflictCycles: 0,
       buildRetriggers: 1,
-      validationCycles: 1,
+      validationCycles: cycles.filter((c) => c.kind === "validation").length,
     },
     validation: {},
-    cycles: [CODING_1],
+    cycles,
     createdAt: "2026-07-10T09:12:00Z",
     startedAt: "2026-07-10T09:13:00Z",
     endedAt: "2026-07-10T10:41:00Z",
@@ -461,14 +470,6 @@ function exhaustedRun(
       // The server omits the path for `unreported`: advertising one would send the
       // client to a 404 to rediscover what the verdict already said.
       ...(reportPath ? { reportPath: REPORT_PATH } : {}),
-    },
-    budgets: {
-      cyclesTotal: 4,
-      cycleCeiling: 8,
-      fixCycles: 0,
-      conflictCycles: 0,
-      buildRetriggers: 1,
-      validationCycles: 2,
     },
     cycles: [
       CODING_1,
@@ -504,14 +505,6 @@ const RUNS: Record<ValidationScenario, MilestoneRunView> = {
     state: "running",
     endedAt: null,
     validation: { verdict: "failed", issue: 12, reportPath: REPORT_PATH },
-    budgets: {
-      cyclesTotal: 3,
-      cycleCeiling: 8,
-      fixCycles: 0,
-      conflictCycles: 0,
-      buildRetriggers: 1,
-      validationCycles: 1,
-    },
     cycles: [CODING_1, validationCycle(2, "failed"), CODING_IN_FLIGHT],
   }),
   // The run is live and has not reached validation at all — the state every run

--- a/services/aep-api/internal/delivery/run/workflow.go
+++ b/services/aep-api/internal/delivery/run/workflow.go
@@ -349,8 +349,10 @@ func (l *loop) runValidation(ctx workflow.Context) (settled bool, res RunResult,
 		return true, l.result(), err
 	}
 	if issue == 0 {
-		// No acceptance oracle — nothing to validate, which is itself a verdict.
-		if err := l.setVerdict(ctx, delivery.ValidationVerdictSkipped); err != nil {
+		// No acceptance oracle — nothing to validate, which is itself a verdict. It
+		// belongs to no cycle: none has been opened, and l.cycleID is still the last
+		// coding cycle's.
+		if err := l.setVerdict(ctx, noCycle, delivery.ValidationVerdictSkipped); err != nil {
 			return true, l.result(), err
 		}
 		res, err = l.settle(ctx, delivery.RunStateSucceeded, "")
@@ -383,7 +385,9 @@ func (l *loop) runValidation(ctx workflow.Context) (settled bool, res RunResult,
 	if err != nil {
 		return true, l.result(), err
 	}
-	if err := l.setVerdict(ctx, out.Verdict); err != nil {
+	// The one verdict a cycle owns: l.cycleID is the validation cycle runCycle just
+	// closed, and out.Verdict was derived from the report at its own merge commit.
+	if err := l.setVerdict(ctx, l.cycleID, out.Verdict); err != nil {
 		return true, l.result(), err
 	}
 	// Which verdicts are fatal, and under which reason, is delivery's to say — one
@@ -467,8 +471,9 @@ func (l *loop) settle(ctx workflow.Context, state, reason string) (RunResult, er
 	if state == delivery.RunStateSucceeded {
 		if l.st.ValidationVerdict == "" {
 			// "The run finished and did not validate" is an honest verdict; an
-			// empty one would read as "not yet".
-			if err := l.setVerdict(ctx, delivery.ValidationVerdictSkipped); err != nil {
+			// empty one would read as "not yet". An empty verdict here means no
+			// validation cycle ever produced one, so it belongs to no cycle.
+			if err := l.setVerdict(ctx, noCycle, delivery.ValidationVerdictSkipped); err != nil {
 				return l.result(), err
 			}
 		}
@@ -581,14 +586,29 @@ func (l *loop) bump(ctx workflow.Context, counter delivery.RunBudget) error {
 		BumpRunBudgetInput{RunID: l.in.RunID, Counter: string(counter)}).Get(ctx, nil)
 }
 
-// setVerdict records the verdict and the issue that produced it in one write. The
-// issue is persisted because it otherwise lives only here, in workflow state — so
-// once Temporal retention lapses a settled run would carry a verdict with no way
+// noCycle is the cycle id for a verdict that belongs to no cycle. Named rather
+// than written as a bare "" at the call sites, because which verdicts have a
+// cycle behind them is the whole point of the argument.
+const noCycle = ""
+
+// setVerdict records the verdict and the issue that produced it in one write: on
+// the run always, and on a cycle only when that cycle is the attempt the verdict
+// came from.
+//
+// cycleID is a PARAMETER rather than a read of l.cycleID, because the loop's
+// current cycle is not always the verdict's source. `skipped` is decided in two
+// places that have no validation cycle at all — before one is opened, and in
+// settle — and at both of them l.cycleID still holds the last CODING cycle's id.
+// Writing there would contradict RunCycle.ValidationVerdict, documented as empty
+// on every other kind, and the cycle write is write-once, so it would be permanent.
+//
+// The issue is persisted because it otherwise lives only here, in workflow state —
+// so once Temporal retention lapses a settled run would carry a verdict with no way
 // back to the criteria, the pull request, or the runner's own summary.
-func (l *loop) setVerdict(ctx workflow.Context, verdict string) error {
+func (l *loop) setVerdict(ctx workflow.Context, cycleID, verdict string) error {
 	if err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).SetValidationVerdict,
 		SetValidationVerdictInput{
-			RunID: l.in.RunID, CycleID: l.cycleID, Verdict: verdict, Issue: l.st.ValidationIssue,
+			RunID: l.in.RunID, CycleID: cycleID, Verdict: verdict, Issue: l.st.ValidationIssue,
 		}).Get(ctx, nil); err != nil {
 		return err
 	}

--- a/services/aep-api/internal/delivery/run/workflow_test.go
+++ b/services/aep-api/internal/delivery/run/workflow_test.go
@@ -811,6 +811,41 @@ func TestValidationCycle_EachAttemptRecordsAgainstItsOwnCycle(t *testing.T) {
 	require.Equal(t, delivery.ValidationVerdictPassed, h.verdictWrites[1].Verdict)
 }
 
+// A `skipped` verdict belongs to NO cycle, and both places that write it are
+// reached with l.cycleID still holding the last CODING cycle's id — there is no
+// validation cycle to name, because none was opened.
+//
+// The cycle write is write-once, so an id sent here would put a validation verdict
+// on a coding row permanently, contradicting RunCycle.ValidationVerdict (documented
+// empty on every other kind) and CycleView, which publishes the field as a
+// validation-cycle property.
+func TestSkippedVerdict_BelongsToNoCycle(t *testing.T) {
+	for name, origin := range map[string]string{
+		// Decided before a validation cycle opens: the project has no oracle.
+		"no acceptance oracle": delivery.RunOriginSpecBuild,
+		// Decided in settle: an incident run never reaches validation at all, so it
+		// arrives at the end with an empty verdict.
+		"validation never reached": delivery.RunOriginIncidentAdoption,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t)
+			h.milestoneIs(MilestoneSnapshot{Work: 1, Total: 1}, MilestoneSnapshot{})
+			h.merges(1)
+
+			h.run(origin, 0)
+			res := h.result(t)
+
+			h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+			require.Equal(t, delivery.ValidationVerdictSkipped, res.ValidationVerdict)
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			require.Len(t, h.verdictWrites, 1, "the verdict is written once")
+			require.Empty(t, h.verdictWrites[0].CycleID,
+				"skipped was stamped onto the last coding cycle's row")
+		})
+	}
+}
+
 // TestIncidentRun_GetsNoValidationCycle pins the origin split: an incident fixes
 // one thing in an already-validated version, and re-validating the whole system
 // for it would price every incident like a release.


### PR DESCRIPTION
Follow-up to the two CodeRabbit findings deferred on #380 and #390 with "will be addressed in a separate PR". Both were re-checked against current `main` and both still hold.

## 1. A `skipped` verdict was stamped onto a coding cycle (#380)

`setVerdict` read `l.cycleID` unconditionally, but two of its three callers reach it with **no validation cycle open**:

- `runValidation`, when `ensureValidationIssue` returns 0 — the project has no acceptance oracle, so no validation cycle is ever appended.
- `settle`, when a run succeeds having never validated (an incident run).

At both points `l.cycleID` still holds the last **coding** cycle's id, so `validation_verdict = 'skipped'` landed on a coding row. The cycle write is write-once, so it was permanent, and it contradicted the contract stated in three places: `SetValidationVerdictInput` ("CycleID is empty for a verdict that belongs to no cycle"), `RunCycle.ValidationVerdict` ("Empty on every other kind"), and `CycleView` in `runread/reads.go`.

**The fix.** `cycleID` becomes a parameter of `setVerdict` rather than a read of loop state, so each call site says which case it is:

```go
l.setVerdict(ctx, noCycle,    delivery.ValidationVerdictSkipped)  // no acceptance oracle
l.setVerdict(ctx, l.cycleID,  out.Verdict)                        // the attempt's own report
l.setVerdict(ctx, noCycle,    delivery.ValidationVerdictSkipped)  // settle, never validated
```

The review suggested gating on `l.st.CycleKind` instead. That was not taken: it makes correctness depend on `settle` reading the field *before* it clears it two statements later, which is exactly the kind of ordering a future edit breaks silently. A parameter cannot be got wrong by reordering.

## 2. Fixture budgets contradicted their own cycle lists (#390)

`skipped` and `none` inherited `validationCycles: 1` from the base `run()` while listing no validation cycle, and `skipped` inherited `cyclesTotal: 2` while listing one cycle.

The review's stated consequence — "a view that reads the budgets next to the cycle list shows contradictory counts" — does **not** hold today: nothing renders `validationCycles`, and `spentBudgets` renders `cyclesTotal` only once it reaches the ceiling (8, unreachable in these fixtures). The underlying inconsistency is real, though, in a file whose own comment insists "the cycles are not decoration".

**The fix.** Rather than add two more hand-written budget blocks, `run()` now **counts** the two derived counters off the cycle list, which is how the server produces them (`CyclesTotal++` per append, `cycle.go:78`; `RunBudgetValidationCycles` bumped per attempt, `workflow.go:368`). That corrects both scenarios and makes the two existing overrides in `exhaustedRun` and `"awaiting-fix"` redundant, so they are deleted — the fixture is 8 lines shorter and no scenario can drift again.

## Proof

**The new test fails without the fix.** `TestSkippedVerdict_BelongsToNoCycle` covers both skipped paths. Reverting only the two `noCycle` call sites back to `l.cycleID`:

```
--- FAIL: TestSkippedVerdict_BelongsToNoCycle (0.06s)
    --- FAIL: TestSkippedVerdict_BelongsToNoCycle/no_acceptance_oracle (0.05s)
        workflow_test.go:843: Should be empty, but was cycle-1
            Messages: skipped was stamped onto the last coding cycle's row
    --- FAIL: TestSkippedVerdict_BelongsToNoCycle/validation_never_reached (0.00s)
        workflow_test.go:843: Should be empty, but was cycle-1
            Messages: skipped was stamped onto the last coding cycle's row
```

With the fix, the whole package passes:

```
ok  github.com/wso2/aep/aep-api/internal/delivery/run  0.664s
```

**No data repair needed.** Checked the live local DB — every row carrying a cycle verdict is a validation cycle:

```
$ SELECT kind, validation_verdict, count(*) FROM run_cycles
    WHERE validation_verdict IS NOT NULL AND validation_verdict <> '' GROUP BY 1,2;
 validation | failed |  3
 validation | passed |  1
```

The one run row carrying `skipped` is from 2026-07-30, five days before #380 merged, so it predates the cycle write entirely and its coding cycle is clean. Every run since happened to have an oracle and reach validation, so the defect never fired here. On a longer-lived environment the check is the query above — any row whose `kind` is not `validation` is affected.

**Gates.** `go build ./...`, `go vet ./...`, `go test ./internal/delivery/...` pass. Console `tsc --noEmit` clean; 711/711 vitest tests pass.

## Deploy note

The workflow change alters an activity's **input payload** only — no command added, removed or reordered, which is the class of edit that trips Temporal replay. Activities are not re-executed on replay, so no in-flight run's already-written verdict changes. There were no `running` or `waiting` runs at the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
