### PR TITLE
Room seed: one request instead of N, and stop it doubling every spec file

### DIFF
--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1401,6 +1401,68 @@ paths:
       summary: List spec files at HEAD
       tags:
       - Files
+  /projects/{projectName}/files/bundle:
+    get:
+      operationId: read-file-bundle
+      description: |-
+        Every readable file under `prefix`, with content, in ONE response read at ONE
+        commit. Equivalent to list-files followed by a read-file per entry, except that
+        the whole bundle is resolved at a single commit — so a push landing mid-read
+        cannot yield a mix of two trees, and the returned shas are all from that one
+        tree (the caller's baseSha preconditions stay coherent).
+
+        Reads are gated exactly like read-file: only paths under specs/ plus the
+        read-only allow-list are included. Anything else in the tree is omitted, never
+        an error — `prefix` narrows what a caller wants, the gate decides what it may
+        have.
+
+        `bundle` is a literal segment under a path that is otherwise a trailing
+        wildcard. It can never shadow a real read: a readable path always starts with
+        `specs/`, so `files/bundle` is not a reachable file address.
+      parameters:
+      - description: Project name (DNS-label slug)
+        in: path
+        name: projectName
+        required: true
+        schema:
+          description: Project name (DNS-label slug)
+          type: string
+      - description: Only include paths under this prefix (e.g. specs/design/). Empty includes everything
+          the read gate admits.
+        explode: false
+        in: query
+        name: prefix
+        schema:
+          description: Only include paths under this prefix (e.g. specs/design/). Empty includes everything
+            the read gate admits.
+          type: string
+      - description: 'Commit to read at (a hex object name). Empty reads the branch tip. Same gate as
+          read-file''s ref: an object name, never a revision expression.'
+        explode: false
+        in: query
+        name: ref
+        schema:
+          description: 'Commit to read at (a hex object name). Empty reads the branch tip. Same gate as
+            read-file''s ref: an object name, never a revision expression.'
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileBundle'
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Error
+      security:
+      - userJWT: []
+      summary: Read every readable file under a prefix at one commit
+      tags:
+      - Files
   /projects/{projectName}/files/apply:
     post:
       operationId: apply-files
@@ -3533,6 +3595,22 @@ components:
       - name
       - config
       - consumers
+      type: object
+    FileBundle:
+      additionalProperties: false
+      description: A set of files read at ONE commit. commitSha names that commit; every entry's sha is
+        a blob of that same tree.
+      properties:
+        commitSha:
+          type: string
+        files:
+          items:
+            $ref: '#/components/schemas/FileContent'
+          type: array
+          nullable: true
+      required:
+      - commitSha
+      - files
       type: object
     FileContent:
       additionalProperties: false

--- a/services/aep-api/internal/edge/method_origin_test.go
+++ b/services/aep-api/internal/edge/method_origin_test.go
@@ -121,6 +121,7 @@ var opOwner = map[string]string{
 	"PromoteTaskFromIssue":          embedDelivery,
 	"ProvisionPlatformResource":     embedDependencies,
 	"ReadFile":                      embedSpec,
+	"ReadFileBundle":                embedSpec,
 	"RequestOrgServiceAccess":       embedDependencies,
 	"RotateIdpClientSecret":         embedOrganization,
 	"SetSkillEnabled":               embedSpec,

--- a/services/aep-api/internal/gen/models_gen.go
+++ b/services/aep-api/internal/gen/models_gen.go
@@ -947,6 +947,12 @@ type ExternalResourceDTO struct {
 	Name        string         `json:"name"`
 }
 
+// FileBundle A set of files read at ONE commit. commitSha names that commit; every entry's sha is a blob of that same tree.
+type FileBundle struct {
+	CommitSha string        `json:"commitSha"`
+	Files     []FileContent `json:"files"`
+}
+
 // FileContent defines model for FileContent.
 type FileContent struct {
 	Content string `json:"content"`
@@ -1873,6 +1879,15 @@ type GetDependencyStatusParams struct {
 type ListFilesParams struct {
 	// Prefix Only list paths under this prefix (e.g. specs/design/)
 	Prefix string `form:"prefix,omitempty" json:"prefix,omitempty"`
+}
+
+// ReadFileBundleParams defines parameters for ReadFileBundle.
+type ReadFileBundleParams struct {
+	// Prefix Only include paths under this prefix (e.g. specs/design/). Empty includes everything the read gate admits.
+	Prefix string `form:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// Ref Commit to read at (a hex object name). Empty reads the branch tip. Same gate as read-file's ref: an object name, never a revision expression.
+	Ref string `form:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // ReadFileParams defines parameters for ReadFile.

--- a/services/aep-api/internal/gen/server_gen.go
+++ b/services/aep-api/internal/gen/server_gen.go
@@ -149,6 +149,9 @@ type ServerInterface interface {
 	// Atomically apply a batch of writes/deletes (single commit to main)
 	// (POST /projects/{projectName}/files/apply)
 	ApplyFiles(w http.ResponseWriter, r *http.Request, projectName string)
+	// Read every readable file under a prefix at one commit
+	// (GET /projects/{projectName}/files/bundle)
+	ReadFileBundle(w http.ResponseWriter, r *http.Request, projectName string, params ReadFileBundleParams)
 	// Read a spec file (or an allow-listed read-only artifact) at HEAD
 	// (GET /projects/{projectName}/files/{path})
 	ReadFile(w http.ResponseWriter, r *http.Request, projectName string, path string, params ReadFileParams)
@@ -1844,6 +1847,67 @@ func (siw *ServerInterfaceWrapper) ApplyFiles(w http.ResponseWriter, r *http.Req
 	handler.ServeHTTP(w, r)
 }
 
+// ReadFileBundle operation middleware
+func (siw *ServerInterfaceWrapper) ReadFileBundle(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectName" -------------
+	var projectName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectName", r.PathValue("projectName"), &projectName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, UserJWTScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ReadFileBundleParams
+
+	// ------------- Optional query parameter "prefix" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", false, false, "prefix", r.URL.Query(), &params.Prefix, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "prefix"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "prefix", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "ref" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", false, false, "ref", r.URL.Query(), &params.Ref, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "ref"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ref", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ReadFileBundle(w, r, projectName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ReadFile operation middleware
 func (siw *ServerInterfaceWrapper) ReadFile(w http.ResponseWriter, r *http.Request) {
 
@@ -3044,6 +3108,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/design/dependencies", wrapper.ListDesignDependencies)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/files", wrapper.ListFiles)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/projects/{projectName}/files/apply", wrapper.ApplyFiles)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/files/bundle", wrapper.ReadFileBundle)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/files/{path}", wrapper.ReadFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/issues", wrapper.ListIssues)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/projects/{projectName}/issues", wrapper.CreateIssue)
@@ -4761,6 +4826,46 @@ func (response ApplyFilesdefaultJSONResponse) VisitApplyFilesResponse(w http.Res
 	return err
 }
 
+type ReadFileBundleRequestObject struct {
+	ProjectName string `json:"projectName"`
+	Params      ReadFileBundleParams
+}
+
+type ReadFileBundleResponseObject interface {
+	VisitReadFileBundleResponse(w http.ResponseWriter) error
+}
+
+type ReadFileBundle200JSONResponse FileBundle
+
+func (response ReadFileBundle200JSONResponse) VisitReadFileBundleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ReadFileBundledefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response ReadFileBundledefaultJSONResponse) VisitReadFileBundleResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response.Body); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ReadFileRequestObject struct {
 	ProjectName string `json:"projectName"`
 	Path        string `json:"path"`
@@ -6074,6 +6179,9 @@ type StrictServerInterface interface {
 	// Atomically apply a batch of writes/deletes (single commit to main)
 	// (POST /projects/{projectName}/files/apply)
 	ApplyFiles(ctx context.Context, request ApplyFilesRequestObject) (ApplyFilesResponseObject, error)
+	// Read every readable file under a prefix at one commit
+	// (GET /projects/{projectName}/files/bundle)
+	ReadFileBundle(ctx context.Context, request ReadFileBundleRequestObject) (ReadFileBundleResponseObject, error)
 	// Read a spec file (or an allow-listed read-only artifact) at HEAD
 	// (GET /projects/{projectName}/files/{path})
 	ReadFile(ctx context.Context, request ReadFileRequestObject) (ReadFileResponseObject, error)
@@ -7334,6 +7442,33 @@ func (sh *strictHandler) ApplyFiles(w http.ResponseWriter, r *http.Request, proj
 	}
 }
 
+// ReadFileBundle operation middleware
+func (sh *strictHandler) ReadFileBundle(w http.ResponseWriter, r *http.Request, projectName string, params ReadFileBundleParams) {
+	var request ReadFileBundleRequestObject
+
+	request.ProjectName = projectName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ReadFileBundle(ctx, request.(ReadFileBundleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ReadFileBundle")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ReadFileBundleResponseObject); ok {
+		if err := validResponse.VisitReadFileBundleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ReadFile operation middleware
 func (sh *strictHandler) ReadFile(w http.ResponseWriter, r *http.Request, projectName string, path string, params ReadFileParams) {
 	var request ReadFileRequestObject
@@ -8115,364 +8250,374 @@ func (sh *strictHandler) ListProjectUsage(w http.ResponseWriter, r *http.Request
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7L39chs5ki/6KgjNRpg6Q1JuT8+eHTk2bqgleVo7/rqS3H3PHfdtglVJEqMiUA2gRHG7HbF/3Qe4sc9w",
-	"H2yf5AQygSoUWUUWacltef3HTFusKnxmJhL58ctfDxI1z5UEac3B8a8HJpnBnOM/T5IEjLmEXwow1v3A",
-	"01RYoSTP3mqVg7YCzMHxhGcG+gd59JNrVJpiDvo0NP6az8E9sMscDo4PjNVCTg8+9Ms332r1D0jsRdr8",
-	"lgZuIT3BcUyUnnN7cHyQcgsDK+Zw0F//RDS3pPT0CvStSKB1SLlWtyLtMvjw5oUxBbwu5mPQtQEKaf/5",
-	"22pwQlqYgl778p3ONja/eW3CW9fc3LS8Yiy3hWl8VOTpbiv7oX+g4ZdCaEgPjv/ulrlpE/stJLC2AeXg",
-	"4k2Oh/VTOQI1do27QZ8kVtwKuzy/BbmdNFMwiRa5e35wfPBGAstpnIz7dhi4hlhPuN04WCVmnlilW1YW",
-	"n/1NSHwKspi7NSkM6IP+AZ+60f20uoL9g7vBVA2am9rAJ34ZG5+CvBVayXnb8xZmoPl2o1iVJIXWu/Gg",
-	"5dPGfq2wWfM06YdqKU0Oyc+eGBytuD/zYpwJM8Mf8ozLn1PQ4hb/tNzc/Gws17b6M4U8U8vq7wkXGaRd",
-	"96WJ3PGVeO/jzaut1CbifQGQ7ki7JyznU2BqskK5huVZYZidAUsKbZRmE6XxTwl3lvVUloI+xI+Ha+Qt",
-	"LMzr//gnDZOD44M/HFVnw5E/GI7qrPehfyCLLONjt51WF1DOl2vNl/gc7ux3MFEa97U+n2qlGsftxvuc",
-	"8bFxzLmYgXSPNDCugUnFcFZ+AYZN5Fd1Tdxb71ykoVMrYKyB36z3Ptwu/3DRGvc5z7PlqZKTTCT7CKmJ",
-	"yIAtZsoAG3MDVzPuJp0pOQXN5twmMzDs+/OTs/Ut9e83CxK34tK2Pc65nTU8WJk1vtUv+6m1unUtzI6L",
-	"wd3HA7cchn379C9srNIl+6//+E/cqkmRZSzxLTMD9jmTys6EnLIFN8x9KyBdX6IkHkw3yq/t54dVSl9Z",
-	"oar91vXYT7VKIQML3Yd9hu+/ybvw6hyM4dNmybzQYpduf3Svd+n1Q/vymCLbXfGcz0UrcSMNdZ7CC5HB",
-	"K7C8y8otuJZCTndYH/qg0/rU6SpMMEynib6+K0SWXsi8sBcW5juuIc+dSgmxyjBWKgMu1xSRFam1cFNi",
-	"5RtM8ma9IIUcZAoyWa43clY+a/38ZkXfgjsLWvJs4JhOuJO8/MUpDKQmWKeyDDQYVejEK6IDQ5roujKA",
-	"klDzOVjQG+TVr03U6/o8VdK2KWPueZvKf8uzYgcSPcUJ/+A+2oeS/EbWNsQvbytVvRRm19MsE8YOvM49",
-	"GLtGDNNgciUNlIL8FrQRSrIM0inoPlMSGEirlywHzdxXlrmVK1+0fNpnEhZgLJsIbWzDOYh9dV5NnN9V",
-	"MZ9zvdx5OX1f7eumpuduOjsyYwa30EwqmWpTrudgLJ/n249x18SmAZs91BYNPEUNFfcsfWJYpqZDdkJ/",
-	"MjvjlgnDjBVZxnQhUWRosIWWhnHJhHQ7486sika4TEm5zYQTKxoGrhfDJlrN2chpa6eoyY2eM84s6LmQ",
-	"PPMdhqbhFvSSFANh2YwbJiQSWcKzzI1vvduEa710H0iFpCjAuKG7kcyUdHT3/iAoGxosFxLS9weMS7Nw",
-	"FCyVdRMCrZVuUkCou3UJeK0LKNVdPwvXbZgXrYYw9YG6wUVzJE154RbZ/crGFaf5VTRW5YblKsuEnA7Z",
-	"C7ehbA5cmrDA6+sb6cPRkZCp6Y5MVjJDxwsEdb++VOe5SmZsLrJMGEd0pLyjSCDZQbsP6XOWc2PYmCc3",
-	"jBs2MkImMBqyk+hyEeuN4bu+o5LFTCQzlnAD2EGu4VaowoTrg7FcpngD6XCNtsry7FQV0na6d68zLFpK",
-	"Au20Mu9bDZNMTGe76k+7XQbLXlDL6LSXkBrUS5qUi5XJRi/3N9yzcL776dLCNb4j6VZa1V6qrR8tMe6O",
-	"w51wkRV6B/UAx/qCvuqyPc32mvZpFHIPbeAknOBPjONcMNZJYV1IM2Sj8geypo6CvA0KHLuBJf5guZO5",
-	"RmW3kDKrmJ1pVUxn+EwXkmm1MHga8ClbCDtzMjz87hrl7Nun31Yyep7bJXN6yrqgXhlSR3OZm8+6vHpN",
-	"sskNhFQWdhKtgQEw7Or8/3x3/vr64uQlrgnjiVbGMGENy8SkkuKoC0VnqreexrpU3/0hGZdLlnEL2p2t",
-	"InXyjqcKh8SEtIoJnHUninoVBntZyB8ELNbvwRuoKGZu91J/bW39urWy+ZX119Md6A0/HBj3JePTqYYp",
-	"t8CUZN5afYX2Z9b7wzf/8u3hmjoanSg1YnU0tFD6RshpH0/kmVrQRviHqcJj9QwyMQbNLWRLlji5P5ho",
-	"ADbAlpXMlkGXoIsJqU456EGl55obZnmWLQMzNPGPkuyvwn5fjPuVfgAyzZWQqG+5cx5Sxi37sxmya6cG",
-	"KGlU5tQdmYI2NDivU7leUGt3nUeKhrCMZ041cKPOUuPUdKLGQk94ArQC4ZWcLw3a1EQDW1U+iVWzXAas",
-	"J0lpcVr/YT+oiX1Gtts+M0WSAKRo1A23QPchEZAkc6439PYPqrc7G+P9Eq8P78qxnRMq3tiqQdqjjBvr",
-	"eRGH/Jy9P3h/wMSERfPYbksMnZY+kXY+8JeU3dVzUou8qlS/cyHt87VLVql9u0HBipZV5wncfadaO86A",
-	"1O07Owmto0bpHkrFMnEL+NIkUwv2SwF62WdGsfcH3nj//sAvHZqIDXPabLsOvckp0XLmNe7//3DfDK/d",
-	"hx/6TYJ/RVGfgWe6aB2Q8yoOdZPE6eJ9I0iXTceZYVb1y0WfcekYApkRKWyApwJq/zxl42VHvVMDN030",
-	"fE3n5ZPofkGvIuNyz3ElPfTopFTuerEQBg77gfVTNgYjUlKRX9BXY55Owc3bVvKm0VLvd30X31IlP0pf",
-	"Uen3EfLnXKupBhNry2klE37q7KzqeGyVTsxqJk3Me4pXrytINNg3hc0L+51KdzUJJFEj20dce7txTMox",
-	"yBUYt8F7DwrmXDTbKbRS8xbvaWGg3eO5MM1GspX5+ebD+1GjfT+o9kn/wDPhiOwBZi03xAy4QYRpN3Cj",
-	"UvMnJvio+5WWOyZRoTRPMvB3cyesB++Lp0//lCg9xX+A/9s3QL+NnnsedNNm3uzJCuPEki39XgYgJbnS",
-	"+8M333x7uP3IkvFC1yfXvOyR8XgXk3RhFR58zTZp9/gM3bwtNus4fKTBGh1tQdNzYfKML1sJNahZnlzr",
-	"O/q2GGciYe8uX4aTM9i8Urhl5Jueg7RD9lblRYYqvNuOBYzJeZVw15JBVbF0hhbSiowFz3az87MjAe4S",
-	"LBK88/UplpvKboRMnbg/OX/7xLAUjJhKdqsSPi4yrslp9/5gAeNBNLX3B0xpd/ITUb4/YD30btIauSaG",
-	"/zB4lpb3ketlDodD9iYHeTpTGhTyC0zEHaTsNH4LfQiG9aqFPvofh1614HkOXJMGKww7eXvRuJBFY/BE",
-	"Ex9spHgy1W+l+1V1ZV3h2RJPtXukFMjbH7jublU4x/e72BNEuhcF3ktMUtxJf2XhqjnvEnVUbmXpogrS",
-	"aTcVvBwL8kjVFNkpnPjFaeJ7hZMHxJFHXi/roS5InDGIv68ur17VemKYEXKaQdXNckCNkZSfqxSyZrV6",
-	"M5WlKyvQ0RNdOpn29lX57av1v3GvOhmoPsYGWh1pu06q3aRZtukk3Mnbi92d4FujLiMZ2eqk7KBcruxL",
-	"vV3fSvMMnTT8Gyx3jn6Y8CKz5PHc5zC/gWXzfFfV6TartGtgbUb1a2SipNU8sWZYTTN6YyDmudLYF0Xb",
-	"HEyFnRXjYaLmRwujnh1xyN3/BjwXR+4OpyXPjspWcUhly2fXb76MNYwnhabFL2tWb51OszMjp0JOX2bz",
-	"j1QbeC7+1jK71VgKLu1Mq1wkDXfk1fn60EdqvGnmU2Hf+ujkj5wBcchLNRWy0zTo/cZ7vjv04ldzblvi",
-	"Pzrcrv0aYJv9laaqdRBp/pHzx0hd3Tj1fyxuTFs4yeqyBLuT2zYz5ToFhcF7xqp5xw1vml/2SCn0w2Y5",
-	"rvSUIoqGMQt/vCQPu3BUdhCJdO+V8FJqb2GRZW8mB8d/36y7vHz5Kuruw0+ru9TAwp3a/Wv10bb2PWts",
-	"9GKevY1bqcjtfua46mLP5qjIhMWsLwEN+Kcd6abq/4GJpzz9dqCbtnPvtuUkbTj1wsstpx/mgeyupyRd",
-	"8m9aE2NWI5ZrqSlxw42DxkshJud0jSyo3/PwU2YVRXF7J5kfwxN3+8rVkKWQFjn8DZZszm/AkAsXvbIp",
-	"zHNlQVoMflM5SIYnAOtlfAzZAGSiUkgP+2grSpT0nijGM9DWOw20aYiI8zbOBu3Ij6U51sz1Wr8TrRuc",
-	"tgUXtCR9rFrY8bU+jbR9bzxP7RtDHaxBb0UOmZDwIIbBTSa4eW6bzb+FAf3EMCGFFeiMwaVxY8Xr/WLG",
-	"rSOmJVtwab1nkb0FbYSxkDJu1kitaoDLlN2I5MYwNZmQow9zZ4jqquyHRZkhRSlR7A//89nhMDjMTRlr",
-	"sBB2pgrLOKMZsRuAnFmV8uUTw8Yw47eCYt/WvQKQq2Yb+CXkygirNAUAl8OqpuR9bq6J58zr/YaCQKrc",
-	"Lvdt3xvMp1yKf/esZRiZCQ3oW9ADdFmVs/ymq8m7nTAvE34yBWndNLTdT3pg8DwNTVMD3hvntuby9GSA",
-	"qWWe2TV21Ja8lmTcGDHxttb11XZyZIBBpn1Gx0n4a+6Wqc+UZlJJijsxYIMXwokYR0SU5NbfNWGtTMpq",
-	"tNeHpw/i1k0Fn0plREPswYsiy9z6svId9kfmeCcVRD0JhXWz3pzrm1Qt5GFjeLswOebntEwPd+r8LgGd",
-	"2/a8vA3hRi2TD+7eldnTV6HZ69bcO7ElFxXpvPGGXEUjdE71az6eD/ql/A+N9ldJON7Bdja8uhFZVkYa",
-	"7nA2tAptDRPQIJNNNt9Wn0mcHuBG9qqrT6F6v3GuyySD0jH2EXZoCl7hTpQnrs0nhs1BT4FdfX/SZz7B",
-	"knyOwprI88J+9FEcl4UcshFZl0d40oxKx/sIU/ZCdNQTw9RCspwL3fehyxhgMOZWzFHO1Bw73mCNMXuJ",
-	"kjRFdknGcFo6prmdgTsmuHRvZcqghLcYVBKPw0dQlbEOGAuGgw0jnxfGhrAdYDnXhgIMU0icPOaSAqzX",
-	"VStuLTSe6t+UR9iEy4EqyvV+zp5Vrlcy1PPCqjm3ImEaBlaL6RSc3NeQ+i2agjVDN/sUz/AQ7uho5Ylh",
-	"VnORuQVROnXz6/vYZWHYAgPC3ft+oBTwRbEpHYNIcAjtnuuIFJ4YOrzdbmLkdbm/Vrk5+FiWTE0NxmOX",
-	"LY+GbYcJhXBsz0naHFyywd25bUL0Zr+aSm/0FqS7J476bHRJbt0RnpjkhMEx+2ODyPaJ8YTbQc+I83Oq",
-	"hY/z5aO4lkB8m4XEwztDKnl0f96QMoNxt5FvSoLdIcu1eURx/tpOsc+x0C2kmAinY90ImQ5S4d50Ysmp",
-	"1pXHjkL2hiteQCdQG1yF4yWq9cNT+qEaqI9ydfzovd+FdRI27fu/8/IK0TurvO4M0z4HKCY1kPZvZzA/",
-	"bPAacpliNM0+HsHT8HGXm2RSutJ3SJJzV9sObW/1Enhr5A6XPZ7ctCXVds0xbBl1RZFVeF+D3kKRxRtd",
-	"fW+bGWJjNIixyy6qnTfCNl+b2hxnZ3FC4v16zpqIbnflqYyfZ07lmI/FtFCFYSHxNOJfvIMblRX4gYGG",
-	"WOhtRLcXbXXcnqBl4tt77E+1iA+3UVclEe4g/xUG9X2k0QoD2ZuVjlbOWFng8rymtvrlwFpOlkwt90lz",
-	"oC93ynNYzLg7hjAYW0gMSHOqsFZZpgrLQgjthgCRXcNfqlCx1U5KRThYMskGsN53uSNdk+32ybOjD8OW",
-	"NW3UevixVNKHpmRqSUaICHpmN9QZNKg7rmq02fxQPtsekz9k1zNh2KuLy8s3l1fhvvAEFfJUJLZ2dZqo",
-	"LKUEWbw44XbMRM4MX5rS8oj3jUTJJCtSSI8Zx8/YQhVZymb8Fs3eTpnhOmWjnGsreOY0ZCHpKyNuwd8Q",
-	"C0nWK7wiWgZ3PLHZcj2jBFMBUfHor10tSX0xXKTujoOTCZc0vHpAOnwvr2cagL28eHF++r9OX54zyrM/",
-	"JtNWL8yKshOsU6ySmbuUlgtdJaGwHo9+Z9ScwOh+yoUkHUtZd4GGbMk4MZhrPySihbVfgj3E+fAFF1bI",
-	"6WAi7lgvat6H34dsAJ9bpMFdnn0qcwj6wkyDahR4Xz59c3bx+q90pa/dBZdRRgeFSLq/hVvUOUhLncek",
-	"ES0FpQ9pR2rcXynDhMLVCF9Z4uN5YQtMXoI7v/eYECDmgDQWkm6FYTORpiDZGGbCLYnEJIPhe0mbyHqY",
-	"3cwSp5BqNzzEd6H7sl8ievOwzzzVsZ5Rc/A/92mzyxQi92Th7sREQIm6BU0uFVrzHo/6ci3o0E2mjD3s",
-	"s5ieWU8qZjG3D2FLDNpSsuywzyoax5cK486bYLX1LBXteN38QnAfh31mbkSe+yZ4kkBuuUwgjJATW5T5",
-	"fbqQJuz3FCzS3EoXh8P3MqKuaJTu15LaMENNua6ENXEj/sZpcJNNDtIeuw4zqJ5omHOf/IGpl0i1hs4Y",
-	"GPi2wPT9Lzw1dUbw386BS7TgOjYuV87pFbTpoAc4I5aCdUNHdvMutyoRx43AoFeht5JMg3eZFSleZZHF",
-	"I8IQD0dL+A8ksTjPLCaIg/5BtaRkxXP71xhpsj3ZLDqio9wyzzobwsC3JZj146O8dui0Kyfz3cP3dwxb",
-	"3hZhvzP83QabbgbcwO6x8B82Ls+D21minbhHO4swiZISkv1Tk3bUiVtHcQt67zHsFSq1ukjURvVF00h9",
-	"HPxnFW1xrrXSOyrlLzKnerkPGchbyFQOJf4FGy8JVcQdnoNnd3dlLnDTrSBtMAy/4slMSAIUwZOPenIv",
-	"s56x+JPJiilJ4TvuVJCD40gU/VzK1wYvohP4TY48AVlKjkx/KtAFIzq/cBimc+I7LuwZNtWU8x4hp9VH",
-	"8n0x53J18v7t+oyDpxfh7VChxNF2sBNj7GEYQStV+MHvA0RYLebqAq5TAb69vg4vFbnvwl1FTSZkO6fm",
-	"WQ+G0yHOfeik9WGjG6B1lX/0qEILraTHe0B/i2t6+7FIQ96yhHeQoAVnj9DkvXJy0gdyf7fk5LTaNTdZ",
-	"Fgu56eTUD5WY3fWUQebx5scGlOHmbSZT1KU3mu4Ttbafcdr11M32jeF0O2HElQF492AAb9Glmq2KJSBf",
-	"NeymVX8hMogQ83Zb7VacvbzVpt3oFWqGOA0d0Fdtg0eYyN1GvuPo+gdG/DvsY8vyE2kbfnOs7s674NTG",
-	"3UTctpB+vMkKuzydcTndFfudPj1vTc8Ob2zvvlXCCWkszzI81SgCtYNFcoc8hYwbGxLUd5r9aoIDz/O1",
-	"3IQ4sAduL7auhoEMNxiD8z7OpN5VetdTK6ILa0VrneOwm4n8wYKx6xHru/HSjJvTZoCH1QiyT54O0j8I",
-	"0Ouahtgl8Npv49qNqqmx/trsO+9wfckfbmfnFNW5HzRxzq0Yi0zY5W46WCYS8HBx3W0bjZDEO3Jr86nu",
-	"t7TsoOlYqUHP7Wkt2px6vLwnPXZljjUoXP9R4wQdQV/IidrjRkXhxhhNlwljjwxwncyGDK+t3h7PNbDT",
-	"k7cX1ycvL/7v87Ng0FwIDaw3E8YqLRKeMTPjORnhgx2QOWKeJ/mAQpwpho1CP1I0uLP3BxNx9/4git9O",
-	"FEWMWUjZq9O34VNvH2uI9viuLZHg5T2kCuyEtHdlvQd/rZv2UNd3ly+3U0IJ7nPtQ1JxzvRx6LacbyuJ",
-	"dJQVTekjc7A85ZYzPrGgfdR9SBtJ/9WtnQds5TJOEinvv4bPIcoyCbhscEeBPuiowkkeFTpjGODKSjzA",
-	"1RAF7LT5OJIqhRaIH7nLVhZdbHMybEuBp4jvu2n966lfn0ClTTSgJsWz1ZIwPBc/k+1O8cLOfrbqBmTj",
-	"EXsDy5fc2G/bcpTfIs7JR2dKfoR+uSEkqDIPlYbITtrBysLFE41W5GO1wDo9PJiO8FJI6BK/sRYDJKby",
-	"uqVijskhue6MzrqG0rkHjHdRmuqqeIJMqbxfiRfyumlIlEbvPLeYyMaKHJ2Fjn4yIWHIXiqVs7dvri6u",
-	"L968RnDMGBXTYxo5aSRsCUdZ4VBy9Kt6H/YYEl4YYBNxh96/svQHPkfoanD7w4DrTLjTb8bd6YdednQA",
-	"Qkq/MccmPmwhE26a6cBNsAlGPp2C3WpouSzkd/7N/YB4aAoNdRWytAS5x2XC2A5cdswPDPkmnY3Zl4XE",
-	"SN02BNdPbn3cD2O3/Ko86NdDuMt3qrwxzDBhATJXKDlkZ5TJR97uEFBBB01IGbiBZYXKWKHDCvIs+6oG",
-	"/l2n1D0xzPJpoxlbaeHv2XGZK/JIkxsZjQ+DgNLbKL4f2sDasJ55xikExk9zIrKMLYRM1WIVN7eGTVvC",
-	"/Y8B8dW1sBYk600dZ7O529HUYxWjAmMY9gQpE/JwyLwDPvRayLEqHIHiAzYGuwDwQQ0Y9AAaMLqDvOOq",
-	"sCUsZQm7KQyGFJHPPLoNB6e/77IWCBBjzpYuqYTLBLJWSEmfZnLZAr7542zJOHrWysZDnEKeQzpk5zyZ",
-	"UaySvxWECKkQyVJoYJgf9dxjWFMIRhQr5FqvlQ5Q0gnCuL9GIq0HoG2RJlVEWrMRfh0wc4V3S6YIxNcv",
-	"pW5tKKWQ3GbIfxMlfT64Oz7uLMjUe3LKrzX94K6nB8t63lSFshFkry6i3DvDd+8uzjprblOlphkcYeMf",
-	"Vpccf+2XjoqNxPTW6QvvzO5BuSdR1nLhvmcmzwQm0V6dvTz1ikjvD8/+8s3hkBKyMfjBlBDvRx5FkTJ+",
-	"sZTJc58KFr1JP/yREWwFg+CsNM9rcV/VB7Eft3zZyxuMHMS6au9oyIpxP9KES5bCVPMUozzxFmOoeobT",
-	"+BBcn2sno7ECTVPhtXHIVtzEULTWEQxZp5e7iyz/yWpUChWLCufwlmiot/4wuYzyK/ZyF36W/rz+/cTP",
-	"71lEq2vKfb0AyUeYGfcsZLavs7fbIfHRhdK6JjN1L6RW/l2mvMQ/FjKAFX/qmmtbkpx2Kn1WX7dmsiuT",
-	"4fc9i1sQEX4/TBLUL3O+oS62hlw1YhyfZk4djSCOa1AdGLBLgB71Yq5S4SOsTqHVrXD3BkgrIIudFIiP",
-	"Aun1+/ngemKgm4+senW6rVau9xVgWYqPLWNbyx7aI90H01IjZQcNMdqKCU8sJSCYPZWEqCJMyT/dAmej",
-	"j5xyddWSAv7+4P1Bn6WaT2yflVUxGwhzxg3lzDabx2fcXNXhVOsPr7m5Mc1Pcc2aMXLqK6kLOSWQ8GMm",
-	"1cAxVh/Za5Bkioqn4F8YtdcPeD09qVDLPOyT8tlz/993nEkrc9hnVAGmN1Z2djhk77GGtnl/UKtIh64l",
-	"yAQGilJSSVnyolJP3Xhpl6r8NFPLSiH8CZ5loJmZoWWOzIEsd6QcdOJWQCE0Or9qCxK8Ai94iBApj8av",
-	"SGuTm2kjpxjGPosWmafLPgVHtrXZ5p7vouw6QirJ19AfH0O8q8FCSG+1qVdjrig5JvmIhGsjWuGu/qp6",
-	"7Rl2g8xBLf2U63T/Ev9PqGoWJsnTFYquYeHKFSJfnK4HkdGZ3nL3mSel0dgDS5msmPbpUoQpbqbQt0Ts",
-	"1kTdYp1moWSTK62Esmgr/BhK5IQ+Q7lv5ICsmCLHEWsQ5hdnUw1LSHFIzVUaVzSDdVNp3KObgLeJulPz",
-	"OZvwLPP1Ez3QFo7DnUF+PuHT5lrsZIbfekBWF+1tpTLeRjhfrHf2+mqAIHUUS+6WxG+bPwurDW0G+Q8i",
-	"Y/dbYx1oPl7lfrnVoYNyHbZR/R519d7o6WAh0mqqWTYock/pfWYF0grCeNHdfJAoY8td8+6FnvvxnXGS",
-	"2rhjAa2y5Tvo+qH2a/bUBGW1VK45kQDrjZfeOBCawLJe//S0asopJ+u8ER7vqlJVomJbYfayh5YtmCsL",
-	"L7Sa7wT+uCXdqS0JGt0H5LMXhvGxKmx3WJjXG7RZUqb3KWhTZVI1nCnn0VMnBkq1nfU8DN8x+3sKmEPi",
-	"XvrpMPZI7Wc82HITXBMKNCBK/g2XSdZTt6B1cAN4k1pADoww3FqBgT/0D+rAfrsaAiXiyvncxfKYiXC0",
-	"ri7PjypovwCv1wtV+sgx8ljg/fYyO1eIgKteEvB5yOCzaylt5A7ztccAsgp96v0AWkyW7IW4Y3amwcxU",
-	"lvbjdOy3lwNMrU0Pm0/J7dCDny/UYPu6ecNwIK6wbOXX5WUyExIr9xHaLNKy0+Lx74G7XhzNuSx4Ngjf",
-	"YhERX5CIs1kx51G7pnmRW7zAq7iIK+r7zLEO0ONgafDD9Z5dbGDNyOCDoniJW9oYMl6HXKx3HTcf3MIB",
-	"A7XOMM8ZzzxyglOJsb5fzwCwo3DuHP0aKQwfjvA6dfRr1P2Hw/oMYnbESRAbu73ogNr2O2JBNm2fo3j/",
-	"yvO4VA2zupAJ+oPxUJwUGmnXkWUmjEXNrWnfOuJLxiWBVor+7AQ4WeO4SGj9tPXAeHDj0sr59JhsTFHk",
-	"zG7HalW9krzFhGnoTnyPg2yKHPStcFNZaGXx/J8zVVjCUBxgBSQ2VurmBiB3IjIEMmRK5aEmrrvZqYX0",
-	"nVAwEaFGEGqBnYEBvBy1mLIuwWM5NpwEl4UkvZ1q/KpJBAJJhpMKCtKX7iXsNmG5JagDGCAIQqAJ/Ovq",
-	"+xM2LdwFFeOtCMDTw00EYEkjLNDh6DUSYbx46wgIGaKvTsvIpS4fuZdPAYEqG+SE5LmZKWtpuBjmEq7b",
-	"KPlYgglBLOGSsFqsVjxxK5EtCbuiQlzpOg0c/nVntKD+wUTc7TTnypd42hLkFYH6nFxfn796e31VhRe5",
-	"E1vlICEdspONYBplAAjeLFiB1jNHvzzL1ILLhGBX5ooAWSVGklAQcQgaMZBNBjPgCILi+B8BWq067LSa",
-	"q9eVaGlXtj5exTVS6q8xTsMitsiSKrZtd7tRqda4q66QjBOI0neay2TWZ7lT20Kmds+rAm4P3l2+JCif",
-	"EjYXHeEvz08uX5+fsReXb16xH8+/+/7Nm79dlTKG1DFizkjKYF8sJKCRaq4I9N1YvvSRPhjHQyGYi5ky",
-	"ZWsCS/FO3AY7kkG1rzbuVujaBqo8KzU5J5iuv7+48l0iZlIFvaKhUghJSgbDrgYDBIfj8XvwfQzh4np5",
-	"2BV5Ftfk/ioefuL4xn+o8aU7uZvMbpESrgspQbN/U+M1ODS/Rc8d42dYblnJeNUbrVqr/l26BUTMRjzY",
-	"FusQJ97rKVxuKCFNVJ+rTCDgoSPjBUYFu3mM8OkPhBE1qqi/sIruYgiuHHB6sJcSRXemDFUxmBSGZ0P2",
-	"ow8eJDx8d/yCpiOMoJpbcAP0tBULNh5cc4geCtOAy1STAKlI2es31zT9PunrVeghQUanzKhjNkohyYSM",
-	"MKij6dO6McOX7jPkrLgXQahk4TTwVcX7bISrEjXpFotRR8j2PiukLrR4FTNNBd/LP0tLFIVkltGuqPx5",
-	"SaP0jZNUh0N2UuqBdTFEU3I3FVKRwirwKRfSlHJBEICcqYkFiiHH6/kx474pdNQkSqd02xqF3RxRPC7w",
-	"ZMYm7qpfkhFTt6ARuTZcJwRkqdciwkbUlwV7zrgFTb0aliqgdaeiFhXKWRwzGhpDLwluRkuS7Znmkwby",
-	"uvDHbphfbUwUNMvJifN/sBP6R0k/KO49zYiSSiZCCjMjhLMSIspPqa4bYP4QORLC6vrg+rChRli0tQRI",
-	"tmoAZQF4JmQqjHurEGaGGCeoSzq1Ij6WfDV/1GEazqMGz6feKRY8142hCdcrvFRiz09LiDDHNP1wX1jA",
-	"eKbUDSvB0DzAXsCIm+cILY9T5BS+8O7ypc8uIHWgUlbxYpsJecNA4G02YlM/EKXJ8muwBPQ5HuzBlrIq",
-	"AwyAbPFTYtCN2RIBTzsxIJxAirNul2xJxsXclLJ6Rb7P/YFlqnNeRAiRHrsuUwYQrN6TF62L780Nw9GW",
-	"AVt3ofmhUaw4QfmH4OZtK1Pek7tgg65chqsTEC3/zWsZhU2SsKwWECVedJZzO2RXgPJxFXqP/PQB9i5w",
-	"vqMv0qUi2EUPv1fp5orIjmxPtzUg0KVhkt+KKTKhd9KFUXJ3xeNz8OLSaxMdla+qmw3HJLekHq5DBFZg",
-	"of3K8l3hHwa1t5LrnRauAiaMaxoYsDYDf01GoFKsL2HiTCL/boWB+rwUiTO1YLx2AcJFn6mFz2/iskws",
-	"Cl1SLkAtkeDeMQI3ANuUuvu2IObLQr71YLvnt12QVtYvR1dX50RGMUmWCL7GauDzIRu5rkcsxrP3Ran4",
-	"MlM8PWYj3M1RuTmcxbc21ksQAoAVuQFtjTv0Req5hZLDUJoljnMIUxsz+ioWOuyzkTuWR/hiNPGXQiKt",
-	"aDHGuCRMdjUhtwyRZVPlvqsVCaGUDG79rcfnRqNbk2ScB1N1028Cxnet75qSFQIAt3wTT2xD5s71+lSw",
-	"Moe7nKEOV0kZvwC4zY2njfUhluWlAqfnR9w/cJ83wxy7Dwa3XGOkoftylSKvlzmc+taanr2kHpoenWGv",
-	"azDObgxbeOGlX+gdWcHNFm115YFGek6mpseBNSRWciv5owTX61EA0m/MKpX9XOA/p8L+TGCv/o+8MDP3",
-	"z9nPnKj7N9c2+827wA5ZnhUmyD6kZ+F3MGgeU62K3PGKB/t2pzSdMLlWaZGgdkNUv4hcRYjZSpNRGhlI",
-	"TZBL0KFhijE+c2ddU3T/hnu6ms95CzgDDuuiwYd1kQZPT7ggCENrP4ZMySm6ocsL5ZpEuIHlsDXT8kKm",
-	"cNdQrmcw5k7Hw6DVErGOhxtQBWhbYWT7BU+4ZBSEwssRBIiFmYfWRiVzhm9jc5kwdhcrZUgsr4/Z/boy",
-	"zp53+f1W3e9+Q6fpbzGWc7l2Ybw4/sY1SwuN37xq0DNHSMlEmSMfhejOUrdFtEQ8yxy53/TZHLgpdOU5",
-	"80aPkMdXvo2Axk43KGyiPFq0u+aEeyOZ7m2hJdeqkGnHVYS5sLbJyffjTFWM4X2LUCoSbogYN2PYKPDA",
-	"qBSc7lW0dSw4KnNUKEti4iEnxnErhBN7TjdeuphBRpGIdcaLlQn3K3qnqM/dRasTcOc06VfUVvPDq7KH",
-	"apUuGt3KTpCE8fQrSxVpaKRrOtW1sI45jZstz5ymh9paIDhRcravilWtUJ95XFBqmtuyN3dvmNGtagKx",
-	"CcKtkg+dwL1opGA/KUTsaLHFVb+sysIpItvHg2G99wcXATGdWZWqAc8F8/kNG+LYoQUboX8Ad8KeNsKo",
-	"NnGYD7VPSPnC6g54InlYbzODLCyor2NWqt9XZ3/zN9DR+Z2wBMf6euSDwIjyT1ac0Lg/Cw+Rz33ztJ3u",
-	"nh80ejZ6Xzx9+qckHG4/43TxNxiVEPjYobdsa+Ap3YETcBfx9wfhBddbUJDfH4RSRfiKWypI2dP3Bx0Z",
-	"fyK6u2vakZjgFrIWjCYJ5iRNmyIxThyNS0iRzCNaxjITXnjwFC9IoahbtUF+XRWl2AVmcdtKlWUKLAAb",
-	"a3LuKIfnFbQ+bd8EMDxU4pVTGquLxHqolw4rgoO8hDlGEe81QU0fR3dAhKeh6XUchbrpxhmxPoOHSZnv",
-	"HAsNsjyiKQtLcG2iR0fYyADUUY0YsXFjWuxYIYJ/PVQC1fgfKvD3Dgtg4Jeub7bBSG4o6LSpjqdSWeuD",
-	"U1U0pdFtpopS3Jt7pPqOdOT6fmcaNc7rIOlIZSn1zRCgOWQnrE5ysYmhOtVGQf6NnNbCpVmAXst28D5c",
-	"6gtFY6Tx0HkZzs9K8Ub8mQzoPCK+br6odQBZDIp3rF3W1OPSzhD0ppbr1A+13Nu9Qjgia49fAdK+QnER",
-	"zEu+fPea+SvHsu9Pohz0gAxdSkIA6SCDTlX1ssqvK0vLUPBGE9qV2NUEiNVdlL6B4GW4Or++fnl+Fi7c",
-	"Tba5ULsjmNexwIZ3MbCnwYfbVB4EHTSmvL1hHbKo8kdHJiAWC5XfWotwY6ENT9TRQMr7Ld1a3VnsRXnJ",
-	"lqg58MDK7ujhiS8GMwbiV5rAyXdX56+vyVfojWANBYKC5kg6io+/wYKva+sTPFfGHXUpZRhCIgz44kKB",
-	"pObA0VMWjkqKr/PzoZ1Mbx1ZGO9Gd2vhhukN+oQeZMB35+1W1hHAt0+/pXgAfuPuADdSLeTAx075FcmU",
-	"umGZwOd45nhEjyF7AdZJCcvsTKtiOqNSj06DISkx0jAZoenc01JbAZmrGWe92LY0DD9XV78wGrTAYwoW",
-	"VUjHyaLGSwclQkKVjrV+OCm9+8mb/n3wghW5ryFAcvH1+Y/nV9ee0UOJHJSFtI2FZEtVMG5uIPVy9qC5",
-	"UsoG+3OwSGbAsXYBtlOHRjRLY2Fe97Q0clgwJD9U+SH3fksJoqCGjOjDkacy9MggpbjVQyosJYhUWDUg",
-	"mUFy83vVMPpUhYvCqIbv5Yim2SAr4hpGfR8FVdlzMcQgPnAGUSWk6Ndo2hpMDj7KLCqARWQSqZcP7QZY",
-	"O3uv+C38gNXM7iHdo62q+f7VzlfyM0APoj7Zrz6m72+wPPY4Rx/YnOdmyAgAmN3AkiBFtAoWey/Y3dM5",
-	"l3wKujQlwVQYizxEyvXwYBu0RG0FmnQbLCRPtTP2WOCxkFwvL2ul41fiHYm+nLCl63txx/Cq6t3nIQ9A",
-	"GIw0Qepk765fDP6Fama8l2LOp04e00UGexRgqEybcGtjPZwsSRkhKfxBSKvey1FV1p5OWJBkODzC8r9G",
-	"ZCBttgxhR2VZEj8Edxq9l+/++OLFi7Oa4xIv/ZgRaxR1iecrSTKldZHbgCEG72WYZAlIK5fsVhiBRqBw",
-	"KF5HptbgCMLI2/cSpEUVXPI5ZSkMNyYerRdV2AbN7AfYFkOEeX4UMfZrY1LJZtAGSMWGr0G6Zy3Qq/eL",
-	"Ga309KINPjkm4f3lQcV77dmvUcKKt7yGMGth3HmSZdXt3Z33iANJ0cAYLlySkbCsN+KQ+0gh989BJd5H",
-	"PogsOmAsNze+vuFcYKkevFomKnfU5TeChkAKUCrcUYg4czLU4TTg6dw61a800qWFBsYXfEkGEBo+BXh7",
-	"C43SFH4+entyffo9O6J+jn512/VhRDFwGCRBSuC3T//SyhSM33KRcaJoZtV0mqEpo5D+wUqcQQYU6VMa",
-	"TBzXNRs0cFSvmqmkyHdEk12VxoERYpaqOCAQaH8FiTwmpGqANaLtr4viGlfHY4/G1HoiXFW2kt3LlTwi",
-	"MbKhdN5XRn7MjLwR2r/OUDU22cqinXlnj4yoVgii769fvYwRiNwO0KpTkN6YJzfVslieqWnRHN5AX3XO",
-	"uqoJg11hH31fFcJG+5ItZUIVEe+rImMp8PapKVTicIc2Wgf+Lt+zwH4JH2ZmdIEkeUFKMYWwpGIyqUFF",
-	"Kz19YtiYG8TPOqbX3sv3fpjvD9i/ImUkKl+yxPFBv8IwCP1IWFTJt2YpE7YQGG6IMcaHz117Pp08BVm2",
-	"OVepmAggMx52EH1MmrdVBVp1qI3glscWxsrOGPpHmBEhqC1MhPU03ApYsLAF7u67ZrPciLtZi9ih1XCn",
-	"aTmNOCdga/iZlxXU7pad34PJk+BN6FIxADvZkV09Te7KraGvvh9h48xLeJ7dKN5917V2/5CdeDifozIe",
-	"2yf4kUXcI5+4EygAVRuwlLWoLEuFtkv2ryUoEOvdvj58Xv5MbVKSnXHP/nj43Bctx6b+lRUylO5J6e3n",
-	"VFLCMMoX/1fmYaXYEhpLSQSorFVAQ4RloMsvNljGFhA41bSMJMTCyI4lEGgHPxsX1ip52IZ9o21DTrJr",
-	"1hx5vlMypJGXYFM+YLSO4x2rVDjrBseXXNKQ0WLrwzKf+9WJD/e/gkQUfIRXZKfXJ839tBaIfkkDvCWP",
-	"+2tyslPXlk+jUtEof8pd256r62fWj0pG0xoGVKdm6ndK2ymVZsACQPuU710rq7ZyNuTUEItfRDASIVnP",
-	"QBSwUBg3aZHckItNppgiWR0Xz/6IT0Efdkxs3DjhvQsW+2zef4dOpYlrb7dsgi3MKzP99LWbr/l0D3lP",
-	"XLa+069hgSZW5PUAuM+nvlTs7Z8OV5EefLgDAu9PW5yirrWzZmlQ3Vu8XCAZmPryO14YLHhD+xGvWj41",
-	"LZXco0k4wVpj2sO+UzzKMg/DjwDOWQ2C5dO23TI3HYsCr6eLynAL3R/eZ5yp5AbS7xq24jWC3XtdvkRo",
-	"FSFjxd3u0LvrKwMo+byMZcYN9MehPzaFYUr+PFNUC/gjBtxW86pLxTLz5iOXqzanlugxj+T9PZYHW3bW",
-	"iurFjTuMpcIM32QN3KnLNfKkPpQ+zbgxTUffGLJBADa4KQNgfc5LVauDLv41SI86eNmc3xCxKXdnGJHB",
-	"wtsUMM4PM6Yw9B9tEBQje9hnoxL/Klggyhxo1N/QZHFcveQ+WbVa2KbwBz+DUQbpFHRofMw1eICdKK3n",
-	"Hwqt+fVCPQnXekmO7dKaMR+y115EYlCEMCEqUBUlng66EbESD/YwVqnwzoNcu4tXbeF8hmWYBi3WKjZG",
-	"QMVYy0Eu12W1wgPNujGP0vHwhoqYO2UMboS4yaoaTpuoOJR6+tA/cITPW01zVcmXdUMaJ95pvrx1xLdZ",
-	"Y/36ilQoN+WsVxksllPV/FfFjt+CfnQG1KRB2zlzhckx95Z35A6AQaamu+QcuW/qwVpY48CNrjXryC2W",
-	"49pyhpRRVBNezelK9RSka18KCxeg/IDnuOD9UNHPfVn2dJH+0cAvh2tZSeRxTleOuL0Sk9ZOlDW83Lin",
-	"EGK8d+JQObWdz4YuyVC1JSZFzNxs/chvflNeE34fj3qfFKcV2r9e5nBN7TY8OY+6anjs058anuyY/VTO",
-	"+qva1+QNfjRq3lfl66vy9VX5+h2Ur4/Ci/589LLaiblrYatCortjEKp8MpBWL4+ZVSlfPjGslqK7d8or",
-	"ulV/Nhby5vxXRDaL8l+rTNdy8mWivrAscTrkRKv5kF0HFBSPY6XVIqqlveKJJazKF+chpxYLXdW1tSMn",
-	"Be8vIVbNc4QOb6sW898xGZN86lX2pZN9eDyspOpR1glK1rJWbZmD2Q9GwyA5ow+FNZBNfIpQQjkfPg/4",
-	"FtiEJ9anHEhWSIzo3ilT82te5e+XV1ny6aYc83WZ0ZRvvvly0yFBOzRepWhT9MhvTOWG4vLphjjABGKU",
-	"OUJOj2o52i1b8TWB9GsC6dcE0vaS0VVxoHU18Wty6T0kl+p2pWVT6qmF/GtO6tecVHQw10gXvyHarHJR",
-	"o+N89ehtvOkUWp6G8KbdLjoUvDFwmi379ulf8I4+REX3ZyF/LrF94vUmMGp854lhIn0e4rYwyeTnuTCG",
-	"MBkD6LKPYCkMDBJ3S5rhEVn7yml8qOri5WUdwBe7dNO8aLtPpHXj5soEqrjN2iC3x4Jhw21rvm8MSKKy",
-	"jI8bslKVmg9MonJ3KXA70vvDv/yzL+f27eFxZAj5hxJ+cauCVr68smuaaaXmVDeLql4B6L63mSCmaOpo",
-	"Ho+YGXfXo1QlZNSiC6spz0ar3NW1WToLf0g2hu68Mwg1iscRO2JTigRy6l0qNGWaDdnoiFQhjH0MGtAk",
-	"UwvmL4+G9UZHKHVHfTbyxaJHffZf//H/H6LlCGXRD+eX351cX7yK0H7QUwB3ObZhZzDvO7WUl1XGXCdP",
-	"DANMrwpx0rg0Ugt8K/Rb3bESntsiLpUmUuDNYoDrKdgNwT30gg/14G75mWvkcHuRgWjN28hy70gdWzLY",
-	"unz2R1/F9uQoUVl2RAsbZOnWKfhe2ka/VyXON7IUSO6KR4mUt+S9iiTcs6fP2H/9v/9fPOwmQDvkgbYk",
-	"hkTJW9AmCuC6D8juTYqbVKcUrdhSQ5Pb2UeWsdYl9PUGpaa+4rqQVBGyNOWErNxGhmgX3Tvn1PQPCgOn",
-	"zYphM6mtbVrVRL+K9Y6LplSDaiJTCrClatf7ZaX+wHeoiH6O7+8cGBW6aZ8BRgvjIbZznsL9ZMu151o1",
-	"ZRK8ahYa78zu8cgnCNRANfx8wb+JRwMspECPReSeUZpxGQUu9/7w7Ns/99flhjteTh0VCSWvsTxg15Ih",
-	"7stL4OluX1EpwwZTmxaeewa+FiJ7d3XGeqaY973rKdSnPXzOHFGVxaTwfR/uXFPsU1VQJkwLDcpg8a8V",
-	"D5hkioeKTI7OdpofGl3XZ/cKbbGC7Ka4PxqRhH04sJJU+83Xvqmm2nhSKzwrdxjW2nlcfb7S2vq29htJ",
-	"JEy02tAmKv+Ra+kLyuykaabQUhWg/bzJPWTKllK67i2veVftNQ5d6Runb10Wco9Kk2Ux2fWTb60QZff0",
-	"vpXaq/d307eh2HUn0R4tDcZNdJHxm9b3watwxXu564HUXiBrdRn2pJKW3dqoW7USSLvpaQNpdK3IjxL6",
-	"Tb4r2gI3sEEttW2hGzsyNDX0UxO0hIGk0MIurxw50KAKA/rffrzG8QHXoF8EEep+XYfDIrASkOkA8xf+",
-	"7cdr1ru8evbnf+6zf/vxb1eDW9DoeXV3IaQ6ZHpsuRLHM2vzgw8f8FiZKJwb+bIPTs7fsu9evGAnby+i",
-	"9I7jg2+GT4dPvS9d8lwcHB/8afh0+KeDSIE+otvzUag25X7z97jSA++02FDMCk7x/RO0YB74gq5YkfXg",
-	"+O/rZXHdu8pfgvGCfnFGFekHdAtWekp3YP+3l1E+gB5RVdzUsSZMyBE/Pvi/Bmg2QK2WuLSpJO9H971G",
-	"O6t9fIdbRCoV+ZNDhe2y0hMmcrkDIyDI2rZJnfgskBC20TaxfTtdnc1PWGUiV9IX8X729GmUz45smueZ",
-	"j/BB6BBMKSlHtUlk0uIHkoku50i/K/fYv1GMFFbuvbcRnKPjsKG78KBibCTckqX//pNbmdJGXW4LllBZ",
-	"p6ke2V0GVg3oX0g4mDDy9zoNUjTfEaHjtLLZX8HSJevgQbfH9eATEd3QHt+2/BVsyA/m0jPNEzJaT3VZ",
-	"bncipqxHmgsYDOcwfVT5EWvIxHv1Rk+ZX/mf6PygGI/69sTXYG9gBVPane5zc7D/D/UDyykcH77SxSa6",
-	"wHXrShk56IH3wPcZt2ouklaSqHj3aCrsAKPtUtDuNwmJHRgwJgRw5so0sDZmFv5V2Lf+U59k+EBk1Jy4",
-	"+YkJqiWZ8vGRFU6EneQ5XrFZTAHMUwDrvXFnxSDV4hbkznSUCuMbaqegs/KdiIy2KWHloEtXt6S05T6r",
-	"vHs+8zbKmMYyzVg8TcOAp4oifXqhwj6WGjtEV12e4Y3bq++o2/xSACaseNWmkL79FbXGbzbdoz7pqFcu",
-	"1pEJZ2BuRD5Q3msxyBX6Qf30HlZrqrb3UfNKNQ3cpKmwrOSVXsJNwlM4LGPhlJ52YBWR5kchgArP7nYm",
-	"uVSWW7hI81N8n0AHH1Sbivp51BtHK4e7cnH2tsQW0AEE1yM09ggFFvEVEjjsuHso326B4j4aVd8z/8ZF",
-	"mm+TaW8uzk4ppF4jRJBVbALh4C97YqlKirkPDO0oqqjRDdev/br+lJevsI6PX4hgvJRk0ZIjGK3lKbd8",
-	"E93FiUZHcGdBO1muwahCew9OIwm+FMae+9cvy7c/cq865mvXez27ftPB2PjYdtWtbwTrtLYzAcgr2tuz",
-	"aCu77a4HZSPWzYBsWiuiBn9fXfNtUie8z8rhetgkFCTelujliH9SV7XbpUpr09sFx7cNSXfKsYP1WZOf",
-	"L4/jLmABxjZCoBQU1vv26V+YmDCBIVWHO5BHiTkWWkYlb7MEeOu/CXRxjV98CinQ1PMXLgnKDSrz1wia",
-	"m8gAN4tVuIihHl5WGEvG8XY6iA0Amzf8Te3NBzya447Qb/VIN06tLFh0EEe/0zZ4s/oWlgsvbVP8cv5L",
-	"ASznUyG9LafQprN2V77cqt21t7/VG3DKDQyENCB9dpEpxvQ2FVd2xOvGgTF33mb/mqR8l7Eb4DqZbfJ4",
-	"7N//1rm94ndiXsx9PWwqHwlzjGGl20AwhDNPuL5SCMbOdzUTZGKOnoq2CX70INYCGx5SDfck/ZjZPK+4",
-	"MnB4yahoJG+8gGOsB/gXH8pIHvdxSR10M25+c98b3LTaNLz0s95hGiPjYZebNzmW4Ee/RiEkHfTrigQ2",
-	"ynT/Gsmm3tnrqwFVXDVZMT1s1q7jUJbuSva2jv476Nqbd7vf6pT88vby6acQBI/Ai7q3ADjCFBVfXqNV",
-	"szsJLz1WymnShRjchhSeoHkElePPT/tszu/Ys6dPMc7+nhSfHXrsEM+5lssMSwPW67rHoQffpVuJxGZL",
-	"prI0YNJjwppKkkJrSE8s612+OP3Tn/70l8PnmGxGiRFU7u4i7boM9P6GdVgZZtS/z4bLuLE0bGYA5LDL",
-	"dtYaZVbAWAO/OV7Js1tpmfVWp3m42yxXYpc+pbgKHPkCnIbyODVTHiWBBTEU6LUXo672/cYO/JWOguz2",
-	"k3NHBLvWKu4IwuvLE3hXV+eYCzuHkvVKliAMP5F6rqhY8jeRHg7ZJWBkGn1tPOwuJdc1BsG95MYOEF9m",
-	"cHH2kRxi4c4eIU0Mqo3bjUU88tw60boloUaDgGigxwlAesy4ZEIKLB6oaTXUhGlInCgJFOskq7EDQlrw",
-	"Nq6F0MCMiqtQenRBJiRTOgV92CdkQJ/yaLnIGDdY7sC3jGXWIHFvp0P2RgJLueXH7N+u3rxmtVmyHDTt",
-	"Zp+JNBauv4nUbWQZ6MIncByPCqEOPUbi8DOP4sAd422bxXp+h/5YLeihW9Grq/PdpQamUR/9Ws/D+nDk",
-	"Q7PNlhDA8psvR468OB8kM2UAA7DK+bGiEGnzONdS2LoOdXNP933YrsaMPzq/P8yWqSZjQDLjtr5ovUCw",
-	"GIoTn55/BXlysdUQdF3orzT8aWj4/u1s9ZT/Tga2Z/fa+eYghhOsPkuGtm+f/uVeey7RJZr6JawCYRjP",
-	"NPAUa51hOUwKa8Lq1EhpfebjnLogQmBtlc8/DJJH0AZHKDDoQoqp5v/xn1jxl6WA0APpcw9CwG4FJ8go",
-	"964HMG4QJhtOVITUag/8+s49/iLsVPfPx7g2O9nJn95339T6Izwer7WYTkFXaiNhu+2sEOJXR7mGSSam",
-	"M7tJ//OkHN78anRtoapqiR4fWZ2qeV74cEsCCywDV5aDVPMFaJZHJLAHscV3jHV4k1C7hvCBUXKrAPqK",
-	"t0HXxnqxnnpVmz4DJ9xLgGRCp8dSZ3Qv9i9XWMq6kISZ6E7AhdI3WGBvyM6+wzLPWFWeorkxVceHehz2",
-	"y7uwx3Gd86WPvBR4Z05hzqWv2q+yDEtxzkTmlFrXJQJs3cKQYEOx3Btdj1PIxBhLdmVL7yt+3gQYi5A6",
-	"FVBdJowdYOYzCzSOCFxeH5ipLMX0+9ZYh+9oh77ydgtvfwGOczYOe7wP8x79avn0wxGBxR79iv+9SDux",
-	"Nr2C7IyfYdisnkKMo2tVn52dX178cH5GVP0mB3k6UxpUBDoeFR7MQQ/KlfMii1jdcTLccXISSGA+eMtJ",
-	"AF3YGaFM8dAWlerEKrwpmKVMZlpJYaIqbp7nh+ws5s3Xb67ZRGWpL3RPHIjDGDiNMwK9C6JkRWIkXJai",
-	"IZkBz7Olh88ShkAcE2UsAuXRAALEbr0ZFDpU6xd7ITR5wl8qBRv3C371/cmQnfinofYxikH0sRiMfpzn",
-	"donTaRYYp+7jRy4u+tvKp7HeqF4+bXTYxzjA7BZSZpVb0fIM8RFAdqZVMZ0FmGvE8B42z9Ly6Q6zWx1c",
-	"p/Av3GKR9hkP4IGIwX1ZSHz0g4DFUKTBvIvjBZ62jNdz+w5jDv1/6lTvkjgfs8C2ldDkKyIzYJZHUvyy",
-	"kLtIcCedumhiJWS3ow2s+dR3F2XuFMBKOIaAWY9givDfVMKH8Gk3a1oo6wJl9zhpdzja4EuQSyZkglgC",
-	"rMygQ4Fb4vOWXRw2KoMlwihJPfI/oNeirOeB7otS52vU7TYocaUgNU5hdmqnT/9zJwXVXY+qf9yCTkVi",
-	"Cfr98t1r5hFGlgSB70U/4SPbUMoDk8SdqLW1tkCmmBHYLKjpplvIr2J6q5hGgiUVY7yk+FS8PgjrqJlP",
-	"uZDG+m39VCL9wVXagFb0aJ3ulaCqSRkTigMJ7Wsb7CQsq4FvjCQ6rV77emlqAm/wPz1mEkviPa5gVMof",
-	"O9LR0a81nLQPm32toQTYFyO0yyntMtY6stwOeufWzn4XLni00ZhJRI/3xwHrVoMW9cV8ZYMvgA1W8REf",
-	"+3GwbkmrsURbBIJ33Xzn/TVf6fr3oetvHoKuH2veTeVOXKHuh5D3R7/if+mnTE3NVq/jS/fSV1b5NKyy",
-	"jiiJVvWIyncZd7nVO4y5e4dbx35JWQNoEwdpsXhKwOI+eXF9fknGJ8hVMhvMRZYJE6Lu/+s//pMCMMc8",
-	"ufHhtHArVFE5154YNpJwZ0/xi1FZl4kqfJTWsTFMBUbiDNkr6kJzX9qJU6AsFnCdGLBsDAkvfBFWP5B5",
-	"YSwzhb4VHmJqxmU6QCAS7CIUF1EpRdt6q1hZJsNInpuZsn22QEuS7xDdjUwYrBAj5DQDY9i4wCJRYg6E",
-	"QG6syDKyjBmWKK0hsdmyNH6spgMLmWzKlThfX+ZOuSEP79dzAuZxKufk88pIQt6jrCaYJNPpllpiT36V",
-	"0F/MXdXv6eNkikqLSQJpVqxR4akWth1N9Stp/26kff+hhmuVYj45iO1j5ypawU6Mtd95U0NI+jWFPOS5",
-	"JWDMwBPFBoRFeuGNnl5RAd+uaPDSFHOMavtEHNy5xw6s7FtKamx23yzc1snW8Sk9HYRqylUYoZ+vT08L",
-	"aLW+7ZaV9tSww7D37PtTmg2IQGvxz4/PcOCHz4hNydeaaGXMIJB3805sRsm6N+lR4ne1C4634ZVVnLMv",
-	"8czHpA8K41U5EFwq6yFJ3dkyl+pBNIBuXW+dy9tV7LxV9r4vCdKlo0+kvZQkGlSXh0xworqPr8x0W27T",
-	"5wu3H5aLcZZv2sUeN0uZHH4iWVQVq2q7T5e9L69CMcSvEuizk0BnDyNvzrZKl7WRnMtboZVESOeAvHLM",
-	"UriFTOXzHUDuoGpok/WuS3efFFR6lV8eq3u9kklPDCt1FiGnjIQG61FFQ8Pm3NxQTJvbOvMQsitTy/nW",
-	"uKez6L2vtpHHb/ar9vPLcM2nNfq8R7N4Wbaug1n8jX/3K4N8QXZxt6knby/aWeQ+c/679Ho9i81yGCZu",
-	"GZfs5O3FAO5yZfAcoRs4JRGOVbr02SCm+vR6mUNZAcUtbeqTgDCfaviYotSeGOYXDHMJ9pAANR2+boM0",
-	"W6AFI6vOl2R+/OlTYM2v2MS+TIR5jikl8SYg5hMa0HRFOLvrdd1qUBzd8qyADTXhTlWWQbJWc+QH+uyL",
-	"OczWy1v0Kj388CHLaDT184lMSVf81m9kuy3p6aexJX32UAjIBXElkPo9jdiIcvtLi5Owe3KuEVNZY+At",
-	"1y/3fq39/67pJ53OlfLYry3ZF3q+UMplrAzFdEWZkBp4OrBiTqpjYSH1poYjDdwgwN/uVDwR2Ra6fSGy",
-	"L+kIeSMzypFnWLucUU11D7UFE3HHejCcDlEJNYHJuxrlqIVNdUH27f13YUG39a/A8i+V6zBpGTmAccu+",
-	"Pz85i3iI6H478xy52SzbVbMT9/hxM9EDKTa4Mr8TmJjv2zji/CRmAewwYAE2m70lMKXZXGnwRDlXt5Cy",
-	"nBOwgNBszA1czTglPSuLqc44JPjMEXNPsCg2z7IljnfJOBtTAv+ELbSw4IRdBhYM6xkMbHaH3FxYZhWb",
-	"c1Grg9yZM391zNKetHkJPHVtfTmH2yXkaqAh41i3yS0CnjOsZzUXmaOWhcjShOv0GLERTM4lmxeZFXkG",
-	"zMAUra99JoYwdDdey4VkJuNmBgZRuHlKYFcmUTn5NOikYnlWGMaZmfMsI00F4/d5lqnFAA88R7MIBS1t",
-	"tgw5/BL0gBd2hoA+ET6Chlxp66SydVfro+rRET0aOkJuSej3f3Vd9bZFcwP2s1NYP7SaDJaWC3P0K7xh",
-	"nF0NtZ7eEUfCLRCO5eR6yN7MhQ2dGg8Dipw+GGsukxmzIh++lxeWwZ0w1pQpCW7U2ooJT3AxOZuIOxQp",
-	"FgGOlJ2BXggDrJA8TTUY4854guVe3w73xS1ox7AWJBsvvd6qC4nQG254AbzNirzEJorw23Qhn2AyBpbR",
-	"RqQlBG/QhWRLVTDylfGxKuyQvRXudkbJETx8Ww1rQLggCK/ipGKvBpETfj5030+BfMl+IqE5xhNboFQK",
-	"6CzD9/KEzeCOEQozsSJusyOHGsYb2myZBn+NhLtcU+1+D0MiDEu4dG+NIVFzcDJPq4UBjatYjueJYTOB",
-	"MC0EOYKbEzEO5XOkkIjUXQXc0D3YCJYydNuaZW3pHU64x6Sfc+suxgfHB//P358O/sIHk5PBi59+/Z/9",
-	"f/72wz99Yvu8k71lzaNHiHbNEYws6JCst1FKBDY83E/VxLLFmy9qF/TK73eYdRJxfBDwcNKAtoMDwEDE",
-	"icgsIrm0UDO9ebBTp3+D5ULplFHdQ2I9XE0CiTkaq3TZZ5rLG8LZSoWxQiZ2YEHP8fWM56yHL7MFiOnM",
-	"DT1VxTiDwz5LeO5OQm7Zsz9jeQOeZYOx4Maj3RXGn5OFnvDEcXyGc6cN9UVf3MRRl8OaC0pCGzv/8qDV",
-	"XjpdCpHMLuREfaG3wiNPKJ44/T5RZFpp+ndyO2Jgz3rbIOzxtc+IQX96yKKKONnf6Xbn+958u/v8KyrG",
-	"JNiVAjecIbqQ5uhXXWD5kITLBLLYbLESNjrmMnV9SiZkQsjyQ3aKXzn9A6uvY4ruXS50qdA/MayQY1XI",
-	"FFK24MJW0J5DdoGai1OibsEp/IhveXXx19cnL1fSaxc+kZjRMDPcjxLeDXHtwCLEl7CEX6fVAu36SaZM",
-	"9DOpiB4rUelUSK5JZR+yZ0+fYSItTcaIqeQZW3DDKuxeDzPGJpnI8YQa+QFBOqKqsPhpkYO+FcYpAIlF",
-	"YSHskP356Z+qd8oZgZwKidhwhdTAkxlqcfGNfoHAj76bAImFGKKg8dqmwerlOnQcbc5l8QWVyXhVAyFs",
-	"q42BJL3DsBpa3X6UPmuqlIzcQJSTfe51WmmwvA65thPAWk2A5FpN3YVnSxmzy0K+DW9+Jcv7J8t7rFYW",
-	"bVVrwbI3r89ZVLTMWOERF70Hi8TtJAjPY8bZCH8c+RJvOeganifr+fJfRW5AW1//69BDPY8yIWufYjWs",
-	"QaamhC/vkUIJHCHGjq8qLkaAyuGSz9yxtI7pTADtiKrMEzc2d603kKAJpBz3kJ2XXfLMqDIqi0s2AjTU",
-	"6BFLZiJHoT6acyFHZZAWHZHuN5pKn41MMcZ/0kvunHDjixC20fvnPkbIeatURiXYRliDbURF2KolouqS",
-	"Pc5W99NdbRIt5lS/0C30yNHX6NCvYgDZGIn0mBE4p4FfPDznczY6ZjcA+YC743uE9lmsNpO7a41I3e2I",
-	"C2uG7M3rl/+LcebuTwKDKKLjmnD9He0cr72CP9PRTfi13ixCgLJYsQ6XgrNRqkqy6Pt1YH8/e/P6/KdR",
-	"iRJOJdxRH+iX6K8Iu0G98aXBpAImZAoTIYWFbBlVqCNLp0hhnivHXR7ju6xXFwiWkCqJbqkmPhWycxSC",
-	"P3sM5j8a+OWR1LWrHRFPDEG2Ix8hpbIg+9dr2m0/REwOyVGi3L1xYMhgtiky9yqH5BTfvvIvfzGnyHfA",
-	"tVN51Q1IUjdTYbBuIKImC7skdTlRTplG3BiMVWmseHmCVnTx76HWXytQz56dftrA3Wi/N1fuegS5InTM",
-	"uBkpIm3myZ6FtpUuzwc0J7ozwDixWouCjVrYwmFbs9Y86T7ylLVPUIv9kScpVeaCq7OXpz5caOcyIvT2",
-	"Bsuzb+aaT78SU2MZQD59zCk6q5Wb9qEgc7OZhK7xjS/maP8RS8jgpJpK7Tu1s2tMGdrPNhzoXbuSxdxt",
-	"mPv7oH+AarG7YfIsO/ipS8FScs14oDrqTk2oTI/T6AjTrIbwj5Fst386JLem+wn9lp0x/qMKFSXcf7CG",
-	"eU+RiBHkX52/+u788ur7i7dRVQBObh4qDbBaEICdY7ZM8FPTHdbPoWsdfqoB0Fp9df9l62NFg3J2c3AL",
-	"ZGYi3zrs38Uv5Ob2g4DFl5sCUp2m3inUw9sk6shEUId9RoVOMKagCpLZsN3te0yhFWgDJwMDFcsfQzZI",
-	"QQvHQyO4g6SwSp9m3JhRzaLhDRdojXbsQDc3p1r2Ga8qqEy5BSwuy9nY3XdnxZyXtfxwnsS+HPLjKCKE",
-	"fBLCMLhLssJdFXrCl0bJZ9zENqB+8H2mlSXDh3L4iirePF8lgIYvDp+zKVB5PB8Ggbd6rJk1XnqZMWQv",
-	"o9EaNuO3wKSipXKrjwzLxmV5mCVe7NF5kQqTqFvQaIMPsqdpP8iokOfANX2J7piR5dPRwO9zqMIUjkY6",
-	"0rafi0e/4sBf42Q2lhhwLX45Z2TNu+XFv6caP9GGsUZLtcNYt3f1+wKaukGcgeUie6RXDccsaJ0sazZN",
-	"iixj5yienLzwpryPZo+jTE23eBxcwy/V9CujfLaM8hE+CjcK2uZWF0XknoiG/sQwkFZoIBMweaUxxBMv",
-	"xX0GgVZNsCAXUkyEO8DFHMjcjzBpjGcZ49bCPEdrdwdL/Mqo2wzxxwxPut+qsbDfyNHwG0upTNq9GupP",
-	"vFk+Jd6NDfDIvi3297q9vVTJY4O7CaqIJC1kg1n9uMmm7tbhqFqFZts6nue0kRoG4GNkMVzV9+UUEsMn",
-	"pMJoWK/Ti+XZ3LAHRqThVmFYr+z6Ij26ETI9jArjlc4mEcUZcGu1GNNoS4+918SmWrkxj5eBavxssc9H",
-	"4hHwLBTxTs/j3Pwx4hz2xzWmOVz3Eewp+XOt5srCwOnbA3yyESHQvet6eqHV/HMLvOok4q1ifspE+V5j",
-	"/zhx31F8PwggnptKuRs7RYY1xF4EWLvSKzcppISsXCYwTBV2oCaDMZefeXbMdaEx0Iqng5lK6mFfWDGT",
-	"s0RhZD3K6Zga3E1oHROvC4cVWpojnlhxC5vuHCf4hhvhV9Nukz5SaLnNSfDs6bfrk3itMP8F4xXc4j4G",
-	"L1YUfRgNnfWePf2WAt2kU1IiOvwryJOLLnT4q/vPRbr59vuYaXBN4iPPi7SqOPLs6TOWUORnoNaWeqW4",
-	"VDuMtWNXnxvbfPYXXrcRT8y6V21nqj+qbkGb7rVf6f+T0n9TdmXGl6EZYRgfG5UVFvxFT8gU7lhvISTl",
-	"ybGX3NgB3vgGF2eHLSkdrrmDjdmJH9npXEgxL+YHx4Nv1tS9/sHdYKoG7teBuRH5IJivB1ieGrR3fTRV",
-	"dL46Z7ywalDdtjSYYh5qIB17e7Wx/kYs0vimZ/jiOdM0OfrOMD5Bn44dsjc5/6WgS7T7Bq/0OSQ+TFoO",
-	"ZDEHLZIS0MXdKKcSs0h7eHWllr3rCRePrMDIPQxXC0+ssbIz/DzXYIAKcjfG19SW9SOzcLbYP1YIgC+8",
-	"7Z7EwFuu/Yq66xbKoRBFh032mUgH3kLwPLq103W9gc4fm/g9sZYnM/IfehFMrOCNPj1HLZ6y/kg3VstF",
-	"1qaX6IQPcH19xu5mP/Vlwk/cy5f+3S3yONAxnwpJjpOyhFYX32L5ciueSHv724OY+Z2TC5GZD/18sRPZ",
-	"m3SCLxk5hmO9tK7e60zMxSaA4o8exCe109d3/zHHdFyenhDVM56Btj4x2gQTZ5Vw8sQwpaf9kL89EdrE",
-	"eFmr/LAtBa7+/sFDJqDVu9rJ3vDNA1HM4y0ZgqH6lJ7aTDqsh/qC5NmRBy5FYAeQ1o0dUoL50M/JrLGR",
-	"ghql8tGv9I8tl8Q1+tooni9PT0psg7YkDt/rLoASK61+yovVdnp7FIGLHgOmmdS2Eo+5EVm2+Ry/olce",
-	"EkjR9XBF83rU0X9hpcKa+6XbJunxtQcV8NjDhcyLTy7VsWdy2LcFpj8GsV4mGieFsWpOW9200xVTHYk5",
-	"smCr5+UCn2/ffEId4toeYa2XlFucN0iydKOvQmQQfXXtg8iidVOJhfIOhfOugE60G5f1qJyhqRWvy7+L",
-	"fOAWWIMxkDIUJTRpZrkec5xD6TIZY/Jwk2odkd7fqa8qpJKAZJphW++PImnZ21PeHwM50hwQB71xIzaR",
-	"pVnKpJ0or5Yy+VQSfykTSll5hALfDR6rE9uBkF7ysx6ZynzKv54+MeGJO46ZmLC5MO7APtyyRwXWo+xw",
-	"Lr/zLz70XlE/j/lw5rdcYKTtyq6xolzCTTtC6OIkGDOwsL4nZ/h7EOcblWl8yRuEN9ibd4Tibmr1vhVq",
-	"nqaCzJ5v41PjQ4MMf2REQttXnfBKMzrAIW0/7fvtyZhfNh18pMr3OG5W7btO4SXrh6ff93PpBE36mW//",
-	"fpeNZgng7Zp1VRL8MlSW/7FSGXC5pgiGN39qlCOfDg3p8ZMukZ6TXqkwhHq4kZDbi8Q/Bgn2ULXUd70v",
-	"f6XAtVrq3a7KheFTKF3/kb67MmU9HSxEGkAV8CvW+8Ozv3xz2EfHXsJ1ij5Q31RICnp58cN5WQwIYUZ1",
-	"6iPhMLxXSTCsJ5VveMYxYOeQ8LY08Iz901N8m1B75ZIZIRMYkBKYlk0jaArl3YR4VwJtgTSM1sww+tVg",
-	"RUT62o3mcMheiGmhvW82ExPAygWmmGP+Ww7aEEJmDnqg1cI3bJ6zRBn7zqT0qrty8LkqpDVl1DO3LOG5",
-	"LTRgkCnrnZxdDp4+/eYbHMYcZAoeP0YYJossC7FJtWQqTu2to2hFCc3v3BwPHj7LHPt5zNcQt4mBaCJi",
-	"bskTxrb1bZC9hc4Ojg+OeC6Obr85+PDTh/8dAAD//w==",
+	"7L39ciM3ki/6KgjNRjR1hqTaHs+eHXVs3JAl9Vg7/XUltX3PHfmaYFWSxKgIlAGUKK7dEfvXfYAb+wz3",
+	"wfZJTiATQFWRVWSRLbWt3v5jxi1WFT4zE4n8+OUvB4ma50qCtObg+JcDk8xgzvGfJ0kCxlzCzwUY637g",
+	"aSqsUJJn77TKQVsB5uB4wjMD/YO88pNrVJpiDvo0NP6Gz8E9sMscDo4PjNVCTg8+9OOb77T6ByT2Im1+",
+	"SwO3kJ7gOCZKz7k9OD5IuYWBFXM46K9/IppbUnp6BfpOJNA6pFyrO5F2GXx488KYAt4U8zHo2gCFtP/8",
+	"TTk4IS1MQa99+V5nG5vfvDbhrWtublteMZbbwjQ+KvJ0t5X90D/Q8HMhNKQHx393y9y0if0WEljbgDi4",
+	"6iZXh/VjHIEau8bdoE8SK+6EXZ7fgdxOmimYRIvcPT84PngrgeU0TsZ9OwxcQ6wn3G4crBIzT6zSLSuL",
+	"z/4mJD4FWczdmhQG9EH/gE/d6H5cXcH+wf1gqgbNTW3gE7+MjU9B3gmt5LzteQsz0Hy7UaxKkkLr3XjQ",
+	"8mljv1bYrHma9EO5lCaH5CdPDI5W3J95Mc6EmeEPecblTylocYd/Wm5ufzKWa1v+mUKeqWX594SLDNKu",
+	"+9JE7vhKde+rm1dbqU3E+xIg3ZF2T1jOp8DUZIVyDcuzwjA7A5YU2ijNJkrjnxLuLeupLAV9iB8P18hb",
+	"WJjX//FPGiYHxwd/OCrPhiN/MBzVWe9D/0AWWcbHbjutLiDOl2vNl/gc7u23MFEa97U+n3KlGsftxvuC",
+	"8bFxzLmYgXSPNDCugUnFcFZ+AYZN5Fd2Tdxb71ykoVMrYKyB3673Ptwu/3DRGvc5z7PlqZKTTCT7CKmJ",
+	"yIAtZsoAG3MDVzPuJp0pOQXN5twmMzDsu/OTs/Ut9e83CxK34tK2Pc65nTU8WJk1vtWP/dRa3boWZsfF",
+	"4O7jgVsOw755/hc2VumS/dd//Cdu1aTIMpb4lpkB+4JJZWdCTtmCG+a+FZCuL1FSHUw3yq/t54dVSl9Z",
+	"obL91vXYT7VKIQML3Yd9hu+/zbvw6hyM4dNmybzQYpduf3Cvd+n1Q/vymCLbXfGcz0UrcSMNdZ7CS5HB",
+	"a7C8y8otuJZCTndYH/qg0/rU6SpMMEynib6+LUSWXsi8sBcW5juuIc+dSglVlWGsVAZcrikiK1Jr4abE",
+	"4htM8ma9IIUcZAoyWa43chaftX5+u6Jvwb0FLXk2cEwn3Ekef3EKA6kJ1qksAw1GFTrxiujAkCa6rgyg",
+	"JNR8Dhb0Bnn1SxP1uj5PlbRtyph73qby3/Gs2IFET3HC37uP9qEkv5G1DfHL20pVr4TZ9TTLhLEDr3MP",
+	"xq4RwzSYXEkDUZDfgTZCSZZBOgXdZ0oCA2n1kuWgmfvKMrdy8UXLp30mYQHGsonQxjacg9hX59XE+V0V",
+	"8znXy52X0/fVvm5qeu6msyMzZnAHzaSSqTbleg7G8nm+/Rh3TWwasNlDbdHAU9RQcc/SZ4ZlajpkJ/Qn",
+	"szNumTDMWJFlTBcSRYYGW2hpGJdMSLcz7swqaYTLlJTbTDixomHgejFsotWcjZy2doqa3OgF48yCngvJ",
+	"M99haBruQC9JMRCWzbhhQiKRJTzL3PjWu0241kv3gVRIigKMG7obyUxJR3c3B0HZ0GC5kJDeHDAuzcJR",
+	"sFTWTQi0VrpJAaHu1iXgtS4gqrt+Fq7bMC9aDWHqA3WDq8yRNOWFW2T3KxuXnOZX0ViVG5arLBNyOmQv",
+	"3YayOXBpwgKvr29FH64cCZma7shkkRk6XiCo+/WlOs9VMmNzkWXCOKIj5R1FAskO2n1IX7CcG8PGPLll",
+	"3LCRETKB0ZCdVC4XVb0xfNd3VLKYiWTGEm4AO8g13AlVmHB9MJbLFG8gHa7RVlmenapC2k737nWGRUtJ",
+	"oJ1W5n2nYZKJ6WxX/Wm3y2DsBbWMTnsJqUG9pEm5WJls5eX+hnsWznc/XVq4xnck3VKr2ku19aMlxt1x",
+	"uBMuskLvoB7gWF/SV122p9le0z6NQu6hDZyEE/yZcZwLxjoprAtphmwUfyBr6ijI26DAsVtY4g+WO5lr",
+	"VHYHKbOK2ZlWxXSGz3QhmVYLg6cBn7KFsDMnw8PvrlHOvnn+TSmj57ldMqenrAvqlSF1NJe5+azLqzck",
+	"m9xASGVhJ5U1MACGXZ3/n+/P31xfnLzCNWE80coYJqxhmZiUUhx1ocqZ6q2nVV2q7/6QjMsly7gF7c5W",
+	"kTp5x1OFQ2JCWsUEzroTRb0Og70s5PcCFuv34A1UVGVu91J/bW39urWy+ZX119Md6A0/HBj3JePTqYYp",
+	"t8CUZN5afYX2Z9b7w1f/8s3hmjpaOVFqxOpoaKH0rZDTPp7IM7WgjfAPU4XH6hlkYgyaW8iWLHFyfzDR",
+	"AGyALSuZLYMuQRcTUp1y0INSzzW3zPIsWwZmaOIfJdlfhf2uGPdL/QBkmishUd9y5zykjFv2ZzNk104N",
+	"UNKozKk7MgVtaHBep3K9oNbuOq8oGsIynjnVwI06S41T04kaCz3hCdAKhFdyvjRoUxMNbFX6JFbNchmw",
+	"niSlxWn9h/2gJvYZ2W77zBRJApCiUTfcAt2HRECSzLne0Ns/KN/ubIz3S7w+vCvHdk6oeGOrBmmPMm6s",
+	"50Uc8gt2c3BzwMSEVeax3ZYYOo0+kXY+8JeU3dVzUou8qlS/cyHt87VLVtS+3aBgRcuq8wTuvlOtHWdA",
+	"6vadnYTWUaN0D6VimbgDfGmSqQX7uQC97DOj2M2BN97fHPilQxOxYU6bbdehNzklWs68xv3/H+6b4bX7",
+	"8EO/SfCvKOoz8ExXWQfkvJJD3SRxunjfCNJl03FmmFX9uOgzLh1DIDMihQ3wVEDtn6dsvOyod2rgpome",
+	"r+m8fFa5X9CryLjcc1ykhx6dlMpdLxbCwGE/sH7KxmBESiryS/pqzNMpuHnbUt40Wur9ru/iWyrlR/QV",
+	"Rb+PkD/lWk01mKq2nJYy4cfOzqqOx1Z0YpYzaWLeU7x6XUGiwb4tbF7Yb1W6q0kgqTSyfcS1txvHpByD",
+	"XIFxG7z3oGDORbOdQis1b/GeFgbaPZ4L02wkW5mfbz68X2m07wfVPunveSYckT3CrOWGmAE3iDDtBm5U",
+	"av7MBB91v9RyxyQqlOZJBv5u7oT14KZ4/vxPidJT/Af4v30D9NvohedBN23mzZ6sME4s2ej3MgApyZXe",
+	"H7766pvD7UeWrC50fXLNy14xHu9iki6swoOv2SbtHp+hm7fFZl0NH2mwRle2oOm5MHnGl62EGtQsT671",
+	"HX1XjDORsPeXr8LJGWxeKdwx8k3PQdohe6fyIkMV3m3HAsbkvEq4a8mgqhidoYW0ImPBs93s/OxIgLsE",
+	"iwTvfH2KcVPZrZCpE/cn5++eGZaCEVPJ7lTCx0XGNTntbg4WMB5UpnZzwJR2Jz8R5c0B66F3k9bINTH8",
+	"h8GzNN5Hrpc5HA7Z2xzk6UxpUMgvMBH3kLLT6lvoQzCsVy700f849KoFz3PgmjRYYdjJu4vGhSwagyea",
+	"+GAjxZOpfivdr6or6wrPlniq3SOlQN59z3V3q8I5vt/FniDSvSjwQWKSqp30VxaunPMuUUdxK6OLKkin",
+	"3VTwOBbkkbIpslM48YvTxPcKJw+II4+8XtZDXZA4Y1D9vry8elXrmWFGyGkGZTfLATVGUn6uUsia1erN",
+	"VJaurEBHT3R0Mu3tq/LbV+t/4151MlB9jA20PNJ2nVS7STO26STcybuL3Z3gW6MuKzKy1UnZQblc2Zd6",
+	"u76V5hk6afg3WO4c/TDhRWbJ47nPYX4Ly+b5rqrTbVZp18DajOrXyERJq3lizbCcZuWNgZjnSmNfFG1z",
+	"MBV2VoyHiZofLYz6+ohD7v434Lk4cnc4LXl2FFvFIcWWz67ffh5rWJ0UmhY/r1m9czrNzoycCjl9lc0/",
+	"Um3gufhby+xWYym4tDOtcpE03JFX5+tDH6nxpplPhX3no5M/cgbEIa/UVMhO06D3G+/57tCrvppz2xL/",
+	"0eF27dcA2+yvNFWug0jzj5w/Rurqxqn/Y3Fr2sJJVpcl2J3ctpkp1ykoDN4zVs07bnjT/LInSqEfNstx",
+	"pacUUTSssvDHS/KwC0exg4pI914JL6X2FhZZ9nZycPz3zbrLq1evK919+HF1lxpYuFO7fy0/2ta+Z42N",
+	"Xsyzd9VWSnJ7mDmuutizOSoyYTHrS0AD/nFHuin7f2TiiaffDnTTdu7dtZykDadeeLnl9MM8kN31lKRL",
+	"/k1rYsxqxHItNaXacOOg8VKIyTldIwvq9zz8lFlFUdzeSebH8MzdvnI1ZCmkRQ5/gyWb81sw5MJFr2wK",
+	"81xZkBaD31QOkuEJwHoZH0M2AJmoFNLDPtqKEiW9J4rxDLT1TgNtGiLivI2zQTvyY2mONXO91u9E6wan",
+	"bcEFLUkfqxZ2fK1PI23fG89T+8ZQB2vQO5FDJiQ8imFwkwlunttm829hQD8zTEhhBTpjcGncWPF6v5hx",
+	"64hpyRZcWu9ZZO9AG2EspIybNVIrG+AyZbciuTVMTSbk6MPcGaK6MvthETOkKCWK/eF/fn04DA5zE2MN",
+	"FsLOVGEZZzQjdguQM6tSvnxm2Bhm/E5Q7Nu6VwBy1WwDv4RcGWGVpgDgOKxySt7n5pp4wbzebygIpMzt",
+	"ct/2vcF8yqX4d89ahpGZ0IC+Az1Al1Wc5VddTd7thHmZ8JMpSOumoe1+0gOD52lomhrw3ji3NZenJwNM",
+	"LfPMrrGjtuS1JOPGiIm3ta6vtpMjAwwy7TM6TsJfc7dMfaY0k0pS3IkBG7wQTsQ4IqIkt/6uCWsxKavR",
+	"Xh+ePopbNxV8KpURDbEHL4ssc+vL4jvsj8zxTiqIehIK62a9Ode3qVrIw8bwdmFyzM9pmR7u1Pl9Ajq3",
+	"7Xl5G8KNWiYf3L0rs6evQrPXrbl3YksuKtJ54w25jEbonOrXfDwf9KP8D432V0m4uoPtbHh1K7IsRhru",
+	"cDa0Cm0NE9Agk00231afSTU9wI3sdVefQvl+41yXSQbRMfYRdmgKXuFOlCeuzWeGzUFPgV19d9JnPsGS",
+	"fI7Cmornhf3gozguCzlkI7Iuj/CkGUXH+whT9kJ01DPD1EKynAvd96HLGGAw5lbMUc7UHDveYI0xe4mS",
+	"NEV2ScZwWjqmuZ2BOya4dG9lyqCEtxhUUh2Hj6CKsQ4YC4aDDSOfF8aGsB1gOdeGAgxTSJw85pICrNdV",
+	"K24tNJ7qX8UjbMLlQBVxvV+wr0vXKxnqeWHVnFuRMA0Dq8V0Ck7ua0j9Fk3BmqGbfYpneAh3dLTyzDCr",
+	"ucjcgiiduvn1feyyMGyBAeHufT9QCvii2JSOQSQ4hHbPdYUUnhk6vN1uYuR13F+r3Bx8LEumpgbjsWPL",
+	"o2HbYUIhHNtzkjYHl2xwd26bEL3ZL6fSG70D6e6Joz4bXZJbd4QnJjlhcMz+2CCyfWY84XbQM6r5OeXC",
+	"V/PlK3Etgfg2C4nHd4aU8ujhvCExg3G3kW9Kgt0hy7V5RNX8tZ1in6tCt5BiIpyOdStkOkiFe9OJJada",
+	"lx47CtkbrngBnUBtcBWOl6jWD0/ph3KgPsrV8aP3fhfWSdi07//O4xWid1Z63RmmfQ5QTGog7d/OYH7Y",
+	"4DXkMsVomn08gqfh4y43ySS60ndIknNX2w5tb/USeGvkDpc9nty2JdV2zTFsGXVJkWV4X4PeQpHFG119",
+	"75oZYmM0iLHLLqqdN8I2X5vaHGdn1YTEh/WcNRHd7spTjJ9nTuWYj8W0UIVhIfG0wr94BzcqK/ADAw2x",
+	"0NuIbi/a6rg9QcvEt/fYn3IRH2+jriIR7iD/FQb1faTRCgPZm5WOVs5YWeB4XlNb/TiwlpMlU8t90hzo",
+	"y53yHBYz7o4hDMYWEgPSnCqsVZapwrIQQrshQGTX8JcyVGy1k6gIB0sm2QDW+4470jXZbp88O/owbFnT",
+	"Rq2HH0slfWhKppZkhKhAz+yGOoMGdcdVjTab7+Oz7TH5Q3Y9E4a9vri8fHt5Fe4Lz1AhT0Via1enicpS",
+	"SpDFixNux0zkzPCliZZHvG8kSiZZkUJ6zDh+xhaqyFI243do9nbKDNcpG+VcW8EzpyELSV8ZcQf+hlhI",
+	"sl7hFdEyuOeJzZbrGSWYCoiKR3/taknqi+EidXccnEy4pOHVA9LhjbyeaQD26uLl+en/On11zijP/phM",
+	"W70wK8pOsE6xSmbuUhoXukxCYT1e+Z1RcwKj+ykXknQsZd0FGrIl48Rgrv2QiBbWfgn2EOfDF1xYIaeD",
+	"ibhnvUrzPvw+ZAP43CIN7vLsU5lD0BdmGpSjwPvy6duzizd/pSt97S64rGR0UIik+1u4RZ2DtNR5lTQq",
+	"S0HpQ9qRGvdXyjChcDXCV5b4eF7YApOX4N7vPSYEiDkgjYWkW2HYTKQpSDaGmXBLIjHJYHgjaRNZD7Ob",
+	"WeIUUu2Gh/gudF/2S0RvHvaZpzrWM2oO/uc+bXZMIXJPFu5OTASUqDvQ5FKhNe/xSl+uBR26yZSxh31W",
+	"pWfWk4pZzO1D2BKDtpQsO+yzksbxpcK48yZYbT1LVXa8bn4huI/DPjO3Is99EzxJILdcJhBGyIktYn6f",
+	"LqQJ+z0FizS30sXh8EZWqKsySvdrpDbMUFOuK2FNtRF/4zS4ySYHaY9dhxmUTzTMuU/+wNRLpFpDZwwM",
+	"fFtg+v4Xnpo6I/hv58AlWnAdG8eVc3oFbTroAc6IpWDd0JHdvMutTMRxIzDoVeitJNPgXWZFipdZZNUR",
+	"YYiHoyX8B5JYNc+sShAH/YNyScmK5/avMdJke7JZ5Yiu5JZ51tkQBr4twaxfPcprh067cjLfPXx/x7Dl",
+	"bRH2O8PfbbDpZsAN7B4L/2Hj8jy6naWyEw9oZxEmUVJCsn9q0o46ceso7kDvPYa9QqVWF4naKL9oGqmP",
+	"g/9dRVuca630jkr5y8ypXu5DBvIOMpVDxL9g4yWhirjDc/D1/X3MBW66FaQNhuHXPJkJSYAiePJRT+5l",
+	"1jMWfzJZMSUpfM+dCnJwXBFFP0X52uBFdAK/yZEnIEvJkelPBbpgVM4vHIbpnPiOC3uGTTXlvFeQ0+oj",
+	"+a6Yc7k6ef92fcbB04vwdqhQ4mg72Ikx9jCMoJUq/OD3ASIsF3N1AdepAN9eX4dXitx34a6iJhOynVPz",
+	"rAfD6RDnPnTS+rDRDdC6yj94VKGFVtLjPaC/xTW9/VikIW9ZwntI0IKzR2jyXjk56SO5v1tyclrtmpss",
+	"i4XcdHLqx0rM7nrKIPN482MDynDzNpMp6tIbTfeJWtvPOO166mb7xnC6nTDiYgDeAxjAW3SpZqtiBOQr",
+	"h9206i9FBt8WMs1gZ3+KAetECqGDYlITt+ztm3N/cxqyCJgY77nc+h9f+KMNHSzPDDMzTtfmcabGJKi4",
+	"ZYbPgVkNzfgDD4o2GVADHwcUstrDzjTdimaYt3oOGpelGUg2dEBftQ0ewTh3G/mOo+sfGPHvsI/F0E+k",
+	"bfjNEdE774JTznc7SLYlTqC9QNjl6YzL6a4I+/TpeWsSfHhje/et54iQxvIsQ92B4nw72H13yAbJuLEB",
+	"BmCn2a+mkfA8X8sAqYZPwd3F1tUwkOEGYwjkxzkuup6R9QSWilmgpLXO0e7NRP5oIe/1vIDdeGnGzWkz",
+	"jMZqnN4nT7rpHwSAe01D7BLe7rdx7d7a1Fh/bfadd7i+5I+3s3OKnd0PADrnVoxFJuxyN003Ewl4UL7u",
+	"FqRG4OcdubVZd/JbGjtoOlZqAH972uQ2J3gvH+i2sDLHGuCw/6hxgo6gL+RE7XFvpaBujFnMhLFHBrhO",
+	"ZkOGxgGvDXIN7PTk3cX1yauL//v8LJiNF0ID682EsUqLhGdONczJ1RGsrcwR8zzJBxRITpGCFGCToluD",
+	"3RxMxP3NQSVKPlEUl2chZa9P34VPvRWyIabm27Z0jVcPkJCxE57hlfVxEmvdtAcUv798tZ0SIoTStQ/8",
+	"xTnTx6HbON9WEukoK5qSdOZgecotZ3xiQfvchpCck/6rWzsPi8tlNRUnWhnwglDm8gT0O7incCp0B+Ik",
+	"jwqdMQwjZhF1cTUQBDttPo6kSqEFSEnuspVFFwuoDNtS4Cni+25a/3qC3SdQaRMNqEnxbLXwDs/FT2Qh",
+	"Vbyws5+sugXZeMTewvIVN/abtkzwd4gm89H5qB+hX24IvCqNcNHc20k7WFm46kQrK/KxWmCdHh5NR3gl",
+	"JHSJklmLtBJTed1Sl8jkkFx3xsBdw0LdAyy9iAbRMmojUyrvl+KFfJsaEqVTb76Y81tgRY4uWUc/mZAw",
+	"ZK+Uytm7t1cX1xdv3yAEaRV71CNHOWkkbAT9LNE+OXqvfaTAGBJeGGATcY8+1lhgBZ8jQDi4/WHAdSbc",
+	"6Tfj7vTDWAZ0s0JKvzHHJj44JBNumunATbAJrD+dgt1qJ7ks5Lf+zf3gjmgKDdUrsjSWEsBlwggaXHbM",
+	"wgxZPZ1dBpeFxHjoNpzcT27j3Q/JOH4VD/r1QPn4Tpmdh3k8LAATCyWH7IzyJSmmIISt0EETEjNuYVli",
+	"X5YYvIL89752hH/XKXXPDLN82ugsUFr4e3a1mBj5/clZj8aHQcBCbhTfj23GbljPPOMUaOSnORFZxhZC",
+	"pmqxik5cQwCORRXGgCj2WlgLkvWmjrPZ3O1o6hGhUYExDHuClAl5OGQ+zCH0WsixKhyB4gM2BrsA8KEj",
+	"GFoCGjCGhmIQVGEj+GcENxUGA7coMqFyGw6hFb7LWrhFFdk3Ov4SLhPIWoE7fTLPZQvE6Q+zJePov4yN",
+	"h2iQPId0yM55MqOIMH8rCHFoIV6o0MAwC+2FRwqnQJdKRJZrvVagQUknCKv9NRJpPcxvizQp4/6aXR3r",
+	"sKQrvBuZIhBfP0rd2lCikNzmLnlbSa199KCHamdBpj5Q6MNa04/u4Hu03PJNtT4boQzrIsq9M3z//uKs",
+	"s+Y2VWqawRE2/mF1yfHXfnQHbSSmd05feG92D30+qeSGF+57ZvJMYKry1dmrU6+I9P7w9V++OhxS2juG",
+	"mJgIpH/ksSoprxoLxrzwCXeVN+mHPzICB2EQXMLmRS26rvyg6i2PL3t5g44mrF73noasGPcjTbhkKUw1",
+	"TzGWFm8xhmqUOI0PSxhw7WQ01vlpKm83DjmhmxiK1roC9tbp5e4iy3+yGvtDJbnCObwl5uydP0wuK1ks",
+	"ezllf5de0/7DZCnsWaqsK7BBvczLR5gZ9ywXt69Lvdsh8dHl6LqmjHUvVxf/jolF1R8LGSChP3Vluy2p",
+	"ZDsVmKuvWzPZRciBfc/iFtyJ3w75BfXLnG+oPq4hV41I0qeZU0crQNI1QBQMiybYlHrJXKnwEdYA0epO",
+	"uHsDpCVcyE4KxEdBIfv9fHQ9MdDNR9YWO91Wkdj7CrD4x8cWC67laO2RVIXJvxVlBw0x2ooJTyyleZg9",
+	"lYRK3Z3IP93CkysfOeXqqiXR/ubg5qDPUs0nts9i7dEGwpxxQ5nJzebxGTdXddDa+sNrbm5N81Ncs2Yk",
+	"ovpK6kJOCYr9mEk1cIzVR/YaJJmiEjX4F8ZG9gMqUk8q1DIP+6R89tz/9x1n0soc9hnV2emNlZ0dDtkN",
+	"Vio3Nwe1un/oWoJMYMwSpe7EwiKleurGS7tUZgGaWu4PoXzwLAPNzAwtc2QOZLkj5aATt8I2odH5dVso",
+	"5hV4wUOESNlKfkVam9xMGzlFivZZZZF5uuxTCGpbm23u+S7KriOkSL6G/vgY4l0NFkJ6q029HHNJyVWS",
+	"r5BwbUQr3NVfVa89w26QOailn3K9D4RMeQRlYgIIRUBXKLqGhStXiHxxuh5UjM70lrvPPItGYw/fZbJi",
+	"2qdLESYSmkLfEbFbU+kWq2ELJZtcaREwpK28ZihEFPoMRdWRA7JiihxHrEHIapxNNSwhxSE118Jc0QzW",
+	"TaXVHt0EvE3UnZov2IRnma9S6eHMcBzuDPLzCZ82V7wnM/zWA7K8aG8rSPKugqbGemdvrgYIBUgR+25J",
+	"/Lb5s7Dc0OZSCkFk7H5rrMP5V1e5H7c6dBDXYRvV71G98K2eDhYiLaeaZYMi95TeZ1YgrSBYGt3NB4ky",
+	"Nu6ady/03I/vjZPUxh0LaJWN76Drh9qv2VMTlNVSueZEAqw3XnrjQGgCi6f90/OyKaecrPNGeLyrSlWK",
+	"im3l72MPLVswVxZeajXfCWJzS1JZW6o5ug/IZy8M42NV2O7gO282aLOkTO9TNqjMV2s4U84rT50YiGo7",
+	"63mww2P29xQwU8e99ONh1SO1n/Fgy01wTSjQgCjFOlwmWU/dgdbBDeBNagGfsYKU1wq//KF/UIdP3NUQ",
+	"KBG9z2eIxmOmglZ2dXl+VAIoBhDDXqiFSI6RpwKiuJfZucRdXPWSgM/2Bp/DTMk595gVPwaQZehT73vQ",
+	"YrJkL8U9szMNZqaytF9Nen93OcAE5vSw+ZTcDvD4+wV0bF83bxgOxBWWLX4dL5OZkFgfkTB9kZadFo9/",
+	"D9z14mjOZcGzQfgWS7X4sk+czYo5r7Rrmhe5xQu8ij65or7PHOsAPQ6WBj9c79nFBtaMDD4oikd02MaQ",
+	"8TqwZb3ravPBLRyQZusM84LxzONTOJUYqyj2DAA7CufO0S8VheHDEV6njn6pdP/hsD6DKjviJIiN3V50",
+	"wMb7DRE3m7bPUbx/5UW1IBCzupAJ+oPxUJwUGmnXkWUmjEXNrWnfOqJ4VgsvrZRW2gnWs8ZxFaH149YD",
+	"49GNSyvn01OyMVUiZ3Y7VssaoeQtJuRId+J7tGlT5KDvhJvKQiuL5/+cqcISUuUA60yxsVK3twC5E5Eh",
+	"kCFTKg+Vh93NTi2k74SCiQibg7Ah7AwM4OWoxZR1CR4xs+EkuCwk6e1USVlNKlCbZDgpATd9gWRCyBOW",
+	"WwKUgAFCTQSawL+uvjth08JdUDHeimBSPahHgO80wgIdjl4jEcaLt46wmyH66jRGLnX5yL18CggH2iAn",
+	"JM/NTFlLw8Uwl3DdRsnHEkwIYgmXhIhjteKJW4lsSQghJa5N12ng8K87YzL1Dybifqc5l77E05Ygrwp0",
+	"0sn19fnrd9dXZXiRO7FVDhLSITvZCFkSA0DwZsEKtJ45+uVZphZcJgRuM1cEeysxkoSCiEPQiIFsMpgB",
+	"R6gZx/8Ig2vVYafVXL2uVJZ2Zeurq7hGSv01xmlYxBZZUsa27W43imqNu+oKyThBVX2ruUxmfZY7tS3k",
+	"w/e8KuD24P3lKwJMiuDE6Ah/dX5y+eb8jL28fPua/XD+7Xdv3/7tKsoYUseIOStSBvtiIQGNVHNF0PrG",
+	"8qWP9ME4HgrBXMyUia0JLHg8cRvsSAbVvtq4WwGCG6jyLGpyTjBdf3dx5btEZKoS4EZDqRCSlAyGXQ0G",
+	"CHTIoyTh+xjCxfXysCu+L67Jw9WV/MTxjf9Q40t3cjeZ3SpKuC6kBM3+TY3XQOf8Fr1wjJ9hUWslq6ve",
+	"aNVa9e/SLaDCbMSDbbEOVXgDPYXLDYW6iepzlQmElXRkvMCoYDePET79npC4RiX1F1bRXQwhrAMaEvYS",
+	"sYpnylCtiElheDZkP/jgQao64I5f0HSEESB2CzqDnrYi7lYH1xyih8I0oF/VJEAqUvbm7TVNv0/6ehl6",
+	"SMDcKTPqmI1SSDIhK0jflenTujHDl+4z5KxqL4Kw38Jp4Gu399kIV6XSpFssRh0h2/uskLrQ4mXMNJXV",
+	"j39GSxSFZMZoV1T+vKRR+tZJqsMhO4l6YF0M0ZTcTYVUpLAKfMqFNFEuCILpMzWxQDHkeD0/Ztw3hY6a",
+	"ROmUblujsJsjiscFnszYxF31IxkxdQca8YHDdUJAlnotImxEfVmw54xb0NSrYakCWncqHVJiyVVjRkNj",
+	"6CXBzWhJsj3TfNJAXhf+2A3zq42JgmY5OXH+D3ZC/4j0g+Le04yIVDIRUpgZ4chFIC4/pbpugPlD5EgI",
+	"q+uD68OGGmHR1hKA78oBxDL7TMhUGPdWIcwMkWRQl3RqRfVYIlogHabhPGrwfOqdYsFz3RiacL3CSxHh",
+	"fxqB2BzT9MN9YQHjmVK3LELOeRjDgMQ3zxHAH6fIKXzh/eUrn11A6kCprOLFNhPyloHA22yFTf1AlCbL",
+	"r8FC2+d4sAdbyqoMMACyxU+JQTdmSwQ87cSA0BgpzrpdsiUZF3MTZfWKfJ/7A8uU57yo4HB6hMBMGcCS",
+	"AJ68aF18b24YjrYM2LoLzQ+NYsWpYEIIbt62MvGe3AWBdeUyXJ6AaPlvXstK2CQJy3IBUeJVznJuh+wK",
+	"UD6uAhySnz6ACwbOd/RFulQF3NKDHJa6uSKyI9vTXQ1udWmY5HdiikzonXRhlNxd8fgcvLj02kRH5avs",
+	"ZsMxyS2ph+tAjCUka7+0fJcok0HtLeV6p4Ur4R+rlSMMWJuBvyYjHCxW8TDVTCL/bok0+yKKxJlaMF67",
+	"AOGiz9TC5zdxGROLQpeUC1BLJHhwJMYN8EFRd98WxHxZyHce0vj8rgvSyvrl6OrqnMioSpIRJ9lYDXw+",
+	"ZCPX9YhVqwb40l98mSmeHrMR7uYobg5n1Vsb6yUIAcCK3IC2xh36IvXcQslhKM0SxzmEXI4ZfSULHfbZ",
+	"yB3LI3yxMvFXQiKtaDHGuCRMdjUhtwzxe1PlvquVYqGUDG79rcfnRqNbk2Sch6x1028qP+Ba3zUlKwQA",
+	"bvmmOrENmTvX61PB+ifucoY6XCll/ALgNjeeNtaHWMZLBU7Pj7h/4D5vBpN2HwzuuMZIQ/flKkVeL3M4",
+	"9a01PXtFPTQ9OsNe18Cy3Ri28MIrv9A7soKbLdrq4oFGek6mpseBNSTWy4v8ESEMexSA9CuzSmU/FfjP",
+	"qbA/EViS/yMvzMz9c/YTJ+r+1bXNfvUusEOWZ4UJsg/pWfgdDJrHVKsid7ziIdXdKU0nTK5VWiSo3RDV",
+	"LyquIkTGpckojQykJsgl6NAwxRifubOuKbp/wz1dzee8BZwBh3XR4MO6SIOnJ1wQhKG1H0Om5BTd0PFC",
+	"uSYRbmE5bM20vJAp3DcURRqMudPxMGg14gLycAMqYYNLJHK/4AmXjIJQeBxBgFiYeQBzVDJn+DY2lwlj",
+	"d7FShsTy+pjdryvj7HmX36/l/e5XdJr+WkXMjmsXxovjb1yztND4zesGPXOElEyUOfJRiO4sdVtES8Sz",
+	"zJH7bZ/NgZtCl54zb/QIeXzxbYSNdrpBYRPlMbndNSfcG8l0bwstuVaFTDuuIsyFtU1Ovh9mqmQM71uE",
+	"qEi4IWLcjGGjwAOjKDjdq2jrWHBU5qgcmcTEQ06M41YIJ+ax3ehiBhlFItYZr6pMuF/RO0V97i5anYA7",
+	"p0m/praaH17FHspVumh0KztBEsbTLy1VpKGRrulU18I65jRutjxzmh5qa4HgRORsX3usXKE+8+ir1DS3",
+	"sTd3b5jRrWoCVROEWyUfOoF70UjBflKI2NFiiyt/WZWFU6wfUB0M690cXARcemZVqgY8F8znN2yIY4cW",
+	"bIT+AdwLe9oIVtvEYT7UPiHlC2to4InkwdPNDLKwoL5aXFS/r87+5m+go/N7YQn09s3IB4ER5Z+sOKFx",
+	"fxa+EAH3zdN2unt+0OjZ6KZ4/vxPSTjcfsLp4m8wioUGsENv2SZwRNdbAu4ifnMQXnC9BQX55iAUhMJX",
+	"3FJByp7fHHRk/Ah6uANM2zpoBtxB1oLRJMGcpGlTJMaJo3EJKZJ5hZaxmIcXHjzFC1IonVdukF9XRSl2",
+	"gVnctlL9ngLL7FY1OXeUw4uygAFt3wQwPFTilVMaq4vEeqiXDiuCg7yEOUYR7zVBTR9X7oAIT0PT6zgK",
+	"dduNM6r6DB4mMd+5KjTI8oimLCx0tokeHWEjA1BHNWLExo1psWOFCP71UAlU478vIfY7LICBn7u+2QYj",
+	"uaFs1qZqqUplrQ9OVdGURreZKqK4Nw9I9R3pyPX93jRqnNdB0pHKEvXNEKA5ZCesTnJVE0N5qo2C/Bs5",
+	"rYVLswC9lu3gfbjUF4rGisZD52U4P0vFG/FnMqDziPi6+aLWAWQxKN5V7bKmHkc7Q9CbWq5T39dyb/cK",
+	"4ahYe/wKkPYVSrhgXvLl+zfMXzmWfX8S5aAHZOhSEgJIBxl0ytqiZX5dLOBDwRtNaFdiVxMg1tBR+haC",
+	"l+Hq/Pr61flZuHA32eZChZRgXscyJt7FwJ4HH25TERZ00Jh4e8Nqb5X6Kh2ZgFgs1NdrLXWO5Uw8UVcG",
+	"Eu+3dGt1Z7EX5ZEtUXPggZXd0cMTX3JnDMSvNIGTb6/O31yTr9AbwRrKMAXNkXQUH3+DZXXX1id4row7",
+	"6lLKMIREGPAlnAJJzYGjpywclRRf5+dDO5neObIw3o3u1sIN0xv0CT3IgO/O262sI4Bvnn9D8QD81t0B",
+	"bqVayIGPnfIrkil1yzKBz/HM8YgeQ/YSrJMSltmZVsV0RgU1nQZDUmKkYTJC07mnpbYyPVczznpV29Iw",
+	"/Fxe/cJo0AKPKVhUhx4nixovHZQICRUda/1wUnr3kzf9++AFK3JfqYHk4pvzH86vrj2jh0JEKAtpGwvJ",
+	"lqpg3NxC6uXsQXM9mg3252CRzIBjhQhspw6NaJbGwrzuaWnksGBIfqwiT+79lkJPQQ0Z0YcjT2XokUFK",
+	"cauHVBgliFRYmyGZQXL7W1WK+lTlocKohjdyRNNskBXVSlF9HwVV2nMxxKB64Awq9aYqv1amrcHk4KPM",
+	"KmXGiEwq6uVjuwHWzt4rfgffY824B0j3aKsdv39N+ZX8DNCDSp/sFx/T9zdYHnucow9sznMzZAQAzG5h",
+	"SZAiWgWLvRfs7umcSz4FHU1JMBXGIg+Rcj082AYtUVuBJt0Gy/VThZI9FngsJNfLy1qB/pV4R6IvJ2zp",
+	"+l7c+5oB5D4PeQDCYKQJUid7f/1y8C9UmeRGijmfOnlMFxnsUYChYnjCrY31cLIkZYSk8AchrbqRIx3H",
+	"RicsSDIcHmGRZSMykDZbhrCjWPzFD8GdRjfy/R9fvnx5VnNc4qUfM2KNoi7xfCVJprQuchswxOBGhklG",
+	"QFq5ZHfCCDQChUPxumJqDY4gjLy9kSAtquCSzylLYbgx8Wi9dMU2aGY/wLYYIszzo4ixXxqTSjaDNkAq",
+	"NnwN0j1rgV59WMxopacXbfDJVRLeXx6UvNee/VpJWPGW1xBmLYw7T7KsvL278x5xICkaGMOFIxkJy3oj",
+	"DrmPFHL/HJTifeSDyCoHjOXm1leRnAssiIRXy0Tljrr8RtAQSAFKhTsKEWdOhmqnBjydW6f6RSNdWmhg",
+	"fMGXZACh4VOAt7fQKE3h56N3J9en37Ej6ufoF7ddH0YUA4dBEqQEfvP8L61MwfgdFxknimZWTacZmjIK",
+	"6R+sxBlkQJE+0WDiuK7ZoIGjet1MJUW+I5rsqjQOjFBlqZIDAoH2V5DIq4RUDrBGtP11UVzj6urYK2Nq",
+	"PRGuSlvJ7uVKnpAY2VCg8AsjP2VG3gjtX2eoGptsZdHOvLNHRlQrBNF3169fVRGI3A7QqlOQ3pgnt+Wy",
+	"WJ6padEc3kBfdc66qgmDXWEffV8lwkb7ki1lQnUnH6ruZRR4+9QUijjcoY3Wgb/HF/YB8AjwYWZGF0iS",
+	"F6QUUwhLKiaTGlS00tNnho25QfysY3rtRt74Yd4csH9FykhUvmSJ44N+iWEQ+pGwKJNvzVImbCEw3BBj",
+	"jA9fuPZ8OnkKMrY5V6mYCCAzHnZQ+Zg0b6sKtOpQG8Etjy2MlZ0x9I8wI0JQW5gI62m4E7BgYQvc3XfN",
+	"ZrkRd7MWsUOr4U7TOI1qTsDW8DMvK6jdLTu/B5MnwZvQpWIAdrIju3qa3JVbQ199P8LGmUd4nt0o3n03",
+	"MO7DEhvJnY019C3W+8NX//LN4ZCdeDifoxiP7RP8yCLukU/cCRSAqg1YylpUlqVC2yX71wgKxHp3bw5f",
+	"xJ+pTUqyM+7ZHw9f+NLw2NS/skKG0j0pvf2CSkoYRvni/8o8rBRbQmMpiQCVtQpoiLAMdPnFBmNsAYFT",
+	"TWMkIZafdiyBQDv42biwVsnDNuwbbRtykl2z5sjznZIhjTyCTfmA0TqOd1Wlwlk3OL7kkoaMFlsflvnC",
+	"r071cP8rSETBR3hFdnp90txPaxnuVzTAO/K4vyEnO3Vt+bRSkBvlT9y17bm6fmb9SmFuWsOA6tRM/U5p",
+	"O6XSDFgAaJ8iyWtl1VbOhpwaYtUXEYxESNYzUAlYKIybtEhuycUmU0yRLI+Lr/+IT0Efdkxs3DjhvctC",
+	"+2zef4dOBaBrb7dsgi3MazP99BWyr/l0D3lPXLa+029ggSZW5PUAuM+nviDv3Z8OV5EefLgDAu9PW5yi",
+	"rrWzZmlQ3lu8XCAZmPryO14YLHhD+xVetXxqWurlVybhBGuNaQ/7TvGIZR6GHwGcsxoEy6dtu2VuO5Ze",
+	"Xk8XleEWuj+8zzhTyS2k3zZsxRsEu/e6fERoFSFjxd3u0LvrKwMo+SLGMuMG+uPQH5vCMCV/mimquPwR",
+	"A26redWlYpl5+5HLVZtTS/SYR/L+DsuDLTtrRfUS0h3GUmKGb7IG7tTlGnlSH0qfZtyYpqNvDNkgABvc",
+	"xgBYn/NS1uqgi38N0qMOXjbnt0Rsyt0ZRmSw8DYFjPPDjCkM/UcbBMXIHvbZKOJfBQtEzIFG/Q1NFsfl",
+	"S+6TVauFbQp/8DMYZZBOQYfGx1yDB9ippPX8Q6E1v16oJ+FaL8mxHa0Z8yF740UkBkUIE6ICVRHxdNCN",
+	"iJV4sIexSoV3HuTaXbxqC+czLMM0aLFWsTECKsZaDnJcl9UKDzTrxjxKx8MbKmLulDG4EeImK2s4baLi",
+	"UOrpQ//AET5vNc2VJV/WDWmceKf58tYR32aN9esrUqLcxFmvMlhVTpXzXxU7fgv6lTOgJg3azpkrTI55",
+	"sLwjdwAMMjXdJefIfVMP1sIaB250rVlHbrEc18YZUkZRTXg1pyvVU5CufSksXID4Ac9xwfuhop/7MvZ0",
+	"kf7RwM+Ha1lJ5HFOV464vRKT1k6UNbzcak8hxHjvxKE4tZ3Phi7JULUlJkXM3G79yG9+U14Tfl8d9T4p",
+	"Tiu0f73M4ZrabXhyXumq4bFPf2p4smP2U5z1F7WvyRv8ZNS8L8rXF+Xri/L1GyhfH4UX/fvRy2on5q6F",
+	"rQqJ7o5BqPLJQFq9PGZWpXz5zLBaiu7eKa/oVv3JWMib818R2ayS/1pmusbJx0R9YVnidMiJVvMhuw4o",
+	"KB7HSqtFpZb2iieWsCpfnoecWix0VdfWjpwUfLiEWDXPETq8rVrMf8dkTPKpl9mXTvbh8bCSqkdZJyhZ",
+	"Y63amIPZD0bDIDkrHwprIJv4FKGEcj58HvAdsAlPrE85kKyQGNG9U6bml7zK3y6vMvLpphzzdZnRlG++",
+	"+XLTIUE7NF6maFP0yK9M5Ybi8umGOMAEYpQ5Qk6PajnaLVvxJYH0SwLplwTS9pLRZXGgdTXxS3LpAySX",
+	"6nalZVPqqYX8S07ql5xUdDDXSBe/Idosc1Erx/nq0dt40ym0PA3hTbtddCh4Y+A0W/bN87/gHX2Iiu5P",
+	"Qv4UsX2q601g1PjOM8NE+iLEbWGSyU9zYQxhMgbQZR/BUhgYJO6WNMMjsvaV0/hQ1cXLyzqAL3bppnnR",
+	"dp9I68bNlQmUcZu1QW6PBcOG29Z83xiQRGUZHzdkpSo1H5hE5e5S4Hak94d/+Wdfzu2bw+OKIeQfSvjF",
+	"LQta+fLKrmmmlZpT3SyqegWg+95mgpiiqaN5PGJm3F2PUpWQUYsurCaejVa5q2uzdBb+kGwM3XlvEGoU",
+	"jyN2xKYUCeTUu1RoyjQbstERqUIY+xg0oEmmFsxfHg3rjY5Q6o76bOSLRY/67L/+4/8/RMsRyqLvzy+/",
+	"Pbm+eF1B+0FPAdzn2Iadwbzv1FIeq4y5Tp4ZBpheFeKkcWmkFvhW6Le8YyU8t0W1VJpIgTeLAa6nYDcE",
+	"99ALPtSDu+VnrpHD7UUGKmveRpZ7R+rYyGDr8tkffSXbk6NEZdkRLWyQpVun4HtpG/1elTjfyiiQ3BWP",
+	"EinvyHtVkXBfP/+a/df/+/9Vh90EaIc80JbEkCh5B9pUArgeArJ7k+Im1SlFK7bU0OR29pFlrHWEvt6g",
+	"1NRXXBeSKkJGU07Iym1kiHbRvXNOTf+gMHDarBg2k9rappVN9MtY72rRlHJQTWRKAbZU7Xq/rNTv+Q4V",
+	"0c/x/Z0Do0I37TPAaGE8xHbOU3iYbLn2XKumTILXzULjvdk9HvkEgRqohp8v+DfxaICFFOixqLhnlGZc",
+	"VgKXe3/4+ps/99flhjteTh0VCSWvsTxg15Ih7stL4OluX1EpwwZTmxaeewa+FiJ7f3XGeqaY973rKdSn",
+	"PXzBHFHFYlL4vg93rin2qSooE6aFBmWw+NeKB0wyxUNFJkdnO80Pja7rs3uNtlhBdlPcH41Iwj4cWEmq",
+	"/eZr35RTbTypFZ6VOwxr7TwuP19pbX1b+40kEiZabmgTlf/AtfQFZXbSNFNoqQrQft7kHjJlSyld95bX",
+	"vMv2Goeu9K3Tty4LuUelyVhMdv3kWytE2T29b6X26sPd9G0odt1JtFeWBuMmusj4Tev76FW4qnu564HU",
+	"XiBrdRn2pJKW3dqoW7USSLvpaQNpdK3IjxL6bb4r2gI3sEEttW2hGzsyNDX0YxO0hIGk0MIurxw50KAK",
+	"A/rffrjG8QHXoF8GEep+XYfDIrASkOkA8xf+7Ydr1ru8+vrP/9xn//bD364Gd6DR8+ruQkh1yPTYcimO",
+	"Z9bmBx8+4LEyUTg38mUfnJy/Y9++fMlO3l1U0juOD74aPh8+9750yXNxcHzwp+Hz4Z8OKgr0Ed2ej0K1",
+	"Kfebv8dFD7zTYkMxKzjF90/QgnngC7piRdaD47+vl8V17yp/CcYL+sUZVaQf0C1Y6Sndgf3fXkb5AHpE",
+	"VXFTx5owIUf8+OD/GqDZALVa4tKmkrwf3fca7az28S1uEalU5E8OFbZjpSdM5HIHRkCQtW2TOvFZICFs",
+	"o21i+3a6OpsfscpErqQv4v318+eVfHZk0zzPfIQPQodgSkkc1SaRSYsfSKZyOUf6XbnH/o1ipLBy74ON",
+	"4Bwdhw3dhQclYyPhRpb++49uZaKNOm4LllBZp6ke2V0GVg3oX0g4mDDy9zoNUjTfEaHjtLLZX8HSJevg",
+	"UbfH9eATEd3Qnt62/BVsyA/m0jPNMzJaT3UstzsRU9YjzQUMhnOYPqr8iDVkqnv1Vk+ZX/kf6fygGI/6",
+	"9lSvwd7ACibanR5yc7D/D/UDyykcH77QxSa6wHXrShk56IH3wPcZt2ouklaSKHn3aCrsAKPtUtDuNwmJ",
+	"HRgwJgRw5so0sDZmFv5V2Hf+U59k+Ehk1Jy4+YkJqiWZ8umRFU6EneQ5XrFZlQKYpwDWe+vOikGqxR3I",
+	"nekoFcY31E5BZ/GdChltU8LioKOrW1Lacp+V3j2feVvJmMYyzVg8TcOAp4oifXqhwj6WGjtEV12e4Y3b",
+	"q++o2/xcACaseNWmkL79FbXGbzbdoz7pqFcu1hUTzsDcinygvNdikCv0g/rpPa7WVG7vk+aVchq4SVNh",
+	"WeSVXsJNwlM4jLFwSk87sIpI86MQQIVndzuTXCrLLVyk+Sm+T6CDj6pNVfp50htHK4e7cnH2LmIL6ACC",
+	"6xEae4QCi/gKCRx23D2Ub3dAcR+Nqu+Zf+MizbfJtLcXZ6cUUq8RIsgqNoFw8MeeWKqSYu4DQzuKKmp0",
+	"w/Vrv64/5eUrrOPTFyIYLyVZZckRjNbylFu+ie6qiUZHcG9BO1muwahCew9OIwm+Esae+9cv49sfuVcd",
+	"87XrvZ5dv+1gbHxqu+rWtwLrtLYzAcirsrdnla3strselI1YNwOyaa2IGvx9dc23SZ3wPovD9bBJKEi8",
+	"LdHLEf+krmq3S5XWprcLjm8aku6UYwfrsyZ/vzyOu4AFGNsIgVJQWO+b539hYsIEhlQd7kAeEXMstIxK",
+	"3mYJ8M5/E+jiGr/4FFKgqefPXBLEDYr5awTNTWSAm8VKXMRQDy8rjCXjeDsdVA0Amzf8be3NRzyaqx2h",
+	"3+qJbpxaWbDKQVz5nbbBm9W3sFx4aZvil/OfC2A5nwrpbTmFNp21u/hyq3bX3v5Wb8ApNzAQ0oD02UWm",
+	"GNPbVFzZEa8bB8bceZv9G5LyXcZugOtktsnjsX//W+f2mt+LeTH39bCpfCTMMYaVbgPBEM484fpKIRg7",
+	"39VMkIk5eiraJvjRg1gLbHhMNdyT9FNm87zkysDhkVHRSN54AcdYD/AvPpaRvNrHJXXQzbj51UNvcNNq",
+	"0/DS3/UO0xgZD7vcvMlVCX70SyWEpIN+XZLARpnuXyPZ1Dt7czWgiqsmK6aHzdp1NZSlu5K9raP/Drr2",
+	"5t3utzolP7+9fP4pBMET8KLuLQCOMEXFl9do1exOwktPlXKadCEGdyGFJ2geQeX48/M+m/N79vXz5xhn",
+	"/0CKzw49dojnXMtlhqUB63Xd49CD79KtRGKzJVNZGjDpMWFNJUmhNaQnlvUuX57+6U9/+svhC0w2o8QI",
+	"Knd3kXZdBnp/wzqsDLPSv8+Gy7ixNGxmAOSwy3bWGmVWwFgDvz1eybNbaZn1Vqd5uNssV2KXPqW4Chz5",
+	"EpyG8jQ1U15JAgtiKNBrr4q62vcbO/BXOgqy20/OHRHsWqu4Iwivz0/gXV2dYy7sHCLrRZYgDD+Req4o",
+	"WfJXkR4O2SVgZBp9bTzsLiXXNQbBveLGDhBfZnBx9pEcYuHeHiFNDMqN241FPPLcOtG6JaFGg4BooMcJ",
+	"QHrMuGRCCiweqGk11IRpSJwoCRTrJKuxA0Ja8DauhdDAjKpWofTogkxIpnQK+rBPyIA+5dFykTFusNyB",
+	"bxnLrEHi3k6H7K0ElnLLj9m/Xb19w2qzZDlo2s0+E2lVuP4qUreRMdCFT+C4OiqEOvQYicPfeRQH7hhv",
+	"2yzW8zv0x3JBD92KXl2d7y41MI366Jd6HtaHIx+abbaEAMZvPh858vJ8kMyUAQzAivNjRSHS5nGupbB1",
+	"Hermnh76sF2NGX9yfn+YLVNNxoBkxm190XqBYDEUp3p6/hXkycVWQ9B1ob/Q8Keh4Ye3s9VT/jsZ2L5+",
+	"0M43BzGcYPVZMrR98/wvD9pzRJdo6pewCoRhPNPAU6x1huUwKawJq1MjpfWZj3PqggiBtVV+/2GQvAJt",
+	"cIQCgy6kmGr+H/+JFX9ZCgg9kL7wIATsTnCCjHLvegDjBmGy4URFSK32wK9v3ePPwk718HyMa7OTnfz5",
+	"Q/dNrT/B4/Fai+kUdKk2ErbbzgohfnWUa5hkYjqzm/Q/T8rhzS9G1xaqKpfo6ZHVqZrnhQ+3JLDAGLiy",
+	"HKSaL0CzvEICexBb9Y6xDm8SatcQPjBKbhVAX/E26NpYL9ZTr2rTZ+CEewRIJnR6LHVG92L/comlrAtJ",
+	"mInuBFwofYsF9obs7Fss84xV5SmaG1N1fKjHYT/ehT2O65wvfeSlwDtzCnMufdV+lWVYinMmMqfUui4R",
+	"YOsOhgQbiuXe6HqcQibGWLIrW3pf8YsmwFiE1CmB6jJh7AAzn1mgcUTg8vrATGUppt+3xjp8Szv0hbdb",
+	"ePszcJyzcdjjfZj36BfLpx+OCCz26Bf870XaibXpFWRn/AzDZvUUqji6VvXZ2fnlxffnZ0TVb3OQpzOl",
+	"QVVAxyuFB3PQg7hyXmQRqztOhntOTgIJzAdvOQmgCzsjlCke2qJSnViFNwWzlMlMKylMpYqb5/khO6vy",
+	"5pu312yistQXuicOxGEMnMZZAb0LomRFYiRcRtGQzIDn2dLDZwlDII6JMhaB8mgAAWK33gwKHar1i70Q",
+	"mjzhL0XBxv2CX313MmQn/mmofYxiEH0sBqMf57ld4nSaBcap+/iJi4v+tvJprDeql08bHfYxDjC7g5RZ",
+	"5VY0niE+AsjOtCqmswBzjRjew+ZZWj7dYXarg+sU/oVbLNI+4wE8EDG4LwuJj74XsBiKNJh3cbzA05bx",
+	"em7fYcyh/0+d6h2J8ykLbFsKTb4iMgNmeUWKXxZyFwnupFMXTSxCdjvawJpPfXdR5k4BLIVjCJj1CKYI",
+	"/00lfAifdrOmhbIuUHaPk3aHow2+BLlkQiaIJcBiBh0K3IjPG7s4bFQGI8IoST3yP6DXItbzQPdF1Pka",
+	"dbsNSlwUpMYpzE7t9Ol/7qSguuuV6h93oFORWIJ+v3z/hnmEkSVB4HvRT/jINpTywCRxJ2ptrS2QKWYE",
+	"NgtquukW8ouY3iqmkWBJxRgvKT4Vrw/COmrmUy6ksX5bP5VIf3SVNqAVPVmneymoalLGhOJAQvvaBjsJ",
+	"y3LgGyOJTsvXvlyamsAb/E9PmcSS6h6XMCrxx450dPRLDSftw2ZfaygB9tkI7TilXcZaR5bbQe/c2tlv",
+	"wgVPNhozqdDjw3HAutWgRX0xX9jgM2CDVXzEp34crFvSaizRFoHgXTffen/NF7r+bej6q8eg66ead1O6",
+	"E1eo+zHk/dEv+F/6KVNTs9Xr+Mq99IVVPg2rrCNKolW9QuW7jDtu9Q5j7t7h1rFfUtYA2sRBWiyeErC4",
+	"T15en1+S8QlylcwGc5FlwoSo+//6j/+kAMwxT259OC3cCVWUzrVnho0k3NtT/GIU6zJRhY9oHRvDVGAk",
+	"zpC9pi4096WdOAXKYgHXiQHLxpDwwhdh9QOZF8YyU+g74SGmZlymAwQiwS5CcRGVUrStt4rFMhlG8tzM",
+	"lO2zBVqSfIfobmTCYIUYIacZGMPGBRaJEnMgBHJjRZaRZcywRGkNic2W0fixmg4sZLIpV+J8fZk75YY8",
+	"vl/PCZinqZyTzysjCfmAsppgkkynW2rEnvwioT+bu6rf06fJFKUWkwTSLFmjxFMtbDua6hfS/s1I++FD",
+	"DdcqxXxyENunzlW0gp0Ya7/zpoaQ9EsKechzS8CYgSeKDQiL9MJbPb2iAr5d0eClKeYY1faJOLhzjx1Y",
+	"2beU1NjsoVm4rZOt41N6OgjVlMswQj9fn54W0Gp92y0r7alhh2Hv2fenNBsQgdbin5+e4cAPnxGbkq81",
+	"0cqYQSDv5p3YjJL1YNIj4ne1C4534ZVVnLPP8czHpA8K41U5EFwq6yFJ3duYS/UoGkC3rrfO5d0qdt4q",
+	"ez+UBOnS0SfSXiKJBtXlMROcqO7jazPdltv0+4XbD8vFOMs37WKPm6VMDj+RLCqLVbXdp2Pvy6tQDPGL",
+	"BPrdSaCzx5E3Z1uly9pIzuWd0EoipHNAXjlmKdxBpvL5DiB3UDa0yXrXpbtPCiq9yi9P1b1eyqRnhkWd",
+	"RcgpI6HBelTR0LA5N7cU0+a2zjyG7MrUcr417ums8t4X28jTN/uV+/l5uObTGn0+oFk8lq3rYBZ/69/9",
+	"wiCfkV3cberJu4t2FnnInP8uvV7PqmY5DBO3jEt28u5iAPe5MniO0A2ckgjHKl36bBBTfnq9zCFWQHFL",
+	"m/okIMynGj6lKLVnhvkFw1yCPSRATYev2yDNFmjBilXnczI//vgpsOZXbGKfJ8I8x5SS6iYg5hMa0HRJ",
+	"OLvrdd1qUBzd8ayADTXhTlWWQbJWc+R7+uyzOczWy1v0Sj388DHLaDT184lMSVf8zm9kuy3p+aexJf3u",
+	"oRCQC6qVQOr3NGIjyu2PFidh9+RcI6ayxsBbrl/u/Vr7/13TTzqdK/HYry3ZZ3q+UMplVRmq0hVlQmrg",
+	"6cCKOamOhYXUmxqONHCDAH+7U/FEZFvo9qXIPqcj5K3MKEeeYe1yRjXVPdQWTMQ968FwOkQl1AQm72qU",
+	"oxY21QXZt/ffhAXd1r8Gyz9XrsOkZeQAxi377vzkrMJDRPfbmefIzWbZrpqduMdPm4keSbHBlfmNwMR8",
+	"38YR5ycxC2CHAQuw2ewtgSnN5kqDJ8q5uoOU5ZyABYRmY27gasYp6VlZTHXGIcHvHDH3BIti8yxb4niX",
+	"jLMxJfBP2EILC07YZWDBsJ7BwGZ3yM2FZVaxORe1OsidOXNcyDSDVsiEczx03bGKNcHcN14gj0gYj/p0",
+	"8vq17DMh2ds35yVQE2b8c+t+vJE04CE7/7kQdzxD95VHl6HtnKgsUwtC8+B0nGOfOWhCy+ozuE8gt4i2",
+	"cCMRvRmBHGgihDHgU+S5u5TWl8pRhVGMs7wwM5ZxgjSYi3Tg+rqRCZdSWbYUkKWYX3+P0DoLxawGMP2Q",
+	"fc1iYVaDEDQaGM+yEBvPEXfmRrpvKC7H7SuW1AzkmWtIlEwFlu9ySopTbWagQdrD4Y28kZcYbO8annKn",
+	"xwTQn0zcQrkwx5QDUD0p6VxkeVYgjtaNxJfxNe4Wd4Bnq2tYyCQrEK36RC6JUyAz7ncylrnRC8PUXFgL",
+	"aZ8wBG6kuzo42sbFDGTAJNcINrCY4bLThNmCS2v6VJyYW2ApJCIF/5awbM6XN3LG7wDnPKJNHBF+RCYs",
+	"aJ4xA1N0ztH0OE6WFtkNzs5AL4QBxpnVXGRCTm/kQmRpwnU6ZBcWsYg8wtKMp2pBhJXhIh57KkPqxoZ5",
+	"tuBL3BFtSau8kSNa0xGCZ4yqjDOKlknXTDIruYSnqQbTgEvmNtax57fEeZ+X1uhJaifVbcjO0SDrvzWk",
+	"6RM9EqvxlKiHp3NhzfBBNc1PNeIuXggvzIPI7HE2g3tGYNe4MbFnSsVBq7fmMpkxK/Ihu3J7R/2aUkY8",
+	"c/+eIDp+pSnPzki4/pYP97kjWaFk1yV25+JGV8fvakaf0rFS4fCniFLOU3/fbjr6eeANOuf82bqP9vGL",
+	"47p2yIggKj8fIXkJuRpoyDhWjSTVxp06vXB2sXB0HSMyk8m5ZPMisyLPIJyEps/EEIaoc3Ehmcm4mYHB",
+	"GiBBaTCJyimioqoPcGbmTk9pVAnccY6FKKTTMzyCkAQ94IWdIZxgBZ1JQ660dRRgwVhzVD46okdDR7st",
+	"cEL+r66r3rZoqMzR7BRWLy8ng4Vtwxz9Cm8Y5+EeAtotEI7l5HrI3pKOVJFinrkHFWl2Iy8sg3thrIkJ",
+	"kW7U2ooJTyzpqxNxjxcaO6urN4X0GoXjRioKsr4d7os70O66YEE6JdpzcSFRd3HDC4eUFXlERqygx+pC",
+	"onh11z5DOI8oVXUh2VIVjCJ1+FgVdsjeCcloSVAfo2/LYQ0IlQzB3ZzS26sB9IWfD933U7D+6MSJhOYY",
+	"T2yBd6KADTe8kSerhwgpwY4cagizQS9bOww8CJowzOv7Y0jU3KmQY6fDgsZVjON5ZthMIEgcAZ55PTEy",
+	"DmWT1lVbU0pOt61Z1pZcunqE5txa0O7F/+fvzwd/4YPJyeDlj7/8z/4/f/Phn36DQyxWXHyapxgvLVis",
+	"t1FKBDY83M/QJYwptpiJL+iV3+4w6yTi+CCg8aUB6w8HgGkQE5FZxJFroWZ682CnTv8Gy4XSKaOqy8R6",
+	"uJoEUXc0VumyzzSXt2QXSIWxQiZ2YEHP8fWM56yHL7MFiOnMDT1VxTiDwz5LeJ6TMeDrP2NxJZ5lg7Hg",
+	"xmPtFsafk4We8MRxfIZzpw31JefcxNGShBWflIQ2dv75UWvNdTJJI5ldyIn6TG3SR55QPHH6faK4+Bh4",
+	"4OR2hYE9620roIOv/Y4Y9MfHLOmMk/2NbMu+78225d9/PecqCXalwA1niC6kOfpFF1i8LOEygazqNFlJ",
+	"Whlzmbo+JRMyobo2Q3aKXzn9w2kvBBBynwsdFfpnhhVyrNxNLmULLmwJLI7WMmFQiboDp/AjuvbVxV/f",
+	"nLxaAfdYeBgTRsPMcD8iuCyi6oJFgFFhCT1XqwVaT5NMmcrPpCJ6pGalUyG5JpV9yL5+/jXCeNBkjJhK",
+	"nrEFN6ysHOBBTtkkEzmeUCM/IEhHVJMePy1y0HfCOAUgsSgshB2yPz//U/lOnBHIqZBo+SxkadSr+hMW",
+	"CDvtu4kmYW/ynGMRRquX66Y/2pzL4jMq0vW6BoHcVpkLSXqHYTW0uv0o/brBAkXcQJST/d6rxNNgeR3w",
+	"dSd415oAybWaugvPliKql4V8F978QpYPT5YPWCu1slWt5VLfvjlnlZKpxgqP9+zjZ0jcToLwPGacjfDH",
+	"kS8wm4OuoYmzni8+WuQGtPXVRw99oYlRJmTtU6zFOcjUNPrreDLz0EzVyjVlvedKOYdwyWfuWFqvKEHl",
+	"YdDmyBM3NnetN5CgCSSOe8jOY5c8MyrGhHPJRoCGGj1iyUzk5MGacyFHMUScjkj3G02lz0amGOM/6SV3",
+	"TrjxVep7oAfUfYwFb6xSGRWAHWEF2BGVgC2XiGpb9zhb3U93tUm0mFP1ZLfQI0dfo0O/igHiayTSY0bQ",
+	"4AZ+9uDgL9jomN0C5APuju8RmmWx1l3urjUidbcjLqwZsrdvXv0vxpm7PwkM4awc11RVyNHO8dor+DMd",
+	"3eR09WYRgrPHerm4FJyNUhXJou/Xgf397O2b8x9HsUYJaHfVQ32gH7HnEfSLeuNLgymNTMgUJkIKC9my",
+	"Uh+XLJ0ihXmuHHf5CiOxWm4gWMLJJrrFvn0ZXUch+LOvAPFHAz8/kaq6tSPimaGCMchHSKksyP71irrb",
+	"DxGTQ3KUKHdvHBgymG3KC7rKITnFt6/8y5/NKfItcO1UXnULktTNVBisWow1G4RdkrqcKKdMo/Mf/SCN",
+	"9bZP0Iou/j1UGm6FCdyz00+bNlTZ7811Q59ApiodM25GikibebJnoW2l4/mA5kR3BhgnVms5OJUWtnDY",
+	"1px5T7pPPGH+MUmwvkJPNUW6NBdcnb069cHKOxcxo7c3WJ59M9d8+oWYGosQ8+lTThBerRu5DwWZ280k",
+	"dI1vfDZH+w9YwA4nRR5dqqvs9xnVzq4R7Wg/23Cgd+1KFnO3Ye7vg/4BqsXuhsmz7ODHLuXSyTXjYXKp",
+	"OzWhIoFOoyNE1Vp9IQxtuvvTIbk13U/V8MntFYYq9bFisaFgDfOeIlGtX/P6/PW355dX3128q9Qk4uTm",
+	"ocJEq+WIYnAQ+anpDuvn0DVIiSoQtdZ+33/Z+lhPKc5uDm6BzEzkW4f9m/iF3Ny+F7D4fBNQy9PUO4V6",
+	"eJtEHZkI6rDPqMwaxhSUQTIbtrt9jym0Am3gZGDAYrVODg1S0MLx0AjuISms0qcZN2ZUs2h4wwVaox07",
+	"0M3NqZZ9xsv6bVNuAUvbczZ2991ZMeexkjDOk9iXQ35ciQghn4QwDO4pypf1hC/Mls+4qdqA+sH3mZaW",
+	"DB/K4eu5efN8CT8Rvjh8waZAxXl9GATe6rFi53jpZcaQvaqM1rAZvwMmFS2VW31kWDaOxemWeLFH50Uq",
+	"TKLuQKMNPsiepv0go0KeA9f0JbpjRpZPRwO/z6EGZDga6Ujbfi4e/YIDf4OT2VjgyLX4+ZyRNe+WF/+e",
+	"avxEG8ZaWaodxrq9q98WTt0N4gwsF9kTvWo4ZkHrZKwYOSmyjJ2jeHLywpvyPpo9jjI13eJxcA2/UtMv",
+	"jPK7ZZSP8FG4UdA2t7ooKu6JytCfGQbSCg1kAiavNIZ44qW4zyDQqgkW5EKKiXAHuJgDmfsRpBVTcbi1",
+	"MM/R2t3BEr8y6jZD/DHDk+7XcizsV3I0/MpSKtL6oIb6E2+WT4l3qwZ4ZN8W+3vd3h5V8qrB3QRVRJIW",
+	"ssGsftxkU3frcFSuQrNtHc9z2kgNA/Axshiu6vtyConhE1JhNGDPKzGcftgDI9JwqzCsF7u+SI9uhUwP",
+	"K2V5o7NJVOIMuLVajGm00WPvNbGpVm7M42WgGj9b7POJeAQ8C1V4p+dR9v5Y4Rz2xzWmOVz3Eewp+XOt",
+	"5srCwOnbA3yyEZ/Yvet6eqnV/PcWeNVJxFvF/JSJ8r3G/nHivqP4fhQ4XjeVuBs7RYY1xF4EUN3olZsU",
+	"UkIWlwkMU4UdqMlgzOXvPDf3utAYaMXTwUwl9bAvrNfNWaIwsh7ldJUa3E1oHZG3C4cVWpojnlhxB5vu",
+	"HCf4hhvhF9Nukz5SaLnNSfD182/WJ/FGYf4Lxiu4xX0KXqxK9GFl6Kz39fNvKNBNOiWlQod/BXly0YUO",
+	"f3H/uUg3336fMg2uSXzkeZGW9c6+fv41SyjyM1BrS7V0XKodxtqxq98b2/zuL7xuI56Zda/azlR/VN6C",
+	"Nt1rv9D/J6X/puzKjC9DM8IwPjYqKyz4i56QKdyz3kJIypNjr7ixA7zxDS7ODltSOlxzBxuzEz+y07mQ",
+	"Yl7MD44HX62pe/2D+8FUDdyvA3Mr8kEwXw9y5d7R3vXRsBrums0LqwblbUuDKeahAuOxt1cb62/EIq3e",
+	"9AxfvGCaJkffGcYn6NOxQ/Y25z8XdIl23+CVPofEh0nLgSzmoEUS4eTcjXIqMYu0h1dXatm7nnDxyAqM",
+	"3MNwtfDEGis7w89zDQakHbbF19SW9SOzcLbYP1YIgC+87Z7EwDuu/Yq66xbKoRBFh032mUgH3kLwonJr",
+	"p+t6A50/NfF7Yi1PZuQ/9CKYWMEbfXqOWjxl/ZFurJaLrE0v0Qkf4Pr6jN3NfurLhJ+4ly/9u1vkcaBj",
+	"PhWSHCexgGcX32J8uRVjor397UHM/N7JhYqZD/18VSeyN+kEXzJyDMdqrV2915mg3P3WmOePHcQntdPX",
+	"d/8px3Rcnp4Q1TOegbY+MdoEE2cNVEjpaT/kb0+ENlUshlV+2JYCV3//4DET0Opd7WRv+OqRKObpFizD",
+	"UH1KT20mHdZDfUHy7MjDpiOwA0jrxg4pgYzpF2TW2EhBjVL56Bf6x5ZL4hp9bRTPl6cnEdugLYnD97oL",
+	"oMRKq5/yYrWd3p5E4KKHVWsmta3EY25Flm0+x6/olceEcXY9XNG8nnT0X1ipsOZ+6bZJenztUQU89nAh",
+	"8+KTS3XsmRz2bYHpT0Gsx0TjpDBWzWmrm3a6ZKojMUcWbPW8XODz7ZtPqENc2yOsNJdyi/MGSZZu9FUI",
+	"go70X137ILLKuqnEQrxD4bxLoBPtxmU9JnhoasXr8u8iH7gF1mAMpAxFCU2aWa7HHOcQXSZjTB5uUq0r",
+	"pPd36qsMqSQgmWbQ+IejSFr29pT3p0CONAeswtK4EZvI0ixl0k6UV0uZfCqJv5QJpaw8QYHvBs/Ghcjs",
+	"QEgv+VmPTGU+5V9Pn5nwxB3HTEzYXBh3YB9u2aMCq2F3OJff+xcfe6+on6d8OPM7LjDSdmXXWBGXcNOO",
+	"UG0TEowZWFjfkzP8PYjzjco0vuQNwhvszTsWAmlq9aEVap4SUi7P3lVPjQ8NMvyJEQltX3nCK83oAIe0",
+	"/bTvtydjft508JEq39O4WbXvOoWXrB+eft/PpRM06e98+/e7bDRLAG/XrKuS4JehtPyPlcqAyzVFMLz5",
+	"Y6Mc+XRoSE+fdIn0nPRKhSHUw42EXDSILzrsn4IEe/j7cmXuO9yXv1BgSYG0gh2vyoXhU4iu/9bqB2/1",
+	"dLAQaQBVwK9Y7w9f/+Wrwz4hH3Odog/UNxWSgl5dfH8eSxEizKhOfSQchvcqCYb1pPINzzgG7BwS3haC",
+	"0//Tc3ybUHvlkhkhExiQEpjGphE0hfJuQrwrgbZAGkZrZhj9arAeM33tRnM4ZC/FtNDeN5uJCWDdJFPM",
+	"Mf8tB20IITMHPdBq4Rs2L1iijH1vUnrVXTn4XBXSmhj1zC1LeG4LDRhkynonZ5eD58+/+gqHMQeZgseP",
+	"EYbJIstCbFItmYpTe+soWpWE5vdujgePn2WO/Tzla4jbxEA0FWJuyRPGtvVdkL2Fzg6OD454Lo7uvjr4",
+	"8OOH/x0AAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/services/aep-api/internal/spec/files/handler.go
+++ b/services/aep-api/internal/spec/files/handler.go
@@ -81,6 +81,27 @@ func (h *Handler) ReadFile(ctx context.Context, request gen.ReadFileRequestObjec
 	}), nil
 }
 
+// ReadFileBundle serves the whole-prefix read. It is registered under the
+// LITERAL path segment `bundle`, which sits beneath read-file's trailing
+// wildcard: ServeMux prefers the literal (it matches a strict subset), and no
+// readable file address can collide with it anyway, since every readable path
+// starts with specs/.
+func (h *Handler) ReadFileBundle(ctx context.Context, request gen.ReadFileBundleRequestObject) (gen.ReadFileBundleResponseObject, error) {
+	org := tenant.BoundOrgFromContext(ctx)
+	bundle, err := h.files.Bundle(ctx, org, request.ProjectName, request.Params.Prefix, request.Params.Ref)
+	if err != nil {
+		return nil, mapFilesError(err)
+	}
+	files := make([]gen.FileContent, 0, len(bundle.Files))
+	for _, f := range bundle.Files {
+		files = append(files, gen.FileContent{Path: f.Path, Content: f.Content, Sha: f.SHA})
+	}
+	return gen.ReadFileBundle200JSONResponse(gen.FileBundle{
+		CommitSha: bundle.CommitSHA,
+		Files:     files,
+	}), nil
+}
+
 func (h *Handler) ApplyFiles(ctx context.Context, request gen.ApplyFilesRequestObject) (gen.ApplyFilesResponseObject, error) {
 	org := tenant.BoundOrgFromContext(ctx)
 	if request.Body == nil {

--- a/services/aep-api/internal/spec/files_bundle_component_test.go
+++ b/services/aep-api/internal/spec/files_bundle_component_test.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Component tier for read-file-bundle, over the same real chain as the rest of
+// the Files API (contract-first handler → real gitfs engine → real bare file://
+// origin). Two properties carry the feature and neither is visible from the
+// response body alone, so they are asserted separately:
+//
+//   - the bundle AGREES with the per-file reads it replaces (content, shas, and
+//     the read gate), and
+//   - it resolves the branch tip EXACTLY ONCE and addresses every subsequent
+//     read by that object name.
+//
+// The second is the whole point. gitfs revalidates the mirror against origin for
+// any read addressed by a ref and serves object-addressed reads from local
+// objects, so "one ref-addressed call" is what makes the bundle one network
+// round trip instead of one per file — and pinning is also what stops a push
+// landing mid-read from splitting the result across two trees.
+package spec_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/edge"
+	"github.com/wso2/aep/aep-api/internal/platform/componenttest"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs/workspacetest"
+	"github.com/wso2/aep/aep-api/internal/platform/gittest"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+	"github.com/wso2/aep/aep-api/internal/spec"
+)
+
+const bundleBase = apiBase + "/bundle"
+
+// ---- wire shapes (decoded structurally, so the contract's field names are
+// pinned here rather than assumed from the Go service types) ----
+
+type wireFileContent struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	SHA     string `json:"sha"`
+}
+
+type wireFileBundle struct {
+	CommitSHA string            `json:"commitSha"`
+	Files     []wireFileContent `json:"files"`
+}
+
+func (r *filesRig) bundle(t *testing.T, query string) wireFileBundle {
+	t.Helper()
+	rec := r.get(bundleBase + query)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bundle%s: code %d (%s)", query, rec.Code, rec.Body.String())
+	}
+	var out wireFileBundle
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode bundle: %v", err)
+	}
+	return out
+}
+
+func (b wireFileBundle) byPath() map[string]wireFileContent {
+	out := make(map[string]wireFileContent, len(b.Files))
+	for _, f := range b.Files {
+		out[f.Path] = f
+	}
+	return out
+}
+
+// ---- tests ----
+
+// The bundle must be substitutable for the fan-out it replaces: same content,
+// same blob shas (they become the caller's baseSha preconditions), same commit
+// the mirror is on. Reaching this handler at all also proves the routing: the
+// literal `bundle` segment sits underneath read-file's trailing wildcard, and if
+// ServeMux preferred the wildcard this would arrive as a read of a file named
+// "bundle" and fail the path gate instead.
+func TestBundle_AgreesWithThePerFileReadsItReplaces(t *testing.T) {
+	r := newFilesRig(t, map[string]string{
+		"specs/requirements/prd.md": "req body",
+		"specs/design/design.md":    "design body",
+		"specs/design/design.cell":  "cell body",
+	})
+
+	got := r.bundle(t, "?prefix=specs/")
+
+	if want := r.mirrorRevParse(t, "refs/heads/main"); got.CommitSHA != want {
+		t.Errorf("commitSha = %s, want the branch tip %s", got.CommitSHA, want)
+	}
+	if len(got.Files) != 3 {
+		t.Fatalf("bundle has %d files, want 3: %+v", len(got.Files), got.Files)
+	}
+	// Sorted by path, so a caller can diff two bundles without normalising.
+	for i := 1; i < len(got.Files); i++ {
+		if got.Files[i-1].Path >= got.Files[i].Path {
+			t.Errorf("files are not sorted by path: %+v", got.Files)
+			break
+		}
+	}
+	for path, want := range map[string]string{
+		"specs/requirements/prd.md": "req body",
+		"specs/design/design.md":    "design body",
+		"specs/design/design.cell":  "cell body",
+	} {
+		f, ok := got.byPath()[path]
+		if !ok {
+			t.Errorf("%s missing from the bundle", path)
+			continue
+		}
+		if f.Content != want {
+			t.Errorf("%s content = %q, want %q", path, f.Content, want)
+		}
+		if sha := r.readSHA(t, path); f.SHA != sha {
+			t.Errorf("%s sha = %s, want the per-file read's %s", path, f.SHA, sha)
+		}
+	}
+}
+
+// prefix narrows; the read gate decides. A tree holds application code as well
+// as specs, so a path the gate refuses is OMITTED rather than turned into an
+// error — otherwise a bundle of any real repo could never succeed. The gate is
+// the same one read-file applies, so this exposes nothing a caller could not
+// already read one file at a time.
+func TestBundle_OmitsWhatTheReadGateRefuses(t *testing.T) {
+	r := newFilesRig(t, map[string]string{
+		"specs/requirements/prd.md": "req",
+		"README.md":                 "readme",
+		"src/main.go":               "package main",
+		".github/workflows/ci.yml":  "on: push",
+	})
+
+	// Empty prefix asks for everything; only the gate stands between the caller
+	// and the rest of the tree.
+	got := r.bundle(t, "")
+
+	if len(got.Files) != 1 || got.Files[0].Path != "specs/requirements/prd.md" {
+		t.Fatalf("bundle leaked past the read gate: %+v", got.Files)
+	}
+	// And the per-file read agrees about each refusal, so the two surfaces
+	// cannot drift into disagreeing about what is readable.
+	for _, path := range []string{"README.md", "src/main.go", ".github/workflows/ci.yml"} {
+		if rec := r.get(apiBase + "/" + path); rec.Code == http.StatusOK {
+			t.Errorf("read-file allows %s but the bundle omits it — the gates disagree", path)
+		}
+	}
+}
+
+func TestBundle_PrefixNarrowsWithinTheGate(t *testing.T) {
+	r := newFilesRig(t, map[string]string{
+		"specs/requirements/prd.md": "req",
+		"specs/design/design.md":    "des",
+	})
+	got := r.bundle(t, "?prefix=specs/design/")
+	if len(got.Files) != 1 || got.Files[0].Path != "specs/design/design.md" {
+		t.Fatalf("prefix filter wrong: %+v", got.Files)
+	}
+}
+
+// `ref` pins the bundle to one commit, exactly like read-file's. Without it the
+// only readable answer is "whatever the tip says now", which is useless for
+// anything reconstructing a past state.
+func TestBundle_ReadsAtAPinnedCommit(t *testing.T) {
+	r := newFilesRig(t, map[string]string{"specs/requirements/prd.md": "v1"})
+	before := r.bundle(t, "?prefix=specs/")
+
+	baseSHA := r.readSHA(t, "specs/requirements/prd.md")
+	if rec := r.apply(mustJSON(t, map[string]any{
+		"writes": []map[string]string{
+			{"path": "specs/requirements/prd.md", "content": "v2", "baseSha": baseSHA},
+		},
+	})); rec.Code != http.StatusOK {
+		t.Fatalf("apply: code %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	if head := r.bundle(t, "?prefix=specs/"); head.Files[0].Content != "v2" {
+		t.Fatalf("unpinned bundle = %q, want the new tip content %q", head.Files[0].Content, "v2")
+	}
+	pinned := r.bundle(t, "?prefix=specs/&ref="+before.CommitSHA)
+	if pinned.CommitSHA != before.CommitSHA {
+		t.Errorf("pinned commitSha = %s, want %s", pinned.CommitSHA, before.CommitSHA)
+	}
+	if pinned.Files[0].Content != "v1" {
+		t.Errorf("pinned content = %q, want %q", pinned.Files[0].Content, "v1")
+	}
+}
+
+// `ref` takes an object name and nothing else — the same gate read-file applies.
+// A revision expression would turn a prefix read into a browser over the repo's
+// whole history.
+func TestBundle_RejectsARevisionExpressionAsRef(t *testing.T) {
+	r := newFilesRig(t, map[string]string{"specs/requirements/prd.md": "v1"})
+	for _, ref := range []string{"main", "HEAD~1", "refs/heads/main"} {
+		if rec := r.get(bundleBase + "?ref=" + ref); rec.Code != http.StatusBadRequest {
+			t.Errorf("ref=%s: code %d, want 400", ref, rec.Code)
+		}
+	}
+}
+
+// ---- the addressing property ----
+
+// recordingWorkspace wraps the real engine and records how each read ADDRESSED
+// the repo. gitfs fetches origin for a symbolic address and serves an object
+// name from local objects, so the recorded values are what decide whether a
+// bundle costs one network round trip or N — and whether every file in it came
+// from the same tree.
+type recordingWorkspace struct {
+	sourcecontrol.Workspace
+	mu   sync.Mutex
+	head []string // `at` of every Head call
+	list []string // `at` of every List call
+	bulk []string // `at` of every ReadBundle call
+	one  []string // `at` of every ReadFile call — the fan-out's per-file read
+}
+
+func (w *recordingWorkspace) record(dst *[]string, at string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	*dst = append(*dst, at)
+}
+
+func (w *recordingWorkspace) Head(ctx context.Context, ref sourcecontrol.RepoRef, at string) (string, error) {
+	w.record(&w.head, at)
+	return w.Workspace.Head(ctx, ref, at)
+}
+
+func (w *recordingWorkspace) List(ctx context.Context, ref sourcecontrol.RepoRef, at string) ([]sourcecontrol.Entry, string, error) {
+	w.record(&w.list, at)
+	return w.Workspace.List(ctx, ref, at)
+}
+
+func (w *recordingWorkspace) ReadBundle(ctx context.Context, ref sourcecontrol.RepoRef, at string, keep func(string) bool) (map[string]string, string, error) {
+	w.record(&w.bulk, at)
+	return w.Workspace.ReadBundle(ctx, ref, at, keep)
+}
+
+func (w *recordingWorkspace) ReadFile(ctx context.Context, ref sourcecontrol.RepoRef, at, path string) ([]byte, string, error) {
+	w.record(&w.one, at)
+	return w.Workspace.ReadFile(ctx, ref, at, path)
+}
+
+// addresses returns the `at` of every recorded read, in no particular order —
+// what each read addressed is the only thing these assertions care about.
+func (w *recordingWorkspace) addresses() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]string, 0, len(w.head)+len(w.list)+len(w.bulk)+len(w.one))
+	for _, group := range [][]string{w.head, w.list, w.bulk, w.one} {
+		out = append(out, group...)
+	}
+	return out
+}
+
+// refAddressed counts the reads that named a REF rather than an object. Each one
+// costs an origin round trip under the mirror's exclusive lock, and each one
+// resolves the tip for itself — so this number is both the network cost and the
+// number of independent answers a caller is being handed.
+func (w *recordingWorkspace) refAddressed() int {
+	n := 0
+	for _, at := range w.addresses() {
+		if at == "" {
+			n++
+		}
+	}
+	return n
+}
+
+func (w *recordingWorkspace) snapshot() (head, list, bulk []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]string(nil), w.head...), append([]string(nil), w.list...), append([]string(nil), w.bulk...)
+}
+
+// newRecordingRig is newFilesRig with the Workspace wrapped, so the assertions
+// below run against the same real engine and origin as every other test here.
+func newRecordingRig(t *testing.T, seed map[string]string) (*componenttest.Harness, *recordingWorkspace) {
+	t.Helper()
+	remote := gittest.NewRemote(t, gittest.WithSeed(seed, "seed"))
+	rec := &sourcecontrol.GitRepository{
+		OrgID:         filesTestOrg,
+		ProjectID:     filesTestProj,
+		RepoURL:       remote.URL(),
+		RepoSlug:      testSlug,
+		DefaultBranch: "main",
+		Status:        "ready",
+	}
+	ws := &recordingWorkspace{Workspace: workspacetest.NewEngine(t)}
+	gitOps := sourcecontrol.NewGitOpsService(filesStubResolver{}, ws)
+	svc := spec.NewFilesService(filesStubRepoResolver{rec: rec}, gitOps)
+	h := componenttest.New(t, componenttest.Options{Deps: edge.Deps{
+		Spec: mustSpecHandlers(t, spec.Deps{Files: svc, FilesActivity: &captureSpecUpdated{}}),
+	}})
+	return h, ws
+}
+
+func TestBundle_ResolvesTheTipOnceThenAddressesObjects(t *testing.T) {
+	h, ws := newRecordingRig(t, map[string]string{
+		"specs/requirements/prd.md": "req",
+		"specs/design/design.md":    "des",
+		"specs/design/design.cell":  "cell",
+		"README.md":                 "readme",
+	})
+	if rec := h.AsOrg(filesTestOrg).Get(bundleBase + "?prefix=specs/"); rec.Code != http.StatusOK {
+		t.Fatalf("bundle: code %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	head, list, bulk := ws.snapshot()
+	if len(head) != 1 || head[0] != "" {
+		t.Fatalf("Head calls = %q, want exactly one at the branch tip — this is the ONLY read allowed to touch origin", head)
+	}
+	resolved := ws.mustResolved(t)
+	// Everything after the resolve addresses that object name. An "" here would
+	// mean another origin round trip AND a second, independent tip resolution.
+	if len(list) != 1 || list[0] != resolved {
+		t.Errorf("List calls = %q, want exactly one at %s", list, resolved)
+	}
+	if len(bulk) != 1 || bulk[0] != resolved {
+		t.Errorf("ReadBundle calls = %q, want exactly one at %s", bulk, resolved)
+	}
+}
+
+// mustResolved returns the commit the recorded Head resolved to, read back from
+// the same wrapped engine.
+func (w *recordingWorkspace) mustResolved(t *testing.T) string {
+	t.Helper()
+	_, list, _ := w.snapshot()
+	if len(list) == 0 {
+		t.Fatal("no List call recorded — nothing to resolve against")
+	}
+	return list[0]
+}
+
+// The fan-out this replaces resolved the tip once PER FILE. Reading three files
+// one at a time is three ref-addressed reads; the bundle is one. Asserted as a
+// comparison so the saving is stated in the same units the old path cost, and so
+// a regression to per-file reads inside Bundle fails here.
+func TestBundle_CostsOneRefAddressedReadWhereTheFanOutCostsOnePerFile(t *testing.T) {
+	seed := map[string]string{
+		"specs/requirements/prd.md": "req",
+		"specs/design/design.md":    "des",
+		"specs/design/design.cell":  "cell",
+	}
+
+	fanOut, fanWS := newRecordingRig(t, seed)
+	if rec := fanOut.AsOrg(filesTestOrg).Get(apiBase); rec.Code != http.StatusOK {
+		t.Fatalf("list: code %d", rec.Code)
+	}
+	for path := range seed {
+		if rec := fanOut.AsOrg(filesTestOrg).Get(apiBase + "/" + path); rec.Code != http.StatusOK {
+			t.Fatalf("read %s: code %d", path, rec.Code)
+		}
+	}
+	// list-files plus one read per file, each resolving the tip for itself.
+	if got, want := fanWS.refAddressed(), 1+len(seed); got != want {
+		t.Fatalf("fan-out made %d ref-addressed reads, expected %d — the baseline this test compares against has moved", got, want)
+	}
+
+	bundled, bundleWS := newRecordingRig(t, seed)
+	if rec := bundled.AsOrg(filesTestOrg).Get(bundleBase + "?prefix=specs/"); rec.Code != http.StatusOK {
+		t.Fatalf("bundle: code %d", rec.Code)
+	}
+	if got := bundleWS.refAddressed(); got != 1 {
+		t.Errorf("bundle made %d ref-addressed reads, want 1 (the fan-out made %d for the same files)",
+			got, fanWS.refAddressed())
+	}
+}

--- a/services/aep-api/internal/spec/files_service.go
+++ b/services/aep-api/internal/spec/files_service.go
@@ -24,6 +24,12 @@
 // one commit and pushes it to origin under `--force-with-lease` (origin stays
 // the CAS arbiter; Mutate owns the bounded fast-forward retry).
 //
+// Reads come in three shapes and the choice matters: `list` for metadata, `read`
+// for one file, and `bundle` for a whole prefix. Reach for `bundle` whenever the
+// answer is more than one file — a List-then-Read-each fan-out costs one origin
+// round trip PER FILE (serialized behind the mirror lock) and resolves the branch
+// tip separately for each, so it can also straddle two commits. See Bundle.
+//
 // Draft state lives on the frontend; committed truth is the git origin. `apply`
 // carries per-file baseSha optimistic-concurrency: a stale baseSha (or a
 // baseSha-omitted write to a path that already exists) fails the whole batch
@@ -77,6 +83,15 @@ type FileContent struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
 	SHA     string `json:"sha"`
+}
+
+// FileBundle is many FileContents read at ONE commit. CommitSHA names it; every
+// entry's SHA is a blob of that same tree, so a caller can use the whole set as
+// its baseSha baseline without the entries disagreeing about which tree they
+// came from.
+type FileBundle struct {
+	CommitSHA string
+	Files     []FileContent
 }
 
 // WriteOp is one file write. BaseSHA omitted (empty) means "must not exist yet".
@@ -168,6 +183,11 @@ type FilesService interface {
 	// no matter which run you asked about. Pinning to the run's own merge commit is
 	// what makes a per-run report addressable at all.
 	ReadAt(ctx context.Context, orgID, projectID, path, at string) (*FileContent, error)
+	// Bundle reads every file under prefix at ONE commit — List plus a Read per
+	// entry, collapsed into a single operation. Any caller that wants a whole
+	// directory should use it rather than fanning out; see the implementation for
+	// why the fan-out is expensive AND incoherent.
+	Bundle(ctx context.Context, orgID, projectID, prefix, at string) (*FileBundle, error)
 	Apply(ctx context.Context, orgID, projectID string, req ApplyRequest) (*ApplyResult, []Conflict, error)
 }
 
@@ -267,6 +287,79 @@ func (s *service) ReadAt(ctx context.Context, orgID, projectID, path, at string)
 		return nil, fmt.Errorf("read %s at %s: %w", path, commitLabel(at), err)
 	}
 	return &FileContent{Path: path, Content: string(content), SHA: blobSHA}, nil
+}
+
+// Bundle returns every readable file under prefix at one commit.
+//
+// It exists because the fan-out it replaces — List, then Read per entry — is
+// wrong on two counts, and only one of them is speed.
+//
+// SPEED: a Workspace read addressed by branch name revalidates against origin
+// before it serves, and that fetch runs under the mirror's exclusive lock. So a
+// fan-out over N files pays N network round trips, SERIALIZED, while the git
+// plumbing it exists to perform costs nothing measurable. Resolving the commit
+// once and addressing every read by that sha pays the round trip once: gitfs
+// freshens only for symbolic addresses, and a raw object name is served from
+// local objects.
+//
+// COHERENCE: a fan-out resolves the branch tip independently per request, so a
+// push landing mid-read hands back content from two different trees along with
+// blob shas from two different trees. Callers precondition their later writes on
+// exactly those shas, so the incoherence does not stay a read problem. One
+// resolved commit means one tree and one self-consistent set of shas.
+func (s *service) Bundle(ctx context.Context, orgID, projectID, prefix, at string) (*FileBundle, error) {
+	if err := validateCommit(at); err != nil {
+		return nil, err
+	}
+	ref, err := s.resolveRef(ctx, orgID, projectID)
+	if err != nil {
+		return nil, err
+	}
+	// The one operation here that addresses a ref rather than an object, and so
+	// the only one that touches the network.
+	commit, err := s.git.Workspace().Head(ctx, ref, at)
+	if err != nil {
+		if errors.Is(err, sourcecontrol.ErrRefNotFound) {
+			return nil, ErrFileNotFound
+		}
+		return nil, fmt.Errorf("resolve %s: %w", commitLabel(at), err)
+	}
+
+	// prefix says what the caller WANTS; validateReadPath says what it MAY have.
+	// A path failing the gate is omitted rather than refused: the tree also holds
+	// application code, so a bundle is a filter over it, not a lookup that can
+	// miss. This is the same gate ReadAt applies per file, so the bundle exposes
+	// no path a caller could not already read one at a time.
+	keep := func(path string) bool {
+		return strings.HasPrefix(path, prefix) && validateReadPath(path) == nil
+	}
+	entries, _, err := s.git.Workspace().List(ctx, ref, commit)
+	if err != nil {
+		return nil, fmt.Errorf("list files at %s: %w", commit, err)
+	}
+	contents, _, err := s.git.Workspace().ReadBundle(ctx, ref, commit, keep)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle at %s: %w", commit, err)
+	}
+
+	shaOf := make(map[string]string, len(entries))
+	for _, e := range entries {
+		shaOf[e.Path] = e.SHA
+	}
+	files := make([]FileContent, 0, len(contents))
+	for path, content := range contents {
+		sha, ok := shaOf[path]
+		if !ok {
+			// Both reads addressed the same commit, so a blob with content but no
+			// tree entry means the mirror moved under us mid-bundle. Fail rather
+			// than hand back a file whose baseSha is the empty string, which the
+			// apply gate reads as "this file must not exist yet".
+			return nil, fmt.Errorf("bundle at %s: %s has content but no tree entry", commit, path)
+		}
+		files = append(files, FileContent{Path: path, Content: content, SHA: sha})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return &FileBundle{CommitSHA: commit, Files: files}, nil
 }
 
 // commitLabel names the pin for an error message: "head" reads better than an

