### PR TITLE
fix: make a project delete finish the job (and bound the DevTools capture)

### DIFF
--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -314,9 +314,11 @@ export function useCreateProject() {
   });
 }
 
-// Delete a project (#107). The BFF cascade destroys the OC project, its
-// deployments, and the GitHub repo; the confirm dialog owns the warning.
-// Invalidates every list page so the card leaves the grid on success.
+// Delete a project (#107). The BFF cascade destroys the OC project and its
+// deployments, ends the run supervisors, and purges the platform's own repo
+// record, executions and run ledger. It does NOT delete the GitHub repository —
+// that survives, and the confirm dialog says so. Invalidates every list page so
+// the card leaves the grid on success.
 export function useDeleteProject() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/console/src/features/projects/components/DeleteProjectDialog.tsx
+++ b/apps/console/src/features/projects/components/DeleteProjectDialog.tsx
@@ -44,8 +44,13 @@ interface DeleteProjectDialogProps {
 }
 
 // Confirmation dialog for deleting a project from the listing (#107).
-// Names the GitHub repository that the cascade destroys when the list
-// payload carries one; projects without a repo get generic copy.
+//
+// The copy states what the cascade ACTUALLY does. The remote repository is not
+// part of it — the platform drops its own record and stops tracking the repo,
+// but never deletes it from GitHub — so the dialog names the repo as the thing
+// that SURVIVES rather than the thing that is destroyed. Saying otherwise told
+// users their code was gone when it was not, and hid the reason a project
+// recreated under the same repo name is refused.
 export function DeleteProjectDialog({
   project,
   onClose,
@@ -71,15 +76,20 @@ export function DeleteProjectDialog({
       <DialogTitle>Delete {displayName}?</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          This permanently deletes the project, its deployments, and{" "}
+          This permanently deletes the project, its deployments, and its build
+          history.
+        </DialogContentText>
+        <DialogContentText sx={{ mt: 2 }}>
           {project?.repoUrl ? (
             <>
-              the GitHub repository <strong>{repoDisplayName(project.repoUrl)}</strong>
+              The GitHub repository{" "}
+              <strong>{repoDisplayName(project.repoUrl)}</strong> is kept, with
+              all specs, code and issues. Delete it on GitHub if you want the
+              name freed — a new project cannot reuse it while it exists.
             </>
           ) : (
-            "its GitHub repository"
-          )}{" "}
-          — including all specs and code.
+            "The project's GitHub repository is kept, with all specs, code and issues."
+          )}
         </DialogContentText>
         {deleteProject.isError && (
           <Alert severity="error" sx={{ mt: 2 }}>

--- a/apps/console/src/features/usage/components/UsageSection.tsx
+++ b/apps/console/src/features/usage/components/UsageSection.tsx
@@ -77,8 +77,11 @@ export function UsageSection() {
 
   return (
     <Stack spacing={1.5}>
+      {/* The name alone is not a key: a project deleted and recreated under the
+          same one is two cards — the live project and the incarnation whose
+          spend it does not inherit. */}
       {cards.map((card) => (
-        <ProjectCard key={card.projectName} card={card} />
+        <ProjectCard key={`${card.projectName}:${card.deleted}`} card={card} />
       ))}
     </Stack>
   );

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -144,6 +144,10 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	repoRepo := sourcecontrol.NewRepoRepository(db)
 	milestoneRunRepo := delivery.NewMilestoneRunRepository(db)
 	runCycleRepo := delivery.NewRunCycleRepository(db, in.RateStamper)
+	// The agent-usage ledger: the read + retire half of delivery's spend record.
+	// The WRITE half needs no wiring — each capture repository mirrors into it as
+	// part of its own stamp, so there is no way to run one without the other.
+	usageLedgerRepo := delivery.NewAgentUsageLedgerRepository(db)
 	orgRepo := organization.NewOrganizationRepository(db)
 	orgCredRepo := organization.NewOrgCredentialRepository(db, in.ColumnCipher)
 	orgAnthropicRepo := organization.NewOrgAnthropicRepository(db)
@@ -424,7 +428,7 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// Build/deploy stage sources for the status poll (#184): the milestone-run
 	// index (one row read) + the org-scoped release-binding list —
 	// consumer-side ports wired here so projects imports neither.
-	projectService.SetStageSources(projectRunRows{runs: milestoneRunRepo, cycles: runCycleRepo}, componentClient)
+	projectService.SetStageSources(projectRunRows{runs: milestoneRunRepo, cycles: runCycleRepo, ledger: usageLedgerRepo}, componentClient)
 	organizationService := organization.NewOrganizationService(orgRepo, namespaceClient)
 	// componentService takes repoSvc + buildCredSvc so TriggerBuild can
 	// pre-stage the per-WorkflowRun build Secret in workflows-<orgID>
@@ -632,6 +636,11 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// its agent dispatcher (delivery.MilestoneDispatcher): a supervisor with no
 	// dispatcher refuses to start runs, so the two must be wired together.
 	runSupervisor := run.NewSupervisor(temporalRuntime, runRuns{runs: milestoneRunRepo}, codingExecutor)
+	// The run-supervisor half of the project-delete cascade. Wired HERE rather
+	// than beside SetStageSources because the supervisor does not exist until the
+	// coding executor does: purging a project's run ROWS leaves the workflows that
+	// write them running, polling a repository the same delete is about to remove.
+	projectService.SetRunAbandoner(projectRunSupervision{runs: milestoneRunRepo, supervisor: runSupervisor})
 
 	platformSender := githubBotLogin(cfg.GitHubAppSlug)
 	registerWebhook := func(event, action string, h func(ctx context.Context, event, action string, payload []byte) error) {
@@ -890,12 +899,13 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// composite; the edge holds no project/component/config service.
 	// Settings → Usage (#291): fold spec-turn + delivery per-project usage,
 	// labelled by the org's live projects (a usage slug with no live project is a
-	// since-deleted project, shown greyed). Delivery's half sums BOTH its capture
-	// tables — cycles, where every agent run lands after the issue-driven flip,
-	// and the older execution rows (see delivery.PhaseUsageRollup).
+	// since-deleted project, shown greyed). Delivery's half reads the agent-usage
+	// LEDGER — the one delivery table a project delete does not purge, and the one
+	// place both its capture surfaces mirror into, so spend survives the project
+	// and is never counted twice (see delivery.PhaseUsageRollup).
 	usageService := projects.NewUsageService(
 		turnRepo.SumUsageByProject,
-		delivery.PhaseUsageRollup(executionRepo, runCycleRepo),
+		delivery.PhaseUsageRollup(usageLedgerRepo),
 		func(ctx context.Context, orgID string) (map[string]string, error) {
 			names := map[string]string{}
 			list, err := projectService.ListProjects(ctx, orgID, 100, "", "")

--- a/services/aep-api/internal/app/eventcore_adapters.go
+++ b/services/aep-api/internal/app/eventcore_adapters.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
@@ -287,6 +288,9 @@ func (a eventcoreAdopter) AdoptIssue(ctx context.Context, orgID, projectID strin
 type projectRunRows struct {
 	runs   delivery.MilestoneRunRepository
 	cycles delivery.RunCycleRepository
+	// ledger is what the purge does NOT delete. It is retired instead — see
+	// DeleteByProject.
+	ledger delivery.AgentUsageLedgerRepository
 }
 
 func (a projectRunRows) ListByProject(ctx context.Context, orgID, projectID string) ([]delivery.MilestoneRun, error) {
@@ -301,9 +305,73 @@ func (a projectRunRows) LatestCycle(ctx context.Context, orgID, runID string) (*
 	return a.cycles.Latest(ctx, orgID, runID)
 }
 
+// DeleteByProject is delivery's whole answer to a project delete, and it is two
+// different verbs on purpose.
+//
+// The cycles and runs are WORKING STATE and go: a recreated same-named project
+// must not inherit a predecessor's timeline, or the status poll would chase
+// versions the fresh repo never had. What that work COST is not working state,
+// and does not go — the Settings → Usage page is built to keep reporting a
+// deleted project's spend, and purging the rows it was stamped on is what
+// silently emptied it.
+//
+// So the ledger is RETIRED first, before the rows it mirrors are removed. The
+// order is load-bearing in one direction only — retirement reads nothing from
+// the cycles — but doing it first means a failure leaves the spend attributed to
+// a live project rather than the rows deleted with their lifetime still open,
+// which is the difference between a retry that fixes it and one that cannot.
 func (a projectRunRows) DeleteByProject(ctx context.Context, orgID, projectID string) error {
+	if err := a.ledger.RetireByProject(ctx, orgID, projectID); err != nil {
+		return err
+	}
 	if err := a.cycles.DeleteByProject(ctx, orgID, projectID); err != nil {
 		return err
 	}
 	return a.runs.DeleteByProject(ctx, orgID, projectID)
+}
+
+// projectRunSupervision adapts the milestone-run index + the run supervisor onto
+// the projects domain's run-teardown port: on a project delete, end the workflows
+// supervising its live runs.
+//
+// It is keyed by MILESTONE rather than by run, because the workflow is: a run's
+// identity is its milestone (delivery.MilestoneRunWorkflowID), so several rows of
+// the same milestone name one supervisor and abandoning it once is enough.
+type projectRunSupervision struct {
+	runs       delivery.MilestoneRunRepository
+	supervisor runAbandonment
+}
+
+// runAbandonment is the single supervisor verb the teardown needs. It is an
+// interface rather than the concrete *run.Supervisor only so the milestone
+// SELECTION below can be proven without a Temporal client — the selection is the
+// part with a decision in it.
+type runAbandonment interface {
+	AbandonRun(ctx context.Context, orgID, projectID string, milestoneNumber int) error
+}
+
+// AbandonProjectRuns terminates the supervisor of every milestone the project
+// still has a LIVE run on. Settled runs are skipped: their workflows have already
+// ended, and a run that settled is not one anything is still polling for.
+//
+// One milestone's failure does not stop the others — this runs inside a delete
+// that has already been committed upstream, so the most complete teardown
+// possible is worth more than a clean early return.
+func (a projectRunSupervision) AbandonProjectRuns(ctx context.Context, orgID, projectID string) error {
+	rows, err := a.runs.ListByProject(ctx, orgID, projectID)
+	if err != nil {
+		return err
+	}
+	seen := make(map[int]bool, len(rows))
+	var errs []error
+	for i := range rows {
+		if delivery.IsTerminalRunState(rows[i].State) || seen[rows[i].MilestoneNumber] {
+			continue
+		}
+		seen[rows[i].MilestoneNumber] = true
+		if aerr := a.supervisor.AbandonRun(ctx, orgID, projectID, rows[i].MilestoneNumber); aerr != nil {
+			errs = append(errs, aerr)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/services/aep-api/internal/app/project_teardown_adapters_test.go
+++ b/services/aep-api/internal/app/project_teardown_adapters_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+// projectRunRowsStub answers the one read the run teardown makes. Every other
+// verb of the repository is unreachable from it, so the embedded interface
+// supplies them and any accidental call panics rather than passing silently.
+type projectRunRowsStub struct {
+	delivery.MilestoneRunRepository
+	rows []delivery.MilestoneRun
+	err  error
+}
+
+func (s projectRunRowsStub) ListByProject(context.Context, string, string) ([]delivery.MilestoneRun, error) {
+	return s.rows, s.err
+}
+
+// recordingAbandoner records the milestones the teardown asked to abandon.
+type recordingAbandoner struct {
+	milestones []int
+	err        error
+}
+
+func (r *recordingAbandoner) AbandonRun(_ context.Context, _, _ string, milestoneNumber int) error {
+	r.milestones = append(r.milestones, milestoneNumber)
+	return r.err
+}
+
+// TestAbandonProjectRuns_OneCallPerLiveMilestone: a run's identity is its
+// milestone, so several rows of the same milestone name ONE supervisor — and a
+// settled run has no supervisor left to end.
+func TestAbandonProjectRuns_OneCallPerLiveMilestone(t *testing.T) {
+	rows := []delivery.MilestoneRun{
+		{MilestoneNumber: 2, State: delivery.RunStateRunning},
+		{MilestoneNumber: 2, State: delivery.RunStateWaiting},   // same supervisor
+		{MilestoneNumber: 1, State: delivery.RunStateSucceeded}, // already ended
+		{MilestoneNumber: 3, State: delivery.RunStatePlanning},
+		{MilestoneNumber: 4, State: delivery.RunStateCancelled}, // already ended
+	}
+	abandoner := &recordingAbandoner{}
+	a := projectRunSupervision{runs: projectRunRowsStub{rows: rows}, supervisor: abandoner}
+
+	if err := a.AbandonProjectRuns(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("AbandonProjectRuns: %v", err)
+	}
+	want := []int{2, 3}
+	if len(abandoner.milestones) != len(want) {
+		t.Fatalf("abandoned milestones = %v, want %v", abandoner.milestones, want)
+	}
+	for i := range want {
+		if abandoner.milestones[i] != want[i] {
+			t.Fatalf("abandoned milestones = %v, want %v", abandoner.milestones, want)
+		}
+	}
+}
+
+// TestAbandonProjectRuns_OneFailureDoesNotStopTheRest: this runs inside a delete
+// that has already been committed upstream, so the most complete teardown
+// possible beats a clean early return — every failure is still reported.
+func TestAbandonProjectRuns_OneFailureDoesNotStopTheRest(t *testing.T) {
+	rows := []delivery.MilestoneRun{
+		{MilestoneNumber: 1, State: delivery.RunStateRunning},
+		{MilestoneNumber: 2, State: delivery.RunStateWaiting},
+	}
+	boom := errors.New("temporal down")
+	abandoner := &recordingAbandoner{err: boom}
+	a := projectRunSupervision{runs: projectRunRowsStub{rows: rows}, supervisor: abandoner}
+
+	err := a.AbandonProjectRuns(context.Background(), "acme", "web")
+	if !errors.Is(err, boom) {
+		t.Fatalf("AbandonProjectRuns error = %v, want it to carry %v", err, boom)
+	}
+	if len(abandoner.milestones) != 2 {
+		t.Errorf("every live milestone must be attempted, got %v", abandoner.milestones)
+	}
+}
+
+// TestAbandonProjectRuns_RowReadFailureIsReported: without the rows the teardown
+// does not know which supervisors to end, and reporting nothing would read as
+// "there were none".
+func TestAbandonProjectRuns_RowReadFailureIsReported(t *testing.T) {
+	boom := errors.New("db down")
+	abandoner := &recordingAbandoner{}
+	a := projectRunSupervision{runs: projectRunRowsStub{err: boom}, supervisor: abandoner}
+
+	if err := a.AbandonProjectRuns(context.Background(), "acme", "web"); !errors.Is(err, boom) {
+		t.Fatalf("AbandonProjectRuns error = %v, want %v", err, boom)
+	}
+	if len(abandoner.milestones) != 0 {
+		t.Errorf("nothing may be abandoned on an unreadable index, got %v", abandoner.milestones)
+	}
+}
+
+// ledgerRetireRecorder + cycleRunPurgeRecorder trace the delete cascade's three
+// writes in the order the adapter issues them.
+type cascadeTrace struct{ steps []string }
+
+type ledgerRetireRecorder struct {
+	delivery.AgentUsageLedgerRepository
+	trace *cascadeTrace
+	err   error
+}
+
+func (l *ledgerRetireRecorder) RetireByProject(context.Context, string, string) error {
+	l.trace.steps = append(l.trace.steps, "retire")
+	return l.err
+}
+
+type cyclePurgeRecorder struct {
+	delivery.RunCycleRepository
+	trace *cascadeTrace
+}
+
+func (c cyclePurgeRecorder) DeleteByProject(context.Context, string, string) error {
+	c.trace.steps = append(c.trace.steps, "cycles")
+	return nil
+}
+
+type runPurgeRecorder struct {
+	delivery.MilestoneRunRepository
+	trace *cascadeTrace
+}
+
+func (r runPurgeRecorder) DeleteByProject(context.Context, string, string) error {
+	r.trace.steps = append(r.trace.steps, "runs")
+	return nil
+}
+
+// TestProjectDelete_RetiresSpendBeforePurgingTheRowsItWasCapturedFrom.
+//
+// The cascade is two different verbs. Cycles and runs are working state and are
+// deleted; what they COST is not, and is retired instead — which is what stopped
+// a project delete from emptying the Settings → Usage page. Retirement goes
+// first so a failure leaves the spend attributed to a live project (a retry
+// fixes it) rather than the rows gone with their lifetime still open (nothing
+// can).
+func TestProjectDelete_RetiresSpendBeforePurgingTheRowsItWasCapturedFrom(t *testing.T) {
+	trace := &cascadeTrace{}
+	a := projectRunRows{
+		runs:   runPurgeRecorder{trace: trace},
+		cycles: cyclePurgeRecorder{trace: trace},
+		ledger: &ledgerRetireRecorder{trace: trace},
+	}
+	if err := a.DeleteByProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("DeleteByProject: %v", err)
+	}
+	want := []string{"retire", "cycles", "runs"}
+	if len(trace.steps) != len(want) {
+		t.Fatalf("cascade = %v, want %v", trace.steps, want)
+	}
+	for i := range want {
+		if trace.steps[i] != want[i] {
+			t.Fatalf("cascade = %v, want %v", trace.steps, want)
+		}
+	}
+}
+
+// TestProjectDelete_AbortsWhenSpendCouldNotBeRetired: the rows must not be
+// purged while the spend they carry is still attributed to a live project —
+// that combination loses the record for good, which is the exact failure the
+// ledger was added to stop.
+func TestProjectDelete_AbortsWhenSpendCouldNotBeRetired(t *testing.T) {
+	trace := &cascadeTrace{}
+	boom := errors.New("db down")
+	a := projectRunRows{
+		runs:   runPurgeRecorder{trace: trace},
+		cycles: cyclePurgeRecorder{trace: trace},
+		ledger: &ledgerRetireRecorder{trace: trace, err: boom},
+	}
+	if err := a.DeleteByProject(context.Background(), "acme", "web"); !errors.Is(err, boom) {
+		t.Fatalf("DeleteByProject error = %v, want %v", err, boom)
+	}
+	if len(trace.steps) != 1 {
+		t.Fatalf("nothing may be purged after a failed retire: %v", trace.steps)
+	}
+}

--- a/services/aep-api/internal/contracts/usage.go
+++ b/services/aep-api/internal/contracts/usage.go
@@ -91,6 +91,20 @@ type StampedUsage struct {
 	CostUsd *float64
 }
 
+// UsageScope names ONE project lifetime's spend. It is the key the delivery
+// roll-up returns, because a project slug is not an identity: a project can be
+// deleted and recreated under the same name, and the two must not share a bill.
+//
+// Retired is the whole discriminator. False is the incarnation that is live now;
+// true is spend that belonged to one the platform has already torn down. All
+// retired generations of a slug share the scope — they are one closed story
+// ("what this name used to cost"), and the record that separates them
+// generation-by-generation stays in the ledger for anyone who needs it.
+type UsageScope struct {
+	ProjectID string
+	Retired   bool
+}
+
 // Add folds another stamped aggregate in: tokens via TokenUsage.Add, and the
 // USD sums only where present — nil + nil stays nil, nil + x is x.
 func (s StampedUsage) Add(other StampedUsage) StampedUsage {

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -121,24 +121,25 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   grammar and that spelling. The milestone **number** is the key; the title is kept
   only as the `v<N>` tag a `?tag=` query resolves through. Loop position is read from the latest cycle, and
   per-component build/deploy status is derived from OpenChoreo on read — neither is stored.
-- **Delivery's agent SPEND**, on the cycle record: a cycle IS one agent run, so its captured token usage
-  and the USD stamped on it at capture (`cost_usd`, amended console ADR-0011) are where both the build and
-  validation phases of Settings → Usage come from. The phase is read from the cycle's kind. `RecordUsage`
-  is the one cycle mutator NOT fenced on `ended_at IS NULL`: usage arrives from the terminal-log capture,
-  and a cycle closes on the merge webhook seconds after its Job exits — fencing it would discard nearly
-  every capture. `PhaseUsageRollup` sums this with the executions table, which today contributes nothing
-  (its only remaining kind, `provision`, runs no model).
+- **Delivery's agent SPEND**, in the `agent_usage_ledger`: an append-only entry per dispatch carrying the
+  captured tokens, the USD stamped at capture (`cost_usd`, amended console ADR-0011), the SDLC phase and
+  the version it paid for. Both capture surfaces mirror into it as part of their own stamp — `RecordUsage`
+  on the cycle and on the execution — so `PhaseUsageRollup` reads the ledger and NOTHING else: adding the
+  dispatch rows back would bill every token twice. `RecordUsage` stays the one cycle mutator NOT fenced on
+  `ended_at IS NULL`: usage arrives from the terminal-log capture, and a cycle closes on the merge webhook
+  seconds after its Job exits — fencing it would discard nearly every capture. Entries are keyed
+  `(source, source_id)`, so a re-read of the same log updates one entry rather than adding a second.
 - The **run loop** (`run`): one Temporal workflow per milestone, `run-<org>-<project>-<milestoneNumber>`,
   whose id is REUSED after a terminal run because a milestone sees sequential runs across its life. It
   owns the four budgets, the no-progress rule, the cycle ceiling, the validation cycle and settle — and
   nothing else: it detects no event and writes no issue.
 - **Persistence**: every gorm in this domain sits at the ROOT (the fence `TestGormFencedToDomainRepository`
   draws), as single write-authority — `repository_execution.go` · `repository_coding_agent_log.go` ·
-  `repository_run.go` · `repository_cycle.go` · `repository_run_cycle_log.go` over the `execution.go` /
-  `coding_agent_log.go` / `milestone_run.go` / `run_cycle.go` / `run_cycle_log.go` entities. Their tables
-  are `executions` · `coding_agent_logs` · `milestone_runs` · `run_cycles` · `run_cycle_logs`.
-  `usage_rollup.go` is the one read that spans two of them, and is a plain function over both
-  repositories rather than a third store.
+  `repository_run.go` · `repository_cycle.go` · `repository_run_cycle_log.go` · `repository_usage_ledger.go`
+  over the `execution.go` / `coding_agent_log.go` / `milestone_run.go` / `run_cycle.go` / `run_cycle_log.go`
+  / `usage_ledger.go` entities. Their tables are `executions` · `coding_agent_logs` · `milestone_runs` ·
+  `run_cycles` · `run_cycle_logs` · `agent_usage_ledger`. `usage_rollup.go` is a plain function over the
+  ledger rather than a third store.
 
 ## Invariants — don't break
 - **`task ⊥ run`.** The GitHub-facing Task surface and the run supervisor are peer sub-packages that never
@@ -204,6 +205,16 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   read model and never read back: a replay must reproduce the same decisions without a database. The one
   budget it does not count is the automatic build re-trigger — that is the event plane's, derived from the
   WorkflowRuns themselves, and the supervisor reads the same runs rather than keeping a second tally.
+- **Activities retry blips forever and answers never.** The supervisor's activities run under Temporal's
+  default policy — unbounded, with backoff — because a supervisor that cannot reach GitHub should stall
+  visibly rather than settle a run on a network blip. A failure that repeating cannot change is told
+  apart wherever the supervisor touches source control and marked non-retryable, so it fails on
+  its first attempt: the project deleted underneath a live run, a milestone or pull request removed on
+  the host, a rejected credential. `sourcecontrol.IsPermanent` owns which failures those are — GitHub's
+  secondary rate limit wears a 403 and is deliberately NOT one — and `run/errors.go` owns turning them
+  into Temporal's vocabulary. The guard is per call site, so an activity added later that returns a
+  source-control error raw is back on unbounded retry; `CloseMilestone` is the one deliberate exception,
+  swallowing its error by contract and so never retrying.
 - **Every terminal reason names exactly one failure class.** `redispatch-budget` is agent death (including
   a Job that exited without a pull request); `build-retrigger-budget` is a build that stayed red through
   its one automatic re-trigger with no fix issue to recover it; `fix-chain-budget` and `conflict-budget`
@@ -275,6 +286,15 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   NOTHING else on that pass: a Job that exited zero says nothing about whether the cycle landed, and the
   cycle's outcome is the supervisor's, learned from webhooks. Without the capture a finished run would
   have no history at all — the Job's TTL reaps the pod long before anyone opens an old version's page.
+- **A project delete purges the WORK and retires the SPEND.** `runs` and `run_cycles` are working state and
+  go, so a recreated same-named project cannot inherit a timeline its repo never had; the
+  `agent_usage_ledger` is not purged by anything — `RetireByProject` stamps its live entries instead, and
+  that stamp is the only lifetime discriminator there is. It runs FIRST and aborts the cascade on failure:
+  rows deleted while their spend is still attributed to a live project is the one combination no retry can
+  repair. `contracts.UsageScope{ProjectID, Retired}` is how the roll-up hands the two lifetimes back, so a
+  slug reused after a delete reads as two Usage cards rather than one inflated one. Spec-turn spend has no
+  such marker (`agent_turns` is never purged and never retired) and stays attributed whole to whichever
+  lifetime is current — a known asymmetry the spec domain owns.
 - **The task-log stream is one connection, no server cursor.** `stream-task-log`
   (`GET .../tasks/{issueNumber}/log`, `text/event-stream`) carries a Task's whole live state — `task` /
   `execution` / `line` / `done` frames, the frame kind in a `type` field inside the `data:` payload so it

--- a/services/aep-api/internal/delivery/repository_cycle.go
+++ b/services/aep-api/internal/delivery/repository_cycle.go
@@ -129,16 +129,11 @@ type RunCycleRepository interface {
 	// before the watcher's next tick. Fencing this on ended_at IS NULL would
 	// discard nearly every capture. Idempotent by value: the capture re-derives
 	// the same figures from the same log, so a repeat write is a no-op in effect.
+	//
+	// It also mirrors the capture into the agent-usage LEDGER, which this row's
+	// purge does not reach. The rollup reads the ledger and nothing else, so the
+	// stamp here is the run spine's own copy — not a second source of spend.
 	RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error
-
-	// SumUsageByProjectPhase rolls up captured CYCLE usage per project across an
-	// org, split into the build and validation SDLC phases (#291) — delivery's
-	// agent spend, since every token-burning dispatch is a cycle after the
-	// issue-driven flip. Validation cycles are the validation phase; coding, fix
-	// and conflict cycles are the build phase (the UsagePhase* constants). Each map
-	// is keyed by project id; CostUsd sums the frozen per-row stamps and is nil
-	// when no contributing row was stamped.
-	SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error)
 }
 
 type runCycleRepository struct {
@@ -301,12 +296,24 @@ func (r *runCycleRepository) RecordUsage(ctx context.Context, id string, u contr
 	if r.stamper != nil {
 		updates["cost_usd"] = stampCapturedCost(r.stamper, u)
 	}
-	// NOT applyOpen: see RecordUsage's contract — a closed cycle is exactly the
-	// case this has to serve.
-	return r.db.WithContext(ctx).
-		Model(&RunCycle{}).
-		Where("id = ?", id).
-		Updates(updates).Error
+	// Both writes commit together or not at all. The ledger entry is copied out of
+	// the row this stamps, and PhaseUsageRollup reads the ledger ALONE — so a
+	// stamped row whose ledger copy failed is spend that exists on the cycle and
+	// is invisible everywhere it is reported. The ledger is bound to the same tx
+	// rather than injected, which is what keeps the two impossible to wire apart.
+	//
+	// Ordering inside the tx is load-bearing: the ledger copies the row, so the
+	// row is stamped first and the INSERT … SELECT reads it uncommitted.
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// NOT applyOpen: see RecordUsage's contract — a closed cycle is exactly the
+		// case this has to serve.
+		if err := tx.Model(&RunCycle{}).
+			Where("id = ?", id).
+			Updates(updates).Error; err != nil {
+			return err
+		}
+		return NewAgentUsageLedgerRepository(tx).RecordCycleUsage(ctx, id)
+	})
 }
 
 // stampCapturedCost prices a capture for a row write (#291): the runner's
@@ -326,77 +333,6 @@ func stampCapturedCost(stamper *modelcost.Stamper, u contracts.CapturedUsage) *f
 		})
 	}
 	return stamper.SumCost(ts)
-}
-
-func (r *runCycleRepository) SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error) {
-	var rows []cyclePhaseUsageRow
-	err = r.db.WithContext(ctx).
-		Model(&RunCycle{}).
-		Select("project_id, "+
-			// Validation is its own phase; every other kind (coding, fix, conflict) is
-			// the build phase. This CASE is where that classification LIVES — see the
-			// UsagePhase* constants.
-			"CASE WHEN kind = ? THEN ? ELSE ? END AS phase, "+
-			"COALESCE(SUM(input_tokens),0) AS input_tokens, "+
-			"COALESCE(SUM(output_tokens),0) AS output_tokens, "+
-			"COALESCE(SUM(cache_read_tokens),0) AS cache_read_tokens, "+
-			"COALESCE(SUM(cache_creation_tokens),0) AS cache_creation_tokens, "+
-			"SUM(cost_usd) AS cost_usd, "+ // NULL when no row is stamped — the #291 semantic
-			// The phase's model id survives only while every contributor THAT SPENT
-			// TOKENS agrees on it — exactly contracts.TokenUsage.Add, which keeps the
-			// model across a zero-token contributor and blanks it on a genuine
-			// disagreement. Hence the CASE: a cycle that captured nothing carries
-			// model_id '' and must not drag a single-model phase to "unknown".
-			// COUNT(DISTINCT …) and MAX(…) both ignore NULL, so those rows drop out.
-			"COUNT(DISTINCT CASE WHEN "+cycleHasTokens+" THEN model_id END) AS models, "+
-			"COALESCE(MAX(CASE WHEN "+cycleHasTokens+" THEN model_id END), '') AS max_model",
-			CycleKindValidation, UsagePhaseValidation, UsagePhaseBuild).
-		Where("org_id = ? AND project_id <> ''", orgID).
-		Group("project_id, phase").
-		// Only phases with real token traffic — a cycle that captured nothing
-		// leaves a 0-token row that must not conjure a phase out of nothing.
-		Having("SUM(input_tokens) + SUM(output_tokens) + SUM(cache_read_tokens) + SUM(cache_creation_tokens) > 0").
-		Scan(&rows).Error
-	if err != nil {
-		return nil, nil, err
-	}
-	build = make(map[string]contracts.StampedUsage)
-	validation = make(map[string]contracts.StampedUsage)
-	for _, row := range rows {
-		u := contracts.TokenUsage{
-			InputTokens:         row.InputTokens,
-			OutputTokens:        row.OutputTokens,
-			CacheReadTokens:     row.CacheReadTokens,
-			CacheCreationTokens: row.CacheCreationTokens,
-		}
-		if row.Models == 1 {
-			u.Model = row.MaxModel
-		}
-		stamped := contracts.StampedUsage{Tokens: u, CostUsd: row.CostUsd}
-		if row.Phase == UsagePhaseValidation {
-			validation[row.ProjectID] = stamped
-		} else {
-			build[row.ProjectID] = stamped
-		}
-	}
-	return build, validation, nil
-}
-
-// cycleHasTokens is the "this row actually spent something" predicate, shared by
-// the model-agreement CASEs so the notion of a contributing row is spelled once.
-const cycleHasTokens = "input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens > 0"
-
-// cyclePhaseUsageRow is the per-(project, phase) aggregate scan shape (#291).
-type cyclePhaseUsageRow struct {
-	ProjectID           string
-	Phase               string
-	InputTokens         int64
-	OutputTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	CostUsd             *float64
-	Models              int64
-	MaxModel            string
 }
 
 // updateOpen applies a guarded update to a cycle that has not been closed and

--- a/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
+++ b/services/aep-api/internal/delivery/repository_cycle_dbtest_test.go
@@ -346,6 +346,9 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 		ModelID: "model-a", InputPerMTok: 1, OutputPerMTok: 10, CacheReadPerMTok: 0.1,
 	}})
 	cycles := delivery.NewRunCycleRepository(db, stamper)
+	// The rollup reads the LEDGER, which RecordUsage mirrors into as it stamps —
+	// the dispatch row is the run spine's copy, not a second source of spend.
+	ledger := delivery.NewAgentUsageLedgerRepository(db)
 	ctx := context.Background()
 
 	run := admitRun(t, runs, "orgu", "shop", 7, "v7")
@@ -421,13 +424,13 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 		t.Fatalf("unpriceable validation cost_usd = %v, want null", got.CostUsd)
 	}
 
-	build, valid, err := cycles.SumUsageByProjectPhase(ctx, "orgu")
+	build, valid, err := ledger.SumUsageByProjectPhase(ctx, "orgu")
 	if err != nil {
 		t.Fatalf("SumUsageByProjectPhase: %v", err)
 	}
 	// coding + fix fold into build; conflict contributed nothing and must not
 	// appear as a project of its own or dilute the model id.
-	b := build["shop"]
+	b := build[liveScope("shop")]
 	if b.Tokens.InputTokens != 2_000_000 || b.Tokens.OutputTokens != 100_000 ||
 		b.Tokens.CacheReadTokens != 2_000_000 {
 		t.Fatalf("build tokens = %+v, want 2M/100k/2M", b.Tokens)
@@ -440,7 +443,7 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 	}
 	// The validation cycle lands in the VALIDATION phase, not build — the split
 	// this whole rollup exists to get right.
-	v := valid["shop"]
+	v := valid[liveScope("shop")]
 	if v.Tokens.InputTokens != 500_000 || v.Tokens.OutputTokens != 10_000 {
 		t.Fatalf("validation tokens = %+v, want 500k/10k", v.Tokens)
 	}
@@ -449,7 +452,7 @@ func TestRunCycleRepository_RecordUsageAndPhaseRollup(t *testing.T) {
 	}
 
 	// Org fence: another org's rollup sees none of it.
-	if b2, v2, err := cycles.SumUsageByProjectPhase(ctx, "other-org"); err != nil ||
+	if b2, v2, err := ledger.SumUsageByProjectPhase(ctx, "other-org"); err != nil ||
 		len(b2) != 0 || len(v2) != 0 {
 		t.Fatalf("cross-org rollup = (%v, %v, %v), want empty", b2, v2, err)
 	}
@@ -523,11 +526,11 @@ func TestRunCycleRepository_RecordUsageStampsMultiModelSplit(t *testing.T) {
 
 	// The phase rollup sums the mixed cycle's stamp and keeps the aggregate
 	// tokens; the poisoned cycle contributes tokens but no dollars.
-	build, _, err := cycles.SumUsageByProjectPhase(ctx, "orgm")
+	build, _, err := delivery.NewAgentUsageLedgerRepository(db).SumUsageByProjectPhase(ctx, "orgm")
 	if err != nil {
 		t.Fatalf("SumUsageByProjectPhase: %v", err)
 	}
-	b := build["shop"]
+	b := build[liveScope("shop")]
 	if b.CostUsd == nil || *b.CostUsd != 3.00 {
 		t.Fatalf("build cost = %v, want 3.00", b.CostUsd)
 	}

--- a/services/aep-api/internal/delivery/repository_execution.go
+++ b/services/aep-api/internal/delivery/repository_execution.go
@@ -105,8 +105,9 @@ type ExecutionRepository interface {
 	ListActive(ctx context.Context) ([]Execution, error)
 
 	// DeleteByProject removes every Execution row for a project — the
-	// project-delete orphan purge (executions are platform-owned rows keyed to
-	// the project; the Task issues are deleted with the repo). Org-scoped so a
+	// project-delete orphan purge. Executions are platform-owned rows keyed to
+	// the project and have no other exit from the system; the Task issues they
+	// point at are GitHub-owned and survive with the repository. Org-scoped so a
 	// per-org project slug reused across orgs cannot cross-delete.
 	DeleteByProject(ctx context.Context, orgID, projectID string) error
 
@@ -123,14 +124,6 @@ type ExecutionRepository interface {
 	// or after the row goes terminal (coding successes end via the PR webhook).
 	// Last write wins; the capture is idempotent upstream.
 	RecordUsage(ctx context.Context, id string, u contracts.CapturedUsage) error
-
-	// SumUsageByProjectPhase rolls up captured execution usage per project
-	// across an org (#291), split into the build and validation SDLC phases —
-	// the delivery half of the Settings → Usage read (spec supplies the
-	// design-turn phase). build folds every non-validation kind (build, coding,
-	// provisioning); validation is the validation kind alone. Each map is keyed
-	// by project id; CostUsd sums the frozen per-row stamps, nil when unstamped.
-	SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error)
 }
 
 type executionRepository struct {
@@ -380,70 +373,16 @@ func (r *executionRepository) RecordUsage(ctx context.Context, id string, u cont
 	if r.stamper != nil {
 		updates["cost_usd"] = stampCapturedCost(r.stamper, u)
 	}
-	return r.db.WithContext(ctx).
-		Model(&Execution{}).
-		Where("id = ?", id).
-		Updates(updates).Error
-}
-
-func (r *executionRepository) SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error) {
-	var rows []execPhaseUsageRow
-	err = r.db.WithContext(ctx).
-		Model(&Execution{}).
-		Select("project_id, "+
-			// validation is its own phase; every other kind (build, coding,
-			// provisioning) is the build phase.
-			"CASE WHEN kind = 'validation' THEN 'validation' ELSE 'build' END AS phase, "+
-			"COALESCE(SUM(input_tokens),0) AS input_tokens, "+
-			"COALESCE(SUM(output_tokens),0) AS output_tokens, "+
-			"COALESCE(SUM(cache_read_tokens),0) AS cache_read_tokens, "+
-			"COALESCE(SUM(cache_creation_tokens),0) AS cache_creation_tokens, "+
-			"SUM(cost_usd) AS cost_usd, "+ // NULL when no row is stamped — the #291 semantic
-			// Count distinct model_id INCLUDING '' so any unknown-model row
-			// makes the phase's model degrade to '' (matching
-			// contracts.TokenUsage.Add: a mix of known + unknown is '').
-			"COUNT(DISTINCT model_id) AS models, "+
-			"COALESCE(MAX(model_id), '') AS max_model").
-		Where("org_id = ? AND project_id <> ''", orgID).
-		Group("project_id, phase").
-		// Only phases with real token traffic — a run that captured nothing
-		// leaves a 0-token row that should not inflate a phase.
-		Having("SUM(input_tokens) + SUM(output_tokens) + SUM(cache_read_tokens) + SUM(cache_creation_tokens) > 0").
-		Scan(&rows).Error
-	if err != nil {
-		return nil, nil, err
-	}
-	build = make(map[string]contracts.StampedUsage)
-	validation = make(map[string]contracts.StampedUsage)
-	for _, row := range rows {
-		u := contracts.TokenUsage{
-			InputTokens:         row.InputTokens,
-			OutputTokens:        row.OutputTokens,
-			CacheReadTokens:     row.CacheReadTokens,
-			CacheCreationTokens: row.CacheCreationTokens,
+	// One transaction, for the reason given on runCycleRepository.RecordUsage: the
+	// rollup reads the ledger alone, so a stamped row without its ledger copy is
+	// spend that is invisible everywhere it is reported. The row is written first
+	// inside the tx — the ledger copies it.
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&Execution{}).
+			Where("id = ?", id).
+			Updates(updates).Error; err != nil {
+			return err
 		}
-		if row.Models == 1 {
-			u.Model = row.MaxModel
-		}
-		stamped := contracts.StampedUsage{Tokens: u, CostUsd: row.CostUsd}
-		if row.Phase == "validation" {
-			validation[row.ProjectID] = stamped
-		} else {
-			build[row.ProjectID] = stamped
-		}
-	}
-	return build, validation, nil
-}
-
-// execPhaseUsageRow is the per-(project, phase) aggregate scan shape (#291).
-type execPhaseUsageRow struct {
-	ProjectID           string
-	Phase               string
-	InputTokens         int64
-	OutputTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	CostUsd             *float64
-	Models              int64
-	MaxModel            string
+		return NewAgentUsageLedgerRepository(tx).RecordExecutionUsage(ctx, id)
+	})
 }

--- a/services/aep-api/internal/delivery/repository_usage_ledger.go
+++ b/services/aep-api/internal/delivery/repository_usage_ledger.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package delivery
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/wso2/aep/aep-api/internal/contracts"
+)
+
+// AgentUsageLedgerRepository is the write-authority over the agent-usage ledger
+// — the record of what an org's agent work cost, kept past the dispatch rows it
+// was captured from and past the project itself.
+//
+// There is no Delete verb, and that absence is the point: the ledger is the one
+// delivery table the project-delete cascade does not purge. Retire closes a
+// lifetime; nothing removes what was spent.
+type AgentUsageLedgerRepository interface {
+	// RecordCycleUsage copies a run cycle's freshly-stamped usage into the ledger.
+	//
+	// It reads the figures from the cycle row rather than taking them as
+	// arguments, so the ledger cannot disagree with the row it mirrors: the
+	// caller stamps the row, then calls this, and one statement carries the
+	// tokens, the write-time USD, the cycle's phase and its milestone across.
+	//
+	// Idempotent on (source, cycle id): re-capture re-derives the same figures
+	// from the same log and updates the entry in place. A cycle with no project
+	// records nothing — there is no card for it to land on.
+	RecordCycleUsage(ctx context.Context, cycleID string) error
+
+	// RecordExecutionUsage is the same for the older per-issue funnel's rows.
+	RecordExecutionUsage(ctx context.Context, executionID string) error
+
+	// RetireByProject closes the project's LIVE lifetime: every entry not already
+	// retired is stamped with one shared instant, so the generation is a single
+	// value the rollup can group on.
+	//
+	// It is what a project delete calls INSTEAD of purging spend. Runs and cycles
+	// go; what they cost stays, attributed to the incarnation that spent it, so a
+	// project recreated under the same name starts at zero.
+	//
+	// Idempotent: a second call finds nothing live and stamps nothing, which is
+	// also what makes a re-run of a half-finished delete safe.
+	RetireByProject(ctx context.Context, orgID, projectID string) error
+
+	// SumUsageByProjectPhase rolls the ledger up per project LIFETIME and SDLC
+	// phase, keyed by contracts.UsageScope so a live project and a deleted
+	// incarnation of the same slug stay apart. Each map is keyed by scope; CostUsd
+	// sums the frozen per-row stamps and is nil when no contributing entry carried
+	// one.
+	SumUsageByProjectPhase(ctx context.Context, orgID string) (build, validation map[contracts.UsageScope]contracts.StampedUsage, err error)
+}
+
+type agentUsageLedgerRepository struct{ db *gorm.DB }
+
+// NewAgentUsageLedgerRepository wires the gorm-backed ledger.
+func NewAgentUsageLedgerRepository(db *gorm.DB) AgentUsageLedgerRepository {
+	return &agentUsageLedgerRepository{db: db}
+}
+
+// ledgerUpsertTail is the conflict clause both writers share. retired_at is
+// deliberately absent: a late capture for a project that has already been
+// deleted must land on the entry without reopening its lifetime.
+const ledgerUpsertTail = `
+	ON CONFLICT (source, source_id) DO UPDATE SET
+	  phase                 = EXCLUDED.phase,
+	  milestone_number      = EXCLUDED.milestone_number,
+	  tag                   = EXCLUDED.tag,
+	  model_id              = EXCLUDED.model_id,
+	  input_tokens          = EXCLUDED.input_tokens,
+	  output_tokens         = EXCLUDED.output_tokens,
+	  cache_read_tokens     = EXCLUDED.cache_read_tokens,
+	  cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+	  cost_usd              = EXCLUDED.cost_usd,
+	  captured_at           = EXCLUDED.captured_at`
+
+func (r *agentUsageLedgerRepository) RecordCycleUsage(ctx context.Context, cycleID string) error {
+	// INSERT … SELECT rather than a read-then-write: the ledger is a copy of the
+	// row that was just stamped, so taking it from the row in the same statement
+	// is what makes the two impossible to desync.
+	//
+	// The milestone join is LEFT: a cycle whose run row has already gone still
+	// records its spend, just without the version label.
+	//
+	// COALESCE(NULLIF(tag,''), milestone_title, '') mirrors MilestoneRun.SpecTag —
+	// the tag is empty on pre-phase and early incident rows, whose title IS the
+	// version.
+	return r.db.WithContext(ctx).Exec(`
+		INSERT INTO agent_usage_ledger (
+		  org_id, project_id, source, source_id, phase, milestone_number, tag,
+		  model_id, input_tokens, output_tokens, cache_read_tokens,
+		  cache_creation_tokens, cost_usd, captured_at)
+		SELECT c.org_id, c.project_id, ?, c.id::text, `+UsagePhaseCaseSQL("c.kind")+`,
+		       COALESCE(m.milestone_number, 0),
+		       COALESCE(NULLIF(m.tag, ''), m.milestone_title, ''),
+		       c.model_id, c.input_tokens, c.output_tokens, c.cache_read_tokens,
+		       c.cache_creation_tokens, c.cost_usd, now()
+		FROM run_cycles c
+		LEFT JOIN milestone_runs m ON m.id::text = c.run_id
+		WHERE c.id::text = ? AND c.org_id <> '' AND c.project_id <> ''`+ledgerUpsertTail,
+		UsageLedgerSourceRunCycle, cycleID).Error
+}
+
+func (r *agentUsageLedgerRepository) RecordExecutionUsage(ctx context.Context, executionID string) error {
+	// Executions belong to no milestone, so the version columns stay zero/empty —
+	// the ledger says "this project, this phase" and does not invent a version.
+	return r.db.WithContext(ctx).Exec(`
+		INSERT INTO agent_usage_ledger (
+		  org_id, project_id, source, source_id, phase, milestone_number, tag,
+		  model_id, input_tokens, output_tokens, cache_read_tokens,
+		  cache_creation_tokens, cost_usd, captured_at)
+		SELECT e.org_id, e.project_id, ?, e.id::text, `+UsagePhaseCaseSQL("e.kind")+`,
+		       0, '',
+		       e.model_id, e.input_tokens, e.output_tokens, e.cache_read_tokens,
+		       e.cache_creation_tokens, e.cost_usd, now()
+		FROM executions e
+		WHERE e.id::text = ? AND e.org_id <> '' AND e.project_id <> ''`+ledgerUpsertTail,
+		UsageLedgerSourceExecution, executionID).Error
+}
+
+func (r *agentUsageLedgerRepository) RetireByProject(ctx context.Context, orgID, projectID string) error {
+	// One instant for the whole generation, computed here rather than as a
+	// per-row now(), so every entry closed by this delete carries the SAME stamp
+	// and the rollup can group on it.
+	return r.db.WithContext(ctx).
+		Model(&AgentUsageLedgerEntry{}).
+		Where("org_id = ? AND project_id = ? AND retired_at IS NULL", orgID, projectID).
+		Update("retired_at", time.Now().UTC()).Error
+}
+
+// ledgerHasTokens is the "this entry actually spent something" predicate, shared
+// by the model-agreement CASEs so the notion of a contributing row is spelled
+// once.
+const ledgerHasTokens = "input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens > 0"
+
+// ledgerPhaseUsageRow is the per-(project, lifetime, phase) aggregate scan shape.
+type ledgerPhaseUsageRow struct {
+	ProjectID           string
+	Phase               string
+	Retired             bool
+	InputTokens         int64
+	OutputTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	CostUsd             *float64
+	Models              int64
+	MaxModel            string
+}
+
+func (r *agentUsageLedgerRepository) SumUsageByProjectPhase(ctx context.Context, orgID string) (map[contracts.UsageScope]contracts.StampedUsage, map[contracts.UsageScope]contracts.StampedUsage, error) {
+	var rows []ledgerPhaseUsageRow
+	err := r.db.WithContext(ctx).
+		Model(&AgentUsageLedgerEntry{}).
+		Select("project_id, phase, (retired_at IS NOT NULL) AS retired, "+
+			"COALESCE(SUM(input_tokens),0) AS input_tokens, "+
+			"COALESCE(SUM(output_tokens),0) AS output_tokens, "+
+			"COALESCE(SUM(cache_read_tokens),0) AS cache_read_tokens, "+
+			"COALESCE(SUM(cache_creation_tokens),0) AS cache_creation_tokens, "+
+			"SUM(cost_usd) AS cost_usd, "+ // NULL when no entry is stamped — the #291 semantic
+			// The phase's model id survives only while every contributor THAT SPENT
+			// TOKENS agrees on it — exactly contracts.TokenUsage.Add, which keeps the
+			// model across a zero-token contributor and blanks it on a genuine
+			// disagreement. COUNT(DISTINCT …) and MAX(…) both ignore NULL, so the
+			// entries that spent nothing drop out instead of dragging a single-model
+			// phase to "unknown".
+			"COUNT(DISTINCT CASE WHEN "+ledgerHasTokens+" THEN model_id END) AS models, "+
+			"COALESCE(MAX(CASE WHEN "+ledgerHasTokens+" THEN model_id END), '') AS max_model").
+		Where("org_id = ? AND project_id <> ''", orgID).
+		Group("project_id, phase, (retired_at IS NOT NULL)").
+		// Only lifetimes with real token traffic — an entry that captured nothing
+		// must not conjure a phase, or a card, out of nothing.
+		Having("SUM(input_tokens) + SUM(output_tokens) + SUM(cache_read_tokens) + SUM(cache_creation_tokens) > 0").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, nil, err
+	}
+	build := make(map[contracts.UsageScope]contracts.StampedUsage)
+	validation := make(map[contracts.UsageScope]contracts.StampedUsage)
+	for _, row := range rows {
+		u := contracts.TokenUsage{
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
+		}
+		if row.Models == 1 {
+			u.Model = row.MaxModel
+		}
+		scope := contracts.UsageScope{ProjectID: row.ProjectID, Retired: row.Retired}
+		stamped := contracts.StampedUsage{Tokens: u, CostUsd: row.CostUsd}
+		if row.Phase == UsagePhaseValidation {
+			validation[scope] = stamped
+		} else {
+			build[scope] = stamped
+		}
+	}
+	return build, validation, nil
+}

--- a/services/aep-api/internal/delivery/repository_usage_ledger_dbtest_test.go
+++ b/services/aep-api/internal/delivery/repository_usage_ledger_dbtest_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package delivery_test
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/wso2/aep/aep-api/internal/contracts"
+	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/platform/dbtest"
+	"github.com/wso2/aep/aep-api/internal/platform/modelcost"
+)
+
+// ledgerFixture is the whole delivery write side against one throwaway schema:
+// runs, cycles (which mirror into the ledger as they stamp), and the ledger's
+// own read/retire surface.
+type ledgerFixture struct {
+	db     *gorm.DB
+	runs   delivery.MilestoneRunRepository
+	cycles delivery.RunCycleRepository
+	ledger delivery.AgentUsageLedgerRepository
+}
+
+// newLedgerFixture prices model-a at round figures ($1/MTok in, $10/MTok out) so
+// an expected stamp reads by inspection rather than reverse-engineering.
+func newLedgerFixture(t *testing.T) ledgerFixture {
+	t.Helper()
+	db := dbtest.New(t)
+	stamper := modelcost.NewStamper([]modelcost.ModelRate{
+		{ModelID: "model-a", InputPerMTok: 1, OutputPerMTok: 10},
+	})
+	return ledgerFixture{
+		db:     db,
+		runs:   delivery.NewMilestoneRunRepository(db),
+		cycles: delivery.NewRunCycleRepository(db, stamper),
+		ledger: delivery.NewAgentUsageLedgerRepository(db),
+	}
+}
+
+// spend appends a cycle of the given kind under run and captures usage on it —
+// one agent dispatch, from dispatch to stamp.
+func (f ledgerFixture) spend(t *testing.T, run *delivery.MilestoneRun, kind string, in, out int64, model string) *delivery.RunCycle {
+	t.Helper()
+	ctx := context.Background()
+	c := &delivery.RunCycle{OrgID: run.OrgID, ProjectID: run.ProjectID, RunID: run.ID, Kind: kind}
+	if err := f.cycles.Append(ctx, c); err != nil {
+		t.Fatalf("Append(%s): %v", kind, err)
+	}
+	if err := f.cycles.RecordUsage(ctx, c.ID, contracts.CapturedUsage{TokenUsage: contracts.TokenUsage{
+		InputTokens: in, OutputTokens: out, Model: model,
+	}}); err != nil {
+		t.Fatalf("RecordUsage(%s): %v", kind, err)
+	}
+	return c
+}
+
+// entries reads an org's ledger rows straight from the table. The repository
+// exposes only the aggregate — the raw entries are what pin the snapshot
+// columns and the retirement stamps, which the aggregate deliberately folds away.
+func (f ledgerFixture) entries(t *testing.T, orgID string) []delivery.AgentUsageLedgerEntry {
+	t.Helper()
+	var rows []delivery.AgentUsageLedgerEntry
+	if err := f.db.Where("org_id = ?", orgID).Order("captured_at").Find(&rows).Error; err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	return rows
+}
+
+func liveScope(project string) contracts.UsageScope {
+	return contracts.UsageScope{ProjectID: project}
+}
+
+func retiredScope(project string) contracts.UsageScope {
+	return contracts.UsageScope{ProjectID: project, Retired: true}
+}
+
+// TestUsageLedger_CaptureMirrorsTheCycleAndSplitsPhases: the ledger is written as
+// part of the cycle's own stamp, carries the version the spend belongs to, and
+// classifies each kind into the SDLC phase the usage page reports.
+func TestUsageLedger_CaptureMirrorsTheCycleAndSplitsPhases(t *testing.T) {
+	t.Parallel()
+	f := newLedgerFixture(t)
+	ctx := context.Background()
+	run := admitRun(t, f.runs, "orgl", "shop", 7, "v7")
+
+	f.spend(t, run, delivery.CycleKindCoding, 1_000_000, 100_000, "model-a")  // $1 + $1 = $2
+	f.spend(t, run, delivery.CycleKindFix, 1_000_000, 0, "model-a")           // $1
+	f.spend(t, run, delivery.CycleKindValidation, 500_000, 10_000, "model-a") // $0.60
+	f.spend(t, run, delivery.CycleKindConflict, 0, 0, "")                     // captured nothing
+
+	build, validation, err := f.ledger.SumUsageByProjectPhase(ctx, "orgl")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	b := build[liveScope("shop")]
+	if b.Tokens.InputTokens != 2_000_000 || b.Tokens.OutputTokens != 100_000 {
+		t.Fatalf("build tokens = %+v, want 2M/100k", b.Tokens)
+	}
+	if b.CostUsd == nil || *b.CostUsd != 3.00 {
+		t.Fatalf("build cost = %v, want 3.00 (2.00 + 1.00)", b.CostUsd)
+	}
+	// The conflict cycle spent nothing, so it must neither add a row nor drag the
+	// phase's agreed model to "unknown".
+	if b.Tokens.Model != "model-a" {
+		t.Fatalf("build model = %q, want model-a", b.Tokens.Model)
+	}
+	v := validation[liveScope("shop")]
+	if v.Tokens.InputTokens != 500_000 || v.Tokens.OutputTokens != 10_000 {
+		t.Fatalf("validation tokens = %+v, want 500k/10k", v.Tokens)
+	}
+
+	// The entry knows which version it paid for — the whole reason the ledger
+	// snapshots the milestone instead of joining back to a row that gets purged.
+	entries := f.entries(t, "orgl")
+	if len(entries) != 4 {
+		t.Fatalf("ledger entries = %d, want 4 (one per dispatch)", len(entries))
+	}
+	for _, e := range entries {
+		if e.MilestoneNumber != 7 || e.Tag != "v7" {
+			t.Errorf("entry %s milestone/tag = %d/%q, want 7/v7", e.SourceID, e.MilestoneNumber, e.Tag)
+		}
+		if e.Source != delivery.UsageLedgerSourceRunCycle {
+			t.Errorf("entry source = %q, want run_cycle", e.Source)
+		}
+		if e.RetiredAt != nil {
+			t.Errorf("a live project's entry must not be retired: %v", e.RetiredAt)
+		}
+	}
+
+	// Org fence.
+	if b2, v2, err := f.ledger.SumUsageByProjectPhase(ctx, "other-org"); err != nil ||
+		len(b2) != 0 || len(v2) != 0 {
+		t.Fatalf("cross-org rollup = (%v, %v, %v), want empty", b2, v2, err)
+	}
+}
+
+// TestUsageLedger_ReCaptureDoesNotDoubleCount: the runner's terminal log is read
+// more than once and re-derives the same figures, so a repeat capture must
+// update the entry in place. Without the (source, source_id) arbiter every tick
+// of the watcher would add another copy of the same bill.
+func TestUsageLedger_ReCaptureDoesNotDoubleCount(t *testing.T) {
+	t.Parallel()
+	f := newLedgerFixture(t)
+	ctx := context.Background()
+	run := admitRun(t, f.runs, "orgr", "shop", 1, "v1")
+
+	cycle := f.spend(t, run, delivery.CycleKindCoding, 1_000_000, 0, "model-a")
+	// The same capture again, and then a REVISED one (the log grew between
+	// ticks) — the ledger must hold the latest figure, once.
+	f.recapture(t, cycle.ID, 1_000_000, 0)
+	f.recapture(t, cycle.ID, 3_000_000, 0)
+
+	build, _, err := f.ledger.SumUsageByProjectPhase(ctx, "orgr")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	b := build[liveScope("shop")]
+	if b.Tokens.InputTokens != 3_000_000 {
+		t.Fatalf("input tokens = %d, want 3M (the latest capture, counted once)", b.Tokens.InputTokens)
+	}
+	if b.CostUsd == nil || *b.CostUsd != 3.00 {
+		t.Fatalf("cost = %v, want 3.00", b.CostUsd)
+	}
+}
+
+func (f ledgerFixture) recapture(t *testing.T, cycleID string, in, out int64) {
+	t.Helper()
+	if err := f.cycles.RecordUsage(context.Background(), cycleID, contracts.CapturedUsage{
+		TokenUsage: contracts.TokenUsage{InputTokens: in, OutputTokens: out, Model: "model-a"},
+	}); err != nil {
+		t.Fatalf("re-capture: %v", err)
+	}
+}
+
+// TestUsageLedger_SpendSurvivesTheProjectDeletePurge is the rule this table
+// exists for: the delete takes the run and its cycles, and what they cost stays
+// — attributed to the incarnation that spent it.
+func TestUsageLedger_SpendSurvivesTheProjectDeletePurge(t *testing.T) {
+	t.Parallel()
+	f := newLedgerFixture(t)
+	ctx := context.Background()
+	run := admitRun(t, f.runs, "orgd", "shop", 3, "v3")
+	f.spend(t, run, delivery.CycleKindCoding, 2_000_000, 0, "model-a") // $2
+
+	// The delete cascade, in the order the composition root runs it.
+	if err := f.ledger.RetireByProject(ctx, "orgd", "shop"); err != nil {
+		t.Fatalf("RetireByProject: %v", err)
+	}
+	if err := f.cycles.DeleteByProject(ctx, "orgd", "shop"); err != nil {
+		t.Fatalf("cycles.DeleteByProject: %v", err)
+	}
+	if err := f.runs.DeleteByProject(ctx, "orgd", "shop"); err != nil {
+		t.Fatalf("runs.DeleteByProject: %v", err)
+	}
+
+	// The working state really is gone.
+	if rows, err := f.runs.ListByProject(ctx, "orgd", "shop"); err != nil || len(rows) != 0 {
+		t.Fatalf("runs after delete = (%d, %v), want none", len(rows), err)
+	}
+
+	build, _, err := f.ledger.SumUsageByProjectPhase(ctx, "orgd")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	if _, live := build[liveScope("shop")]; live {
+		t.Error("a deleted project's spend must not read as the live lifetime's")
+	}
+	r := build[retiredScope("shop")]
+	if r.Tokens.InputTokens != 2_000_000 {
+		t.Fatalf("retired tokens = %d, want 2M (spend survives the purge)", r.Tokens.InputTokens)
+	}
+	if r.CostUsd == nil || *r.CostUsd != 2.00 {
+		t.Fatalf("retired cost = %v, want 2.00", r.CostUsd)
+	}
+}
+
+// TestUsageLedger_RecreatedProjectDoesNotInheritTheDeletedOnesSpend: a slug is
+// not an identity. The retirement stamp is what keeps the two lifetimes apart,
+// so the fresh project starts at zero while the bill it did not run stays
+// readable under the retired scope.
+func TestUsageLedger_RecreatedProjectDoesNotInheritTheDeletedOnesSpend(t *testing.T) {
+	t.Parallel()
+	f := newLedgerFixture(t)
+	ctx := context.Background()
+
+	first := admitRun(t, f.runs, "orgx", "shop", 1, "v1")
+	f.spend(t, first, delivery.CycleKindCoding, 5_000_000, 0, "model-a") // $5, the first lifetime
+
+	if err := f.ledger.RetireByProject(ctx, "orgx", "shop"); err != nil {
+		t.Fatalf("RetireByProject: %v", err)
+	}
+	if err := f.cycles.DeleteByProject(ctx, "orgx", "shop"); err != nil {
+		t.Fatalf("cycles.DeleteByProject: %v", err)
+	}
+	if err := f.runs.DeleteByProject(ctx, "orgx", "shop"); err != nil {
+		t.Fatalf("runs.DeleteByProject: %v", err)
+	}
+
+	// Same name, new project, new run.
+	second := admitRun(t, f.runs, "orgx", "shop", 1, "v1")
+	f.spend(t, second, delivery.CycleKindCoding, 1_000_000, 0, "model-a") // $1, the second lifetime
+
+	build, _, err := f.ledger.SumUsageByProjectPhase(ctx, "orgx")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	live := build[liveScope("shop")]
+	if live.Tokens.InputTokens != 1_000_000 {
+		t.Fatalf("live tokens = %d, want 1M — the recreated project pays only for its own work", live.Tokens.InputTokens)
+	}
+	if live.CostUsd == nil || *live.CostUsd != 1.00 {
+		t.Fatalf("live cost = %v, want 1.00", live.CostUsd)
+	}
+	retired := build[retiredScope("shop")]
+	if retired.Tokens.InputTokens != 5_000_000 {
+		t.Fatalf("retired tokens = %d, want 5M — the deleted lifetime's bill is still readable", retired.Tokens.InputTokens)
+	}
+
+	// Retiring again closes the second lifetime without disturbing the first: two
+	// deletes leave two generations, not one merged heap.
+	if err := f.ledger.RetireByProject(ctx, "orgx", "shop"); err != nil {
+		t.Fatalf("second RetireByProject: %v", err)
+	}
+	entries := f.entries(t, "orgx")
+	stamps := map[string]bool{}
+	for _, e := range entries {
+		if e.RetiredAt == nil {
+			t.Fatal("every entry is retired after the second delete")
+		}
+		stamps[e.RetiredAt.String()] = true
+	}
+	if len(stamps) != 2 {
+		t.Fatalf("distinct retirement stamps = %d, want 2 (one generation per delete)", len(stamps))
+	}
+}