--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -14,6 +14,12 @@ AGENT_REASONING_EFFORT=medium
 # which truncates a real spec/design mid-tool-call (no tool-call frame → empty
 # fold). Sonnet-class models support 64k output tokens.
 AGENT_MAX_OUTPUT_TOKENS=64000
+# Anthropic prompt caching (default true). Caching is opt-in per request: with
+# no cache_control breakpoint every step of a tool loop re-bills the whole
+# prefix. History is append-only, so that prefix is stable and cacheable. Set
+# false only where turns are reliably single-step — a cache WRITE costs more
+# than plain input, so writing a cache nothing reads back is a small loss.
+AGENT_PROMPT_CACHE=true
 
 # SSE keep-alive cadence (ms) while a turn streams, so long generations survive
 # an idle-timeout ingress.

--- a/services/agents/src/agents/main/run-turn.ts
+++ b/services/agents/src/agents/main/run-turn.ts
@@ -37,6 +37,7 @@ import {
   type ModelMessage,
   type LanguageModel,
   type LanguageModelUsage,
+  type TelemetryOptions,
   type ToolLoopAgentSettings,
   type ToolSet,
 } from "ai";
@@ -86,6 +87,13 @@ export interface RunTurnInput {
    * conversation would blow the provider's per-request limit.
    */
   cacheBreakpoint?: ProviderOptions;
+  /**
+   * Trace-capture options for this turn (the `functionId` its steps are stamped
+   * with), built by the telemetry seam and passed through opaquely — runTurn
+   * knows nothing about which tool is capturing. Absent → the call is
+   * byte-identical to an untraced one.
+   */
+  telemetry?: TelemetryOptions;
 }
 
 export interface RunTurnResult {
@@ -138,6 +146,7 @@ export async function runTurn(input: RunTurnInput): Promise<RunTurnResult> {
 
   const result = await agent.stream({
     messages: markLastMessage(input.messages, input.cacheBreakpoint),
+    ...(input.telemetry ? { telemetry: input.telemetry } : {}),
     ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
   });
 

--- a/services/agents/src/agents/main/run-turn.ts
+++ b/services/agents/src/agents/main/run-turn.ts
@@ -32,6 +32,7 @@
 import {
   ToolLoopAgent,
   isStepCount,
+  type Instructions,
   type StopCondition,
   type ModelMessage,
   type LanguageModel,
@@ -73,11 +74,52 @@ export interface RunTurnInput {
    * provider-agnostic.
    */
   providerOptions?: ProviderOptions;
+  /**
+   * Provider-specific prompt-cache breakpoint, built by the model seam and
+   * applied opaquely — runTurn never names a provider. Absent → nothing is
+   * marked and the request is byte-identical to an uncached one.
+   *
+   * Applied to the system block and to the LAST message of this turn's prompt,
+   * which together cover the whole stable prefix (tools + system + history).
+   * The marker never reaches `input.messages`: the stored history must stay
+   * clean, or every turn would leave another breakpoint behind and a long
+   * conversation would blow the provider's per-request limit.
+   */
+  cacheBreakpoint?: ProviderOptions;
 }
 
 export interface RunTurnResult {
   finishReason: string;
   usage: LanguageModelUsage;
+}
+
+/**
+ * The instructions as a system message carrying `breakpoint`, or the plain
+ * string when there is none. `Instructions` accepts a `SystemModelMessage`,
+ * which is the only place a provider option can ride on the system block.
+ */
+function withCacheBreakpoint(
+  instructions: string,
+  breakpoint: ProviderOptions | undefined,
+): Instructions {
+  if (!breakpoint) return instructions;
+  return { role: "system", content: instructions, providerOptions: breakpoint };
+}
+
+/**
+ * `messages` with `breakpoint` on its last entry — as a COPY. The caller's
+ * array is the conversation that gets persisted and it must not carry cache
+ * markers, so the last message is cloned rather than mutated. Everything before
+ * it is shared by reference: nothing downstream mutates message objects, and
+ * copying a long history every step would be the expensive part.
+ */
+function markLastMessage(
+  messages: ModelMessage[],
+  breakpoint: ProviderOptions | undefined,
+): ModelMessage[] {
+  if (!breakpoint || messages.length === 0) return messages;
+  const last = messages[messages.length - 1]!;
+  return [...messages.slice(0, -1), { ...last, providerOptions: breakpoint }];
 }
 
 export async function runTurn(input: RunTurnInput): Promise<RunTurnResult> {
@@ -87,7 +129,7 @@ export async function runTurn(input: RunTurnInput): Promise<RunTurnResult> {
 
   const agent = new ToolLoopAgent({
     model: input.model,
-    instructions: input.instructions,
+    instructions: withCacheBreakpoint(input.instructions, input.cacheBreakpoint),
     tools: input.tools,
     stopWhen: input.stopWhen ?? [isStepCount(input.maxSteps ?? 20)],
     ...(input.maxOutputTokens ? { maxOutputTokens: input.maxOutputTokens } : {}),
@@ -95,7 +137,7 @@ export async function runTurn(input: RunTurnInput): Promise<RunTurnResult> {
   });
 
   const result = await agent.stream({
-    messages: input.messages,
+    messages: markLastMessage(input.messages, input.cacheBreakpoint),
     ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
   });
 

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -49,7 +49,12 @@ import { buildInstructions, buildTaskPlanInstructions, buildPrompt, buildEagerSk
 import type { SkillSource } from "../agents/main/skill-source.js";
 import { buildManifestPart, toTurnUsage } from "./manifest.js";
 import { config } from "../shared/config.js";
-import { isAnthropicModel, modelProviderOptions, webSearchTool } from "../shared/model.js";
+import {
+  isAnthropicModel,
+  modelCacheBreakpoint,
+  modelProviderOptions,
+  webSearchTool,
+} from "../shared/model.js";
 import { loadMcpTools } from "../shared/mcp-client.js";
 import type { Conversation, ConversationStore } from "../store/conversation-store.js";
 
@@ -268,6 +273,7 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
     // spending a whole model call on loadSkill. Unknown names skip silently
     // (the snapshot is the authority on what exists).
     const eagerBlock = buildEagerSkillsBlock(skills, input.eagerSkills);
+    const cacheBreakpoint = modelCacheBreakpoint();
     const startLen = conv.messages.length;
     const res = await runTurn({
       model: input.model,
@@ -284,6 +290,11 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       ],
       maxOutputTokens: config.maxOutputTokens,
       providerOptions: modelProviderOptions(),
+      // History is append-only (see the module doc above), so the prefix this
+      // marks is byte-identical on the next step and the next turn — which is
+      // exactly what makes it cacheable. Omitted entirely when caching is off,
+      // so the request is byte-identical to before this existed.
+      ...(cacheBreakpoint ? { cacheBreakpoint } : {}),
       onEvent,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -56,6 +56,7 @@ import {
   webSearchTool,
 } from "../shared/model.js";
 import { loadMcpTools } from "../shared/mcp-client.js";
+import { turnTelemetry } from "../shared/telemetry.js";
 import type { Conversation, ConversationStore } from "../store/conversation-store.js";
 
 /** Thrown when a second turn starts for an id whose turn is still in flight (→ HTTP 409). */
@@ -274,6 +275,9 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
     // (the snapshot is the authority on what exists).
     const eagerBlock = buildEagerSkillsBlock(skills, input.eagerSkills);
     const cacheBreakpoint = modelCacheBreakpoint();
+    // Stamps this turn's steps with the conversation they belong to, so two
+    // projects generating at once are attributable in the trace UI.
+    const telemetry = turnTelemetry(conv.id);
     const startLen = conv.messages.length;
     const res = await runTurn({
       model: input.model,
@@ -295,6 +299,7 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       // exactly what makes it cacheable. Omitted entirely when caching is off,
       // so the request is byte-identical to before this existed.
       ...(cacheBreakpoint ? { cacheBreakpoint } : {}),
+      ...(telemetry ? { telemetry } : {}),
       onEvent,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });

--- a/services/agents/src/main.ts
+++ b/services/agents/src/main.ts
@@ -27,8 +27,10 @@
  */
 
 import pg from "pg";
+import { registerTelemetry } from "ai";
 import { createApp } from "./server.js";
 import { createModel, resolveModelId } from "./shared/model.js";
+import { captureTelemetry } from "./shared/telemetry.js";
 import { intEnv } from "./shared/env.js";
 import { config } from "./shared/config.js";
 import type { AgentsAuthConfig } from "./shared/auth.js";
@@ -74,6 +76,15 @@ async function buildStore(): Promise<ConversationStore> {
 }
 
 async function main(): Promise<void> {
+  // Trace capture registers ONCE per process — it is a property of the
+  // deployment, not of a turn. It used to be a middleware wrapped around the
+  // per-turn model, which is what made every turn its own unrelated run: the
+  // capture minted a run id when that short-lived object was constructed.
+  // Registering here leaves model lifetimes alone; each turn stamps its own
+  // functionId instead (shared/telemetry.ts).
+  const telemetry = captureTelemetry();
+  if (telemetry) registerTelemetry(telemetry);
+
   const store = await buildStore();
   const app = createApp({
     store,

--- a/services/agents/src/shared/config.ts
+++ b/services/agents/src/shared/config.ts
@@ -52,6 +52,15 @@ export const config = {
   // Sonnet-class models support 64k output tokens; default high so a single-doc
   // generation completes in one step. intEnv guards a non-numeric override.
   maxOutputTokens: intEnv(process.env.AGENT_MAX_OUTPUT_TOKENS, 64_000),
+  // Anthropic prompt caching (AGENT_PROMPT_CACHE, default ON). Caching is
+  // opt-in per request: with no `cache_control` breakpoint Anthropic caches
+  // nothing, so every step of a tool loop re-bills the whole prefix — measured
+  // at ~1.07M input tokens across one 19-step turn, every token uncached.
+  // History is append-only, so the prefix is stable and cacheable by
+  // construction (run-conversation-turn.ts). Off by env only as an escape
+  // hatch: a cache WRITE costs more than plain input, so a deployment whose
+  // turns are reliably single-step could rationally decline.
+  promptCache: boolEnv(process.env.AGENT_PROMPT_CACHE, true),
   logLevel: process.env.LOG_LEVEL || "info",
   // AI SDK DevTools (AGENT_DEVTOOLS, default off): wrap the model in
   // `devToolsMiddleware` so every LLM call is captured to

--- a/services/agents/src/shared/model.ts
+++ b/services/agents/src/shared/model.ts
@@ -28,62 +28,10 @@
  * key from the environment. See run.ts.)
  */
 
-import { wrapLanguageModel, type LanguageModel, type LanguageModelMiddleware } from "ai";
+import type { LanguageModel } from "ai";
 import { anthropic, createAnthropic, type AnthropicLanguageModelOptions } from "@ai-sdk/anthropic";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 import type { ProviderOptions } from "../agents/main/run-turn.js";
 import { config } from "./config.js";
-
-/**
- * Make a middleware NON-FATAL: a throw in any of its hooks degrades to the
- * unwrapped behavior instead of failing the model call. DevTools' `wrapStream`
- * runs its trace-capture (`ensureRunCreated`/`createStep`, which touch
- * `.devtools/generations.json`) BEFORE its own try/catch, so a corrupt/missing
- * db or an FS error there propagates into the stream and KILLS THE TURN (seen
- * live: "Cannot read properties of undefined (reading 'find')" → "stream ended
- * without a manifest"). Trace capture is a debugging aid — it must never be able
- * to break a live generation. The `wrapStream`/`wrapGenerate` fallbacks call the
- * original `doStream`/`doGenerate` exactly once (DevTools only throws BEFORE it
- * calls them, so there is no double model call).
- */
-function nonFatalMiddleware(mw: LanguageModelMiddleware): LanguageModelMiddleware {
-  return {
-    ...mw,
-    ...(mw.transformParams
-      ? {
-          transformParams: async (o) => {
-            try {
-              return await mw.transformParams!(o);
-            } catch {
-              return o.params;
-            }
-          },
-        }
-      : {}),
-    ...(mw.wrapGenerate
-      ? {
-          wrapGenerate: async (o) => {
-            try {
-              return await mw.wrapGenerate!(o);
-            } catch {
-              return o.doGenerate();
-            }
-          },
-        }
-      : {}),
-    ...(mw.wrapStream
-      ? {
-          wrapStream: async (o) => {
-            try {
-              return await mw.wrapStream!(o);
-            } catch {
-              return o.doStream();
-            }
-          },
-        }
-      : {}),
-  };
-}
 
 /** Resolved LLM configuration for a single run. */
 export interface LlmConfig {
@@ -113,16 +61,12 @@ export function createModel(cfg: LlmConfig): LanguageModel {
     apiKey: cfg.apiKey,
     ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}),
   });
-  const model = provider(resolveModelId(cfg));
-  // AI SDK DevTools (AGENT_DEVTOOLS): wrap the model so every LLM call/step —
-  // request, response, tool calls, token usage, timing — is captured to
-  // `.devtools/generations.json` (and pushed to a running viewer on
-  // AI_SDK_DEVTOOLS_PORT) for the trace UI. Opt-in: the middleware writes a file
-  // + best-effort-notifies per call, so it stays off unless explicitly enabled.
-  if (config.devtools) {
-    return wrapLanguageModel({ model, middleware: nonFatalMiddleware(devToolsMiddleware()) });
-  }
-  return model;
+  // Trace capture is NOT wrapped around the model: a capturing object's
+  // lifetime became the trace's run identity, and this object is rebuilt every
+  // turn (the key is per-request), which split one conversation across N runs.
+  // Capture registers once at the composition root and is stamped per turn —
+  // see shared/telemetry.ts.
+  return provider(resolveModelId(cfg));
 }
 
 /**

--- a/services/agents/src/shared/model.ts
+++ b/services/agents/src/shared/model.ts
@@ -137,6 +137,22 @@ export function modelProviderOptions(): ProviderOptions {
 }
 
 /**
+ * The provider-specific PROMPT-CACHE breakpoint, or undefined when caching is
+ * off. Lives in this seam for the same reason `modelProviderOptions` does: the
+ * marker is Anthropic's (`cacheControl`), and the turn loop stays
+ * provider-agnostic by passing whatever this returns through opaquely.
+ *
+ * Anthropic caches the prompt prefix UP TO AND INCLUDING the marked block, so a
+ * caller marks the last stable block rather than every block — the API allows
+ * only a handful of breakpoints, and marking history messages individually
+ * would exhaust them as a conversation grows.
+ */
+export function modelCacheBreakpoint(): ProviderOptions | undefined {
+  if (!config.promptCache) return undefined;
+  return { anthropic: { cacheControl: { type: "ephemeral" } } };
+}
+
+/**
  * True iff `model` is served by the Anthropic provider (`provider` starts with
  * "anthropic") — gates the provider-executed `web_search` tool (external-
  * dependency-discovery #252), which is Anthropic-specific: injecting it

--- a/services/agents/src/shared/telemetry.ts
+++ b/services/agents/src/shared/telemetry.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Trace-capture seam — the single module that knows about DevTools. Capture
+ * used to ride the MODEL seam (a `devToolsMiddleware` wrapped around the model
+ * built for each turn), which is why every turn of one conversation showed up
+ * as its own unrelated run: DevTools mints a run id when the capturing object
+ * is constructed, and that object's lifetime was one turn. Identity was being
+ * derived from an object's lifetime.
+ *
+ * Here it is derived from the TURN instead: the integration registers once at
+ * the composition root, and each turn stamps its own `functionId`. Model
+ * lifetimes are untouched — the per-request key still leaves with the response.
+ *
+ * DevTools does NOT merge runs by `functionId`; a run is still one SDK call.
+ * What the label buys is attribution: the viewer renders `function_id` in its
+ * run list, so two projects generating at the same time are told apart at a
+ * glance instead of guessed at by timestamp.
+ */
+
+import type { Telemetry, TelemetryOptions } from "ai";
+import { DevToolsTelemetry } from "@ai-sdk/devtools";
+import { config } from "./config.js";
+
+/**
+ * Make a telemetry integration NON-FATAL. The SDK awaits integration callbacks
+ * with no try/catch of its own (`mergeTelemetryCallback` → `await
+ * mergedIntegrationCallback(event)`), so a throw inside one propagates into the
+ * generation and kills the turn. DevTools reads and rewrites a JSON file on
+ * these hooks, so a corrupt or unwritable capture file is enough — this is the
+ * same failure that once surfaced as "stream ended without a manifest", and the
+ * reason the retired middleware was wrapped the same way. Trace capture is a
+ * debugging aid; it must never be able to break a live generation.
+ *
+ * Observer hooks (`on*`) are swallowed. `executeTool` is a WRAPPER, not an
+ * observer — swallowing it would drop the tool's result, so it falls through to
+ * the unwrapped `execute()` exactly once, mirroring the middleware's
+ * `catch { return o.doGenerate(); }`.
+ */
+export function nonFatalTelemetry(integration: Telemetry): Telemetry {
+  const guarded: Telemetry = {};
+  for (const [key, value] of Object.entries(integration)) {
+    if (typeof value !== "function") continue;
+    if (key === "executeTool") continue; // handled below — it returns a value
+    const hook = value as (event: unknown) => unknown;
+    Object.assign(guarded, {
+      [key]: async (event: unknown) => {
+        try {
+          await hook.call(integration, event);
+        } catch {
+          // Capture is best-effort: the turn continues untraced.
+        }
+      },
+    });
+  }
+
+  const { executeTool } = integration;
+  if (executeTool) {
+    // Generic in T: the wrapper returns the TOOL's result, so erasing T here
+    // would erase every tool's result type at the call site.
+    guarded.executeTool = async <T>(options: {
+      callId: string;
+      toolCallId: string;
+      execute: () => PromiseLike<T>;
+    }): Promise<T> => {
+      try {
+        // `.call` preserves `this` for integrations that need it but erases the
+        // generic; the declared signature returns PromiseLike<T> for this same
+        // T, so the cast restores what the call site already knows.
+        return (await executeTool.call(integration, options)) as T;
+      } catch {
+        return options.execute();
+      }
+    };
+  }
+  return guarded;
+}
+
+/**
+ * The capture integration to register at the composition root, or undefined
+ * when capture is off. Registration is global and once-per-process, which is
+ * why it belongs to the root and not to a turn.
+ *
+ * `DevToolsTelemetry()` THROWS under `NODE_ENV=production` by design, so the
+ * `config.devtools` gate is load-bearing rather than merely tidy.
+ */
+export function captureTelemetry(): Telemetry | undefined {
+  if (!config.devtools) return undefined;
+  return nonFatalTelemetry(DevToolsTelemetry());
+}
+
+/**
+ * A conversation id rendered for the viewer's run list. Ids are namespaced
+ * `org_<org>--proj_<project>--<useCase>--<uuid>`; the list truncates from the
+ * right, so the uuid — the only segment that differs between two conversations
+ * of the same project — is dropped rather than allowed to push the project name
+ * out of view.
+ *
+ * Defensive by construction: an id that does not match the namespaced shape is
+ * returned verbatim. Evals, the playground and lazily-created conversations all
+ * use plain ids, and a LABEL must never be able to fail a turn — which is also
+ * why this does not reuse `snapshot-path.ts`'s parser, whose job is to reject.
+ */
+export function threadLabel(conversationId: string): string {
+  const segments = conversationId.split("--");
+  if (segments.length !== 4) return conversationId;
+  const [orgSeg, projSeg, useCase] = segments as [string, string, string, string];
+  if (!orgSeg.startsWith("org_") || !projSeg.startsWith("proj_")) return conversationId;
+  return `${orgSeg.slice("org_".length)}/${projSeg.slice("proj_".length)}/${useCase}`;
+}
+
+/**
+ * This turn's telemetry options — the `functionId` every step of the turn is
+ * stamped with. Undefined when capture is off, so the call is byte-identical to
+ * one made before any of this existed.
+ */
+export function turnTelemetry(conversationId: string): TelemetryOptions | undefined {
+  if (!config.devtools) return undefined;
+  return { functionId: threadLabel(conversationId) };
+}

--- a/services/agents/test/prompt-cache.test.ts
+++ b/services/agents/test/prompt-cache.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Prompt-cache breakpoints. Anthropic caches nothing unless the request carries
+ * a `cache_control` marker, so an unmarked turn re-bills its whole prefix on
+ * every step of the tool loop — measured live at ~1.07M input tokens across one
+ * 19-step turn, all uncached. These assert the marker reaches the provider and,
+ * just as importantly, never reaches the conversation we persist.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ModelMessage } from "ai";
+import { runTurn } from "../src/agents/main/run-turn.js";
+import { mockModel } from "../src/shared/mock-model.js";
+
+const BREAKPOINT = { anthropic: { cacheControl: { type: "ephemeral" } } };
+
+/** The prompt the model actually received for `callIndex`. */
+function promptAt(model: ReturnType<typeof mockModel>, callIndex: number): ModelMessage[] {
+  return model.doStreamCalls[callIndex]!.prompt as unknown as ModelMessage[];
+}
+
+test("the cache breakpoint rides the system block and the last message", async () => {
+  const model = mockModel([{ kind: "text", text: "Done." }]);
+  const messages: ModelMessage[] = [
+    { role: "user", content: "earlier turn" },
+    { role: "assistant", content: "earlier reply" },
+  ];
+
+  await runTurn({
+    model,
+    instructions: "You are a spec agent.",
+    tools: {},
+    messages,
+    prompt: "this turn",
+    cacheBreakpoint: BREAKPOINT,
+  });
+
+  const prompt = promptAt(model, 0);
+  const system = prompt.filter((m) => m.role === "system");
+  assert.equal(system.length, 1, "instructions should reach the model as one system block");
+  assert.deepEqual(
+    system[0]!.providerOptions,
+    BREAKPOINT,
+    "the system block carries the breakpoint (it fronts the stable tools+system prefix)",
+  );
+
+  // Anthropic caches UP TO the marked block, so marking the final message caches
+  // the entire prefix for every later step of this turn's loop.
+  const last = prompt[prompt.length - 1]!;
+  assert.deepEqual(last.providerOptions, BREAKPOINT, "the last message carries the breakpoint");
+});
+
+test("the breakpoint never reaches the persisted conversation", async () => {
+  const model = mockModel([{ kind: "text", text: "Done." }]);
+  const messages: ModelMessage[] = [{ role: "user", content: "earlier turn" }];
+
+  await runTurn({
+    model,
+    instructions: "You are a spec agent.",
+    tools: {},
+    messages,
+    prompt: "this turn",
+    cacheBreakpoint: BREAKPOINT,
+  });
+
+  // `messages` is the aggregate the store writes. A marker left behind here
+  // would accumulate one breakpoint per turn and eventually exceed the
+  // provider's per-request limit — the failure would surface as a 400 on a
+  // long-running conversation, far from this code.
+  for (const m of messages) {
+    assert.equal(
+      m.providerOptions,
+      undefined,
+      `persisted ${m.role} message must carry no cache marker`,
+    );
+  }
+});
+
+test("no breakpoint leaves the request untouched", async () => {
+  const model = mockModel([{ kind: "text", text: "Done." }]);
+  const messages: ModelMessage[] = [{ role: "user", content: "earlier turn" }];
+
+  await runTurn({
+    model,
+    instructions: "You are a spec agent.",
+    tools: {},
+    messages,
+    prompt: "this turn",
+  });
+
+  for (const m of promptAt(model, 0)) {
+    assert.equal(m.providerOptions, undefined, `${m.role} must be unmarked when caching is off`);
+  }
+});

--- a/services/agents/test/telemetry.test.ts
+++ b/services/agents/test/telemetry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The trace-capture seam. Two properties matter more than the labels
+ * themselves: capture can never break a turn, and a malformed conversation id
+ * can never break one either — a debugging aid that can fail a generation is
+ * worse than no debugging aid.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Telemetry } from "ai";
+import { nonFatalTelemetry, threadLabel } from "../src/shared/telemetry.js";
+
+test("threadLabel renders a namespaced id as org/project/useCase", () => {
+  assert.equal(
+    threadLabel("org_default--proj_staff-maintain--design--0192a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b"),
+    "default/staff-maintain/design",
+  );
+});
+
+test("threadLabel returns anything else verbatim rather than throwing", () => {
+  // Evals, the playground and lazily-created conversations use plain ids. A
+  // LABEL must never be able to fail a turn, so unparseable is not an error.
+  for (const id of ["c-42", "", "org_only--two", "not--four--segments--but--five"]) {
+    assert.equal(threadLabel(id), id, `\`${id}\` must pass through untouched`);
+  }
+});
+
+test("a throwing observer hook cannot break the turn", async () => {
+  const exploding: Telemetry = {
+    onStart: () => {
+      throw new Error("capture file is corrupt");
+    },
+  };
+  // The SDK awaits integration callbacks with NO try/catch of its own, so an
+  // unguarded throw here propagates into the generation — this is the failure
+  // that once surfaced as "stream ended without a manifest".
+  await assert.doesNotReject(() => Promise.resolve(nonFatalTelemetry(exploding).onStart!({} as never)));
+});
+
+test("a throwing executeTool falls through to the real tool instead of losing its result", async () => {
+  let ran = 0;
+  const exploding: Telemetry = {
+    executeTool: () => {
+      throw new Error("capture file is corrupt");
+    },
+  };
+  const result = await nonFatalTelemetry(exploding).executeTool!({
+    callId: "c1",
+    toolCallId: "t1",
+    execute: () => {
+      ran += 1;
+      return Promise.resolve("tool output");
+    },
+  } as never);
+
+  // executeTool WRAPS the tool — swallowing it would drop the result and leave
+  // the model with nothing, so the guard must call through, exactly once.
+  assert.equal(result, "tool output");
+  assert.equal(ran, 1, "the underlying tool runs exactly once");
+});
+
+test("hooks the integration does not implement are not invented", () => {
+  const guarded = nonFatalTelemetry({ onStart: () => {} });
+  assert.equal(typeof guarded.onStart, "function");
+  assert.equal(guarded.onStepEnd, undefined, "absent hooks stay absent");
+  assert.equal(guarded.executeTool, undefined, "absent wrapper stays absent");
+});
+
+test("a turn's functionId reaches a registered telemetry integration", async () => {
+  // End-to-end through the REAL SDK telemetry path: `registerTelemetry` +
+  // `agent.stream({ telemetry })`. DevTools reads `event.functionId` and writes
+  // it to the run row, so this is the hop that decides whether a run is
+  // attributable — asserted against a fake integration so it needs no provider,
+  // no key and no capture file.
+  const { registerTelemetry } = await import("ai");
+  const { runTurn } = await import("../src/agents/main/run-turn.js");
+  const { mockModel } = await import("../src/shared/mock-model.js");
+
+  const seen: (string | undefined)[] = [];
+  registerTelemetry({
+    onStart: (event: { functionId?: string }) => {
+      seen.push(event.functionId);
+    },
+  } as never);
+
+  try {
+    await runTurn({
+      model: mockModel([{ kind: "text", text: "Done." }]),
+      instructions: "You are a spec agent.",
+      tools: {},
+      messages: [],
+      prompt: "hello",
+      telemetry: { functionId: "default/staff-maintain/design" },
+    });
+    assert.deepEqual(seen, ["default/staff-maintain/design"]);
+  } finally {
+    registerTelemetry(); // clear — global state must not leak into other tests
+  }
+});

--- a/services/collab/src/bff.test.ts
+++ b/services/collab/src/bff.test.ts
@@ -60,3 +60,65 @@ test("applyFiles still throws ApplyConflictError on 409", async () => {
       e instanceof ApplyConflictError && e.paths.includes("a.md"),
   );
 });
+
+// ---- the seed read ----
+
+/** Records every request the client makes, answering each with `body`. */
+function recordingFetch(body: unknown, status = 200) {
+  const urls: string[] = [];
+  const impl: typeof fetch = async (input) => {
+    urls.push(String(input));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return { urls, impl };
+}
+
+test("fetchSpecFiles reads the whole seed in ONE request", async () => {
+  // The count is the point, not an implementation detail. Each request the seed
+  // makes costs the BFF an origin round trip under the mirror's exclusive lock,
+  // so a per-file fan-out is what pushed a 10-file room past the agents' sync
+  // timeout. It also resolved the branch tip separately per file, which could
+  // straddle two commits.
+  const { urls, impl } = recordingFetch({
+    commitSha: "abc123",
+    files: [
+      { path: "specs/requirements/prd.md", content: "req", sha: "s1" },
+      { path: "specs/design/design.md", content: "des", sha: "s2" },
+    ],
+  });
+  const files = await createBffClient("http://bff", impl).fetchSpecFiles(
+    "t",
+    "proj",
+  );
+
+  assert.equal(urls.length, 1, `expected one request, got ${urls.join(", ")}`);
+  assert.equal(urls[0], "http://bff/projects/proj/files/bundle?prefix=specs%2F");
+  // Paths stay VERBATIM full repo paths — the one doc-key scheme shared with
+  // the console, the committer and the agents' live-peer writes.
+  assert.deepEqual(files, [
+    { path: "specs/requirements/prd.md", content: "req", sha: "s1" },
+    { path: "specs/design/design.md", content: "des", sha: "s2" },
+  ]);
+});
+
+test("fetchSpecFiles treats a null files array as an empty seed", async () => {
+  // The contract marks `files` nullable, and a room with no committed specs is
+  // ordinary (a brand-new project). Seeding nothing must open an empty room, not
+  // throw on `.map` of null and fail the join.
+  const { impl } = recordingFetch({ commitSha: "abc123", files: null });
+  assert.deepEqual(
+    await createBffClient("http://bff", impl).fetchSpecFiles("t", "proj"),
+    [],
+  );
+});
+
+test("fetchSpecFiles surfaces a failed read rather than seeding a partial room", async () => {
+  const { impl } = recordingFetch({ title: "boom" }, 500);
+  await assert.rejects(
+    () => createBffClient("http://bff", impl).fetchSpecFiles("t", "proj"),
+    /Failed to read spec files for proj \(500\)/,
+  );
+});

--- a/services/collab/src/bff.ts
+++ b/services/collab/src/bff.ts
@@ -133,43 +133,34 @@ export function createBffClient(
 
     async fetchSpecFiles(token, projectName) {
       const project = encodeURIComponent(projectName);
-      const headers = { Authorization: `Bearer ${token}` };
-
-      const listRes = await fetchImpl(`${base}/projects/${project}/files`, {
-        headers,
-      });
-      if (!listRes.ok) {
+      // ONE request for the whole seed. This used to be a list followed by a
+      // read per file, which was slow AND wrong: every one of those reads
+      // revalidated the mirror against origin (a network round trip each,
+      // serialized behind the mirror's write lock — a 10-file spec took ~15s and
+      // blew the agents' room-sync timeout), and each resolved the branch tip
+      // independently, so a push landing mid-seed produced a document mixing two
+      // commits with baseline shas to match. The bundle resolves one commit and
+      // reads everything at it. Server-side `prefix` also means the whole repo's
+      // file list — application code included — is no longer shipped here to be
+      // filtered away in JS.
+      const res = await fetchImpl(
+        `${base}/projects/${project}/files/bundle?prefix=${encodeURIComponent(SPECS_PREFIX)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (!res.ok) {
         throw new Error(
-          `Failed to list spec files for ${projectName} (${listRes.status})`,
+          `Failed to read spec files for ${projectName} (${res.status})`,
         );
       }
-      const metas = ((await listRes.json()) ?? []) as { path: string }[];
-
-      return Promise.all(
-        metas.flatMap((meta) => {
-          // Spec room seeds only specs/ files; the path is kept VERBATIM.
-          if (!meta.path.startsWith(SPECS_PREFIX)) return [];
-          const encoded = meta.path
-            .split("/")
-            .map(encodeURIComponent)
-            .join("/");
-          return [
-            (async (): Promise<SpecFile> => {
-              const res = await fetchImpl(
-                `${base}/projects/${project}/files/${encoded}`,
-                { headers },
-              );
-              if (!res.ok) {
-                throw new Error(
-                  `Failed to read ${meta.path} for ${projectName} (${res.status})`,
-                );
-              }
-              const body = (await res.json()) as { content: string; sha: string };
-              return { path: meta.path, content: body.content, sha: body.sha };
-            })(),
-          ];
-        }),
-      );
+      const body = (await res.json()) as {
+        files?: SpecFile[] | null;
+      };
+      // Paths arrive VERBATIM (full repo paths) — the one doc-key scheme.
+      return (body.files ?? []).map((f) => ({
+        path: f.path,
+        content: f.content,
+        sha: f.sha,
+      }));
     },
 
     async applyFiles(token, projectName, batch) {

--- a/services/collab/src/mockbff.test.ts
+++ b/services/collab/src/mockbff.test.ts
@@ -82,7 +82,7 @@ test("validate: rooms outside the caller's org are denied", async () => {
   );
 });
 
-test("spec files: list + per-file reads through the real client, full specs/ paths verbatim", async () => {
+test("spec files: one bundle read through the real client, full specs/ paths verbatim", async () => {
   const bff = createBffClient(base);
   const files = await bff.fetchSpecFiles("opaque-token", "demo-shop");
   assert.equal(files.length, devSpecFiles.length);

--- a/services/collab/src/mockbff.ts
+++ b/services/collab/src/mockbff.ts
@@ -75,6 +75,10 @@ function json(res: http.ServerResponse, status: number, body: unknown): void {
 
 const FILES_LIST_PATH = /^\/api\/v1\/projects\/([^/]+)\/files$/;
 const FILES_APPLY_PATH = /^\/api\/v1\/projects\/([^/]+)\/files\/apply$/;
+const FILES_BUNDLE_PATH = /^\/api\/v1\/projects\/([^/]+)\/files\/bundle$/;
+// Matched LAST: `bundle` and `apply` are literal segments under what is
+// otherwise a trailing wildcard, so they must be tried first here exactly as the
+// real server's ServeMux prefers a literal over a wildcard.
 const FILE_READ_PATH = /^\/api\/v1\/projects\/([^/]+)\/files\/(.+)$/;
 
 let applyCount = 0;
@@ -127,6 +131,28 @@ export function createMockBff(options: MockBffOptions = {}): http.Server {
           size: f.content.length,
         })),
       );
+    }
+
+    // The seed read: every readable file under `prefix`, at one commit. Mirrors
+    // the real endpoint's shape — a commitSha plus content-bearing entries — so
+    // the client's one-call seed path is exercised for real here.
+    const bundleMatch =
+      req.method === "GET" && url.pathname.match(FILES_BUNDLE_PATH);
+    if (bundleMatch) {
+      if (!token) return json(res, 401, { title: "Unauthorized" });
+      const project = decodeURIComponent(bundleMatch[1] ?? "");
+      const prefix = url.searchParams.get("prefix") ?? "";
+      const files = projects[project] ?? devSpecFiles;
+      return json(res, 200, {
+        commitSha: "mockhead",
+        files: files
+          .filter((f) => f.path.startsWith(prefix))
+          .map((f) => ({
+            path: f.path,
+            content: f.content,
+            sha: mockSha(f.path + f.content),
+          })),
+      });
     }
 
     const readMatch =

--- a/services/collab/src/seed-rejoin.test.ts
+++ b/services/collab/src/seed-rejoin.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Seeding against a client that already holds the room's content — the case
+ * that silently doubled every markdown spec file in git, once per session.
+ *
+ * A browser keeps ONE Y.Doc for as long as the spec view is mounted, while the
+ * server (unloadImmediately) discards its document the moment the last peer
+ * leaves. So a reconnect after any blip — a redeploy, a laptop sleep, a dropped
+ * socket — puts a client holding a full copy of the room in front of a server
+ * that believes the room is new and seeds it from git. Yjs merges; it does not
+ * deduplicate, because two independent insertions of identical text are two
+ * distinct sets of items. The room ends up holding the document twice, the
+ * committer flushes exactly what it sees, and git gets a file twice as long.
+ * Repeat per session: 374 → 750 → 1502 → 3006 → … lines.
+ *
+ * These run the REAL server against a REAL provider, because the bug lives in
+ * the interaction between them, not in either alone.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import * as Y from "yjs";
+import { HocuspocusProvider, HocuspocusProviderWebsocket } from "@hocuspocus/provider";
+import WebSocket from "ws";
+import { fragmentToMarkdown } from "@aep/collab-doc";
+import { createCollabServer } from "./server.js";
+import { dropRoomState } from "./rooms.js";
+import type { BffClient } from "./bff.js";
+import type { CollabConfig } from "./env.js";
+
+const ROOM = "spec-acme-shop";
+const PRD_PATH = "specs/requirements/prd.md";
+const PRD = "# PRD\n\nA paragraph of body text.\n\n## Section\n\nMore text.\n";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function config(port: number): CollabConfig {
+  return {
+    port,
+    aepApiBase: "http://bff.test/api/v1",
+    devMode: false,
+    mockBff: false,
+    mockBffPort: 0,
+    // Long enough that no debounced store fires mid-test; the assertions read
+    // the doc directly rather than waiting on a commit.
+    commitDebounceMs: 60_000,
+    commitMaxDebounceMs: 300_000,
+  };
+}
+
+/** A BFF whose spec bundle is one markdown file, and which records applies. */
+function fakeBff(applied: { paths: string[] }[]): BffClient {
+  return {
+    validateAccess: async () => ({
+      name: "Jo",
+      email: "jo@example.com",
+      projectName: "shop",
+    }),
+    fetchSpecFiles: async () => [{ path: PRD_PATH, content: PRD, sha: "s1" }],
+    applyFiles: async (_t, _p, batch) => {
+      applied.push({ paths: batch.writes.map((w) => w.path) });
+      return { commitSha: "c1", files: [] };
+    },
+  };
+}
+
+/** Attach `doc` to the room and resolve once synced. */
+async function join(port: number, doc: Y.Doc) {
+  const socket = new HocuspocusProviderWebsocket({
+    url: `ws://127.0.0.1:${port}`,
+    WebSocketPolyfill: WebSocket,
+  });
+  const provider = new HocuspocusProvider({
+    websocketProvider: socket,
+    name: ROOM,
+    document: doc,
+    token: "jwt",
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("sync timeout")), 10_000);
+    provider.on("synced", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    provider.on("authenticationFailed", () => {
+      clearTimeout(timer);
+      reject(new Error("auth rejected"));
+    });
+    provider.attach();
+  });
+  return {
+    leave: async () => {
+      provider.destroy();
+      socket.destroy();
+      // Let the server observe the close and run its unload path.
+      await new Promise((r) => setTimeout(r, 250));
+    },
+  };
+}
+
+/** How many times the seeded document appears in the room's markdown. */
+function copies(doc: Y.Doc): number {
+  const md = fragmentToMarkdown(doc.getXmlFragment(PRD_PATH));
+  return md.split("# PRD").length - 1;
+}
+
+test("a client that rejoins with its existing doc does not get a second copy seeded in", async () => {
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const applied: { paths: string[] }[] = [];
+  const server = createCollabServer(config(port), { bff: fakeBff(applied) });
+  await server.listen(port);
+
+  // The browser's doc: created once when the spec view mounts, and kept for as
+  // long as it stays mounted — across every reconnect underneath it.
+  const browserDoc = new Y.Doc();
+  try {
+    const first = await join(port, browserDoc);
+    assert.equal(copies(browserDoc), 1, "first join seeds the room once");
+    // The socket drops (redeploy / sleep / blip). The server unloads the room;
+    // the browser keeps its doc, exactly as useCollabSpec does.
+    await first.leave();
+
+    const second = await join(port, browserDoc);
+    assert.equal(
+      copies(browserDoc),
+      1,
+      "rejoining must not append a second copy of the document",
+    );
+    await second.leave();
+  } finally {
+    await server.destroy();
+  }
+});
+
+test("repeated rejoins do not compound — the production failure was exponential", async () => {
+  // The observed timeline was 374 → 750 → 1502 → 3006 → 6014 → 12030 → 24062 →
+  // 48126 lines: each session doubled what the last one wrote, so a single
+  // surviving rejoin path is not a small leak, it is a doubling per session.
+  // Four rounds would have been 16 copies.
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const server = createCollabServer(config(port), { bff: fakeBff([]) });
+  await server.listen(port);
+
+  const browserDoc = new Y.Doc();
+  try {
+    for (let round = 1; round <= 4; round++) {
+      const session = await join(port, browserDoc);
+      assert.equal(copies(browserDoc), 1, `still one copy after rejoin ${round}`);
+      await session.leave();
+    }
+  } finally {
+    await server.destroy();
+  }
+});
+
+test("a client's own edits survive a rejoin", async () => {
+  // The dedupe must key on the SEED's identity, not on "drop anything that
+  // looks like a duplicate" — a client reconnecting with unsynced work has to
+  // keep it, or the fix would trade doubling for data loss.
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const server = createCollabServer(config(port), { bff: fakeBff([]) });
+  await server.listen(port);
+
+  const browserDoc = new Y.Doc();
+  try {
+    const first = await join(port, browserDoc);
+    const fragment = browserDoc.getXmlFragment(PRD_PATH);
+    const para = new Y.XmlElement("paragraph");
+    fragment.push([para]);
+    para.push([new Y.XmlText("a sentence typed while connected")]);
+    await first.leave();
+
+    const second = await join(port, browserDoc);
+    const md = fragmentToMarkdown(browserDoc.getXmlFragment(PRD_PATH));
+    assert.match(md, /a sentence typed while connected/, "the edit must not be dropped");
+    assert.equal(copies(browserDoc), 1, "and the document must still appear once");
+    await second.leave();
+  } finally {
+    await server.destroy();
+  }
+});
+
+test("a genuinely new client still gets the room seeded from git", async () => {
+  // The guard above must not be so eager that it stops seeding altogether: a
+  // first joiner with an empty doc has to receive the committed content.
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const server = createCollabServer(config(port), { bff: fakeBff([]) });
+  await server.listen(port);
+
+  const doc = new Y.Doc();
+  try {
+    const session = await join(port, doc);
+    assert.equal(copies(doc), 1);
+    assert.match(fragmentToMarkdown(doc.getXmlFragment(PRD_PATH)), /A paragraph of body text/);
+    await session.leave();
+  } finally {
+    await server.destroy();
+  }
+});
+
+test("a second, empty client joining a live room sees the room's content once", async () => {
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const server = createCollabServer(config(port), { bff: fakeBff([]) });
+  await server.listen(port);
+
+  const first = new Y.Doc();
+  const second = new Y.Doc();
+  try {
+    const a = await join(port, first);
+    const b = await join(port, second); // joins while A is still connected
+    assert.equal(copies(first), 1, "the established peer keeps one copy");
+    assert.equal(copies(second), 1, "the joining peer receives one copy");
+    await b.leave();
+    await a.leave();
+  } finally {
+    await server.destroy();
+  }
+});

--- a/services/collab/src/seed.ts
+++ b/services/collab/src/seed.ts
@@ -31,23 +31,123 @@ import type { SpecFile } from "./bff.js";
 export { FILES_MAP, filesMap } from "@aep/collab-doc";
 
 /**
+ * SEEDING IS IDEMPOTENT ACROSS PROCESSES, and that is the whole point of this
+ * module rather than an incidental nicety.
+ *
+ * A room's document is seeded from git on every LOAD, and a load happens far
+ * more often than a room is "new": `unloadImmediately` discards the server's
+ * document the moment the last peer leaves, while a browser keeps ONE Y.Doc for
+ * as long as the spec view stays mounted. Any reconnect — a redeploy, a laptop
+ * waking, a dropped socket — therefore puts a client holding a full copy of the
+ * room in front of a server that believes the room is empty.
+ *
+ * Written the obvious way, that merge DOUBLES the document. Yjs identifies every
+ * insertion by (clientID, clock) and merges by union: two independently-built
+ * copies of identical text are two disjoint sets of items, so the room ends up
+ * holding the file twice, and the committer faithfully writes twice as much to
+ * git. Observed in production as 374 → 750 → 1502 → 3006 → 6014 → 12030 → 24062
+ * → 48126 lines, one doubling per session.
+ *
+ * The fix is to give the seed a STABLE IDENTITY: build it in a scratch document
+ * whose clientID is a pure function of the content, then transfer it as an
+ * update. Re-seeding the same bytes reproduces byte-identical items, and Yjs
+ * skips items it already has — so the client's retained copy and the fresh seed
+ * collapse into one. A client's own EDITS carry that client's own id, so they
+ * are untouched by the dedupe and still merge normally.
+ */
+function seedClientId(path: string, content: string): number {
+  // FNV-1a over path + content. Any stable 32-bit hash would do; what matters
+  // is that it depends on BOTH — on the path so two files never share a clock
+  // line, and on the content so that changed bytes get a fresh identity rather
+  // than colliding with the old item ids at the same clocks. The NUL separator
+  // keeps the fields from running together, so ("ab", "c") and ("a", "bc") hash
+  // differently; it is spelled as an escape because a raw NUL in the source
+  // makes the whole file binary to git.
+  let hash = 0x811c9dc5;
+  const input = `${path}\u0000${content}`;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  // 0 is avoided only to keep the id visibly non-default in a debugger; Yjs
+  // ascribes it no special meaning.
+  return hash === 0 ? 1 : hash;
+}
+
+/**
+ * The update that puts ONE file into a room, built under that file's stable
+ * identity. Separate scratch docs per file (rather than one for the batch) keep
+ * each file's item ids independent: editing one file must not renumber the
+ * others, or every unchanged file would fail to dedupe on the next rejoin.
+ */
+function seedUpdateFor(file: SpecFile): Uint8Array {
+  const scratch = new Y.Doc();
+  scratch.clientID = seedClientId(file.path, file.content);
+  if (isMarkdownPath(file.path)) {
+    markdownToFragment(file.content, scratch.getXmlFragment(file.path));
+  } else {
+    const text = new Y.Text();
+    filesMap(scratch).set(file.path, text);
+    text.insert(0, file.content);
+  }
+  return Y.encodeStateAsUpdate(scratch);
+}
+
+/** Whether `doc` is still missing `file` — live content always wins over a seed. */
+function needsSeeding(doc: Y.Doc, file: SpecFile): boolean {
+  if (isMarkdownPath(file.path)) {
+    return doc.getXmlFragment(file.path).length === 0;
+  }
+  return !filesMap(doc).has(file.path);
+}
+
+/** Whether the seed for `file` actually materialized in `doc`. */
+function isPresent(doc: Y.Doc, file: SpecFile): boolean {
+  return !needsSeeding(doc, file);
+}
+
+/**
  * Populate an (empty or partial) doc from a spec bundle. Existing entries are
  * never overwritten — a rejoin after eviction reseeds only what's missing, and
  * live peer content always wins over a late seed.
+ *
+ * Safe to run against a room a client is about to sync its own copy into: see
+ * the note on `seedClientId` for why the two collapse rather than stack.
+ *
+ * `onAnomaly` reports the one failure this scheme can have — two files in one
+ * bundle whose (path, content) hash collides, which would make the second file's
+ * items look already-applied and silently drop them. Odds are ~1e-8 for a
+ * ten-file bundle, but silent data loss is not something to leave unobserved, so
+ * a dropped file is re-seeded WITHOUT a stable identity (content present, at the
+ * cost of that one file doubling on a future rejoin) and reported.
  */
-export function seedDocument(doc: Y.Doc, files: SpecFile[]): void {
-  const map = filesMap(doc);
+export function seedDocument(
+  doc: Y.Doc,
+  files: SpecFile[],
+  onAnomaly?: (message: string) => void,
+): void {
+  const seeded: SpecFile[] = [];
   doc.transact(() => {
     for (const file of files) {
+      if (!needsSeeding(doc, file)) continue;
+      Y.applyUpdate(doc, seedUpdateFor(file));
+      seeded.push(file);
+    }
+  });
+
+  const dropped = seeded.filter((file) => !isPresent(doc, file));
+  if (dropped.length === 0) return;
+  doc.transact(() => {
+    for (const file of dropped) {
+      onAnomaly?.(
+        `seed identity collision on ${file.path} — re-seeded without a stable id`,
+      );
       if (isMarkdownPath(file.path)) {
-        const fragment = doc.getXmlFragment(file.path);
-        if (fragment.length === 0) {
-          markdownToFragment(file.content, fragment);
-        }
-      } else if (!map.has(file.path)) {
+        markdownToFragment(file.content, doc.getXmlFragment(file.path));
+      } else {
         const text = new Y.Text();
+        filesMap(doc).set(file.path, text);
         text.insert(0, file.content);
-        map.set(file.path, text);
       }
     }
   });

--- a/services/collab/src/server.ts
+++ b/services/collab/src/server.ts
@@ -186,8 +186,13 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
   ) => {
     const { document, documentName, context } = data;
 
+    // A seed anomaly is never fatal (the content still lands) but it must not be
+    // silent — it is the one path where this room could lose a file's identity.
+    const onAnomaly = (message: string) =>
+      deps.log?.(`seed anomaly in ${documentName}: ${message}`);
+
     if (config.devMode) {
-      seedDocument(document, devSeedFiles);
+      seedDocument(document, devSeedFiles, onAnomaly);
       deps.log?.(`seeded ${documentName} from dev fixtures`);
       return document;
     }
@@ -208,7 +213,7 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
         context.token,
         context.projectName,
       );
-      seedDocument(document, files);
+      seedDocument(document, files, onAnomaly);
       // Committer baseline (#133): the flush diffs the live doc against what
       // was seeded (content) and preconditions on the shas we read.
       const state = ensureRoomState(documentName, context.projectName);


### PR DESCRIPTION
Four fixes from one thread: a room seed that was timing out, a data-corruption
bug it exposed, and two agent-side changes that came out of chasing them.

## `fix(collab)`: the room seed doubled every markdown spec file

Every collab session appended each markdown spec file to itself. Observed in one
project over nine hours:

```
374 -> 750 -> 1502 -> 3006 -> 6014 -> 12030 -> 24062 -> 48126 lines
```

One doubling per session, until the room could not be opened at all — the
markdown parse is superlinear, so a 48k-line document blew a 120s sync.

Three individually-reasonable facts caused it:

- `onLoadDocument` seeds the room from git on **every** document load;
- `unloadImmediately` discards the server's document the moment the last peer
  leaves, so a load happens far more often than a room is new;
- a client keeps **one** `Y.Doc` for as long as its view stays mounted, across
  every reconnect underneath it.

Any reconnect therefore puts a client holding a full copy of the room in front
of a server that believes the room is empty. **Yjs merges by union and never
deduplicates** — it identifies insertions by `(clientID, clock)`, so two
independently-built copies of identical text are two disjoint item sets. The
committer then faithfully wrote what it saw. `seedDocument`'s
`fragment.length === 0` guard was right in intent but evaluated at load time,
before any client state arrives, when the fragment is always empty.

The seed now carries a **stable identity**: built in a scratch `Y.Doc` whose
`clientID` is a pure function of `(path, content)`, transferred as an update.
Re-seeding the same bytes reproduces byte-identical items and Yjs skips what it
already has, so the client's retained copy and the fresh seed collapse into one.
A client's own edits carry that client's id and are untouched — this does not
trade doubling for data loss. Identity is per file, not per bundle, so editing
one file does not renumber the others.

**Proof.** Tests run the real server against a real provider, because the bug
lives in the interaction between them rather than in either alone. The three
rejoin cases fail against the previous seed and pass against this one; the two
control cases pass either way.

| | with fix | without |
|---|---|---|
| rejoin with an existing doc | pass | **fail** — 2 copies |
| four repeated rejoins | pass | **fail** |
| a client's own edits survive a rejoin | pass | **fail** |
| a new client still gets seeded | pass | pass |
| a second client joins a live room | pass | pass |

Live: three consecutive sessions produce **zero commits**, where before every
session produced a doubling commit. Cost is 82ms on a 32k-line document — 0.8%
over the markdown parse the old path paid anyway.

> [!NOTE]
> A client holding a room seeded *before* this change has items built with random
> client ids, which cannot dedupe against the stable seed. Such a client has to
> be reloaded once.

## `perf(collab)`: seed a room in one request instead of one per file

Seeding read the file list and then one file per entry — 11 HTTP calls for a
10-file project. That cost far more than the round trips suggest: every
Workspace read addressed by branch name revalidates the mirror against origin
first, and that fetch runs under the mirror's **exclusive** lock, so the reads
serialize. Ten reads issued simultaneously against a live project:

```
200  1.34s  specs/.agentic-engineer.toml
200  2.57s  specs/design/components/maintenance-webapp/wireframes.dsl
200  4.05s  specs/design/design.cell
...
200 14.95s  specs/design/components/maintenance-api/openapi.yaml
```

A staircase ~1.3s apart. Local git plumbing for the same tree measures **0.00s**,
so essentially all of it was redundant network fetch plus lock queueing — and it
blew the agents service's 10s room-sync budget, which is how this surfaced.

The fan-out was also **incoherent**, independently of speed: each call resolved
the branch tip for itself, so a push landing mid-seed produced a document mixing
two commits with blob shas to match — and the committer preconditions its writes
on exactly those shas.

`read-file-bundle` returns every readable file under a prefix at **one** commit:
it resolves the tip once via `Head` and addresses `List`/`ReadBundle` by that
object name, and gitfs freshens only for symbolic addresses. No change to the
`Workspace` port — `ReadBundle` already existed with four internal callers and
simply had no HTTP surface.

The bundle applies `validateReadPath` **per path** rather than trusting the
caller's prefix: it returns content, so filtering by prefix alone would make it a
whole-repo reader and an escalation over the per-file gate.

**Live, same ten files: 17.87s -> 1.51s.** A real room join now syncs in 931ms
against a 10,000ms budget.

## `perf(agents)`: turn on Anthropic prompt caching

Caching is opt-in per request: with no `cache_control` breakpoint Anthropic
caches nothing, so every step of a tool loop re-bills the whole prefix —
measured at ~1.07M input tokens across one 19-step turn, every token uncached.
History is append-only, so the prefix is stable and cacheable by construction.
Live-verified: turn 2 read 24,623 cached tokens.

The breakpoint rides the provider-aware model seam, so the generic turn loop
stays provider-agnostic. The marker never reaches stored history — otherwise
every turn would leave another breakpoint behind and a long conversation would
exhaust the provider's per-request limit.

## `fix(agents)`: make a trace run say which conversation it belongs to

Capture rode the **model** seam, so DevTools minted a run id per capturing
object — and that object is rebuilt every turn, which split one conversation
across N unrelated runs. Identity was being derived from an object's lifetime.
It is now derived from the **turn**: the integration registers once at the
composition root and each turn stamps its own `functionId`. Model lifetimes are
untouched, so the per-request key still leaves with the response.

Capture is also made non-fatal. The SDK awaits integration callbacks with no
`try/catch` of its own, so a throw inside one propagates into the generation —
the failure that once surfaced as "stream ended without a manifest". `executeTool`
is a wrapper rather than an observer, so it falls through to the unwrapped
`execute()` exactly once instead of swallowing the tool's result.

## Verification

All gates run on this branch, rebased on `bug-fixes`:

| gate | result |
|---|---|
| `go build ./...` | ok |
| Go suite (`-short`) | **65 packages, 0 failures** |
| `make gen-api-check` | ok |
| `make deadcode-check` | ok |
| `@aep/collab` tests | **51/51** |
| `@aep/agents` tests | **223/223** |
| typecheck + lint (both) | ok |

The generated `server_gen.go` conflicted with #409 during the rebase; it was
resolved by re-running `make gen-api` from the merged contract rather than
hand-merging generated output. The contract merge is purely additive over
`bug-fixes` (+78 lines, no deletions).

## Not included, deliberately

The per-read origin fetch is still live for the console's file-open and the ~30s
design-bundle poll — every branch-tip read costs a round trip under the mirror's
exclusive lock. Fixing that means changing the freshness rule (fetch coalescing
or a `ReadBundleLocal`), which has a staleness trade-off worth deciding
separately. Related: `deployments/docker-compose.yml:60` points at
`docs/design/gitfs-fetch-on-read-followup.md`, which does not exist in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