--- a/services/aep-api/internal/delivery/run/activities.go
+++ b/services/aep-api/internal/delivery/run/activities.go
@@ -277,7 +277,7 @@ func (a *Activities) PollMilestone(ctx context.Context, in MilestoneRef) (Milest
 	}
 	counts, err := a.milestones.MilestoneIssueCounts(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber)
 	if err != nil {
-		return MilestoneSnapshot{}, err
+		return MilestoneSnapshot{}, sourceControlErr(err)
 	}
 	if counts == nil {
 		return MilestoneSnapshot{}, nil
@@ -331,11 +331,11 @@ func (a *Activities) PollCycleBuilds(ctx context.Context, in CycleBuildsInput) (
 	}
 	files, err := a.prs.ListPullRequestFiles(ctx, in.OrgID, in.ProjectID, in.PRNumber)
 	if err != nil {
-		return CycleBuildState{}, err
+		return CycleBuildState{}, sourceControlErr(err)
 	}
 	paths, err := a.design.ComponentPaths(ctx, in.OrgID, in.ProjectID)
 	if err != nil {
-		return CycleBuildState{}, err
+		return CycleBuildState{}, sourceControlErr(err)
 	}
 	diff := delivery.DiffComponents(files, paths)
 	out := CycleBuildState{Expected: len(diff.Components)}
@@ -404,7 +404,8 @@ func (a *Activities) EnsureValidationIssue(ctx context.Context, in MilestoneRef)
 	if a.validation == nil {
 		return 0, nil
 	}
-	return a.validation.EnsureValidationIssue(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber)
+	issue, err := a.validation.EnsureValidationIssue(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber)
+	return issue, sourceControlErr(err)
 }
 
 // ValidationReportRef identifies the report to read: the project, plus the commit
@@ -443,7 +444,7 @@ func (a *Activities) ReadValidationVerdict(ctx context.Context, in ValidationRep
 	}
 	verdict, digest, err := a.validation.Verdict(ctx, in.OrgID, in.ProjectID, in.At)
 	if err != nil {
-		return ValidationOutcome{}, err
+		return ValidationOutcome{}, sourceControlErr(err)
 	}
 	return ValidationOutcome{Verdict: verdict, Digest: digest}, nil
 }
@@ -470,7 +471,8 @@ func (a *Activities) MintValidationRepairIssues(ctx context.Context, in MintVali
 	if a.validation == nil {
 		return nil, nil
 	}
-	return a.validation.MintRepairIssues(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber, in.At, in.CycleID)
+	filed, err := a.validation.MintRepairIssues(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber, in.At, in.CycleID)
+	return filed, sourceControlErr(err)
 }
 
 // ---- dispatch --------------------------------------------------------------

--- a/services/aep-api/internal/delivery/run/errors.go
+++ b/services/aep-api/internal/delivery/run/errors.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package run
+
+// Which activity failures are worth repeating.
+//
+// The supervisor's activities run under Temporal's DEFAULT retry policy —
+// unbounded, with backoff — and that is deliberate (see activityCtx): a
+// supervisor that cannot reach GitHub should stall visibly rather than settle a
+// run on a network blip. Unbounded is the right answer for a blip.
+//
+// It is the wrong answer for an ANSWER. When a project is deleted its repo row
+// goes with it, and every boundary poll thereafter fails identically; the
+// activity was observed live at attempt 325, a day after the project was gone,
+// with nothing but log volume to show for it. Retrying a fact does not change
+// it — it only hides the one failure that mattered behind a thousand copies.
+//
+// So the two are told apart wherever the supervisor touches source control, and
+// only the permanent half is marked non-retryable. Which half that is belongs to
+// sourcecontrol.IsPermanent, not here: this package knows Temporal, that one
+// knows the host.
+//
+// sourceControlErr is applied per call site rather than at the port boundary,
+// which is the one weakness worth naming: an activity added later that returns a
+// source-control error raw is silently back on unbounded retry. The activities
+// that return one all wrap it today; CloseMilestone is the deliberate exception,
+// because it swallows its error by contract and so never retries at all.
+
+import (
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+// errTypePermanentSourceControl is the ApplicationError type a permanent source
+// control failure carries. It is what a reader of a failed workflow sees first,
+// so it names the CLASS ("this run's repository, issue or credential is gone")
+// rather than the call that happened to notice.
+const errTypePermanentSourceControl = "PermanentSourceControlFailure"
+
+// sourceControlErr classifies one source-control round trip's error for
+// Temporal: permanent failures come back non-retryable, so the activity fails
+// on its first attempt and the workflow fails with the cause still legible;
+// everything else is returned untouched and keeps the unbounded retry that is
+// right for it.
+//
+// The original error is carried as the ApplicationError's CAUSE, so an
+// errors.Is/As on the way out still sees ErrRepoNotFound, an HTTPStatusError or
+// a GraphQLError rather than a flattened string.
+func sourceControlErr(err error) error {
+	if !sourcecontrol.IsPermanent(err) {
+		return err
+	}
+	return temporal.NewNonRetryableApplicationError(err.Error(), errTypePermanentSourceControl, err)
+}

--- a/services/aep-api/internal/delivery/run/errors_test.go
+++ b/services/aep-api/internal/delivery/run/errors_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package run
+
+// What the retry classification is worth is measured in ATTEMPTS, so these
+// tests run the REAL activity — not a mocked one — over a scripted port and
+// count how many times the port was asked. A mocked activity would prove
+// nothing here: the whole behaviour under test lives in the error the activity
+// returns and in what Temporal's retry machinery does with it.
+//
+// The pair is the point. The first test pins that an answer is asked once; the
+// second pins that a blip is still asked again, so a future "just stop
+// retrying" cannot pass by making the supervisor give up on everything.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+// scriptedMilestones answers the boundary poll from a queued script — one entry
+// per call, the last repeating — and counts how often it was asked. A nil entry
+// answers an empty milestone, which parks the run.
+type scriptedMilestones struct {
+	mu     sync.Mutex
+	script []error
+	calls  int
+}
+
+func (s *scriptedMilestones) MilestoneIssueCounts(context.Context, string, string, int) (*sourcecontrol.MilestoneIssueCounts, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	err := s.script[min(s.calls-1, len(s.script)-1)]
+	if err != nil {
+		return nil, err
+	}
+	return &sourcecontrol.MilestoneIssueCounts{}, nil
+}
+
+func (s *scriptedMilestones) CloseMilestone(context.Context, string, string, int) error { return nil }
+
+func (s *scriptedMilestones) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// pollEnv wires the real PollMilestone over a scripted port. The run row's
+// writes stay mocked: they are not what is being measured, and a fake store
+// would only add a second thing that could fail.
+func pollEnv(t *testing.T, script ...error) (*testsuite.TestWorkflowEnvironment, *scriptedMilestones) {
+	t.Helper()
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestWorkflowEnvironment()
+	port := &scriptedMilestones{script: script}
+	acts := NewActivities(Deps{Milestones: port})
+	env.RegisterActivity(acts)
+	env.OnActivity(acts.SetRunState, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(acts.SettleRun, mock.Anything, mock.Anything).Return(nil)
+	return env, port
+}
+
+func executePoll(env *testsuite.TestWorkflowEnvironment) {
+	env.ExecuteWorkflow(MilestoneRunWorkflow, RunInput{
+		RunID:           testRunID,
+		OrgID:           testOrg,
+		ProjectID:       testProject,
+		MilestoneNumber: testMilepost,
+		MilestoneTitle:  "v3",
+		Origin:          delivery.RunOriginSpecBuild,
+	})
+}
+
+// A deleted project takes its repo row with it, and every later boundary poll
+// fails identically. The run must fail on the FIRST one: this is the defect
+// that ran an activity to attempt 325 against a project that no longer existed.
+func TestPollMilestoneStopsAtTheFirstPermanentFailure(t *testing.T) {
+	env, port := pollEnv(t, sourcecontrol.ErrRepoNotFound)
+
+	executePoll(env)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Equal(t, 1, port.count(), "a permanent failure must be asked exactly once")
+
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, errTypePermanentSourceControl, appErr.Type())
+	require.True(t, appErr.NonRetryable())
+	// The cause survives the trip, so the failed workflow still names what went
+	// wrong rather than only that something did.
+	require.Contains(t, err.Error(), sourcecontrol.ErrRepoNotFound.Error())
+}
+
+// The GraphQL surface answers 200 with an errors[] entry, so a repository
+// deleted on GitHub reaches the supervisor as NOT_FOUND rather than as a 404.
+// It is the same answer and must cost the same one attempt.
+func TestPollMilestoneStopsOnGraphQLNotFound(t *testing.T) {
+	env, port := pollEnv(t, &sourcecontrol.GraphQLError{Errors: []sourcecontrol.GraphQLErrorDetail{{
+		Type:    sourcecontrol.GraphQLTypeNotFound,
+		Message: "Could not resolve to a Repository with the name 'org1/proj1'.",
+	}}})
+
+	executePoll(env)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Equal(t, 1, port.count())
+	require.Error(t, env.GetWorkflowError())
+}
+
+// The other half of the contract: a blip is still retried, unbounded, exactly
+// as before. Two 500s then an answer, and the run carries on to its park.
+func TestPollMilestoneKeepsRetryingATransientFailure(t *testing.T) {
+	blip := &sourcecontrol.HTTPStatusError{StatusCode: http.StatusInternalServerError, Body: "server error"}
+	env, port := pollEnv(t, blip, blip, nil)
+
+	// The poll succeeds into an empty milestone with no cycles behind it, which
+	// parks the run in the unbounded wait; cancel is that wait's only expiry.
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(delivery.SigRunCancel, delivery.RunSignal{
+			Signal: delivery.SigRunCancel, MilestoneNumber: testMilepost,
+		})
+	}, time.Minute)
+
+	executePoll(env)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 3, port.count(), "a transient failure must be retried until it answers")
+
+	var res RunResult
+	require.NoError(t, env.GetWorkflowResult(&res))
+	require.Equal(t, delivery.RunStateCancelled, res.State)
+}
+
+// sourceControlErr is the whole seam, so its pass-through half is pinned
+// directly: an error nothing can classify must reach Temporal untouched, or a
+// blip would silently become terminal.
+func TestSourceControlErrLeavesUnclassifiedErrorsAlone(t *testing.T) {
+	require.NoError(t, sourceControlErr(nil))
+
+	transient := errors.New("dial tcp: connection refused")
+	require.Same(t, transient, sourceControlErr(transient))
+}

--- a/services/aep-api/internal/delivery/run/supervisor.go
+++ b/services/aep-api/internal/delivery/run/supervisor.go
@@ -210,6 +210,60 @@ func (s *Supervisor) CancelRun(ctx context.Context, row *delivery.MilestoneRun) 
 	})
 }
 
+// AbandonRun ends the supervisor over a milestone whose PROJECT is going away.
+//
+// It TERMINATES where CancelRun signals, and the difference is the whole reason
+// it exists. Cancel is the graceful expiry: the loop wakes, settles its run row
+// and closes the version's milestone on GitHub. Both of those targets are gone
+// by the time a project is deleted — the rows are purged in the same teardown
+// and the repository with them — so a cancel would leave the workflow retrying
+// against what is no longer there. Terminate needs neither.
+//
+// Nothing else ends a run workflow, which is what made this necessary: the
+// supervisor outlives the rows it writes, its milestone poll retries forever
+// (Temporal's default policy is unbounded) against a deleted repository, and its
+// workflow id — run-<org>-<project>-<milestone> — is claimed again by any
+// project later created under the same name, whose first run would then be
+// refused as AlreadyStarted and never supervised at all.
+//
+// A workflow that is not running is success: the id may never have been started,
+// and terminating a settled execution is the same no-op. Temporal reports both
+// as NotFound.
+//
+// An unreachable engine is reported, not swallowed — the same choice CancelRun
+// makes and for the same reason. A supervisor this could not reach is still
+// there when the engine comes back, so the caller has to be able to say so.
+func (s *Supervisor) AbandonRun(ctx context.Context, orgID, projectID string, milestoneNumber int) error {
+	if s == nil {
+		return nil
+	}
+	if s.rt == nil || !s.rt.Available() {
+		return delivery.ErrTemporalUnavailable
+	}
+	c, err := s.rt.Client()
+	if err != nil {
+		return nil // raced with a client teardown
+	}
+	workflowID := delivery.MilestoneRunWorkflowID(orgID, projectID, milestoneNumber)
+	ctx, cancel := context.WithTimeout(ctx, signalTimeout)
+	defer cancel()
+	if terr := c.TerminateWorkflow(ctx, workflowID, "", abandonReason); terr != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(terr, &notFound) {
+			return nil
+		}
+		return terr
+	}
+	slog.InfoContext(ctx, "run: abandoned a supervisor whose project was deleted",
+		"workflowId", workflowID, "project", projectID, "milestone", milestoneNumber)
+	return nil
+}
+
+// abandonReason is what a terminated run's history records. It is a sentence
+// rather than a code because the only reader is a human looking at why a
+// workflow stopped.
+const abandonReason = "the project was deleted — its run rows are purged and its repository is gone"
+
 func (s *Supervisor) signal(ctx context.Context, orgID, projectID string, milestoneNumber int, name string, payload delivery.RunSignal) error {
 	c, err := s.rt.Client()
 	if err != nil {

--- a/services/aep-api/internal/delivery/run/supervisor_test.go
+++ b/services/aep-api/internal/delivery/run/supervisor_test.go
@@ -70,6 +70,9 @@ func TestSupervisorIsNilSafe(t *testing.T) {
 	if err := s.CancelRun(context.Background(), &delivery.MilestoneRun{}); err != nil {
 		t.Fatalf("CancelRun on a nil supervisor: %v", err)
 	}
+	if err := s.AbandonRun(context.Background(), testOrg, testProject, testMilepost); err != nil {
+		t.Fatalf("AbandonRun on a nil supervisor: %v", err)
+	}
 }
 
 // TestStartRunRefusesWithoutADispatcher: a run that could dispatch nothing must
@@ -119,6 +122,12 @@ func TestSignalAndCancelAreInertWhileTemporalIsDown(t *testing.T) {
 	}
 	if err := s.CancelRun(context.Background(), row); !errors.Is(err, delivery.ErrTemporalUnavailable) {
 		t.Fatalf("CancelRun error = %v, want ErrTemporalUnavailable", err)
+	}
+	// Abandon reports for the same reason cancel does: a supervisor this could
+	// not reach is still there when the engine comes back, and the project-delete
+	// teardown has to be able to say the workflow outlived its project.
+	if err := s.AbandonRun(context.Background(), testOrg, testProject, testMilepost); !errors.Is(err, delivery.ErrTemporalUnavailable) {
+		t.Fatalf("AbandonRun error = %v, want ErrTemporalUnavailable", err)
 	}
 }
 

--- a/services/aep-api/internal/delivery/run/workflow.go
+++ b/services/aep-api/internal/delivery/run/workflow.go
@@ -549,6 +549,11 @@ func (l *loop) cancelRequested() bool { return l.cancel.ReceiveAsync(nil) }
 // deliberate: none of these activities has a "give up" answer that would be
 // better than waiting. A supervisor that cannot reach GitHub should stall
 // visibly, not settle a run on a network blip.
+//
+// Unbounded applies to the blips only. A failure that repeating cannot change —
+// the project deleted underneath the run, a rejected credential — is marked
+// non-retryable by the activity itself (errors.go) and fails on its first
+// attempt, so the policy here never gets to spend a lifetime on it.
 func activityCtx(ctx workflow.Context) workflow.Context {
 	return workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: activityTimeout,

--- a/services/aep-api/internal/delivery/runread/progress.go
+++ b/services/aep-api/internal/delivery/runread/progress.go
@@ -30,6 +30,11 @@ package runread
 // ONLY A TERMINAL RUN SETTLES THE STREAM. That is not just a UX rule: it is what
 // makes the endpoint testable, because a terminal run's stream is finite and an
 // httptest recorder can capture the whole of it.
+//
+// The one other ending is a run row that STOPS EXISTING — a project delete purges
+// its runs — because such a run never goes terminal and the stream would otherwise
+// tick forever. It settles with a `done` frame carrying no state: the platform has
+// no outcome to report for a row it no longer holds.
 
 import (
 	"context"
@@ -159,20 +164,29 @@ func (s *ProgressService) run(ctx context.Context, w io.Writer, flush func(), or
 	cursor := map[string]int64{}         // cycle id → last emitted log ts millis
 
 	// derive re-reads the run row, walks its cycles oldest-first emitting changed
-	// `cycle` frames and new `line` frames, and reports the run's state. Returns
-	// alive=false when the client is gone; a transient read failure keeps the
-	// stream and retries next tick.
-	derive := func(row *delivery.MilestoneRun) (state string, alive bool) {
+	// `cycle` frames and new `line` frames, and reports the run's state.
+	//
+	// Three outcomes, and telling them apart is the whole contract:
+	//   - alive=false — the client is gone, so stop writing.
+	//   - gone=true — the run ROW is gone (a project delete purges its runs).
+	//   - otherwise — state is what the row says, and a transient read failure
+	//     keeps the stream and retries next tick.
+	derive := func(row *delivery.MilestoneRun) (state string, gone, alive bool) {
 		if row == nil {
 			fresh, err := s.runs.GetByIDScoped(ctx, orgID, first.ID)
-			if err != nil || fresh == nil {
-				return "", true
+			if err != nil {
+				// A read that FAILED says nothing about the row. Hold the stream open
+				// and ask again next tick.
+				return "", false, true
+			}
+			if fresh == nil {
+				return "", true, true
 			}
 			row = fresh
 		}
 		cycles, err := s.cycles.ListByRun(ctx, orgID, row.ID)
 		if err != nil {
-			return row.State, true
+			return row.State, false, true
 		}
 		for i := range cycles {
 			c := &cycles[i]
@@ -181,23 +195,42 @@ func (s *ProgressService) run(ctx context.Context, w io.Writer, flush func(), or
 			if lastCycleJSON[c.ID] != string(b) {
 				lastCycleJSON[c.ID] = string(b)
 				if !writeFrame(&runFrame{Type: "cycle", Cycle: &view}) {
-					return row.State, false
+					return row.State, false, false
 				}
 			}
 			if !s.emitLines(ctx, c, i+1, cursor, writeFrame) {
-				return row.State, false
+				return row.State, false, false
 			}
 		}
-		return row.State, true
+		return row.State, false, true
+	}
+
+	// settled reports whether this pass ends the stream, and closes it when it
+	// does. A VANISHED row settles with no state: the platform has no outcome to
+	// report for a row it no longer holds, and `state` on the `done` frame is
+	// contract-defined as the run's TERMINAL state — so naming the last state seen
+	// would render a run that was deleted mid-flight as one that finished in it.
+	// Holding the connection open instead is the failure this replaced: a deleted
+	// run never goes terminal, so the stream ticked forever and the console spun
+	// on a run that was never coming back.
+	settled := func(state string, gone bool) bool {
+		switch {
+		case gone:
+			writeDone("")
+			return true
+		case delivery.IsTerminalRunState(state):
+			writeDone(state)
+			return true
+		}
+		return false
 	}
 
 	// Initial full derive (reuses the pre-stream row — no double read).
-	state, alive := derive(first)
+	state, gone, alive := derive(first)
 	if !alive {
 		return
 	}
-	if delivery.IsTerminalRunState(state) {
-		writeDone(state)
+	if settled(state, gone) {
 		return
 	}
 
@@ -216,14 +249,13 @@ func (s *ProgressService) run(ctx context.Context, w io.Writer, flush func(), or
 			}
 			flush()
 		case <-tick.C:
-			state, alive := derive(nil)
+			state, gone, alive := derive(nil)
 			if !alive {
 				return
 			}
 			// A terminal run has just had its final derive, so everything the run
 			// ever produced is on the wire before the stream closes.
-			if delivery.IsTerminalRunState(state) {
-				writeDone(state)
+			if settled(state, gone) {
 				return
 			}
 		}

--- a/services/aep-api/internal/delivery/runread/progress_settle_test.go
+++ b/services/aep-api/internal/delivery/runread/progress_settle_test.go
@@ -23,6 +23,7 @@ package runread
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -32,10 +33,14 @@ import (
 )
 
 // flipRuns answers with a run whose state the test flips under a lock — the
-// supervisor settling its row, seen through the reader.
+// supervisor settling its row, seen through the reader. It can also stop
+// answering with a row at all (the project-delete purge) or start failing (a
+// database blip), which are the two ways a live derive comes back without one.
 type flipRuns struct {
-	mu  sync.Mutex
-	row delivery.MilestoneRun
+	mu     sync.Mutex
+	row    delivery.MilestoneRun
+	purged bool
+	err    error
 }
 
 func (f *flipRuns) set(state string) {
@@ -44,9 +49,31 @@ func (f *flipRuns) set(state string) {
 	f.row.State = state
 }
 
+// purge is the project-delete cascade seen through the reader: the row is gone
+// for good.
+func (f *flipRuns) purge() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.purged = true
+}
+
+// fail makes the read error — a transient outage, which says nothing about
+// whether the row is still there.
+func (f *flipRuns) fail(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
 func (f *flipRuns) GetByIDScoped(context.Context, string, string) (*delivery.MilestoneRun, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.purged {
+		return nil, nil
+	}
 	row := f.row
 	return &row, nil
 }
@@ -152,6 +179,51 @@ func TestRunProgress_SettlesWhenTheRunGoesTerminal(t *testing.T) {
 	waitFor(t, buf, "data: [DONE]", time.Second)
 	if got := buf.String(); !strings.Contains(got, `"state":"cancelled"`) {
 		t.Errorf("the done frame must carry the terminal state\n---\n%s", got)
+	}
+}
+
+// TestRunProgress_SettlesWhenTheRunRowIsPurged: a run row deleted underneath a
+// live stream (a project delete purges its runs) ends the stream. It never goes
+// terminal, so without this the loop ticked forever and the console spun on a
+// run that was never coming back.
+//
+// The `done` frame carries NO state: `state` is the run's TERMINAL state, and a
+// row that was deleted mid-flight reached none.
+func TestRunProgress_SettlesWhenTheRunRowIsPurged(t *testing.T) {
+	runs := &flipRuns{row: delivery.MilestoneRun{
+		ID: "r1", OrgID: "acme", ProjectID: "widgets", State: delivery.RunStateRunning,
+	}}
+	buf, cancel := startStream(t, runs)
+	defer cancel()
+
+	time.Sleep(20 * time.Millisecond)
+	if strings.Contains(buf.String(), "[DONE]") {
+		t.Fatal("a running run must not settle the stream")
+	}
+	runs.purge()
+
+	waitFor(t, buf, `"type":"done"`, time.Second)
+	waitFor(t, buf, "data: [DONE]", time.Second)
+	if got := buf.String(); strings.Contains(got, `"state":`) {
+		t.Errorf("a purged run has no terminal state to report\n---\n%s", got)
+	}
+}
+
+// TestRunProgress_ReadFailure_DoesNotSettle: the counterweight to the purge
+// case. A read that FAILED says nothing about whether the row is there, so it
+// keeps the stream and retries — settling on it would end every live run's
+// stream on one database blip. Negative assertion, 50ms window.
+func TestRunProgress_ReadFailure_DoesNotSettle(t *testing.T) {
+	runs := &flipRuns{row: delivery.MilestoneRun{
+		ID: "r1", OrgID: "acme", ProjectID: "widgets", State: delivery.RunStateRunning,
+	}}
+	buf, cancel := startStream(t, runs)
+	defer cancel()
+
+	runs.fail(errors.New("connection reset"))
+	time.Sleep(50 * time.Millisecond)
+	if got := buf.String(); strings.Contains(got, "[DONE]") {
+		t.Fatalf("a failed read must not settle the stream\n---\n%s", got)
 	}
 }
 

--- a/services/aep-api/internal/delivery/usage_ledger.go
+++ b/services/aep-api/internal/delivery/usage_ledger.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package delivery
+
+import (
+	"fmt"
+	"time"
+)
+
+// The agent-usage LEDGER: what an org's agent work cost, kept for good.
+//
+// It exists because spend outlived the rows that used to carry it. Delivery's
+// dispatch records — run_cycles and executions — are working state, and the
+// project-delete cascade purges them so a recreated same-named project starts
+// with a clean timeline. Usage was stamped on those same rows, so deleting a
+// project also erased the record of what it had cost, which the Settings → Usage
+// page is built to keep showing (its cards carry a `deleted` flag for exactly
+// this case).
+//
+// The ledger is therefore APPEND-ONLY and deliberately outside every purge. It
+// is written at capture, beside the stamp on the dispatch row, so the record is
+// complete whatever happens to the project afterwards — and in particular it does
+// not depend on the delete path running, which is best-effort by contract.
+
+// UsageLedgerSource names which dispatch history an entry came from. Both write
+// here, so the rollup has ONE source of truth and cannot double-count.
+const (
+	// UsageLedgerSourceRunCycle is the milestone loop's cycle — where agent spend
+	// lives after the issue-driven flip.
+	UsageLedgerSourceRunCycle = "run_cycle"
+	// UsageLedgerSourceExecution is the older per-issue funnel's row. The only
+	// kind still minted runs no model, so in practice it contributes nothing
+	// today; it is carried anyway, because a populated table the rollup ignored
+	// would under-report spend rather than fail visibly.
+	UsageLedgerSourceExecution = "execution"
+)
+
+// AgentUsageLedgerEntry is one dispatch's captured spend, frozen.
+//
+// Identity is (Source, SourceID) — the cycle or execution the capture came from.
+// That is what makes re-capture idempotent: the runner's terminal log is read more
+// than once, re-deriving the same figures, so a repeat write updates the entry in
+// place instead of adding a second one.
+//
+// Everything else is a SNAPSHOT taken at capture, not a join. The dispatch row,
+// its run, its milestone and eventually its project may all be gone by the time
+// anybody reads this; an entry that had to join back to them would answer nothing
+// for exactly the projects this table exists to remember.
+type AgentUsageLedgerEntry struct {
+	ID string `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+
+	OrgID     string `gorm:"index;not null"`
+	ProjectID string `gorm:"index;not null"`
+
+	// Source + SourceID are the idempotency key (unique together).
+	Source   string `gorm:"not null"`
+	SourceID string `gorm:"not null"`
+
+	// Phase is the SDLC phase this spend belongs to, decided at WRITE time by
+	// UsagePhaseCaseSQL. It used to be a CASE in the rollup query, once per source
+	// and drifting between them; storing it means the classification is made once,
+	// from one spelling, at the moment the facts are in hand.
+	Phase string `gorm:"not null"`
+
+	// MilestoneNumber and Tag place the spend in the project's delivery history —
+	// which version cost this. Both are zero/empty for an execution-sourced entry,
+	// which belongs to no milestone.
+	MilestoneNumber int    `gorm:"not null;default:0"`
+	Tag             string `gorm:"not null;default:''"`
+
+	ModelID             string   `gorm:"type:text;not null;default:''"`
+	InputTokens         int64    `gorm:"not null;default:0"`
+	OutputTokens        int64    `gorm:"not null;default:0"`
+	CacheReadTokens     int64    `gorm:"not null;default:0"`
+	CacheCreationTokens int64    `gorm:"not null;default:0"`
+	CostUsd             *float64 `gorm:"column:cost_usd"`
+
+	CapturedAt time.Time `gorm:"not null;default:now()"`
+
+	// RetiredAt is the LIFETIME BOUNDARY, and the only column ever rewritten
+	// after the entry is captured.
+	//
+	// It is stamped when the project this entry belongs to is deleted, which is
+	// what keeps two lifetimes of the same project NAME apart: a slug is only a
+	// slug, and a project deleted and recreated under the same name would
+	// otherwise inherit its predecessor's bill. Live spend is the entries with a
+	// NULL RetiredAt; each delete closes off exactly the entries that were live at
+	// the time, so a slug deleted twice leaves two distinguishable generations
+	// (one per stamp) rather than one merged heap.
+	//
+	// Nil is not "unknown" — it is a positive claim that this spend belongs to the
+	// incarnation that is live now.
+	RetiredAt *time.Time
+}
+
+// TableName pins the table name so a struct rename cannot silently move the
+// table.
+func (AgentUsageLedgerEntry) TableName() string { return "agent_usage_ledger" }
+
+// UsagePhaseCaseSQL classifies a dispatch into the SDLC phase its spend is
+// reported under, as the SQL fragment every ledger writer stamps with: a
+// VALIDATION cycle is the validation phase, and every other kind — coding, fix,
+// conflict, and the older funnel's build/provision rows, all of them agent work
+// driving the increment toward green — is the build phase.
+//
+// It is a fragment rather than a Go predicate because the write is an INSERT …
+// SELECT: the classification is applied to whatever rows the statement selects,
+// so a Go twin could only be used by reading each row back first.
+//
+// This is the ONE spelling. It used to be written once per rollup query, and the
+// two copies had already drifted — the executions side tested for a kind that
+// table never had. Every caller now stamps through here, and the STORED phase is
+// what the rollup groups on, so a future change is one edit and cannot half-land.
+//
+// kindColumn is a caller-supplied column reference (`c.kind`), never user input;
+// the values interpolated beside it are this package's own constants.
+func UsagePhaseCaseSQL(kindColumn string) string {
+	return fmt.Sprintf("CASE WHEN %s = '%s' THEN '%s' ELSE '%s' END",
+		kindColumn, CycleKindValidation, UsagePhaseValidation, UsagePhaseBuild)
+}

--- a/services/aep-api/internal/delivery/usage_rollup.go
+++ b/services/aep-api/internal/delivery/usage_rollup.go
@@ -24,48 +24,31 @@ import (
 )
 
 // PhaseUsageRollup returns delivery's whole answer to "what did this org's agent
-// work cost, per project, per SDLC phase" (#291): the sum of both places
-// delivery captures usage.
+// work cost, per project lifetime, per SDLC phase" (#291).
 //
-// There are two because delivery has two dispatch histories:
+// It reads the agent-usage LEDGER and nothing else. That is the design, not an
+// optimisation:
 //
-//   - CYCLES are where agent spend lives now. After the issue-driven flip every
-//     token-burning dispatch is a cycle — coding, fix, conflict, validation.
-//   - EXECUTIONS are the older per-issue funnel's rows. The only kind still
-//     minted is KindProvision, which stands up OpenChoreo resources and runs no
-//     model, so in practice this side contributes nothing today. It is summed
-//     anyway rather than dropped: the column and its capture path are real, and a
-//     rollup that silently ignored a populated table would under-report spend
-//     rather than fail visibly.
+//   - ONE SOURCE. Delivery has two dispatch histories — cycles (where agent spend
+//     lives after the issue-driven flip) and the older funnel's executions — and
+//     both mirror every capture into the ledger. Summing the dispatch rows as well
+//     would count the same tokens twice, so they are not summed at all.
+//   - IT OUTLIVES THE PURGE. The dispatch rows are working state and a project
+//     delete removes them; the ledger is deliberately outside that cascade, so the
+//     Settings → Usage page can still answer for a project that no longer exists —
+//     which is exactly what its `deleted` cards are for.
+//   - IT KEEPS LIFETIMES APART. The result is keyed by contracts.UsageScope, so a
+//     project recreated under a deleted one's name does not inherit its bill.
 //
 // The fold lives HERE, not in the composition root and not in the usage service,
-// because "which dispatch records count, and which phase each belongs to" is
-// delivery's knowledge. Callers see one function with the phase-split shape the
-// usage service already consumes.
-func PhaseUsageRollup(execs ExecutionRepository, cycles RunCycleRepository) func(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error) {
-	return func(ctx context.Context, orgID string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
-		cycleBuild, cycleValidation, err := cycles.SumUsageByProjectPhase(ctx, orgID)
+// because "which records count, and which phase each belongs to" is delivery's
+// knowledge.
+func PhaseUsageRollup(ledger AgentUsageLedgerRepository) func(ctx context.Context, orgID string) (build, validation map[contracts.UsageScope]contracts.StampedUsage, err error) {
+	return func(ctx context.Context, orgID string) (map[contracts.UsageScope]contracts.StampedUsage, map[contracts.UsageScope]contracts.StampedUsage, error) {
+		build, validation, err := ledger.SumUsageByProjectPhase(ctx, orgID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("delivery: cycle usage rollup: %w", err)
+			return nil, nil, fmt.Errorf("delivery: agent usage rollup: %w", err)
 		}
-		execBuild, execValidation, err := execs.SumUsageByProjectPhase(ctx, orgID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("delivery: execution usage rollup: %w", err)
-		}
-		return mergeStamped(cycleBuild, execBuild), mergeStamped(cycleValidation, execValidation), nil
+		return build, validation, nil
 	}
-}
-
-// mergeStamped folds b into a copy of a, per project. StampedUsage.Add carries
-// the model-agreement and nil-cost semantics, so a project present in only one
-// source keeps its own figures untouched.
-func mergeStamped(a, b map[string]contracts.StampedUsage) map[string]contracts.StampedUsage {
-	out := make(map[string]contracts.StampedUsage, len(a)+len(b))
-	for slug, u := range a {
-		out[slug] = u
-	}
-	for slug, u := range b {
-		out[slug] = out[slug].Add(u)
-	}
-	return out
 }

--- a/services/aep-api/internal/delivery/usage_rollup_test.go
+++ b/services/aep-api/internal/delivery/usage_rollup_test.go
@@ -24,42 +24,21 @@ import (
 	"github.com/wso2/aep/aep-api/internal/contracts"
 )
 
-// fakePhaseUsage is the canned answer either repository's phase-split read
-// returns. Held as a NAMED field rather than embedded: embedding it beside the
-// repository interface would make SumUsageByProjectPhase an ambiguous selector,
-// and the fake would satisfy neither interface.
-type fakePhaseUsage struct {
-	build      map[string]contracts.StampedUsage
-	validation map[string]contracts.StampedUsage
+// fakeLedgerUsage answers the one read the rollup makes. It embeds the
+// repository interface for the verbs the rollup never calls — nil, so calling
+// one panics, which is the point.
+type fakeLedgerUsage struct {
+	AgentUsageLedgerRepository
+	build      map[contracts.UsageScope]contracts.StampedUsage
+	validation map[contracts.UsageScope]contracts.StampedUsage
 	err        error
 }
 
-func (f fakePhaseUsage) result() (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
+func (f fakeLedgerUsage) SumUsageByProjectPhase(context.Context, string) (map[contracts.UsageScope]contracts.StampedUsage, map[contracts.UsageScope]contracts.StampedUsage, error) {
 	if f.err != nil {
 		return nil, nil, f.err
 	}
 	return f.build, f.validation, nil
-}
-
-// Each fake embeds its repository interface for the methods the rollup never
-// calls (nil — calling one would panic, which is the point) and answers only
-// the read under test.
-type fakeExecUsage struct {
-	ExecutionRepository
-	usage fakePhaseUsage
-}
-
-func (f fakeExecUsage) SumUsageByProjectPhase(context.Context, string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
-	return f.usage.result()
-}
-
-type fakeCycleUsage struct {
-	RunCycleRepository
-	usage fakePhaseUsage
-}
-
-func (f fakeCycleUsage) SumUsageByProjectPhase(context.Context, string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
-	return f.usage.result()
 }
 
 func usd(v float64) *float64 { return &v }
@@ -71,98 +50,64 @@ func stamped(in, out int64, model string, cost *float64) contracts.StampedUsage 
 	}
 }
 
-// The whole point of the rollup: a project's build spend is its cycle spend PLUS
-// any execution spend, not one or the other. Before cycles were summed the build
-// phase read empty for every project, because every agent run is a cycle.
-func TestPhaseUsageRollup_SumsCyclesAndExecutions(t *testing.T) {
-	cycles := fakeCycleUsage{usage: fakePhaseUsage{
-		build:      map[string]contracts.StampedUsage{"shop": stamped(100, 20, "m1", usd(3))},
-		validation: map[string]contracts.StampedUsage{"shop": stamped(10, 2, "m1", usd(1))},
-	}}
-	execs := fakeExecUsage{usage: fakePhaseUsage{
-		build: map[string]contracts.StampedUsage{"shop": stamped(5, 1, "m1", usd(2))},
-	}}
+// TestPhaseUsageRollup_ReadsTheLedgerAndKeepsLifetimesApart pins what the rollup
+// is now: ONE source, handed through with its lifetimes intact.
+//
+// It used to sum two — the cycle rows and the execution rows — and that is
+// exactly what it must not do any more. Both capture surfaces mirror into the
+// ledger, so adding the dispatch rows back in would bill every token twice; and
+// the dispatch rows are purged when a project is deleted, which is how the spend
+// record used to vanish with it.
+//
+// The per-lifetime split is the ledger's, not this function's (it is a GROUP BY,
+// proven against real SQL in the ledger dbtests). What is proven here is that the
+// rollup carries it through instead of folding a slug's two lifetimes together.
+func TestPhaseUsageRollup_ReadsTheLedgerAndKeepsLifetimesApart(t *testing.T) {
+	live := contracts.UsageScope{ProjectID: "shop"}
+	retired := contracts.UsageScope{ProjectID: "shop", Retired: true}
+	ledger := fakeLedgerUsage{
+		build: map[contracts.UsageScope]contracts.StampedUsage{
+			live:    stamped(100, 20, "m1", usd(3)),
+			retired: stamped(900, 90, "m1", usd(50)),
+		},
+		validation: map[contracts.UsageScope]contracts.StampedUsage{
+			live: stamped(10, 2, "m1", usd(1)),
+		},
+	}
 
-	build, validation, err := PhaseUsageRollup(execs, cycles)(context.Background(), "org1")
+	build, validation, err := PhaseUsageRollup(ledger)(context.Background(), "org1")
 	if err != nil {
 		t.Fatalf("rollup: %v", err)
 	}
-	got := build["shop"]
-	if got.Tokens.InputTokens != 105 || got.Tokens.OutputTokens != 21 {
-		t.Fatalf("build tokens = %d/%d, want 105/21", got.Tokens.InputTokens, got.Tokens.OutputTokens)
+	if got := build[live]; got.Tokens.InputTokens != 100 || got.CostUsd == nil || *got.CostUsd != 3 {
+		t.Fatalf("live build = %+v, want the live lifetime's own figures", got)
 	}
-	if got.CostUsd == nil || *got.CostUsd != 5 {
-		t.Fatalf("build cost = %v, want 5", got.CostUsd)
+	if got := build[retired]; got.CostUsd == nil || *got.CostUsd != 50 {
+		t.Fatalf("retired build = %+v, want the deleted lifetime's bill intact", got)
 	}
-	// Validation has no execution contributor — it must pass through untouched
-	// rather than be dropped or zeroed.
-	if v := validation["shop"]; v.CostUsd == nil || *v.CostUsd != 1 || v.Tokens.InputTokens != 10 {
-		t.Fatalf("validation = %+v, want the cycle figures intact", v)
+	// The two must not have been folded into one entry for the slug.
+	if len(build) != 2 {
+		t.Fatalf("build scopes = %d, want 2 (one per lifetime): %+v", len(build), build)
 	}
-}
-
-// A project in only one source keeps its own figures, and the model id survives
-// only while contributors agree — StampedUsage.Add's semantics must not be
-// bypassed by the merge.
-func TestPhaseUsageRollup_DisjointProjectsAndModelDisagreement(t *testing.T) {
-	cycles := fakeCycleUsage{usage: fakePhaseUsage{
-		build: map[string]contracts.StampedUsage{
-			"only-cycles": stamped(7, 3, "m1", usd(1)),
-			"mixed":       stamped(7, 3, "m1", usd(1)),
-		},
-	}}
-	execs := fakeExecUsage{usage: fakePhaseUsage{
-		build: map[string]contracts.StampedUsage{
-			"only-execs": stamped(4, 2, "m2", nil),
-			"mixed":      stamped(1, 1, "m2", usd(1)),
-		},
-	}}
-
-	build, _, err := PhaseUsageRollup(execs, cycles)(context.Background(), "org1")
-	if err != nil {
-		t.Fatalf("rollup: %v", err)
+	// A phase the retired lifetime never spent in stays absent rather than
+	// inheriting the live one's.
+	if _, ok := validation[retired]; ok {
+		t.Fatalf("validation must not invent a retired entry: %+v", validation)
 	}
-	if len(build) != 3 {
-		t.Fatalf("build projects = %d, want 3: %+v", len(build), build)
-	}
-	if u := build["only-cycles"]; u.Tokens.Model != "m1" || u.Tokens.InputTokens != 7 {
-		t.Fatalf("cycle-only project = %+v", u)
-	}
-	// Unstamped stays unstamped: nil cost must not become 0.
-	if u := build["only-execs"]; u.CostUsd != nil {
-		t.Fatalf("exec-only project cost = %v, want nil (unpriced)", u.CostUsd)
-	}
-	if u := build["mixed"]; u.Tokens.Model != "" {
-		t.Fatalf("mixed-model aggregate model = %q, want \"\"", u.Tokens.Model)
+	if got := validation[live]; got.Tokens.InputTokens != 10 {
+		t.Fatalf("live validation = %+v, want the ledger figures intact", got)
 	}
 }
 
-// A failure in either source must surface, not silently under-report spend as a
-// partial total the console would render as authoritative.
-func TestPhaseUsageRollup_PropagatesEitherError(t *testing.T) {
+// A read failure must surface, not silently under-report spend as a partial
+// total the console would render as authoritative.
+func TestPhaseUsageRollup_PropagatesTheLedgerError(t *testing.T) {
 	boom := errors.New("boom")
-	for _, tc := range []struct {
-		name   string
-		execs  fakeExecUsage
-		cycles fakeCycleUsage
-	}{
-		{
-			name:   "cycle source fails",
-			cycles: fakeCycleUsage{usage: fakePhaseUsage{err: boom}},
-		},
-		{
-			name:  "execution source fails",
-			execs: fakeExecUsage{usage: fakePhaseUsage{err: boom}},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			build, validation, err := PhaseUsageRollup(tc.execs, tc.cycles)(context.Background(), "org1")
-			if !errors.Is(err, boom) {
-				t.Fatalf("err = %v, want boom", err)
-			}
-			if build != nil || validation != nil {
-				t.Fatalf("maps must be nil on error, got %v / %v", build, validation)
-			}
-		})
+	build, validation, err := PhaseUsageRollup(fakeLedgerUsage{err: boom})(context.Background(), "org1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+	if build != nil || validation != nil {
+		t.Fatalf("maps must be nil on error, got %v / %v", build, validation)
 	}
 }

--- a/services/aep-api/internal/migrate/agent_usage_ledger.go
+++ b/services/aep-api/internal/migrate/agent_usage_ledger.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+// RunAgentUsageLedger finishes the agent-usage ledger: the idempotency index its
+// writers upsert against, and the one-time backfill from the dispatch rows that
+// carried spend before the ledger existed.
+//
+// AutoMigrate (migrate.BaseModels) creates the table and its indexes from the
+// model, this step's index create included — it is repeated here because the
+// ledger's two writers use ON CONFLICT (source, source_id), and an INSERT whose
+// arbiter index is missing does not degrade, it errors. The one thing that must
+// exist for a capture to land is therefore asserted where it can be read, not
+// left to be inferred from a struct tag.
+//
+// THE BACKFILL is the whole reason this is a migration rather than only a model.
+// Spend used to live on run_cycles.cost_usd and executions.cost_usd, and the
+// rollup now reads neither; without this, every deployment would show a usage
+// page that had forgotten everything before the upgrade. It runs ON CONFLICT DO
+// NOTHING, so a re-run adds nothing and never overwrites a capture the live
+// writers have since refreshed.
+//
+// What it CANNOT recover is the spend of projects already deleted: their cycles
+// and executions were purged by the delete cascade this ledger exists to survive,
+// so there is nothing left to copy. Those projects start the ledger empty, and
+// that is a fact about the past, not a defect in the backfill.
+//
+// captured_at is COALESCEd against now(): the dispatch row's own creation time is
+// the honest capture date, but it is a Go-side default rather than a column
+// default, so a row written by anything other than the repository can carry null
+// — and an entry with no capture date at all would be worse than an approximate
+// one.
+//
+// Idempotent throughout: CREATE … IF NOT EXISTS, and both backfills conflict
+// against the same index.
+func RunAgentUsageLedger(ctx context.Context, db *gorm.DB) error {
+	if !hasTable(db, "agent_usage_ledger") {
+		return nil
+	}
+	// The arbiter for both writers' ON CONFLICT. Named, not anonymous, so a
+	// future predicate change is a rename rather than a silent no-op.
+	if err := db.WithContext(ctx).Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS ux_agent_usage_ledger_source
+		ON agent_usage_ledger (source, source_id)`).Error; err != nil {
+		return fmt.Errorf("agent_usage_ledger source index: %w", err)
+	}
+	// The list read: "what did this org's project spend", newest lifetime first.
+	if err := db.WithContext(ctx).Exec(`
+		CREATE INDEX IF NOT EXISTS idx_agent_usage_ledger_org_project
+		ON agent_usage_ledger (org_id, project_id, retired_at)`).Error; err != nil {
+		return fmt.Errorf("agent_usage_ledger org/project index: %w", err)
+	}
+
+	if hasTable(db, "run_cycles") {
+		// The version columns mirror MilestoneRun.SpecTag: the tag is empty on
+		// pre-phase and early incident rows, whose milestone title IS the version.
+		// LEFT JOIN, because a cycle whose run row is already gone still spent what
+		// it spent.
+		if err := db.WithContext(ctx).Exec(`
+			INSERT INTO agent_usage_ledger (
+			  org_id, project_id, source, source_id, phase, milestone_number, tag,
+			  model_id, input_tokens, output_tokens, cache_read_tokens,
+			  cache_creation_tokens, cost_usd, captured_at)
+			SELECT c.org_id, c.project_id, ?, c.id::text, `+delivery.UsagePhaseCaseSQL("c.kind")+`,
+			       COALESCE(m.milestone_number, 0),
+			       COALESCE(NULLIF(m.tag, ''), m.milestone_title, ''),
+			       c.model_id, c.input_tokens, c.output_tokens, c.cache_read_tokens,
+			       c.cache_creation_tokens, c.cost_usd, COALESCE(c.created_at, now())
+			FROM run_cycles c
+			LEFT JOIN milestone_runs m ON m.id::text = c.run_id
+			WHERE c.org_id <> '' AND c.project_id <> ''
+			  AND c.input_tokens + c.output_tokens + c.cache_read_tokens + c.cache_creation_tokens > 0
+			ON CONFLICT (source, source_id) DO NOTHING`,
+			delivery.UsageLedgerSourceRunCycle,
+		).Error; err != nil {
+			return fmt.Errorf("agent_usage_ledger backfill from run_cycles: %w", err)
+		}
+	}
+
+	if hasTable(db, "executions") {
+		if err := db.WithContext(ctx).Exec(`
+			INSERT INTO agent_usage_ledger (
+			  org_id, project_id, source, source_id, phase, milestone_number, tag,
+			  model_id, input_tokens, output_tokens, cache_read_tokens,
+			  cache_creation_tokens, cost_usd, captured_at)
+			SELECT e.org_id, e.project_id, ?, e.id::text, `+delivery.UsagePhaseCaseSQL("e.kind")+`,
+			       0, '',
+			       e.model_id, e.input_tokens, e.output_tokens, e.cache_read_tokens,
+			       e.cache_creation_tokens, e.cost_usd, COALESCE(e.created_at, now())
+			FROM executions e
+			WHERE e.org_id <> '' AND e.project_id <> ''
+			  AND e.input_tokens + e.output_tokens + e.cache_read_tokens + e.cache_creation_tokens > 0
+			ON CONFLICT (source, source_id) DO NOTHING`,
+			delivery.UsageLedgerSourceExecution,
+		).Error; err != nil {
+			return fmt.Errorf("agent_usage_ledger backfill from executions: %w", err)
+		}
+	}
+	return nil
+}

--- a/services/aep-api/internal/migrate/agent_usage_ledger_dbtest_test.go
+++ b/services/aep-api/internal/migrate/agent_usage_ledger_dbtest_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package migrate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/contracts"
+	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/migrate"
+	"github.com/wso2/aep/aep-api/internal/platform/dbtest"
+)
+
+// TestAgentUsageLedger_BacksfillsSpendCapturedBeforeTheLedgerExisted.
+//
+// Every deployment upgrading into the ledger already has spend, stamped on
+// run_cycles and executions by the code that came before it. The rollup reads
+// neither of those any more, so without this backfill the Settings → Usage page
+// would come back from the upgrade having forgotten everything.
+//
+// The seed goes in by raw SQL on purpose: going through the repository would
+// write the ledger entry itself, which is precisely the state this migration
+// exists to repair.
+func TestAgentUsageLedger_BacksfillsSpendCapturedBeforeTheLedgerExisted(t *testing.T) {
+	db := dbtest.New(t)
+	ctx := context.Background()
+
+	runs := delivery.NewMilestoneRunRepository(db)
+	admitted, run, err := runs.TryAdmit(ctx, &delivery.MilestoneRun{
+		OrgID: "orgb", ProjectID: "shop", MilestoneNumber: 4, MilestoneTitle: "v4", Tag: "v4",
+		Origin: delivery.RunOriginSpecBuild, State: delivery.RunStateWaiting,
+	})
+	if err != nil || !admitted {
+		t.Fatalf("TryAdmit = (%v, %v)", admitted, err)
+	}
+
+	// A pre-ledger capture: tokens and a frozen stamp on the cycle row, nothing
+	// in the ledger.
+	if err := db.Exec(`
+		INSERT INTO run_cycles (org_id, project_id, run_id, kind, attempts,
+		  input_tokens, output_tokens, cost_usd)
+		VALUES (?, ?, ?, ?, 1, 1000000, 100000, 7.5)`,
+		run.OrgID, run.ProjectID, run.ID, delivery.CycleKindCoding).Error; err != nil {
+		t.Fatalf("seed legacy cycle: %v", err)
+	}
+	// A validation cycle too, so the backfill is proven to carry the phase split
+	// rather than dumping everything into build.
+	if err := db.Exec(`
+		INSERT INTO run_cycles (org_id, project_id, run_id, kind, attempts, input_tokens)
+		VALUES (?, ?, ?, ?, 1, 250000)`,
+		run.OrgID, run.ProjectID, run.ID, delivery.CycleKindValidation).Error; err != nil {
+		t.Fatalf("seed legacy validation cycle: %v", err)
+	}
+	// A cycle that captured nothing must not become a ledger entry.
+	if err := db.Exec(`
+		INSERT INTO run_cycles (org_id, project_id, run_id, kind, attempts)
+		VALUES (?, ?, ?, ?, 1)`,
+		run.OrgID, run.ProjectID, run.ID, delivery.CycleKindConflict).Error; err != nil {
+		t.Fatalf("seed empty cycle: %v", err)
+	}
+
+	ledger := delivery.NewAgentUsageLedgerRepository(db)
+	if build, validation, err := ledger.SumUsageByProjectPhase(ctx, "orgb"); err != nil ||
+		len(build) != 0 || len(validation) != 0 {
+		t.Fatalf("ledger before the backfill = (%v, %v, %v), want empty", build, validation, err)
+	}
+
+	if err := migrate.RunAgentUsageLedger(ctx, db); err != nil {
+		t.Fatalf("RunAgentUsageLedger: %v", err)
+	}
+
+	live := contracts.UsageScope{ProjectID: "shop"}
+	build, validation, err := ledger.SumUsageByProjectPhase(ctx, "orgb")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase: %v", err)
+	}
+	b := build[live]
+	if b.Tokens.InputTokens != 1_000_000 || b.Tokens.OutputTokens != 100_000 {
+		t.Fatalf("backfilled build tokens = %+v, want 1M/100k", b.Tokens)
+	}
+	if b.CostUsd == nil || *b.CostUsd != 7.5 {
+		t.Fatalf("backfilled cost = %v, want the stamp frozen on the row (7.5)", b.CostUsd)
+	}
+	if v := validation[live]; v.Tokens.InputTokens != 250_000 {
+		t.Fatalf("backfilled validation tokens = %+v, want 250k in its own phase", v.Tokens)
+	}
+	// Backfilled spend belongs to the LIVE lifetime — the project still exists.
+	if _, retired := build[contracts.UsageScope{ProjectID: "shop", Retired: true}]; retired {
+		t.Error("backfilled entries must not arrive pre-retired")
+	}
+
+	// Re-running the migration is a no-op, not a second bill. Upgrades re-run
+	// every step, so this is the ordinary case rather than the exotic one.
+	if err := migrate.RunAgentUsageLedger(ctx, db); err != nil {
+		t.Fatalf("RunAgentUsageLedger (second run): %v", err)
+	}
+	again, _, err := ledger.SumUsageByProjectPhase(ctx, "orgb")
+	if err != nil {
+		t.Fatalf("SumUsageByProjectPhase after re-run: %v", err)
+	}
+	if again[live].Tokens.InputTokens != 1_000_000 {
+		t.Fatalf("re-run doubled the ledger: input tokens = %d, want 1M", again[live].Tokens.InputTokens)
+	}
+}

--- a/services/aep-api/internal/migrate/run_all.go
+++ b/services/aep-api/internal/migrate/run_all.go
@@ -66,6 +66,7 @@ func BaseModels() []any {
 		&projects.ActivityEvent{},
 		&delivery.MilestoneRun{},
 		&delivery.RunCycle{},
+		&delivery.AgentUsageLedgerEntry{},
 	}
 }
 
@@ -154,6 +155,11 @@ func Steps(db *gorm.DB, deploymentTier string, credKey []byte) []database.Step {
 		// stream reads once the Job's pod is reaped. FK'd to run_cycles(id), so it
 		// follows milestone_runs.
 		ctxStep("run_cycle_logs", RunRunCycleLogs),
+		// agent_usage_ledger: the spend record that outlives the project. Its
+		// upsert arbiter index, plus the one-time backfill from the dispatch rows
+		// spend used to live on — so it must follow both of those tables
+		// (AutoMigrate) and the milestone_runs it joins for the version label.
+		ctxStep("agent_usage_ledger", RunAgentUsageLedger),
 		// model_rates seed (#291): the platform's active model at today's
 		// rates. AutoMigrate (BaseModels) creates the table; this idempotent
 		// step inserts the claude-sonnet-5 row so write-time USD stamping has

--- a/services/aep-api/internal/migrate/step_order_test.go
+++ b/services/aep-api/internal/migrate/step_order_test.go
@@ -65,6 +65,7 @@ var goldenStepOrder = []string{
 	"phase10_rca_agent_reports",
 	"milestone_runs",
 	"run_cycle_logs",
+	"agent_usage_ledger",
 	"model_rates_seed",
 	"phase11_secret_ref_columns",
 	"phase12_encrypt_credential_columns",

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -48,6 +48,8 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
 | design read · spec-stage snapshot | needs | `spec` — the Stage aggregate's spec column + component OpenAPI source |
 | `descriptorWriter` | needs | `spec` — stamps `specs/.agentic-engineer.toml` on create (best-effort; nil is a no-op) |
 | build/exec status (`SetStageSources` port) | needs | `delivery` — the build/deploy columns of the Stage aggregate, wired at the root |
+| `runAbandoner` (`SetRunAbandoner`) | needs | `delivery` — ends the supervisors of a deleted project's live runs, wired at the root (nil is a no-op) |
+| per-project agent usage (`UsageService`) | needs | `delivery` — the agent-usage ledger, keyed by lifetime (`contracts.UsageScope`) |
 | OC `Project`/`Component`/`ReleaseBinding` CRUD | needs | `openchoreo` client — OC is the store |
 | `Service` · `ComponentService` · `ConfigService` | offers | the edge (the 14 public ops) |
 
@@ -84,4 +86,15 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
   exactly one failure class, so no tally or recency heuristic is needed. Every other terminal reason keeps
   the Build card as the catch-all. `deploy.validation` itself is the run row's VERDICT column; the report
   and the per-cycle detail behind it live on the version's run story (list-build-runs).
+- **A project delete takes its run SUPERVISORS down before its run ROWS.** Purging the rows does not stop
+  the workflows that write them: nothing else ends a run workflow, its milestone poll retries unbounded
+  against a repository the same delete removes, and its id is keyed on (org, project, milestone) alone —
+  so a project later created under the same name collides with the survivor and its first run is refused
+  as already-started, leaving it unsupervised. Order is therefore abandon → repo → rows, and every step is
+  best-effort because the OC delete upstream has already been committed.
+- **Deleting a project does not delete what it cost.** The delete purges its runs and cycles; delivery's
+  `agent_usage_ledger` is retired, not purged, so Settings → Usage keeps the greyed card the page was
+  always designed to show. A slug deleted and recreated therefore renders TWO cards — the live project
+  billed only for its own work, and the incarnation that spent the rest — because a slug is not an
+  identity. Spec-turn spend carries no lifetime marker and sits whole on whichever card is current.
 - Platform-wide rules (tenant gate, secrets fence, feature-free domains) → [../../README.md](../../README.md).

--- a/services/aep-api/internal/projects/project_delete_idempotence_test.go
+++ b/services/aep-api/internal/projects/project_delete_idempotence_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	ocmocks "github.com/wso2/aep/aep-api/internal/clients/openchoreo/mocks"
+)
+
+// A project delete is a cascade across five systems that fail independently:
+// OpenChoreo, Temporal, the repo record, the executions rows and the run ledger.
+// Only the first of them can refuse the delete. Everything after it is the
+// platform's own state, and the platform's own state has NO other exit — there
+// is no second endpoint that purges an execution row or ends a run supervisor.
+//
+// That is what these tests pin: the cascade must be re-runnable to completion,
+// because the half-deleted project is the state operators actually find
+// themselves in, and the retry is the only tool they have.
+
+// TestDeleteProject_AlreadyGoneOCProjectStillTearsDownPlatformState is the
+// regression for the defect that produced a run supervisor polling a deleted
+// repository at attempt 300+.
+//
+// The OC Project going first is ordinary: a delete that got past OpenChoreo and
+// then failed, an out-of-band teardown, or simply the same DELETE arriving
+// twice. Treating that as a failed delete meant every retry took the same early
+// return, so the supervisors were never abandoned, the repo record was never
+// dropped and the executions and run rows were never purged — permanently,
+// because this endpoint is the only thing that purges them.
+func TestDeleteProject_AlreadyGoneOCProjectStillTearsDownPlatformState(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return openchoreo.ErrNotFound },
+	}
+	repoSvc := &fakeRepoSvc{DeleteRepoFunc: func(context.Context, string, string) error {
+		trace.steps = append(trace.steps, "repo")
+		return nil
+	}}
+	execs := &fakeExecs{}
+	abandoner := &fakeRunAbandoner{trace: trace}
+
+	svc := NewProjectService(oc, repoSvc, nil, nil, execs)
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	// "Already gone" is the requested end state, not a failure to report.
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("an already-deleted OC project must not fail the teardown, got %v", err)
+	}
+	if abandoner.calls != 1 || abandoner.args != [2]string{"acme", "web"} {
+		t.Errorf("run supervisors were not abandoned: calls=%d args=%v", abandoner.calls, abandoner.args)
+	}
+	if execs.deleteCalls != 1 || execs.deleteArgs != [2]string{"acme", "web"} {
+		t.Errorf("executions purge: calls=%d args=%v, want 1 (acme,web)", execs.deleteCalls, execs.deleteArgs)
+	}
+	assertTeardownOrder(t, trace, "abandon", "repo", "purge")
+}
+
+// TestDeleteProject_IsIdempotent runs the whole cascade twice against a service
+// that has already been fully torn down — OC answers not-found and the repo row
+// is gone — and requires the second pass to succeed and to reach every step
+// again.
+//
+// Re-running the teardown is not a no-op worth skipping: the pass that failed is
+// precisely the one whose steps did not all run, so the retry has to attempt all
+// of them rather than short-circuit on the parts that look done.
+func TestDeleteProject_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return openchoreo.ErrNotFound },
+	}
+	// The repo service reports success with nothing to delete — DeleteRepo
+	// ensures absence rather than performing a removal (see its contract).
+	repoSvc := &fakeRepoSvc{DeleteRepoFunc: func(context.Context, string, string) error {
+		trace.steps = append(trace.steps, "repo")
+		return nil
+	}}
+	execs := &fakeExecs{}
+	abandoner := &fakeRunAbandoner{trace: trace}
+
+	svc := NewProjectService(oc, repoSvc, nil, nil, execs)
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+			t.Fatalf("attempt %d: delete must be safe to re-run, got %v", attempt, err)
+		}
+	}
+	if abandoner.calls != 2 {
+		t.Errorf("abandon ran %d times across two deletes, want 2", abandoner.calls)
+	}
+	if execs.deleteCalls != 2 {
+		t.Errorf("executions purge ran %d times across two deletes, want 2", execs.deleteCalls)
+	}
+	assertTeardownOrder(t, trace,
+		"abandon", "repo", "purge",
+		"abandon", "repo", "purge")
+}
+
+// --- webhook unregistration --------------------------------------------------
+
+// TestDeleteProject_UnregistersWebhookBeforeDroppingTheRepoRow pins the ORDER,
+// which is the only thing that makes the step possible at all: the hook id and
+// the repo identity the credential resolves against both live on the repo row,
+// so unregistering after DeleteRepo would have nothing left to address. The
+// remote survives a project delete, so without this its webhook would go on
+// posting deliveries for a project the platform has forgotten.
+func TestDeleteProject_UnregistersWebhookBeforeDroppingTheRepoRow(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return nil },
+	}
+	repoSvc := &fakeRepoSvc{DeleteRepoFunc: func(context.Context, string, string) error {
+		trace.steps = append(trace.steps, "repo")
+		return nil
+	}}
+	webhooks := &fakeWebhookSvc{trace: trace}
+	abandoner := &fakeRunAbandoner{trace: trace}
+
+	svc := NewProjectService(oc, repoSvc, webhooks, nil, &fakeExecs{})
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if webhooks.unregisterCalls != 1 || webhooks.unregisterArgs != [2]string{"acme", "web"} {
+		t.Fatalf("unregister: calls=%d args=%v, want 1 (acme,web)",
+			webhooks.unregisterCalls, webhooks.unregisterArgs)
+	}
+	assertTeardownOrder(t, trace, "abandon", "webhook", "repo", "purge")
+}
+
+// TestDeleteProject_WebhookUnregisterFailureIsSwallowed: a webhook left on a
+// repository is untidy, not dangerous — the event plane resolves every delivery
+// through the repo row and drops what it cannot place. It must never be the
+// thing that blocks a delete, least of all one whose OC half is already
+// committed and cannot be undone.
+func TestDeleteProject_WebhookUnregisterFailureIsSwallowed(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return nil },
+	}
+	repoSvc := &fakeRepoSvc{DeleteRepoFunc: func(context.Context, string, string) error {
+		trace.steps = append(trace.steps, "repo")
+		return nil
+	}}
+	webhooks := &fakeWebhookSvc{trace: trace, UnregisterFunc: func(context.Context, string, string) error {
+		return errors.New("github unreachable")
+	}}
+	execs := &fakeExecs{}
+
+	svc := NewProjectService(oc, repoSvc, webhooks, nil, execs)
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("webhook cleanup failure must be best-effort, got %v", err)
+	}
+	// Everything downstream still ran — the delete completed.
+	if execs.deleteCalls != 1 {
+		t.Errorf("executions purge ran %d times after a failed unregister, want 1", execs.deleteCalls)
+	}
+	assertTeardownOrder(t, trace, "webhook", "repo", "purge")
+}
+
+// assertTeardownOrder compares the recorded steps against the expected cascade.
+// The ORDER is the contract: a supervisor abandoned after its repository is gone
+// has already spent a poll on a repository that no longer exists, and one
+// abandoned after its rows are purged has nothing left to identify it by.
+func assertTeardownOrder(t *testing.T, trace *deleteTrace, want ...string) {
+	t.Helper()
+	if len(trace.steps) != len(want) {
+		t.Fatalf("teardown steps = %v, want %v", trace.steps, want)
+	}
+	for i := range want {
+		if trace.steps[i] != want[i] {
+			t.Fatalf("teardown steps = %v, want %v", trace.steps, want)
+		}
+	}
+}

--- a/services/aep-api/internal/projects/project_service.go
+++ b/services/aep-api/internal/projects/project_service.go
@@ -59,7 +59,28 @@ type Service struct {
 	deprovisioner  resourceDeprovisioner // dependency provisioning teardown; may be nil
 	runReader      milestoneRunRows      // build/deploy stage reads + delete purge (status_stages.go)
 	bindingsReader bindingsReader        // deploy stage: OC release bindings (status_stages.go)
+	runAbandoner   runAbandoner          // run-supervisor teardown on delete; may be nil
 }
+
+// runAbandoner is project_service's narrow consumer port for the run-supervisor
+// half of the delete cascade: it ends the workflows supervising the project's
+// live runs. An app-root adapter over the milestone-run index and the run
+// supervisor satisfies it. Wired via SetRunAbandoner; nil is a documented no-op.
+//
+// It is a SEPARATE port from milestoneRunRows, whose purge deletes rows. Deleting
+// the rows is not what stops a supervisor — nothing reads them back — so the two
+// halves are two different writes to two different systems, and folding the
+// workflow teardown behind a name that says "delete rows" would hide a Temporal
+// call inside a database one.
+type runAbandoner interface {
+	// AbandonProjectRuns ends the supervisor over every live run of the project.
+	// Already-settled runs and milestones that were never supervised are no-ops.
+	AbandonProjectRuns(ctx context.Context, orgID, projectID string) error
+}
+
+// SetRunAbandoner wires the run-supervisor teardown so a project delete stops
+// the workflows supervising its runs. A nil abandoner is a documented no-op.
+func (s *Service) SetRunAbandoner(a runAbandoner) { s.runAbandoner = a }
 
 // resourceDeprovisioner is project_service's narrow consumer port for the
 // dependency-provisioning teardown: on project delete it deprovisions the
@@ -279,21 +300,77 @@ func (s *Service) DeleteProject(ctx context.Context, orgName, projectName string
 		}
 	}
 
-	if err := translateHTTPError(s.client.DeleteProject(ctx, orgName, projectName)); err != nil {
+	// An OC Project that is ALREADY GONE is not a failure of this delete — it is
+	// the state this delete exists to reach. Everything below outlives the OC
+	// Project and has no other exit from the system: the run supervisors, the
+	// repository row, the executions and the run ledger. Aborting here would
+	// strand all four permanently, because the second attempt takes this same
+	// branch and never gets past it — which is exactly how a half-deleted project
+	// keeps a supervisor polling a repository nobody can reach any more.
+	//
+	// Every other OC failure still aborts. A delete that could not REACH
+	// OpenChoreo has established nothing, and tearing down the platform's half of
+	// a project that still exists there would strand the project instead.
+	if err := translateHTTPError(s.client.DeleteProject(ctx, orgName, projectName)); err != nil &&
+		!errors.Is(err, ErrProjectNotFound) {
 		return err
 	}
 
-	// Clean up the git clone
+	// The run SUPERVISORS come down before the things they read do — before the
+	// repository they poll and before the rows they write.
+	//
+	// Nothing else ends a run workflow. Its milestone poll retries forever
+	// (Temporal's default policy is unbounded) against a repository that is about
+	// to stop existing, and its workflow id is keyed on (org, project, milestone)
+	// alone — so a project later created under the SAME NAME collides with it, and
+	// that project's first run is refused as AlreadyStarted and never supervised.
+	// Best-effort, like the rest of the teardown: the project delete has already
+	// been committed upstream and cannot be undone by a failure here.
+	if s.runAbandoner != nil {
+		if err := s.runAbandoner.AbandonProjectRuns(ctx, orgName, projectName); err != nil {
+			slog.ErrorContext(ctx, "failed to abandon run supervisors for project — they will keep polling a deleted repository",
+				"org", orgName, "project", projectName, "error", err)
+		}
+	}
+
+	// Stop the deliveries this project's repo would otherwise keep making.
+	//
+	// The remote survives a project delete, so its webhook survives with it —
+	// and it would go on posting `issues`, `push` and `pull_request` events for a
+	// project the platform has already forgotten. This is the last point at which
+	// it can be removed at all: the hook ID and the repo identity both live on
+	// the repo row that the very next step deletes.
+	//
+	// Best-effort by construction. A webhook left on a repository is untidy, not
+	// dangerous — the event plane resolves every delivery through the repo row
+	// and drops what it cannot place — so it must never be the thing that blocks
+	// a delete from completing.
+	if s.webhookSvc != nil {
+		if err := s.webhookSvc.Unregister(ctx, orgName, projectName); err != nil {
+			slog.ErrorContext(ctx, "failed to unregister webhook — the repo will keep posting deliveries for a deleted project",
+				"org", orgName, "project", projectName, "error", err)
+		}
+	}
+
+	// Drop the platform's own repository record and its workspace clone.
+	//
+	// The REMOTE is deliberately not touched, and that is the one piece of this
+	// teardown that leaves something behind: the GitHub repository survives a
+	// project delete, along with its issues and its milestones. DeleteRepo
+	// announces the URL it is orphaning, which is the last moment anything can
+	// name it. The consequence worth knowing at this call site is that the repo
+	// NAME stays taken — a project recreated under it is refused with
+	// ErrRepoNameConflict until a human intervenes.
 	if s.repoSvc != nil {
 		if err := s.repoSvc.DeleteRepo(ctx, orgName, projectName); err != nil {
 			slog.ErrorContext(ctx, "failed to delete git repo for project", "org", orgName, "project", projectName, "error", err)
 		}
 	}
 
-	// Tasks are GitHub issues (deleted with the repo). The platform-owned
-	// executions rows for the project ARE purged here — they are keyed to the
-	// project and would otherwise orphan (no FK to cascade). Best-effort, like
-	// the repo cleanup.
+	// Tasks are GitHub ISSUES, and they survive with the remote above; nothing
+	// here deletes them. The platform-owned executions rows for the project ARE
+	// purged — they are keyed to the project and would otherwise orphan (no FK to
+	// cascade). Best-effort, like the repo cleanup.
 	if s.execs != nil {
 		if err := s.execs.DeleteByProject(ctx, orgName, projectName); err != nil {
 			slog.ErrorContext(ctx, "failed to purge executions for project", "org", orgName, "project", projectName, "error", err)

--- a/services/aep-api/internal/projects/project_service_test.go
+++ b/services/aep-api/internal/projects/project_service_test.go
@@ -86,8 +86,14 @@ func (f *fakeRepoSvc) DeleteRepo(ctx context.Context, orgID, projectID string) e
 }
 
 type fakeWebhookSvc struct {
-	RegisterFunc func(ctx context.Context, orgID, projectID string) (*int64, error)
-	calls        int
+	RegisterFunc   func(ctx context.Context, orgID, projectID string) (*int64, error)
+	UnregisterFunc func(ctx context.Context, orgID, projectID string) error
+	calls          int
+	// trace, when set, records the unregister step in the delete cascade so its
+	// ORDER relative to the repo-row delete can be asserted.
+	trace           *deleteTrace
+	unregisterArgs  [2]string
+	unregisterCalls int
 }
 
 func (f *fakeWebhookSvc) Register(ctx context.Context, orgID, projectID string) (*int64, error) {
@@ -96,6 +102,18 @@ func (f *fakeWebhookSvc) Register(ctx context.Context, orgID, projectID string) 
 		return nil, nil
 	}
 	return f.RegisterFunc(ctx, orgID, projectID)
+}
+
+func (f *fakeWebhookSvc) Unregister(ctx context.Context, orgID, projectID string) error {
+	f.unregisterCalls++
+	f.unregisterArgs = [2]string{orgID, projectID}
+	if f.trace != nil {
+		f.trace.steps = append(f.trace.steps, "webhook")
+	}
+	if f.UnregisterFunc == nil {
+		return nil
+	}
+	return f.UnregisterFunc(ctx, orgID, projectID)
 }
 
 // fakeExecs fakes the slice of delivery.ExecutionRepository the project
@@ -524,8 +542,9 @@ func TestDeleteProject_CleansUpRepoAndPurgesExecutions(t *testing.T) {
 		t.Error("git repo cleanup was not invoked")
 	}
 	// The platform-owned executions rows are purged, org+project scoped (§7).
-	// The Task issues themselves are GitHub-owned (deleted with the repo) — the
-	// service never calls an issue-delete path.
+	// The Task issues themselves are GitHub-owned and SURVIVE: the delete leaves
+	// the remote repository standing, and the service never calls an issue-delete
+	// path.
 	if execs.deleteCalls != 1 || execs.deleteArgs != [2]string{"acme", "web"} {
 		t.Errorf("executions purge: calls=%d args=%v, want 1 (acme,web)", execs.deleteCalls, execs.deleteArgs)
 	}
@@ -545,10 +564,17 @@ func TestDeleteProject_ExecutionsPurgeFailureIsSwallowed(t *testing.T) {
 	}
 }
 
+// TestDeleteProject_OCErrorSkipsCleanup: a delete that could not REACH
+// OpenChoreo has established nothing about the project, so the platform's half
+// of it stays put. Tearing down the repo and the rows underneath a project that
+// still exists in OC would strand it.
+//
+// The one OC failure that does NOT stop the cascade is not-found — see
+// TestDeleteProject_AlreadyGoneOCProjectStillTearsDownPlatformState.
 func TestDeleteProject_OCErrorSkipsCleanup(t *testing.T) {
 	t.Parallel()
 	oc := &ocmocks.ProjectClientMock{
-		DeleteProjectFunc: func(context.Context, string, string) error { return openchoreo.ErrNotFound },
+		DeleteProjectFunc: func(context.Context, string, string) error { return openchoreo.ErrForbidden },
 	}
 	repoSvc := &fakeRepoSvc{DeleteRepoFunc: func(context.Context, string, string) error {
 		t.Error("repo cleanup must not run when the OC delete failed")
@@ -559,8 +585,8 @@ func TestDeleteProject_OCErrorSkipsCleanup(t *testing.T) {
 		return nil
 	}}
 	svc := NewProjectService(oc, repoSvc, nil, nil, execs)
-	if err := svc.DeleteProject(context.Background(), "acme", "web"); !errors.Is(err, ErrProjectNotFound) {
-		t.Fatalf("want ErrProjectNotFound, got %v", err)
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("want ErrForbidden, got %v", err)
 	}
 	if execs.deleteCalls != 0 {
 		t.Errorf("executions purge ran despite OC delete failure (%d calls)", execs.deleteCalls)
@@ -578,6 +604,141 @@ func TestDeleteProject_RepoCleanupFailureIsSwallowed(t *testing.T) {
 	svc := NewProjectService(oc, repoSvc, nil, nil, &fakeExecs{})
 	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
 		t.Fatalf("repo cleanup failure must be best-effort, got %v", err)
+	}
+}
+
+// --- the run-supervisor half of the delete cascade ---------------------------
+
+// deleteTrace records the teardown steps in the order the service ran them. The
+// ORDER is the contract, not just the calls: a supervisor abandoned after its
+// repository is gone has already spent a poll on a repository that no longer
+// exists, and one abandoned after its rows are purged has nothing left to
+// identify.
+type deleteTrace struct {
+	steps []string
+}
+
+// fakeRunAbandoner is the run-supervisor teardown port.
+type fakeRunAbandoner struct {
+	trace *deleteTrace
+	args  [2]string
+	calls int
+	err   error
+}
+
+func (f *fakeRunAbandoner) AbandonProjectRuns(_ context.Context, orgID, projectID string) error {
+	f.calls++
+	f.args = [2]string{orgID, projectID}
+	f.trace.steps = append(f.trace.steps, "abandon")
+	return f.err
+}
+
+// tracingRunRows is the milestoneRunRows port with its purge traced.
+type tracingRunRows struct {
+	trace *deleteTrace
+	err   error
+}
+
+func (tracingRunRows) ListByProject(context.Context, string, string) ([]delivery.MilestoneRun, error) {
+	return nil, nil
+}
+
+func (tracingRunRows) LatestCycle(context.Context, string, string) (*delivery.RunCycle, error) {
+	return nil, nil
+}
+
+func (t tracingRunRows) DeleteByProject(context.Context, string, string) error {
+	t.trace.steps = append(t.trace.steps, "purge")
+	return t.err
+}
+
+// TestDeleteProject_AbandonsRunSupervisorsBeforeTheirRepoAndRows: purging a
+// project's run rows does not stop the workflows that write them. Left running,
+// a supervisor retries its milestone poll forever against a deleted repository,
+// and its workflow id — keyed on (org, project, milestone) alone — collides with
+// any project later created under the same name, whose first run is then refused
+// as AlreadyStarted and never supervised.
+func TestDeleteProject_AbandonsRunSupervisorsBeforeTheirRepoAndRows(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return nil },
+	}
+	repoSvc := &fakeRepoSvc{
+		GetRepoFunc: func(context.Context, string, string) (*sourcecontrol.GitRepository, error) {
+			return nil, nil
+		},
+		DeleteRepoFunc: func(context.Context, string, string) error {
+			trace.steps = append(trace.steps, "repo")
+			return nil
+		},
+	}
+	abandoner := &fakeRunAbandoner{trace: trace}
+	svc := NewProjectService(oc, repoSvc, nil, nil, &fakeExecs{})
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if abandoner.calls != 1 || abandoner.args != [2]string{"acme", "web"} {
+		t.Fatalf("abandon: calls=%d args=%v, want 1 (acme,web)", abandoner.calls, abandoner.args)
+	}
+	want := []string{"abandon", "repo", "purge"}
+	if len(trace.steps) != len(want) {
+		t.Fatalf("teardown order = %v, want %v", trace.steps, want)
+	}
+	for i := range want {
+		if trace.steps[i] != want[i] {
+			t.Fatalf("teardown order = %v, want %v", trace.steps, want)
+		}
+	}
+}
+
+// TestDeleteProject_AbandonFailureIsSwallowed: the OC delete has already been
+// committed by the time the teardown runs, so a Temporal outage must not leave
+// the caller a half-deleted project it cannot retry — the rest of the cascade
+// still runs.
+func TestDeleteProject_AbandonFailureIsSwallowed(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return nil },
+	}
+	abandoner := &fakeRunAbandoner{trace: trace, err: errors.New("temporal down")}
+	svc := NewProjectService(oc, nil, nil, nil, &fakeExecs{})
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("abandon failure must be best-effort, got %v", err)
+	}
+	if len(trace.steps) != 2 || trace.steps[1] != "purge" {
+		t.Errorf("the purge must still run after a failed abandon: %v", trace.steps)
+	}
+}
+
+// TestDeleteProject_UnreachableOCSkipsTheRunTeardown: a delete that could not
+// REACH OpenChoreo has established nothing, so the project still exists there —
+// and killing the supervisors of a project that is still alive would strand it
+// mid-run with no way to resume.
+func TestDeleteProject_UnreachableOCSkipsTheRunTeardown(t *testing.T) {
+	t.Parallel()
+	trace := &deleteTrace{}
+	unreachable := errors.New("openchoreo unreachable")
+	oc := &ocmocks.ProjectClientMock{
+		DeleteProjectFunc: func(context.Context, string, string) error { return unreachable },
+	}
+	abandoner := &fakeRunAbandoner{trace: trace}
+	svc := NewProjectService(oc, nil, nil, nil, &fakeExecs{})
+	svc.SetStageSources(tracingRunRows{trace: trace}, fakeBindingsReader{})
+	svc.SetRunAbandoner(abandoner)
+
+	if err := svc.DeleteProject(context.Background(), "acme", "web"); !errors.Is(err, unreachable) {
+		t.Fatalf("want the OC error, got %v", err)
+	}
+	if abandoner.calls != 0 {
+		t.Errorf("run supervisors abandoned despite a failed OC delete (%d calls)", abandoner.calls)
 	}
 }
 

--- a/services/aep-api/internal/projects/usage_service.go
+++ b/services/aep-api/internal/projects/usage_service.go
@@ -37,9 +37,14 @@ type UsageByProjectFunc func(ctx context.Context, orgID string) (map[string]cont
 // deleted project whose spend still counts.
 type ProjectNameLister func(ctx context.Context, orgID string) (map[string]string, error)
 
-// ExecPhaseUsageFunc rolls up captured execution usage per project split into
-// the build and validation phases — the delivery repository's shape.
-type ExecPhaseUsageFunc func(ctx context.Context, orgID string) (build, validation map[string]contracts.StampedUsage, err error)
+// DeliveryPhaseUsageFunc rolls up delivery's captured agent usage split into the
+// build and validation phases — the delivery ledger's shape.
+//
+// It is keyed by contracts.UsageScope, not by slug, because a slug is not an
+// identity: a project deleted and recreated under the same name is two
+// lifetimes, and the roll-up hands them over separately so this service can
+// render them as two cards instead of one inflated one.
+type DeliveryPhaseUsageFunc func(ctx context.Context, orgID string) (build, validation map[contracts.UsageScope]contracts.StampedUsage, err error)
 
 // UsageService assembles the org-wide Settings → Usage roll-up (#291): per
 // project it folds the three SDLC phases (spec/design turns, build + coding
@@ -49,14 +54,14 @@ type ExecPhaseUsageFunc func(ctx context.Context, orgID string) (build, validati
 // every costUsd is a sum of stamps frozen at capture (amended ADR-0011).
 type UsageService struct {
 	specUsage      UsageByProjectFunc
-	execPhaseUsage ExecPhaseUsageFunc
+	deliveryPhaseUsage DeliveryPhaseUsageFunc
 	liveNames      ProjectNameLister
 }
 
 // NewUsageService wires the roll-up from the spec-turn source, the phase-split
 // execution source, and the live project lister.
-func NewUsageService(specUsage UsageByProjectFunc, execPhaseUsage ExecPhaseUsageFunc, liveNames ProjectNameLister) *UsageService {
-	return &UsageService{specUsage: specUsage, execPhaseUsage: execPhaseUsage, liveNames: liveNames}
+func NewUsageService(specUsage UsageByProjectFunc, deliveryPhaseUsage DeliveryPhaseUsageFunc, liveNames ProjectNameLister) *UsageService {
+	return &UsageService{specUsage: specUsage, deliveryPhaseUsage: deliveryPhaseUsage, liveNames: liveNames}
 }
 
 // ListProjectUsage returns a card for every LIVE project in the org (zero usage
@@ -69,7 +74,7 @@ func (s *UsageService) ListProjectUsage(ctx context.Context, orgID string) (gen.
 	if err != nil {
 		return gen.ProjectUsageList{}, err
 	}
-	build, validation, err := s.execPhaseUsage(ctx, orgID)
+	build, validation, err := s.deliveryPhaseUsage(ctx, orgID)
 	if err != nil {
 		return gen.ProjectUsageList{}, err
 	}
@@ -78,42 +83,49 @@ func (s *UsageService) ListProjectUsage(ctx context.Context, orgID string) (gen.
 		return gen.ProjectUsageList{}, err
 	}
 
-	// The set of projects with real spend is the union of the three phase maps
-	// (each already drops zero-token projects).
-	slugs := map[string]struct{}{}
+	// The set of LIFETIMES with real spend is the union of the phase maps (each
+	// already drops zero-token entries). Delivery's two are already scoped; spec
+	// turns are not — see specScope.
+	scopes := map[contracts.UsageScope]struct{}{}
+	for scope := range build {
+		scopes[scope] = struct{}{}
+	}
+	for scope := range validation {
+		scopes[scope] = struct{}{}
+	}
 	for slug := range spec {
-		slugs[slug] = struct{}{}
-	}
-	for slug := range build {
-		slugs[slug] = struct{}{}
-	}
-	for slug := range validation {
-		slugs[slug] = struct{}{}
+		scopes[specScope(slug, names)] = struct{}{}
 	}
 
-	cards := make([]gen.ProjectUsageCard, 0, len(slugs)+len(names))
-	for slug := range slugs {
-		displayName, live := names[slug]
-		if !live {
-			displayName = slug // deleted project: fall back to the stored slug
+	cards := make([]gen.ProjectUsageCard, 0, len(scopes)+len(names))
+	for scope := range scopes {
+		displayName, live := names[scope.ProjectID]
+		if scope.Retired || !live {
+			displayName = scope.ProjectID // deleted project: fall back to the stored slug
 		}
-		total := spec[slug].Add(build[slug]).Add(validation[slug])
+		// Spec-turn usage joins the lifetime specScope assigned it to, and only
+		// that one, so it is never counted on both cards of a recreated slug.
+		specUsage := contracts.StampedUsage{}
+		if specScope(scope.ProjectID, names) == scope {
+			specUsage = spec[scope.ProjectID]
+		}
+		total := specUsage.Add(build[scope]).Add(validation[scope])
 		cards = append(cards, gen.ProjectUsageCard{
-			ProjectName: slug,
+			ProjectName: scope.ProjectID,
 			DisplayName: displayName,
-			Deleted:     !live,
+			Deleted:     scope.Retired || !live,
 			Usage:       toGenUsage(total),
 			Phases: gen.PhaseUsage{
-				Spec:       phaseUsage(spec, slug),
-				Build:      phaseUsage(build, slug),
-				Validation: phaseUsage(validation, slug),
+				Spec:       stampedOrZero(specUsage),
+				Build:      scopeUsage(build, scope),
+				Validation: scopeUsage(validation, scope),
 			},
 		})
 	}
 	// Every live project with no spend yet gets a $0 card so the page lists the
 	// org's projects, not only the ones that happen to have run an agent.
 	for slug, displayName := range names {
-		if _, hasSpend := slugs[slug]; hasSpend {
+		if _, hasSpend := scopes[contracts.UsageScope{ProjectID: slug}]; hasSpend {
 			continue
 		}
 		cards = append(cards, gen.ProjectUsageCard{
@@ -128,14 +140,40 @@ func (s *UsageService) ListProjectUsage(ctx context.Context, orgID string) (gen.
 	return gen.ProjectUsageList{Projects: cards}, nil
 }
 
-// phaseUsage maps a project's phase entry to wire Usage: a captured phase keeps
-// its stamped/unpriced figures; a phase that never ran shows a real $0 rather
-// than a null "0 tok", so all three phase rows read cleanly.
-func phaseUsage(m map[string]contracts.StampedUsage, slug string) gen.Usage {
-	if u, ok := m[slug]; ok {
+// specScope decides which lifetime a project's SPEC-turn spend belongs to.
+//
+// Spec turns are the one capture surface with no lifetime marker: `agent_turns`
+// is never purged and carries no retirement stamp, so a recreated slug's turns sit
+// in the same rows as its predecessor's and cannot be told apart. The honest
+// placement is therefore the whole slug's spec spend on the LIVE card while the
+// project exists, and on the retired card once it does not — which is exactly what
+// the page showed before delivery's half learned to distinguish lifetimes.
+//
+// A recreated project consequently inherits the deleted one's SPEC figure while
+// keeping none of its build or validation figure. Splitting it needs a lifetime
+// marker on the turns themselves, which is the spec domain's to add.
+func specScope(slug string, names map[string]string) contracts.UsageScope {
+	_, live := names[slug]
+	return contracts.UsageScope{ProjectID: slug, Retired: !live}
+}
+
+// scopeUsage maps one lifetime's phase entry to wire Usage: a captured phase
+// keeps its stamped/unpriced figures; a phase that never ran shows a real $0
+// rather than a null "0 tok", so all three phase rows read cleanly.
+func scopeUsage(m map[contracts.UsageScope]contracts.StampedUsage, scope contracts.UsageScope) gen.Usage {
+	if u, ok := m[scope]; ok {
 		return toGenUsage(u)
 	}
 	return zeroUsage()
+}
+
+// stampedOrZero renders a phase aggregate the caller already holds, showing a
+// real $0 for one that never ran.
+func stampedOrZero(u contracts.StampedUsage) gen.Usage {
+	if u.Tokens.IsZero() && u.CostUsd == nil {
+		return zeroUsage()
+	}
+	return toGenUsage(u)
 }
 
 // zeroUsage is an idle phase/project: a real $0 (the model is known to be

--- a/services/aep-api/internal/projects/usage_service_test.go
+++ b/services/aep-api/internal/projects/usage_service_test.go
@@ -33,15 +33,35 @@ func stamped(input int64, cost *float64) contracts.StampedUsage {
 }
 
 // newTestUsageService wires the service from the three phase maps directly:
-// spec (turns), build, validation (executions).
+// spec (turns), build, validation (delivery). Delivery's two are lifted into the
+// LIVE lifetime, which is what every case that is not about a deleted-then-
+// recreated slug is describing.
 func newTestUsageService(spec, build, validation map[string]contracts.StampedUsage, live map[string]string) *UsageService {
+	return newScopedUsageService(spec, liveScoped(build), liveScoped(validation), live)
+}
+
+// newScopedUsageService is the same wiring with delivery's maps keyed by
+// lifetime, for the cases that turn on the difference.
+func newScopedUsageService(
+	spec map[string]contracts.StampedUsage,
+	build, validation map[contracts.UsageScope]contracts.StampedUsage,
+	live map[string]string,
+) *UsageService {
 	return NewUsageService(
 		func(context.Context, string) (map[string]contracts.StampedUsage, error) { return spec, nil },
-		func(context.Context, string) (map[string]contracts.StampedUsage, map[string]contracts.StampedUsage, error) {
+		func(context.Context, string) (map[contracts.UsageScope]contracts.StampedUsage, map[contracts.UsageScope]contracts.StampedUsage, error) {
 			return build, validation, nil
 		},
 		func(context.Context, string) (map[string]string, error) { return live, nil },
 	)
+}
+
+func liveScoped(m map[string]contracts.StampedUsage) map[contracts.UsageScope]contracts.StampedUsage {
+	out := make(map[contracts.UsageScope]contracts.StampedUsage, len(m))
+	for slug, u := range m {
+		out[contracts.UsageScope{ProjectID: slug}] = u
+	}
+	return out
 }
 
 // The headline behaviour: spec + delivery fold per project; every live project
@@ -152,5 +172,82 @@ func TestListProjectUsageEmpty(t *testing.T) {
 	}
 	if len(got.Projects) != 0 {
 		t.Fatalf("cards = %d, want 0 for an org with no projects or usage", len(got.Projects))
+	}
+}
+
+// TestListProjectUsageKeepsARecreatedSlugsLifetimesApart: deleting a project and
+// making a new one with the same name produces TWO cards — the live project
+// billed for its own work, and the deleted incarnation still carrying what it
+// spent. A single card summing both would tell the user their fresh project had
+// already cost $50, which is the failure this whole ledger exists to prevent.
+func TestListProjectUsageKeepsARecreatedSlugsLifetimesApart(t *testing.T) {
+	live := contracts.UsageScope{ProjectID: "shop"}
+	retired := contracts.UsageScope{ProjectID: "shop", Retired: true}
+	build := map[contracts.UsageScope]contracts.StampedUsage{
+		live:    stamped(10_000, usd(2.00)),
+		retired: stamped(900_000, usd(50.00)),
+	}
+	names := map[string]string{"shop": "Shop"}
+
+	got, err := newScopedUsageService(nil, build, nil, names).
+		ListProjectUsage(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("ListProjectUsage: %v", err)
+	}
+	if len(got.Projects) != 2 {
+		t.Fatalf("cards = %d, want 2 (one per lifetime): %+v", len(got.Projects), got.Projects)
+	}
+	// Tier 0 orders by cost, so the deleted incarnation's $50 leads.
+	dead, fresh := got.Projects[0], got.Projects[1]
+	if !dead.Deleted || dead.ProjectName != "shop" {
+		t.Fatalf("first card = %+v, want the deleted shop incarnation", dead)
+	}
+	if c := dead.Usage.CostUsd; c == nil || *c != 50.00 {
+		t.Errorf("deleted incarnation cost = %v, want 50.00", c)
+	}
+	if dead.DisplayName != "shop" {
+		t.Errorf("deleted displayName = %q, want the slug — the live name is the new project's", dead.DisplayName)
+	}
+	if fresh.Deleted || fresh.DisplayName != "Shop" {
+		t.Fatalf("second card = %+v, want the live Shop", fresh)
+	}
+	if c := fresh.Usage.CostUsd; c == nil || *c != 2.00 {
+		t.Errorf("live project cost = %v, want 2.00 — it inherits none of the $50", c)
+	}
+}
+
+// TestListProjectUsageAttributesSpecSpendToOneLifetime: spec turns carry no
+// lifetime marker (agent_turns is never purged and never retired), so the slug's
+// whole spec figure sits on exactly ONE card — the live one while the project
+// exists. What must never happen is it being counted on both.
+func TestListProjectUsageAttributesSpecSpendToOneLifetime(t *testing.T) {
+	live := contracts.UsageScope{ProjectID: "shop"}
+	retired := contracts.UsageScope{ProjectID: "shop", Retired: true}
+	spec := map[string]contracts.StampedUsage{"shop": stamped(1_000, usd(4.00))}
+	build := map[contracts.UsageScope]contracts.StampedUsage{
+		live:    stamped(10_000, usd(2.00)),
+		retired: stamped(900_000, usd(50.00)),
+	}
+
+	got, err := newScopedUsageService(spec, build, nil, map[string]string{"shop": "Shop"}).
+		ListProjectUsage(context.Background(), "org")
+	if err != nil {
+		t.Fatalf("ListProjectUsage: %v", err)
+	}
+	var total float64
+	for _, c := range got.Projects {
+		if s := c.Phases.Spec.CostUsd; s != nil {
+			total += *s
+		}
+	}
+	if total != 4.00 {
+		t.Fatalf("spec spend across cards = %v, want 4.00 counted exactly once", total)
+	}
+	for _, c := range got.Projects {
+		if c.Deleted {
+			if s := c.Phases.Spec.CostUsd; s == nil || *s != 0 {
+				t.Errorf("deleted card spec = %v, want $0 while the project is live", s)
+			}
+		}
 	}
 }

--- a/services/aep-api/internal/sourcecontrol/errors.go
+++ b/services/aep-api/internal/sourcecontrol/errors.go
@@ -18,6 +18,7 @@ package sourcecontrol
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 )
@@ -65,4 +66,56 @@ var (
 // IsRepoNameConflict reports whether err represents a host name-conflict rejection.
 func IsRepoNameConflict(err error) bool {
 	return errors.Is(err, ErrRepoNameConflict)
+}
+
+// GraphQLTypeNotFound is GitHub's machine-readable errors[].type for a node the
+// query could not resolve — how a deleted repository or milestone arrives on
+// the GraphQL surface, which answers 200 with a populated errors[] rather than
+// a 404. Spelled once here because IsPermanent branches on it.
+const GraphQLTypeNotFound = "NOT_FOUND"
+
+// IsPermanent reports whether err is an answer rather than a blip: a failure
+// that repeating the same call cannot change.
+//
+// It exists for the callers that retry on a schedule they do not control —
+// above all the Temporal run supervisor, whose activities retry with the SDK
+// default of "forever". There, a deleted project or a revoked credential turns
+// a one-second failure into an unbounded error storm that buries the cause;
+// the supervisor asks this and stops.
+//
+// Permanent:
+//   - ErrRepoNotFound / ErrIssueNotFound / ErrMilestoneNotFound — the subject
+//     is gone, either from the repo ledger or from the host.
+//   - 404 / 410 — the repository, issue or pull request no longer exists for
+//     this credential.
+//   - 401 — the credential was rejected. Tokens are resolved per REQUEST (see
+//     githubhost.authHeaders), so a short-lived App token has already been
+//     re-minted by the time one arrives: a repeat presents the same rejection.
+//   - GraphQL NOT_FOUND — the 404 of the GraphQL surface.
+//
+// Deliberately NOT permanent, and each for a reason:
+//   - 403, because GitHub answers its SECONDARY RATE LIMIT with one, and that
+//     clears on its own. A permission loss shares the status and will retry
+//     pointlessly; the alternative — parsing the body — is worse, and a run
+//     that stalls visibly on a real 403 is the safer of the two mistakes.
+//   - 5xx and every transport error, which are the blips retries exist for.
+//   - GraphQL RATE_LIMITED, same reason as 403.
+//   - ErrRepoNotReady, which is a state the mirror heals out of.
+func IsPermanent(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, ErrRepoNotFound),
+		errors.Is(err, ErrIssueNotFound),
+		errors.Is(err, ErrMilestoneNotFound):
+		return true
+	case IsHTTPStatus(err, http.StatusNotFound),
+		IsHTTPStatus(err, http.StatusGone),
+		IsHTTPStatus(err, http.StatusUnauthorized):
+		return true
+	case IsGraphQLType(err, GraphQLTypeNotFound):
+		return true
+	}
+	return false
 }

--- a/services/aep-api/internal/sourcecontrol/errors_test.go
+++ b/services/aep-api/internal/sourcecontrol/errors_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sourcecontrol_test
+
+// IsPermanent decides whether a caller keeps asking. The table below is the
+// whole contract, and the NEGATIVE half carries as much weight as the positive
+// one: classifying a secondary rate limit as permanent would fail runs GitHub
+// was only asking us to slow down for.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+func TestIsPermanent(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is not a failure at all", err: nil, want: false},
+
+		{name: "missing repo row", err: sourcecontrol.ErrRepoNotFound, want: true},
+		{name: "missing issue", err: sourcecontrol.ErrIssueNotFound, want: true},
+		{name: "missing milestone", err: sourcecontrol.ErrMilestoneNotFound, want: true},
+		{
+			name: "wrapped sentinel — the supervisor sees these through a port",
+			err:  fmt.Errorf("poll milestone: %w", sourcecontrol.ErrRepoNotFound),
+			want: true,
+		},
+
+		{
+			name: "404 — the repository is gone for this credential",
+			err:  &sourcecontrol.HTTPStatusError{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "410 gone",
+			err:  &sourcecontrol.HTTPStatusError{StatusCode: http.StatusGone},
+			want: true,
+		},
+		{
+			name: "401 — the credential was rejected, and tokens are minted per request",
+			err:  &sourcecontrol.HTTPStatusError{StatusCode: http.StatusUnauthorized},
+			want: true,
+		},
+		{
+			name: "graphql NOT_FOUND — the 404 of the GraphQL surface",
+			err: &sourcecontrol.GraphQLError{Errors: []sourcecontrol.GraphQLErrorDetail{{
+				Type:    sourcecontrol.GraphQLTypeNotFound,
+				Message: "Could not resolve to a Repository with the name 'org/proj'.",
+			}}},
+			want: true,
+		},
+
+		{
+			name: "403 — GitHub's secondary rate limit wears this status and clears itself",
+			err:  &sourcecontrol.HTTPStatusError{StatusCode: http.StatusForbidden},
+			want: false,
+		},
+		{
+			name: "500 is the blip retries exist for",
+			err:  &sourcecontrol.HTTPStatusError{StatusCode: http.StatusInternalServerError},
+			want: false,
+		},
+		{
+			name: "graphql RATE_LIMITED, same reason as 403",
+			err: &sourcecontrol.GraphQLError{Errors: []sourcecontrol.GraphQLErrorDetail{{
+				Type: "RATE_LIMITED", Message: "API rate limit exceeded",
+			}}},
+			want: false,
+		},
+		{
+			name: "repo not ready is a state the mirror heals out of",
+			err:  sourcecontrol.ErrRepoNotReady,
+			want: false,
+		},
+		{name: "transport failure", err: errors.New("dial tcp: connection refused"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sourcecontrol.IsPermanent(tt.err))
+		})
+	}
+}

--- a/services/aep-api/internal/sourcecontrol/githubhost/client.go
+++ b/services/aep-api/internal/sourcecontrol/githubhost/client.go
@@ -727,6 +727,25 @@ func (c *Client) UpdateWebhookEvents(ctx context.Context, owner, repo string, cr
 	return c.doJSON(ctx, http.MethodPatch, url, "update webhook events", cred, map[string]any{"events": events}, nil, http.StatusOK)
 }
 
+// DeleteWebhook removes one repo webhook via DELETE
+// /repos/{owner}/{repo}/hooks/{id} — the teardown twin of RegisterWebhook.
+//
+// It is addressed by the hook ID the platform PERSISTED at registration, never
+// by scanning the repo's hooks, so it can only ever remove the delivery this
+// platform installed. A repository commonly carries hooks belonging to other
+// integrations, and a project delete has no business touching them.
+//
+// 404 and 410 are success, exactly like RemoveIssueLabel's 404: the hook is
+// already absent (deleted by hand, or by a previous run of this teardown), which
+// is the desired post-state. 410 is what GitHub answers once a hook has been
+// auto-disabled and reaped after repeated delivery failures — precisely the
+// state an orphaned webhook ends up in.
+func (c *Client) DeleteWebhook(ctx context.Context, owner, repo string, cred secrets.Credential, hookID int64) error {
+	url := fmt.Sprintf(c.apiBase+"/repos/%s/%s/hooks/%d", owner, repo, hookID)
+	return c.doJSON(ctx, http.MethodDelete, url, "delete webhook", cred, nil, nil,
+		http.StatusNoContent, http.StatusNotFound, http.StatusGone)
+}
+
 // GetUser performs GET /user using the credential's token. Returns
 // HTTPStatusError for non-2xx responses so the validator can branch on
 // 401 (revoked) vs 5xx (transient).

--- a/services/aep-api/internal/sourcecontrol/ports.go
+++ b/services/aep-api/internal/sourcecontrol/ports.go
@@ -145,6 +145,11 @@ type WebhookOps interface {
 	// "issues" joined the subscription must be PATCHed to add it
 	// (docs/design/tasks-github-native.md §9.2 cutover).
 	UpdateWebhookEvents(ctx context.Context, owner, repo string, cred secrets.Credential, hookID int64, events []string) error
+	// DeleteWebhook removes the hook the platform registered, addressed by the
+	// stored hook ID so no other integration's delivery can be caught by it. A
+	// hook that is already gone (404, or 410 after GitHub reaped a failing one)
+	// is success — the desired post-state is absence.
+	DeleteWebhook(ctx context.Context, owner, repo string, cred secrets.Credential, hookID int64) error
 }
 
 // AppInstallOps is the GitHub-App installation lifecycle + credential-account

--- a/services/aep-api/internal/sourcecontrol/repo_delete_test.go
+++ b/services/aep-api/internal/sourcecontrol/repo_delete_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sourcecontrol_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+	githubclient "github.com/wso2/aep/aep-api/internal/sourcecontrol/githubhost"
+)
+
+// DeleteRepo ensures ABSENCE rather than performing a removal. Its only caller
+// is the project teardown, which is best-effort and re-runnable, so "there was
+// nothing to delete" has to be reported as success — reporting ErrRepoNotFound
+// made every legitimate re-run log a cleanup error and left callers unable to
+// tell "already clean" from "cleanup broke".
+
+func TestDeleteRepo_DropsTheRowAndTrashesTheWorkspace(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepoRepo()
+	repo.put(&sourcecontrol.GitRepository{
+		OrgID: "org1", ProjectID: "proj1",
+		RepoURL: "https://github.com/test-org/proj1.git",
+		Status:  "ready", RepoSlug: "test-org-proj1",
+	})
+
+	var trashed [3]string
+	var trashCalls int
+	svc := sourcecontrol.NewRepoService(repo, githubclient.NewClient(), fakeResolver{}, "private",
+		sourcecontrol.WithWorkspaceTrash(func(_ context.Context, orgID, projectID, repoSlug string) {
+			trashCalls++
+			trashed = [3]string{orgID, projectID, repoSlug}
+		}))
+
+	if err := svc.DeleteRepo(testContext(), "org1", "proj1"); err != nil {
+		t.Fatalf("DeleteRepo: %v", err)
+	}
+	// GetRepo, unlike DeleteRepo, is a lookup: an absent row is ErrRepoNotFound.
+	if _, err := svc.GetRepo(testContext(), "org1", "proj1"); !errors.Is(err, sourcecontrol.ErrRepoNotFound) {
+		t.Fatalf("row survived the delete: %v", err)
+	}
+	if trashCalls != 1 || trashed[0] != "org1" || trashed[1] != "proj1" {
+		t.Errorf("workspace trash: calls=%d args=%v", trashCalls, trashed)
+	}
+}
+
+// TestDeleteRepo_AbsentRowIsSuccess covers both shapes of "nothing to delete":
+// a project whose repo was never provisioned, and a teardown being re-run after
+// an earlier attempt already got this far.
+func TestDeleteRepo_AbsentRowIsSuccess(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepoRepo()
+	trashCalls := 0
+	svc := sourcecontrol.NewRepoService(repo, githubclient.NewClient(), fakeResolver{}, "private",
+		sourcecontrol.WithWorkspaceTrash(func(context.Context, string, string, string) { trashCalls++ }))
+
+	if err := svc.DeleteRepo(testContext(), "org1", "never-provisioned"); err != nil {
+		t.Fatalf("deleting an absent repo must succeed, got %v", err)
+	}
+	// Nothing was renamed into trash, because there was no slug to rename.
+	if trashCalls != 0 {
+		t.Errorf("workspace trash ran %d times for an absent row, want 0", trashCalls)
+	}
+}
+
+func TestDeleteRepo_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepoRepo()
+	repo.put(&sourcecontrol.GitRepository{
+		OrgID: "org1", ProjectID: "proj1",
+		RepoURL: "https://github.com/test-org/proj1.git",
+		Status:  "ready", RepoSlug: "test-org-proj1",
+	})
+	svc := sourcecontrol.NewRepoService(repo, githubclient.NewClient(), fakeResolver{}, "private")
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err := svc.DeleteRepo(testContext(), "org1", "proj1"); err != nil {
+			t.Fatalf("attempt %d: %v", attempt, err)
+		}
+	}
+}

--- a/services/aep-api/internal/sourcecontrol/repo_service.go
+++ b/services/aep-api/internal/sourcecontrol/repo_service.go
@@ -50,6 +50,10 @@ type RepoService interface {
 	// is provisioned for the repo on GitHub. Stored alongside the repo record
 	// so cleanup can deregister.
 	SetWebhookID(ctx context.Context, orgID, projectID string, hookID int64) error
+	// DeleteRepo drops the repo record and trashes its workspace clone. It
+	// ensures ABSENCE rather than performing a removal, so a project with no
+	// repo row — never provisioned, or a teardown being re-run after it got
+	// this far once — succeeds with nothing to do. The remote is untouched.
 	DeleteRepo(ctx context.Context, orgID, projectID string) error
 }
 
@@ -265,12 +269,25 @@ func (s *repoService) DeleteRepo(ctx context.Context, orgID, projectID string) e
 		return fmt.Errorf("get repo: %w", err)
 	}
 	if repo == nil {
-		return ErrRepoNotFound
+		// Nothing to delete IS the requested end state. Reporting ErrRepoNotFound
+		// here made the project teardown log an error on every legitimate re-run
+		// and gave callers no way to tell "already clean" from "cleanup broke".
+		return nil
 	}
 
 	if err := s.repo.DeleteByOrgAndProjectID(ctx, orgID, projectID); err != nil {
 		return fmt.Errorf("delete repo record: %w", err)
 	}
+
+	// The REMOTE is deliberately left standing, and this is the last moment
+	// anything can name it: the row that resolved (org, project) to a URL has
+	// just been dropped, so after this line the platform has no route back to
+	// the repository, its issues, its milestones or the webhook registered at
+	// create. Announce it rather than leak it silently — and note the practical
+	// consequence, which is that the repo NAME stays taken: a project recreated
+	// under it is refused with ErrRepoNameConflict until a human intervenes.
+	slog.InfoContext(ctx, "repo record deleted; the remote repository is left in place",
+		"org", orgID, "project", projectID, "repoUrl", repo.RepoURL)
 
 	// Best-effort disk cleanup AFTER the DB delete succeeded: rename the
 	// workspace subtree into trash (O(1); open fds keep working — design

--- a/services/aep-api/internal/sourcecontrol/webhook_service.go
+++ b/services/aep-api/internal/sourcecontrol/webhook_service.go
@@ -18,6 +18,7 @@ package sourcecontrol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -37,6 +38,15 @@ type WebhookService interface {
 	// Register installs a webhook on the repo. No-op when the credential's
 	// strategy is WebhookPlatform. Idempotent on (repo, deliveryURL).
 	Register(ctx context.Context, orgID, projectID string) (hookID *int64, err error)
+
+	// Unregister removes the hook Register installed, addressed by the hook ID
+	// persisted on the repo row. It is the project teardown's counterpart to
+	// Register and is total: a project with no repo row, no stored hook, a
+	// platform-strategy credential, or a hook GitHub no longer has all resolve to
+	// "nothing to remove" and return nil. Only a live failure to reach GitHub is
+	// an error, and even that is best-effort at the call site — the delete is
+	// never blocked by webhook cleanup.
+	Unregister(ctx context.Context, orgID, projectID string) error
 }
 
 // issueRepoResolver is the private capability webhookService borrows from the
@@ -131,4 +141,49 @@ func (s *webhookService) Register(ctx context.Context, orgID, projectID string) 
 		return nil, fmt.Errorf("persist webhook id: %w", err)
 	}
 	return &hookID, nil
+}
+
+// Unregister removes the hook Register installed. See the interface for the
+// contract; the shape below is Register's, run backwards.
+//
+// It must be called BEFORE the repo row is deleted: the row carries both the
+// hook ID and the repo identity the credential resolves against, and once it is
+// gone the platform has no way left to name the hook it created.
+func (s *webhookService) Unregister(ctx context.Context, orgID, projectID string) error {
+	// The hook ID is the whole point: it is what makes this removal precise. A
+	// project that never registered one — App-mode delivery, a failed
+	// registration, a repo provisioned before hooks existed — has nothing of ours
+	// on the repo to remove.
+	repo, err := s.repoSvc.GetRepo(ctx, orgID, projectID)
+	if err != nil {
+		if errors.Is(err, ErrRepoNotFound) {
+			return nil
+		}
+		return fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil || repo.WebhookID == nil {
+		return nil
+	}
+
+	resolver, ok := s.issue.(issueRepoResolver)
+	if !ok {
+		return fmt.Errorf("webhook: issue service %T cannot resolve repo credentials", s.issue)
+	}
+	owner, repoName, cred, err := resolver.resolveRepoAndCredential(ctx, orgID, projectID)
+	if err != nil {
+		return err
+	}
+
+	// Same short-circuit as Register, and for the same reason: under App-mode
+	// delivery no per-repo hook was ever installed, so there is none to remove.
+	if cred.WebhookStrategy() == secrets.WebhookPlatform {
+		return nil
+	}
+
+	if err := s.github.DeleteWebhook(ctx, owner, repoName, cred, *repo.WebhookID); err != nil {
+		return fmt.Errorf("delete webhook: %w", err)
+	}
+	slog.InfoContext(ctx, "webhook unregistered from repo",
+		"org", orgID, "project", projectID, "hookId", *repo.WebhookID)
+	return nil
 }

--- a/services/aep-api/internal/sourcecontrol/webhook_unregister_test.go
+++ b/services/aep-api/internal/sourcecontrol/webhook_unregister_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sourcecontrol_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/platform/gittest"
+	"github.com/wso2/aep/aep-api/internal/platform/secrets"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+// Unregister is Register run backwards, and the property that matters most is
+// PRECISION: it deletes the hook whose id the platform persisted at
+// registration, never a hook it found by scanning. Repositories carry other
+// integrations' webhooks, and a project delete has no business touching them.
+//
+// Everything else about it is total. A project with no repo row, no stored hook
+// or a platform-strategy credential has nothing of ours installed, and a hook
+// GitHub has already dropped is the post-state we wanted anyway.
+
+const hookPath = "/repos/acme/widgets/hooks/12345"
+
+// registerHook drives a real registration so the hook id is persisted the way
+// production persists it — the test then unregisters what registration stored,
+// rather than a number the test made up.
+func registerHook(t *testing.T, stub *gittest.Stub, wh sourcecontrol.WebhookService) {
+	t.Helper()
+	stub.On(http.MethodPost, "/repos/acme/widgets/hooks", http.StatusCreated, `{"id":12345}`)
+	stub.On(http.MethodPatch, hookPath, http.StatusOK, `{}`)
+	if _, err := wh.Register(context.Background(), "org1", "proj1"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+}
+
+func TestWebhookUnregister_DeletesTheStoredHook(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, repo := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+	registerHook(t, stub, wh)
+	if got := storedWebhookID(t, repo, "org1", "proj1"); got == nil || *got != 12345 {
+		t.Fatalf("precondition: stored hook id = %v, want 12345", got)
+	}
+	stub.On(http.MethodDelete, hookPath, http.StatusNoContent, "")
+
+	if err := wh.Unregister(context.Background(), "org1", "proj1"); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+
+	// The DELETE went to the STORED hook's id, and nothing listed the repo's
+	// hooks looking for something to remove.
+	var deletes, lists int
+	for _, r := range stub.Requests() {
+		if r.Method == http.MethodDelete && r.Path == hookPath {
+			deletes++
+		}
+		if r.Method == http.MethodGet && r.Path == "/repos/acme/widgets/hooks" {
+			lists++
+		}
+	}
+	if deletes != 1 {
+		t.Errorf("DELETE %s sent %d times, want 1", hookPath, deletes)
+	}
+	if lists != 0 {
+		t.Errorf("Unregister listed the repo's hooks %d times; it must address the stored id only", lists)
+	}
+}
+
+// TestWebhookUnregister_AlreadyGoneHookIsSuccess covers the two ways GitHub says
+// "that hook is not here": a plain 404, and the 410 it returns once a hook has
+// been auto-disabled and reaped after repeated delivery failures — which is
+// exactly where an orphaned webhook ends up.
+func TestWebhookUnregister_AlreadyGoneHookIsSuccess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"404 not found", http.StatusNotFound},
+		{"410 gone", http.StatusGone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := gittest.NewStub(t)
+			wh, _ := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+			registerHook(t, stub, wh)
+			stub.On(http.MethodDelete, hookPath, tc.status, `{"message":"Not Found"}`)
+
+			if err := wh.Unregister(context.Background(), "org1", "proj1"); err != nil {
+				t.Fatalf("an already-absent hook must be success, got %v", err)
+			}
+		})
+	}
+}
+
+func TestWebhookUnregister_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, _ := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+	registerHook(t, stub, wh)
+	// First call removes it; every call after that finds it gone.
+	stub.OnSequence(http.MethodDelete, hookPath,
+		gittest.Response{Status: http.StatusNoContent},
+		gittest.Response{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+	)
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err := wh.Unregister(context.Background(), "org1", "proj1"); err != nil {
+			t.Fatalf("attempt %d: %v", attempt, err)
+		}
+	}
+}
+
+// TestWebhookUnregister_NothingRegisteredIsANoOp: no hook id was ever persisted,
+// so there is nothing of ours on the repo. It must not probe GitHub at all —
+// guessing which hook was "probably" ours is what this design refuses to do.
+func TestWebhookUnregister_NothingRegisteredIsANoOp(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, _ := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+
+	if err := wh.Unregister(context.Background(), "org1", "proj1"); err != nil {
+		t.Fatalf("no stored hook must be a no-op, got %v", err)
+	}
+	if n := len(stub.Requests()); n != 0 {
+		t.Errorf("Unregister made %d GitHub calls with no hook stored, want 0", n)
+	}
+}
+
+// TestWebhookUnregister_UnknownProjectIsANoOp: the repo row is already gone, so
+// the platform cannot name a hook. Nothing to do, and not an error — the project
+// teardown re-runs this path.
+func TestWebhookUnregister_UnknownProjectIsANoOp(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, _ := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+
+	if err := wh.Unregister(context.Background(), "org1", "no-such-project"); err != nil {
+		t.Fatalf("an unresolvable project must be a no-op, got %v", err)
+	}
+}
+
+// TestWebhookUnregister_PlatformStrategyIsANoOp mirrors Register's short-circuit:
+// App-installation delivery never installed a per-repo hook, so there is none to
+// remove.
+func TestWebhookUnregister_PlatformStrategyIsANoOp(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, repo := newWebhookSvcOnStub(t, stub, secrets.WebhookPlatform)
+	// Stamp a hook id directly: under App mode Register would never persist one,
+	// and this proves the strategy check — not an absent id — is what stops it.
+	hookID := int64(12345)
+	repo.preload(&sourcecontrol.GitRepository{
+		OrgID: "org1", ProjectID: "proj1",
+		RepoURL: "https://github.com/acme/widgets", WebhookID: &hookID,
+	})
+
+	if err := wh.Unregister(context.Background(), "org1", "proj1"); err != nil {
+		t.Fatalf("platform strategy must be a no-op, got %v", err)
+	}
+	if n := len(stub.Requests()); n != 0 {
+		t.Errorf("Unregister made %d GitHub calls under platform delivery, want 0", n)
+	}
+}
+
+// TestWebhookUnregister_GitHubFailureIsReported: only a live failure to reach
+// GitHub is an error. The project teardown swallows it (see
+// TestDeleteProject_WebhookUnregisterFailureIsSwallowed) — but it has to be told,
+// or the log line naming the leftover hook could never be written.
+func TestWebhookUnregister_GitHubFailureIsReported(t *testing.T) {
+	t.Parallel()
+	stub := gittest.NewStub(t)
+	wh, _ := newWebhookSvcOnStub(t, stub, secrets.WebhookPerRepo)
+	registerHook(t, stub, wh)
+	stub.On(http.MethodDelete, hookPath, http.StatusInternalServerError, `{"message":"boom"}`)
+
+	err := wh.Unregister(context.Background(), "org1", "proj1")
+	if err == nil {
+		t.Fatal("a 500 from GitHub must be reported, got nil")
+	}
+	if got := fmt.Sprint(err); got == "" {
+		t.Error("error must carry a message")
+	}
+}

--- a/services/aep-api/internal/sourcecontrol/wire.go
+++ b/services/aep-api/internal/sourcecontrol/wire.go
@@ -325,11 +325,9 @@ func (e *GraphQLError) Error() string {
 // IsGraphQLType reports true when err is a GraphQLError carrying at least one
 // error of the given machine-readable type (e.g. "NOT_FOUND", "RATE_LIMITED").
 //
-// Retained infra, not a phase leftover: the milestone predicate already
-// surfaces *GraphQLError, but no caller branches on its type yet (the plan path
-// recovers a duplicate milestone through REST's 422 instead).
-//
-//deadcode:keep the typed discriminator for the GraphQL seam — see above.
+// This is the discriminator IsPermanent branches on: the milestone predicate is
+// a GraphQL call, so a deleted repository reaches the run supervisor as a
+// NOT_FOUND entry here rather than as an HTTP 404.
 func IsGraphQLType(err error, typ string) bool {
 	var ge *GraphQLError
 	if !errors.As(err, &ge) {

--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -20,6 +20,12 @@ AGENT_MAX_OUTPUT_TOKENS=64000
 # false only where turns are reliably single-step — a cache WRITE costs more
 # than plain input, so writing a cache nothing reads back is a small loss.
 AGENT_PROMPT_CACHE=true
+# DevTools capture retention in days (default 3; 0 keeps everything). The
+# library caps nothing and rewrites the WHOLE capture file synchronously on
+# every step, so an unbounded file becomes an ever-larger blocking write on the
+# event loop mid-turn. Applied once at boot, before the server listens — never
+# on a turn.
+AGENT_DEVTOOLS_RETENTION_DAYS=3
 
 # SSE keep-alive cadence (ms) while a turn streams, so long generations survive
 # an idle-timeout ingress.

--- a/services/agents/AGENTS.md
+++ b/services/agents/AGENTS.md
@@ -109,5 +109,8 @@ this service ships only the runtime + its unit tests.
   here; the client-safe fold + wire contracts live in `@aep/agent-stream`.
 - Latest Claude models by default (see the `claude-api` skill for model ids).
 - One agent per `src/agents/<name>/`; the loop (`run-turn.ts`) is shared.
-- `src/` writes no files; its only filesystem READS are the §12 snapshot dirs
-  (`load-workspace.ts`, paths derived solely by `snapshot-path.ts`).
+- `src/` writes no files **on the turn path**; its only filesystem READS are the
+  §12 snapshot dirs (`load-workspace.ts`, paths derived solely by
+  `snapshot-path.ts`). The one write is DevTools retention
+  (`shared/devtools-retention.ts`), which prunes the debug capture once at boot
+  before the server listens — never while a turn runs, and never a spec file.

--- a/services/agents/src/main.ts
+++ b/services/agents/src/main.ts
@@ -31,6 +31,7 @@ import { registerTelemetry } from "ai";
 import { createApp } from "./server.js";
 import { createModel, resolveModelId } from "./shared/model.js";
 import { captureTelemetry } from "./shared/telemetry.js";
+import { pruneDevtoolsFile } from "./shared/devtools-retention.js";
 import { intEnv } from "./shared/env.js";
 import { config } from "./shared/config.js";
 import type { AgentsAuthConfig } from "./shared/auth.js";
@@ -76,6 +77,17 @@ async function buildStore(): Promise<ConversationStore> {
 }
 
 async function main(): Promise<void> {
+  // DevTools retention, BEFORE anything can capture. The library lazily loads
+  // the whole capture into a process-memory cache on its first write and
+  // flushes it back whole on every step, so this is the only moment a prune
+  // sticks — and doing it here is also what keeps it off the turn path: the
+  // server is not listening yet, so no turn (`/start` included) ever waits on
+  // it. Best-effort; a null result means nothing to do or something unreadable.
+  if (config.devtools && config.devtoolsRetentionDays > 0) {
+    const summary = pruneDevtoolsFile(config.devtoolsRetentionDays);
+    if (summary) process.stdout.write(summary);
+  }
+
   // Trace capture registers ONCE per process — it is a property of the
   // deployment, not of a turn. It used to be a middleware wrapped around the
   // per-turn model, which is what made every turn its own unrelated run: the

--- a/services/agents/src/shared/config.ts
+++ b/services/agents/src/shared/config.ts
@@ -68,6 +68,13 @@ export const config = {
   // (`npx @ai-sdk/devtools`, port AI_SDK_DEVTOOLS_PORT / 4983). Heavier than the
   // timing lines (per-call file write + viewer notify), so it is opt-in.
   devtools: boolEnv(process.env.AGENT_DEVTOOLS, false),
+  // How much DevTools capture history to keep (AGENT_DEVTOOLS_RETENTION_DAYS).
+  // The library caps nothing, and `saveDb` rewrites the WHOLE file synchronously
+  // on every step — so an unbounded capture turns into an ever-larger blocking
+  // write on the event loop mid-turn. Applied once at boot, never on a turn.
+  // 3 days: at the observed ~12MB/day a 7-day window reclaims nothing until
+  // week two, by which point the file is ~170MB. 0 disables retention.
+  devtoolsRetentionDays: intEnv(process.env.AGENT_DEVTOOLS_RETENTION_DAYS, 3),
   // SSE keep-alive cadence: a `: keep-alive` comment this often while a turn
   // streams, so long generations don't die behind an idle-timeout ingress.
   keepAliveMs: intEnv(process.env.AGENT_KEEPALIVE_MS, 15_000),

--- a/services/agents/src/shared/devtools-retention.ts
+++ b/services/agents/src/shared/devtools-retention.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Retention for the DevTools capture file (`.devtools/generations.json`).
+ *
+ * The library caps nothing: it declares a `MAX_DB_BYTES` and never reads it, so
+ * the file grows for as long as capture is enabled — observed at 80 MB beside a
+ * 175 MB archive someone had already rotated by hand. Size is not a cosmetic
+ * problem there: `saveDb` re-serialises the WHOLE db with `JSON.stringify(db,
+ * null, 2)` and `writeFileSync`s it on EVERY step, so an 80 MB file means an
+ * 80 MB synchronous write per step, on the event loop, while a turn streams.
+ * That is why a big capture file reads as "the agent hung".
+ *
+ * WHEN this runs is the whole design. The library keeps the db in a
+ * process-memory `dbCache`, lazily filled on its first write and flushed back
+ * whole every time after; pruning the file underneath a running service would
+ * simply be overwritten by the next step. So retention runs ONCE, at boot,
+ * before the server accepts a request — which is also what keeps it off the
+ * turn path. A `/start` turn never waits for it, because by the time any turn
+ * can arrive the prune has already happened and the file is small.
+ *
+ * Best-effort by construction: a missing, unreadable or malformed file leaves
+ * everything untouched and boots anyway. Trace capture is a debugging aid and
+ * must never be able to stop the service — the same rule `nonFatalMiddleware`
+ * enforces for the live path.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** A captured run. Only the fields retention needs are modelled. */
+interface DevtoolsRun {
+  id?: unknown;
+  started_at?: unknown;
+}
+
+/** A captured step. Steps carry the bulk (raw_request/raw_response/raw_chunks). */
+interface DevtoolsStep {
+  run_id?: unknown;
+}
+
+export interface DevtoolsDb {
+  runs: DevtoolsRun[];
+  steps: DevtoolsStep[];
+}
+
+export interface PruneResult {
+  db: DevtoolsDb;
+  removedRuns: number;
+  removedSteps: number;
+}
+
+/**
+ * Drop every run started before `cutoff`, and every step belonging to one.
+ *
+ * Steps are pruned by OWNING RUN rather than by their own timestamp: a step is
+ * what carries the raw request/response payloads, so orphans left behind by a
+ * run-only prune would keep essentially all of the bytes and the file would
+ * never shrink. A step whose `run_id` matches no surviving run is dropped for
+ * the same reason — it can no longer be reached through the viewer.
+ *
+ * A run with an absent or unparseable `started_at` is KEPT. Retention deletes
+ * data, so anything it cannot positively date is out of its remit.
+ */
+export function pruneDevtoolsDb(db: DevtoolsDb, cutoff: Date): PruneResult {
+  const runs = Array.isArray(db.runs) ? db.runs : [];
+  const steps = Array.isArray(db.steps) ? db.steps : [];
+  const cutoffMs = cutoff.getTime();
+
+  const keptRunIds = new Set<unknown>();
+  const keptRuns = runs.filter((r) => {
+    const started = typeof r?.started_at === "string" ? Date.parse(r.started_at) : Number.NaN;
+    const keep = Number.isNaN(started) || started >= cutoffMs;
+    if (keep) keptRunIds.add(r?.id);
+    return keep;
+  });
+
+  const keptSteps = steps.filter((s) => keptRunIds.has(s?.run_id));
+
+  return {
+    db: { runs: keptRuns, steps: keptSteps },
+    removedRuns: runs.length - keptRuns.length,
+    removedSteps: steps.length - keptSteps.length,
+  };
+}
+
+/**
+ * Prune `<cwd>/.devtools/generations.json` in place, keeping `retentionDays` of
+ * history. Returns a one-line summary for the boot log, or null when there was
+ * nothing to do (no file, nothing old enough, or anything went wrong).
+ *
+ * Rewrites only when something was actually removed, so a warm boot on an
+ * already-pruned file costs a read and no write.
+ */
+export function pruneDevtoolsFile(
+  retentionDays: number,
+  now: Date = new Date(),
+  cwd: string = process.cwd(),
+): string | null {
+  const file = path.join(cwd, ".devtools", "generations.json");
+  try {
+    if (!fs.existsSync(file)) return null;
+    const bytesBefore = fs.statSync(file).size;
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf-8"));
+    if (typeof parsed !== "object" || parsed === null) return null;
+
+    const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+    const { db, removedRuns, removedSteps } = pruneDevtoolsDb(parsed as DevtoolsDb, cutoff);
+    if (removedRuns === 0 && removedSteps === 0) return null;
+
+    // Match the library's own on-disk shape: it reads this file back with a
+    // plain JSON.parse and re-writes it pretty-printed, so anything else here
+    // would just be reformatted on the first step anyway.
+    fs.writeFileSync(file, JSON.stringify(db, null, 2));
+    const mb = (n: number): string => `${(n / 1024 / 1024).toFixed(1)}MB`;
+    return (
+      `@aep/agents: devtools retention (${retentionDays}d) removed ${removedRuns} run(s) ` +
+      `and ${removedSteps} step(s), ${mb(bytesBefore)} → ${mb(fs.statSync(file).size)}\n`
+    );
+  } catch {
+    // Corrupt or unreadable capture is not a reason to fail a boot.
+    return null;
+  }
+}

--- a/services/agents/test/devtools-retention.test.ts
+++ b/services/agents/test/devtools-retention.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pruneDevtoolsDb, pruneDevtoolsFile } from "../src/shared/devtools-retention.js";
+
+const NOW = new Date("2026-08-07T12:00:00.000Z");
+const cutoff7d = new Date(NOW.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+const run = (id: string, started_at: string): { id: string; started_at: string } => ({
+  id,
+  started_at,
+});
+
+test("runs older than the cutoff go, with the steps that belong to them", () => {
+  const db = {
+    runs: [run("old", "2026-07-20T00:00:00.000Z"), run("fresh", "2026-08-06T00:00:00.000Z")],
+    steps: [{ run_id: "old" }, { run_id: "old" }, { run_id: "fresh" }],
+  };
+
+  const { db: pruned, removedRuns, removedSteps } = pruneDevtoolsDb(db, cutoff7d);
+
+  assert.deepEqual(
+    pruned.runs.map((r) => r.id),
+    ["fresh"],
+  );
+  assert.equal(removedRuns, 1);
+  // Steps carry the raw payloads — leaving them behind would keep the bytes and
+  // the file would never actually shrink.
+  assert.equal(removedSteps, 2);
+  assert.deepEqual(pruned.steps, [{ run_id: "fresh" }]);
+});
+
+test("a step whose run is gone is dropped even if the run was never listed", () => {
+  const db = { runs: [run("fresh", "2026-08-06T00:00:00.000Z")], steps: [{ run_id: "ghost" }] };
+  const { db: pruned, removedSteps } = pruneDevtoolsDb(db, cutoff7d);
+  assert.equal(removedSteps, 1, "an unreachable step is dead weight");
+  assert.deepEqual(pruned.steps, []);
+});
+
+test("a run that cannot be dated is KEPT — retention never guesses", () => {
+  const db = {
+    runs: [{ id: "undated" }, { id: "bad", started_at: "not-a-date" }],
+    steps: [{ run_id: "undated" }, { run_id: "bad" }],
+  };
+  const { db: pruned, removedRuns, removedSteps } = pruneDevtoolsDb(db, cutoff7d);
+  assert.equal(removedRuns, 0);
+  assert.equal(removedSteps, 0);
+  assert.equal(pruned.runs.length, 2);
+});
+
+test("the file is rewritten only when something was removed", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "devtools-retention-"));
+  const dbDir = path.join(dir, ".devtools");
+  fs.mkdirSync(dbDir);
+  const file = path.join(dbDir, "generations.json");
+
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      runs: [run("old", "2026-07-01T00:00:00.000Z"), run("fresh", "2026-08-06T00:00:00.000Z")],
+      steps: [{ run_id: "old" }, { run_id: "fresh" }],
+    }),
+  );
+
+  const summary = pruneDevtoolsFile(7, NOW, dir);
+  assert.ok(summary && summary.includes("removed 1 run(s)"), `unexpected summary: ${summary}`);
+  const after = JSON.parse(fs.readFileSync(file, "utf-8")) as { runs: { id: string }[] };
+  assert.deepEqual(
+    after.runs.map((r) => r.id),
+    ["fresh"],
+  );
+
+  // Nothing left to prune: no rewrite, and the caller is told so.
+  const before = fs.statSync(file).mtimeMs;
+  assert.equal(pruneDevtoolsFile(7, NOW, dir), null);
+  assert.equal(fs.statSync(file).mtimeMs, before, "a second prune must not rewrite the file");
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a missing or corrupt capture is not a reason to fail a boot", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "devtools-retention-"));
+  assert.equal(pruneDevtoolsFile(7, NOW, dir), null, "absent file");
+
+  fs.mkdirSync(path.join(dir, ".devtools"));
+  fs.writeFileSync(path.join(dir, ".devtools", "generations.json"), "{ not json");
+  assert.equal(pruneDevtoolsFile(7, NOW, dir), null, "corrupt file");
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## What happened

Three symptoms were reported as separate failures:

- "several project repos are gone" — `repository not found` spam in the `aep-api` log
- Temporal activities retrying at **attempt 130+** (observed live at **340**)
- `milestone_runs` was cleared

They were **one event**: a project deleted through the product.

The repos were never gone. `gh repo list asdlc-repos` showed every repo alive and private.
`repository not found` is our OWN sentinel (`sourcecontrol.ErrRepoNotFound`) for a missing
`git_repositories` row — not a GitHub 404 — and nothing in the tree deletes a GitHub repo
(the `RepoAdmin` port only exposes `CreateOrgRepo`). The message reads like a remote 404,
which is what sent the investigation to GitHub instead of to the database.

`milestone_runs` was purged deliberately by the delete cascade. Postgres agreed:
`pg_stat_user_tables` showed `milestone_runs` 12 inserted / **7 deleted**, `run_cycles` 21/13,
`git_repositories` 8/**6** — one delete-set per project, with every surviving row belonging to
the one project that still existed.

The retry storm was two **orphaned supervisors**: the delete purged the rows that identify the
run workflows and never told Temporal. There was **zero** `CancelWorkflow`/`TerminateWorkflow`
anywhere in the repo before this change.

```
WorkflowId:"run-default-staff-maintain-demo-1"      ActivityType:"PollMilestone"   Attempt:340
WorkflowId:"run-default-staff-report-maintenance-1" ActivityType:"PollCycleBuilds" Attempt:343
Error:"repository not found"
```

The delete was also **wedged**: it returned early when the OpenChoreo project was already gone,
so a retry could never reach the cleanup, and the orphans it left could not be recovered by
re-running it. That is the state the environment was stuck in.

## What this changes

| Defect | Fix |
|---|---|
| Delete never stopped the work it owned | `Supervisor.AbandonRun` terminates the supervisors per live milestone, before the rows and repo they depend on are purged |
| Permanent failures retried forever | `sourcecontrol.IsPermanent` + `run.sourceControlErr` mark them non-retryable |
| Delete aborted on "OpenChoreo already gone" | Not-found falls through to the full teardown; every other OC failure still aborts |
| `DeleteRepo` errored on a second call | Ensures absence, returns nil |
| Webhook survived the delete | `Unregister` deletes the stored hook id only |
| Delete destroyed spend history | Append-only `agent_usage_ledger`, written at capture time, with a backfill |
| A vanished run row spun the console forever | The progress SSE stream settles; a failed *read* still holds it |
| The dialog claimed it deleted your GitHub repo | Corrected — the repo is kept, and it explains why the name stays taken |

**Terminate, not cancel.** A workflow blocked inside a forever-retrying activity never processes
a cancel signal.

**403 stays retryable.** GitHub's secondary rate limit wears that status and clears itself.
So do 5xx, transport errors, GraphQL `RATE_LIMITED`, and `ErrRepoNotReady`. Only 404/410/401,
GraphQL `NOT_FOUND` and the repo/issue/milestone sentinels are permanent.

**The repo is deliberately kept.** It is the user's durable artifact and deletion is
irreversible. The cost is that the name stays taken (`ErrRepoNameConflict` on re-create), which
the dialog now states instead of claiming the opposite.

**Spend survives, runs do not.** `run_cycles` carries `cost_usd` and token usage, and
`PhaseUsageRollup` read it — so a delete erased the spend record. The ledger is written at
capture time rather than minted at delete, because the delete path is best-effort by contract: a
record that only exists if that path completes is one you find out you don't have at audit time.
Lifetimes are separated by a `retired_at` stamp, so a recreated same-named project starts at
zero. Both `SumUsageByProjectPhase` sources were deleted rather than left as a second source of
the same tokens, and the row + ledger write now commit in **one transaction** — the rollup reads
the ledger alone, so a stamped row without its copy is spend that is invisible everywhere it is
reported.

The second commit is unrelated to the delete path and bounds the DevTools capture file: the
library declares a `MAX_DB_BYTES` and never reads it, and `saveDb` re-serialises the whole db
and `writeFileSync`s it on **every step**. An 80MB capture (observed, beside a 175MB hand-rotated
archive) means an 80MB synchronous write per step on the event loop while a turn streams — which
is why a large capture reads as "the agent hung". Retention runs once at boot, before the server
listens, so it can never cost a turn.

## Proof of execution

Rebuilt `aep-api` and drove a real project lifecycle against a live local cluster.

**Setup** — created `del-verify-0808`, repo created with webhook `662895426` active, milestone
`v1`, supervisor `run-default-del-verify-0808-1` **Running**. That is exactly the pre-delete
state that used to produce orphans.

**After `DELETE /projects/del-verify-0808` → 204:**

| Check | Result |
|---|---|
| Supervisor workflow | **Terminated** — not orphaned |
| Webhook on GitHub | **0 hooks** — unregistered |
| GitHub repo | **Survives**, private |
| `git_repositories` / `milestone_runs` | **0 / 0** — purged |
| 2nd and 3rd DELETE | **204, 204** — idempotent |
| `repository not found` storm | **None** — one WARN per re-delete, no retry loop |

```
$ temporal workflow list --query 'WorkflowId="run-default-del-verify-0808-1"'
  Status             WorkflowId                    Type
  Terminated  run-default-del-verify-0808-1  MilestoneRunWorkflow
```

The migration also ran on this deploy and backfilled **5 real spend rows** for the live project,
phases split correctly (`build` / `validation`, $0.79–$5.84) — live proof the backfill works and
the usage page is not empty after upgrade.

**Caveats, stated plainly.** The run row was seeded and the supervisor started directly, because
a product-native run needs a full PRD + design + build cycle; the delete path exercised is
identical, the route to the run is not. Ledger **retirement** was not exercised live — the
throwaway project had no agent spend — so that path rests on the Postgres-backed tests.

## Tests

Red-green verified, not just green: with `sourceControlErr` short-circuited the same test reached
**attempt 10** and failed `expected: 1, actual: 10`, reproducing the live defect; the four
idempotence tests and the SSE settle test each fail with their fix reverted.

- `TestPollMilestoneStopsAtTheFirstPermanentFailure` — port called exactly **1** time
- `TestPollMilestoneKeepsRetryingATransientFailure` — two 500s then success, **3** calls
- `TestDeleteProject_AbandonsRunSupervisorsBeforeTheirRepoAndRows`
- `TestDeleteProject_AlreadyGoneOCProjectStillTearsDownPlatformState`
- `TestWebhookUnregister_DeletesTheStoredHook` — one DELETE to the stored id, **zero** `GET /hooks`
- `TestUsageLedger_SpendSurvivesTheProjectDeletePurge`
- `TestRunProgress_SettlesWhenTheRunRowIsPurged`

`go build`, `go vet`, `make deadcode-check`, `make lint`, `make license-check`, `knip --production`,
console `tsc`, and `@aep/agents` (228 pass / 0 fail) are all clean.

**Note on the DB tier:** `make test` runs `-short`, which self-skips every `dbtest`. The ledger
tests were silently skipping until `DOCKER_HOST` was pointed at Colima's socket. The runs backing
this PR ran the DB tier for real — **zero skips**.

## Known gaps, not fixed here

- **Re-running a delete cannot recover already-orphaned supervisors.** Discovery goes through
  `milestone_runs`, which the first delete clears. Only future deletes are protected; the two
  pre-existing zombies were terminated by hand. A proper fix discovers them from Temporal by
  workflow-id prefix.
- **`ErrRepoNotFound`'s message still reads like a GitHub 404** — the direct cause of this
  misdiagnosis. Renaming an established sentinel is a wider change.
- **`activityCtx` is still unbounded** for activities that are not source-control shaped, and
  there is no `ContinueAsNew`, so long-lived runs grow history without limit.
- **Spec-turn spend has no lifetime marker** — `agent_turns` is never retired, so a recreated slug
  still inherits its predecessor's spec figure. That belongs to the spec domain.
- **Webhooks for projects deleted before this ships cannot be cleaned by code** — their repo rows
  are gone, so nothing can name them. They need removing by hand in the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
