### PR TITLE
fix(remote-worker): make git push use the Job's GITHUB_TOKEN

### DIFF
--- a/runners/AGENTS.md
+++ b/runners/AGENTS.md
@@ -20,18 +20,16 @@ into the runner pod at `/app/skills` for live skill edits (see
   messages (which the BFF forwards to the console build log), into `ps`, and into
   `.git/config`. Rationale inline in `git_clone.ts`; the BFF keeps a shape-based
   second line of defense in `delivery/codingagent/redact.go`.
-- **ONE credential mechanism: the git credential helper in `lib/credhelper.ts`.**
-  Every authenticated git operation in a run goes through it, the provisioning
-  clone included — the clone wires it in with `git -c credential.<origin>.helper`
-  because `.git/config` doesn't exist yet, and `workspace.ts` installs the same
-  script durably afterwards. No GIT_ASKPASS, no token in argv or env, and the
-  runner process never holds a GitHub token. Don't add a second path: the last
-  one shipped a script serving two protocols that dispatched on `[ -n "$1" ]`,
-  which is true for both, so the clone worked and every agent operation failed
-  its auth silently. Putting the helper on the clone is what makes a break a
-  provisioning failure instead. Any change to the generated scripts must keep
-  `credhelper.test.ts` green — it drives them with real `git`, which is the only
-  thing that would have caught that.
+- **Git credentials — two modes, one helper value in `.git/config`.**
+  When `GITHUB_TOKEN` / `GH_TOKEN` is set (cloud Jobs mount the org PAT),
+  `workspace.ts` installs `gh auth git-credential` (the same helper
+  `gh auth setup-git` uses), pinned to the **real** `gh` absolute path so the
+  `.aep/gh` wrapper cannot intercept. Clone and push share that path; they do
+  **not** call `credentials/refresh`. When those env vars are absent, every
+  authenticated git op goes through `lib/credhelper.ts` → refresh (clone via
+  `git -c`, then the same script installed durably). No GIT_ASKPASS, no token
+  in argv or URL. Don't add a third path. Changes to the generated refresh
+  scripts must keep `credhelper.test.ts` green — it drives them with real `git`.
 - Runner `console.*` is a **user-facing** channel, and it shares the file
   descriptor the NDJSON progress feed writes to. `installConsoleScrubber()` at
   each entry point converts every call into a scrubbed `log` progress event, so

--- a/runners/remote-worker/src/lib/gh_git_auth.test.ts
+++ b/runners/remote-worker/src/lib/gh_git_auth.test.ts
@@ -19,6 +19,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  absoluteGhPathFromWhich,
   envHasGitHubToken,
   ghGitCredentialHelper,
   ghPassthroughScript,
@@ -27,8 +28,20 @@ import {
 test("envHasGitHubToken: true when GITHUB_TOKEN or GH_TOKEN is non-empty", () => {
   assert.equal(envHasGitHubToken({}), false);
   assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "" }), false);
+  assert.equal(envHasGitHubToken({ GH_TOKEN: "" }), false);
   assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "ghs_x" }), true);
   assert.equal(envHasGitHubToken({ GH_TOKEN: "ghs_x" }), true);
+  // Empty GITHUB_TOKEN must not mask a set GH_TOKEN (`??` would).
+  assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "", GH_TOKEN: "ghs_x" }), true);
+  assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "ghs_x", GH_TOKEN: "" }), true);
+});
+
+test("absoluteGhPathFromWhich: only absolute paths", () => {
+  assert.equal(absoluteGhPathFromWhich(""), null);
+  assert.equal(absoluteGhPathFromWhich("gh\n"), null);
+  assert.equal(absoluteGhPathFromWhich("./gh\n"), null);
+  assert.equal(absoluteGhPathFromWhich("/usr/bin/gh\n"), "/usr/bin/gh");
+  assert.equal(absoluteGhPathFromWhich("/opt/homebrew/bin/gh\n/other\n"), "/opt/homebrew/bin/gh");
 });
 
 test("ghGitCredentialHelper: setup-git equivalent pinned to an absolute binary", () => {

--- a/runners/remote-worker/src/lib/gh_git_auth.test.ts
+++ b/runners/remote-worker/src/lib/gh_git_auth.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  envHasGitHubToken,
+  ghGitCredentialHelper,
+  ghPassthroughScript,
+} from "./gh_git_auth.js";
+
+test("envHasGitHubToken: true when GITHUB_TOKEN or GH_TOKEN is non-empty", () => {
+  assert.equal(envHasGitHubToken({}), false);
+  assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "" }), false);
+  assert.equal(envHasGitHubToken({ GITHUB_TOKEN: "ghs_x" }), true);
+  assert.equal(envHasGitHubToken({ GH_TOKEN: "ghs_x" }), true);
+});
+
+test("ghGitCredentialHelper: setup-git equivalent pinned to an absolute binary", () => {
+  assert.equal(ghGitCredentialHelper("/usr/bin/gh"), "!/usr/bin/gh auth git-credential");
+});
+
+test("ghPassthroughScript: execs the real binary, no platform exchange", () => {
+  const body = ghPassthroughScript("/usr/bin/gh");
+  assert.match(body, /^#!/);
+  assert.match(body, /exec "\/usr\/bin\/gh" "\$@"/);
+  assert.match(body, /GITHUB_TOKEN/);
+  assert.ok(!body.includes("credhelper.sh"), body);
+  assert.ok(!body.includes("credentials/refresh"), body);
+});

--- a/runners/remote-worker/src/lib/gh_git_auth.ts
+++ b/runners/remote-worker/src/lib/gh_git_auth.ts
@@ -17,6 +17,7 @@
  */
 
 import { exec } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
@@ -34,20 +35,33 @@ const execAsync = promisify(exec);
  * binary's absolute path.
  */
 export function envHasGitHubToken(env: NodeJS.ProcessEnv = process.env): boolean {
-  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "";
-  return token !== "";
+  // Check each independently: `GITHUB_TOKEN=""` must not mask a set GH_TOKEN
+  // (`??` would keep the empty string and skip the fallback).
+  return (env.GITHUB_TOKEN ?? "") !== "" || (env.GH_TOKEN ?? "") !== "";
+}
+
+/** First absolute path from `which gh` stdout, or null. */
+export function absoluteGhPathFromWhich(stdout: string): string | null {
+  const p = stdout.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (p === "" || !path.isAbsolute(p)) return null;
+  return p;
 }
 
 /** Absolute path to the real `gh` binary (never the workspace `.aep/gh` wrapper). */
 export async function resolveRealGhPath(): Promise<string> {
   try {
     const which = await execAsync("which gh");
-    const p = which.stdout.trim();
-    if (p !== "") return p;
+    const p = absoluteGhPathFromWhich(which.stdout);
+    if (p !== null) return p;
   } catch {
     // fall through
   }
-  return "/usr/bin/env gh";
+  // Must be absolute: ghPassthroughScript quotes the value as one executable
+  // (`exec "/usr/bin/env gh"`), which cannot run. Same requirement for the
+  // durable `!/abs/path/gh auth git-credential` helper pin.
+  throw new Error(
+    "could not resolve an absolute path to `gh` (required for git credential helper and .aep/gh)",
+  );
 }
 
 /**

--- a/runners/remote-worker/src/lib/gh_git_auth.ts
+++ b/runners/remote-worker/src/lib/gh_git_auth.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/**
+ * Cloud coding Jobs mount a long-lived GitHub PAT as GITHUB_TOKEN (gh also
+ * accepts GH_TOKEN). When present, git authenticates through `gh auth
+ * git-credential` — the same helper `gh auth setup-git` installs — instead of
+ * the AEP credhelper → credentials/refresh path.
+ *
+ * Why not call `gh auth setup-git` itself: it writes --global config, and a bare
+ * `!gh auth git-credential` resolves `gh` via PATH. The agent's PATH puts
+ * `.aep/gh` first (the refresh wrapper), which would reintroduce the broken
+ * refresh hop. We install the same helper value locally, pinned to the real
+ * binary's absolute path.
+ */
+export function envHasGitHubToken(env: NodeJS.ProcessEnv = process.env): boolean {
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "";
+  return token !== "";
+}
+
+/** Absolute path to the real `gh` binary (never the workspace `.aep/gh` wrapper). */
+export async function resolveRealGhPath(): Promise<string> {
+  try {
+    const which = await execAsync("which gh");
+    const p = which.stdout.trim();
+    if (p !== "") return p;
+  } catch {
+    // fall through
+  }
+  return "/usr/bin/env gh";
+}
+
+/**
+ * Git credential.helper value equivalent to `gh auth setup-git`, using an
+ * absolute binary so PATH wrappers cannot intercept.
+ */
+export function ghGitCredentialHelper(realGhPath: string): string {
+  return `!${realGhPath} auth git-credential`;
+}
+
+/** Minimal wrapper: exec the real gh. Env GITHUB_TOKEN/GH_TOKEN is enough for auth. */
+export function ghPassthroughScript(realGhPath: string): string {
+  return `#!/usr/bin/env bash
+# Env-token mode: exec the real gh binary. GitHub auth comes from
+# GITHUB_TOKEN/GH_TOKEN in the environment — no platform token exchange.
+exec ${JSON.stringify(realGhPath)} "$@"
+`;
+}

--- a/runners/remote-worker/src/lib/git_clone.test.ts
+++ b/runners/remote-worker/src/lib/git_clone.test.ts
@@ -102,6 +102,24 @@ test("buildCloneInvocation: --depth 1 when requested", () => {
   assert.match(cmd, /clone --depth 1 'https:\/\/github\.com\/acme\/org-skills\.git' '\/tmp\/skills'$/);
 });
 
+test("buildCloneInvocation: gh shell helper carries no AEP_BEARER_FILE", () => {
+  const helper = "!/usr/bin/gh auth git-credential";
+  const { cmd, env } = buildCloneInvocation({
+    repoUrl: "https://github.com/o/r.git",
+    destDir: "/tmp/dest",
+    helperPath: helper,
+    bearerFile: "",
+    baseEnv: { GITHUB_TOKEN: "ghs_test" },
+  });
+  assert.equal(
+    cmd,
+    `git -c credential.helper= -c 'credential.https://github.com.helper=${helper}' ` +
+      "clone 'https://github.com/o/r.git' '/tmp/dest'",
+  );
+  assert.equal(env.AEP_BEARER_FILE, undefined);
+  assert.equal(env.GITHUB_TOKEN, "ghs_test");
+});
+
 test("buildCloneInvocation: no helperPath configures no helper at all", () => {
   // So a genuinely missing credential surfaces as git's own error rather than as
   // a helper that answers with nothing.

--- a/runners/remote-worker/src/lib/git_clone.ts
+++ b/runners/remote-worker/src/lib/git_clone.ts
@@ -68,11 +68,19 @@ const CLONE_MAX_BUFFER = 16 * 1024 * 1024;
  * How a clone authenticates. Both fields empty means an unauthenticated origin
  * (file:// in tests), which configures no helper at all so a genuinely missing
  * credential surfaces as git's own error rather than an empty password.
+ *
+ * `helperPath` is either:
+ *   - an absolute path to the AEP credhelper script (reads AEP_BEARER_FILE), or
+ *   - a git `!` shell helper, e.g. `!/usr/bin/gh auth git-credential` when a
+ *     GITHUB_TOKEN/GH_TOKEN is mounted (see gh_git_auth.ts).
  */
 export interface CloneAuth {
-  /** Absolute path to the credential helper script (see credhelper.ts). */
+  /** Credential helper value for `credential.<scope>.helper`. */
   helperPath: string;
-  /** Absolute path to the platform bearer the helper exchanges for a token. */
+  /**
+   * Absolute path to the platform bearer the AEP helper exchanges for a token.
+   * Empty when using the gh shell helper (token comes from GITHUB_TOKEN/GH_TOKEN).
+   */
   bearerFile: string;
 }
 
@@ -137,11 +145,12 @@ export function buildCloneInvocation(
     ...(opts.baseEnv ?? process.env),
     GIT_TERMINAL_PROMPT: "0",
   };
-  // The helper reads the bearer from this path. It is a PATH, not a secret, and
-  // it is set on a per-child env object rather than process.env: runner.ts
+  // AEP credhelper reads the bearer from this path. It is a PATH, not a secret,
+  // and it is set on a per-child env object rather than process.env: runner.ts
   // spreads process.env into the agent's child env, and provisioning's staged
-  // bearer is gone by the time the agent starts.
-  if (authed && opts.bearerFile !== "") {
+  // bearer is gone by the time the agent starts. The gh shell helper does not
+  // use it — GITHUB_TOKEN/GH_TOKEN is already in the inherited env.
+  if (authed && opts.bearerFile !== "" && !opts.helperPath.startsWith("!")) {
     env.AEP_BEARER_FILE = opts.bearerFile;
   }
   return { cmd, env };

--- a/runners/remote-worker/src/lib/provision_e2e.test.ts
+++ b/runners/remote-worker/src/lib/provision_e2e.test.ts
@@ -34,7 +34,7 @@
 // neutered, a developer running this gets keychain prompts and git's post-success
 // `store` writes the test token into their real keychain.
 
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -50,6 +50,11 @@ const GH_TOKEN = "ghs_TESTONLYabcdefghijklmnopqrstuv01";
 const BEARER = "test-platform-bearer";
 const EXPECTED_BASIC = Buffer.from(`x-access-token:${GH_TOKEN}`).toString("base64");
 
+function restoreEnvVar(name: string, previous: string | undefined): void {
+  if (previous === undefined) delete process.env[name];
+  else process.env[name] = previous;
+}
+
 // Neuter host git config BEFORE anything imports or runs git. buildCloneInvocation
 // spreads process.env into the clone child, so setting it here covers that too.
 process.env.GIT_CONFIG_GLOBAL = "/dev/null";
@@ -58,9 +63,17 @@ process.env.GIT_CONFIG_NOSYSTEM = "1";
 process.env.GIT_TERMINAL_PROMPT = "0";
 // This suite exercises the AEP credhelper → refresh path. A developer machine
 // with GITHUB_TOKEN/GH_TOKEN set would take the gh-token provision branch and
-// skip the helper under test.
+// skip the helper under test. Capture both before deleting so suite cleanup
+// can restore the host environment.
+const suitePrevGithubToken = process.env.GITHUB_TOKEN;
+const suitePrevGhToken = process.env.GH_TOKEN;
 delete process.env.GITHUB_TOKEN;
 delete process.env.GH_TOKEN;
+
+after(() => {
+  restoreEnvVar("GITHUB_TOKEN", suitePrevGithubToken);
+  restoreEnvVar("GH_TOKEN", suitePrevGhToken);
+});
 
 // config.workspaceBasePath is captured at module load and defaults to the
 // developer's homedir, so it must be set before workspace.js is imported —
@@ -348,9 +361,11 @@ exit 1
     const stub = await startRefreshStub(TASK_ID);
 
     const prevPath = process.env.PATH;
-    const prevToken = process.env.GITHUB_TOKEN;
+    const prevGithubToken = process.env.GITHUB_TOKEN;
+    const prevGhToken = process.env.GH_TOKEN;
     process.env.PATH = `${binDir}:${prevPath ?? ""}`;
     process.env.GITHUB_TOKEN = GH_TOKEN;
+    delete process.env.GH_TOKEN;
 
     try {
       const layout = await provisionWorkspace({
@@ -402,8 +417,8 @@ exit 1
       assert.match(refs.stdout, /refs\/heads\/aep\/m1-c1/);
     } finally {
       process.env.PATH = prevPath;
-      if (prevToken === undefined) delete process.env.GITHUB_TOKEN;
-      else process.env.GITHUB_TOKEN = prevToken;
+      restoreEnvVar("GITHUB_TOKEN", prevGithubToken);
+      restoreEnvVar("GH_TOKEN", prevGhToken);
       await gitServer.close();
       await stub.close();
       await fs.promises.rm(root, { recursive: true, force: true });

--- a/runners/remote-worker/src/lib/provision_e2e.test.ts
+++ b/runners/remote-worker/src/lib/provision_e2e.test.ts
@@ -56,6 +56,11 @@ process.env.GIT_CONFIG_GLOBAL = "/dev/null";
 process.env.GIT_CONFIG_SYSTEM = "/dev/null";
 process.env.GIT_CONFIG_NOSYSTEM = "1";
 process.env.GIT_TERMINAL_PROMPT = "0";
+// This suite exercises the AEP credhelper → refresh path. A developer machine
+// with GITHUB_TOKEN/GH_TOKEN set would take the gh-token provision branch and
+// skip the helper under test.
+delete process.env.GITHUB_TOKEN;
+delete process.env.GH_TOKEN;
 
 // config.workspaceBasePath is captured at module load and defaults to the
 // developer's homedir, so it must be set before workspace.js is imported —
@@ -293,7 +298,115 @@ test(
       await gitServer.close();
       await stub.close();
       await fs.promises.rm(root, { recursive: true, force: true });
-      await fs.promises.rm(WORKSPACE_ROOT, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "provisioning e2e (GITHUB_TOKEN): clone and push use gh auth git-credential, not refresh",
+  {
+    skip: HAS_HTTP_BACKEND ? false : "git-http-backend not available",
+    timeout: 90_000,
+  },
+  async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-e2e-gh-"));
+    const binDir = path.join(root, "bin");
+    await fs.promises.mkdir(binDir, { recursive: true });
+    // Minimal `gh` that implements the credential-helper protocol git expects
+    // from `gh auth git-credential` — same shape setup-git installs.
+    await fs.promises.writeFile(
+      path.join(binDir, "gh"),
+      `#!/usr/bin/env bash
+set -e
+if [ "$1" = "auth" ] && [ "$2" = "git-credential" ]; then
+  cat >/dev/null || true
+  echo "username=x-access-token"
+  echo "password=\${GITHUB_TOKEN}"
+  exit 0
+fi
+echo "fake-gh: unexpected args: $*" >&2
+exit 1
+`,
+      { mode: 0o755 },
+    );
+
+    const serveRoot = path.join(root, "serve");
+    const origin = path.join(serveRoot, "store.git");
+    await fs.promises.mkdir(serveRoot, { recursive: true });
+    await execAsync(`git init --bare -q "${origin}"`);
+    await execAsync(`git -C "${origin}" symbolic-ref HEAD refs/heads/main`);
+    await execAsync(`git -C "${origin}" config http.receivepack true`);
+
+    const seed = path.join(root, "seed");
+    await execAsync(`git init -q "${seed}"`);
+    await fs.promises.writeFile(path.join(seed, "README.md"), "seed\n");
+    await execAsync(`git -C "${seed}" add .`);
+    await execAsync(`git -C "${seed}" -c user.name=T -c user.email=t@e.com commit -qm seed`);
+    await execAsync(`git -C "${seed}" push -q "${origin}" HEAD:refs/heads/main`);
+
+    const gitServer = await startGitServer(serveRoot);
+    const stub = await startRefreshStub(TASK_ID);
+
+    const prevPath = process.env.PATH;
+    const prevToken = process.env.GITHUB_TOKEN;
+    process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+    process.env.GITHUB_TOKEN = GH_TOKEN;
+
+    try {
+      const layout = await provisionWorkspace({
+        orgId: "default",
+        projectId: "store-gh",
+        taskId: TASK_ID,
+        repoUrl: `http://127.0.0.1:${gitServer.port}/store.git`,
+        bearer: BEARER,
+        identity: { name: "Token User", email: "u@e.com", login: "token-user" },
+        gitServiceUrl: `http://127.0.0.1:${gitServer.port}`,
+        refreshUrl: stub.url,
+        correlationId: "e2e-gh-1",
+      });
+
+      assert.ok(fs.existsSync(path.join(layout.workspace, "README.md")), "clone should check out");
+      assert.ok(gitServer.rejected() > 0, "origin must demand auth");
+      assert.equal(stub.calls(), 0, "credentials/refresh must not be called when GITHUB_TOKEN is set");
+      assert.ok(!fs.existsSync(layout.helperBin), "credhelper.sh must not be installed in gh-token mode");
+
+      const cfg = await fs.promises.readFile(path.join(layout.workspace, ".git", "config"), "utf-8");
+      assert.ok(cfg.includes("auth git-credential"), `durable helper must be gh:\n${cfg}`);
+      assert.ok(!cfg.includes("credhelper"), `must not wire AEP credhelper:\n${cfg}`);
+      assert.ok(!cfg.includes(GH_TOKEN), "no credential at rest in .git/config");
+
+      const wrapper = await fs.promises.readFile(layout.ghWrapper, "utf-8");
+      assert.match(wrapper, /Env-token mode/);
+      assert.ok(!wrapper.includes("credhelper.sh"), wrapper);
+
+      const agentEnv = {
+        PATH: `${layout.aepDir}:${binDir}:${prevPath ?? ""}`,
+        HOME: root,
+        GH_CONFIG_DIR: layout.ghConfigDir,
+        GITHUB_TOKEN: GH_TOKEN,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+      };
+      const g = (cmd: string) => execAsync(`git -C "${layout.workspace}" ${cmd}`, { env: agentEnv });
+
+      await g("checkout -q -b aep/m1-c1");
+      await fs.promises.writeFile(path.join(layout.workspace, "feature.txt"), "work\n");
+      await g("add feature.txt");
+      await g('commit -qm "feat: add feature (#1)"');
+      await g("push -q -u origin HEAD");
+
+      assert.equal(stub.calls(), 0, "push must not call credentials/refresh");
+      const refs = await execAsync(`git -C "${origin}" for-each-ref --format='%(refname)'`);
+      assert.match(refs.stdout, /refs\/heads\/aep\/m1-c1/);
+    } finally {
+      process.env.PATH = prevPath;
+      if (prevToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = prevToken;
+      await gitServer.close();
+      await stub.close();
+      await fs.promises.rm(root, { recursive: true, force: true });
     }
   },
 );

--- a/runners/remote-worker/src/lib/workspace.ts
+++ b/runners/remote-worker/src/lib/workspace.ts
@@ -22,28 +22,30 @@
 // the dataplane schedules an ephemeral pod whose entrypoint (src/oneshot.ts)
 // calls this function. We clone the project's repo on its **default
 // branch** into $WORKSPACE_BASE_PATH/<orgId>/<projectId>/<taskId>/ and
-// configure `.git/config` + `gh` so the agent can git/gh against GitHub
-// without ever seeing a token in environment variables. The agent itself
-// creates the feature branch and opens the PR with `Closes #<issueNumber>`
-// — see skills/aep/SKILL.md.
+// configure `.git/config` + `gh` so the agent can git/gh against GitHub.
+// The agent itself creates the feature branch and opens the PR with
+// `Closes #<issueNumber>` — see skills/aep/SKILL.md.
 //
-// The clone and every operation after it authenticate through the SAME
-// credential helper (lib/credhelper.ts): the clone gets it via `git -c`, since
-// `.git/config` does not exist yet, and step 2 installs it durably afterwards.
-// The runner process itself never holds a GitHub token.
+// Authentication — two modes, chosen by whether GITHUB_TOKEN/GH_TOKEN is set:
+//
+//   1. Env token (cloud Jobs mount a PAT as GITHUB_TOKEN): clone and every later
+//      git op use `gh auth git-credential` (same helper `gh auth setup-git`
+//      installs), pinned to the real `gh` binary. No credentials/refresh call.
+//   2. Otherwise: AEP credhelper (lib/credhelper.ts) exchanges AEP_BEARER for a
+//      GitHub token via credentials/refresh — used when no env token is mounted.
 //
 // Layout inside the workspace:
 //
 //   <workspace>/
 //     .git/                     ← cloned repo, default branch checked out
-//     .gh-config/hosts.yml      ← gh's auth config (rewritten by ghWrapper)
+//     .gh-config/hosts.yml      ← gh's auth config (refresh-wrapper mode only)
 //     .aep/
-//       bearer                  ← chmod 600 — per-task JWT
-//       credhelper.sh           ← chmod 700 — git credential helper
-//       gh                      ← chmod 755 — gh wrapper, on PATH
+//       bearer                  ← chmod 600 — per-task JWT (platform callbacks)
+//       credhelper.sh           ← chmod 700 — only in refresh mode
+//       gh                      ← chmod 755 — on PATH (passthrough or refresh wrap)
 //
 // The agent runs with cwd=<workspace> and PATH prefixed with <workspace>/.aep
-// so `gh ...` resolves to the wrapper. No tokens cross via process env.
+// so `gh ...` resolves to the wrapper.
 
 import fs from "node:fs";
 import { exec } from "node:child_process";
@@ -51,6 +53,12 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { config } from "../config.js";
 import { CREDHELPER_FILE, credHelperScript, ghWrapperScript } from "./credhelper.js";
+import {
+  envHasGitHubToken,
+  ghGitCredentialHelper,
+  ghPassthroughScript,
+  resolveRealGhPath,
+} from "./gh_git_auth.js";
 import { cloneCredentialScope, cloneWithHelper } from "./git_clone.js";
 import { shellQuote } from "./shell.js";
 
@@ -78,7 +86,7 @@ export interface ProvisionRequest {
   // `${platformUrl}/internal/v1/executions/{executionId}/credentials/refresh`
   // (accepts both publisher-cc and legacy Task-JWT; taskId carries the
   // execution id, §9.2). Falls back to a path-scoped URL built from
-  // gitServiceUrl below when unset.
+  // gitServiceUrl below when unset. Only used when GITHUB_TOKEN/GH_TOKEN is unset.
   refreshUrl?: string;
 }
 
@@ -112,19 +120,36 @@ function resolveRefreshUrl(req: ProvisionRequest): string {
   return url.toString();
 }
 
+async function installCommitIdentity(
+  workspace: string,
+  identity: ProvisionRequest["identity"],
+): Promise<void> {
+  await execAsync(`git -C ${shellQuote(workspace)} config user.name ${shellQuote(identity.name)}`);
+  await execAsync(`git -C ${shellQuote(workspace)} config user.email ${shellQuote(identity.email)}`);
+}
+
+async function installScopedCredentialHelper(workspace: string, scope: string, helper: string): Promise<void> {
+  // Empty value first: reset any helper list inherited from system/global.
+  // Git takes the FIRST helper that answers.
+  await execAsync(`git -C ${shellQuote(workspace)} config credential.helper ""`);
+  await execAsync(
+    `git -C ${shellQuote(workspace)} config ${shellQuote(`credential.${scope}.helper`)} ${shellQuote(helper)}`,
+  );
+}
+
 // provisionWorkspace clones the feature branch and writes credentials.
 // Idempotent: it removes any existing workspace first (§12.1 step 5
 // resume-safety: a crash mid-clone leaves DispatchedAt=null, the resume
 // sweep re-enters this step, which begins with rm -rf).
 //
 // Order matters: `git clone <url> <dir>` refuses to write into an existing
-// non-empty directory. So we stage the bearer AND the credential helper in a
-// sibling tmp dir, clone into the workspace path (which must not exist yet)
-// authenticating through that staged helper, and only then drop the .aep/ and
-// .gh-config/ directories inside the cloned tree.
+// non-empty directory. So we stage auth material in a sibling tmp dir, clone
+// into the workspace path (which must not exist yet), and only then drop the
+// .aep/ and .gh-config/ directories inside the cloned tree.
 export async function provisionWorkspace(req: ProvisionRequest): Promise<WorkspaceLayout> {
   const layout = computeLayout(req.orgId, req.projectId, req.taskId);
   const stageDir = layout.workspace + ".stage";
+  const useGhToken = envHasGitHubToken();
 
   // Wipe both the target and any prior stage. Don't pre-create the workspace
   // dir — git clone will materialise it.
@@ -133,81 +158,69 @@ export async function provisionWorkspace(req: ProvisionRequest): Promise<Workspa
   await fs.promises.mkdir(path.dirname(layout.workspace), { recursive: true, mode: 0o755 });
   await fs.promises.mkdir(stageDir, { recursive: true, mode: 0o700 });
 
-  // The helper body is generated ONCE and written twice, byte-identical: to the
-  // stage dir for the clone, and into the cloned tree for the agent. It reads
-  // the bearer from $AEP_BEARER_FILE, so only that path differs between the two
-  // phases — the script itself is never rewritten, which is what makes "one
-  // credential flow" literal rather than aspirational.
-  const helperBody = credHelperScript({
-    taskId: req.taskId,
-    workspaceDir: layout.workspace,
-    refreshUrl: resolveRefreshUrl(req),
-  });
-
-  // Stage the bearer and helper in the sibling dir: they have to live somewhere
-  // outside the not-yet-existing workspace, and are removed with it below.
-  const stageBearer = path.join(stageDir, "bearer");
-  const stageHelper = path.join(stageDir, CREDHELPER_FILE);
-  await fs.promises.writeFile(stageBearer, req.bearer, { mode: 0o600 });
-  await fs.promises.writeFile(stageHelper, helperBody, { mode: 0o700 });
+  const realGhPath = await resolveRealGhPath();
+  const ghHelper = ghGitCredentialHelper(realGhPath);
 
   try {
-    // Clone the PLAIN URL, authenticating through the staged helper (see
-    // git_clone.ts). No token is passed to git at all — the helper mints one
-    // itself — so nothing lands in argv, in the error message on failure, or in
-    // .git/config. The durable copy of the same helper is installed below and is
-    // what authenticates the agent's own later fetch/push.
-    //
     // No --branch: clone the remote's default branch (HEAD). The agent
     // creates its own feature branch via `git checkout -b ...` once it
     // starts working, per the aep skill workflow.
-    await cloneWithHelper({
-      repoUrl: req.repoUrl,
-      destDir: layout.workspace,
-      helperPath: stageHelper,
-      bearerFile: stageBearer,
-    });
+    if (useGhToken) {
+      // GITHUB_TOKEN/GH_TOKEN in the process env: authenticate via gh's
+      // credential helper (setup-git equivalent). Clone and later push share
+      // this path — credentials/refresh is never consulted for git.
+      await cloneWithHelper({
+        repoUrl: req.repoUrl,
+        destDir: layout.workspace,
+        helperPath: ghHelper,
+        bearerFile: "",
+      });
+    } else {
+      // AEP credhelper: stage bearer + helper outside the not-yet-existing
+      // workspace; clone through `git -c`; install the same helper durably below.
+      const helperBody = credHelperScript({
+        taskId: req.taskId,
+        workspaceDir: layout.workspace,
+        refreshUrl: resolveRefreshUrl(req),
+      });
+      const stageBearer = path.join(stageDir, "bearer");
+      const stageHelper = path.join(stageDir, CREDHELPER_FILE);
+      await fs.promises.writeFile(stageBearer, req.bearer, { mode: 0o600 });
+      await fs.promises.writeFile(stageHelper, helperBody, { mode: 0o700 });
+      await cloneWithHelper({
+        repoUrl: req.repoUrl,
+        destDir: layout.workspace,
+        helperPath: stageHelper,
+        bearerFile: stageBearer,
+      });
+      await fs.promises.mkdir(layout.aepDir, { recursive: true, mode: 0o755 });
+      await fs.promises.writeFile(layout.helperBin, helperBody, { mode: 0o700 });
+    }
 
     // Materialise the runtime layout inside the cloned tree.
     await fs.promises.mkdir(layout.aepDir, { recursive: true, mode: 0o755 });
     await fs.promises.mkdir(layout.ghConfigDir, { recursive: true, mode: 0o755 });
-    await fs.promises.writeFile(layout.bearerFile, req.bearer, { mode: 0o600 });
-    await fs.promises.writeFile(layout.helperBin, helperBody, { mode: 0o700 });
-
-    // gh wrapper (chmod 755). Resolve the real gh binary path eagerly so the
-    // wrapper doesn't have to. If gh is not on PATH we fall back to
-    // /usr/bin/env gh and let the wrapper fail at run time with a useful error.
-    let realGhPath = "gh";
-    try {
-      const which = await execAsync("which gh");
-      realGhPath = which.stdout.trim() || "gh";
-    } catch {
-      realGhPath = "/usr/bin/env gh";
+    if (req.bearer !== "") {
+      await fs.promises.writeFile(layout.bearerFile, req.bearer, { mode: 0o600 });
     }
-    await fs.promises.writeFile(layout.ghWrapper, ghWrapperScript(realGhPath), { mode: 0o755 });
 
-    // .git/config: commit identity + the durable credential helper. The scope is
-    // derived from the repo URL with the same function the clone used, so a
-    // self-hosted origin gets a helper that actually fires — hardcoding
-    // github.com here meant a GHE repo cloned fine and then failed every
-    // subsequent operation.
-    await execAsync(
-      `git -C ${shellQuote(layout.workspace)} config user.name ${shellQuote(req.identity.name)}`,
+    // gh on PATH: passthrough when env token auth is active; otherwise the
+    // refresh wrapper that rewrites hosts.yml from credhelper.
+    await fs.promises.writeFile(
+      layout.ghWrapper,
+      useGhToken ? ghPassthroughScript(realGhPath) : ghWrapperScript(realGhPath),
+      { mode: 0o755 },
     );
-    await execAsync(
-      `git -C ${shellQuote(layout.workspace)} config user.email ${shellQuote(req.identity.email)}`,
-    );
+
+    await installCommitIdentity(layout.workspace, req.identity);
+
     const scope = cloneCredentialScope(req.repoUrl);
     if (scope) {
-      // Empty value first: it resets any helper list inherited from system or
-      // global config. Git takes the FIRST helper that answers, so an inherited
-      // one would authenticate the agent's pushes as something else and would be
-      // handed our token by git's post-success `store`. Mirrors the `-c` pair the
-      // clone uses (git_clone.ts).
-      await execAsync(`git -C ${shellQuote(layout.workspace)} config credential.helper ""`);
-      await execAsync(
-        `git -C ${shellQuote(layout.workspace)} config ${shellQuote(`credential.${scope}.helper`)} ${shellQuote(layout.helperBin)}`,
-      );
+      if (useGhToken) {
+        await installScopedCredentialHelper(layout.workspace, scope, ghHelper);
+      } else {
+        await installScopedCredentialHelper(layout.workspace, scope, layout.helperBin);
+      }
     }
   } finally {
     await fs.promises.rm(stageDir, { recursive: true, force: true });


### PR DESCRIPTION
## What this fixes

Cloud coding-agent Jobs could talk to GitHub with `gh` (issues, PRs) but **`git push` failed** with:

```text
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The Job already had a working GitHub PAT in `GITHUB_TOKEN`. `gh` used that token; **`git` did not** — it called `credentials/refresh` with the Task JWT via the public gateway, which returns 401. This PR makes `git` use the same mounted token as `gh`.

Related: wso2-enterprise/lab-app-factory#104

## Why it broke

OC Job dispatch (local k3d **and** cloud) already mounts the org GitHub secret as `GITHUB_TOKEN`. That is the intended credential for the runner.

Git ignored it. Every clone/push went through an AEP credential helper → `POST …/credentials/refresh`. On cloud, that hop leaves the dataplane through the public gateway; the Task JWT is rejected (401). Symptom: Anthropic + `gh` work, first `git push` dies.

## What we change

**One auth path for OC Jobs:** if `GITHUB_TOKEN` or `GH_TOKEN` is set (always true for dispatched coding Jobs), install git's credential helper as `gh auth git-credential` — the same helper `gh auth setup-git` uses — pinned to the **real absolute `gh` binary** so the workspace `.aep/gh` wrapper cannot intercept. Clone and push never call `credentials/refresh`.

```mermaid
sequenceDiagram
  participant Dispatch as aep-api dispatch
  participant Job as coding-agent Job
  participant Git
  participant Gh as gh auth git-credential
  participant GH as github.com

  Dispatch->>Job: mount org PAT as GITHUB_TOKEN
  Note over Job: provisionWorkspace sees token → token mode
  Job->>Git: clone / push
  Git->>Gh: credential get
  Gh->>Job: read GITHUB_TOKEN
  Gh-->>Git: username + password
  Git->>GH: HTTPS auth
  GH-->>Git: 200
```

```mermaid
flowchart LR
  A[OC Job starts<br/>GITHUB_TOKEN mounted] --> B[Pin .git/config to<br/>!/abs/path/gh auth git-credential]
  B --> C[git clone / commit / push]
  C --> D[gh reads GITHUB_TOKEN]
  D --> E[GitHub ✅]
```

The AEP credhelper → `credentials/refresh` path remains in the binary only for runs **without** an env token (e.g. the offline `runners/remote-worker/local` harness). It is not the local-vs-cloud split — OC Jobs on both planes use the flow above.

## Stack

Sits **on top of #413** (coding agents as OpenChoreo Job Components). Stack #418:

```text
main
 └── #413  phase-08-coding-agent
  └── #417  this PR
```

## Rollout

1. Merge #413, then this PR.
2. Publish `ghcr.io/wso2/aep/remote-worker:0.6.0-rc5`.
3. Bump cloud `AGENT_RUNNER_IMAGE` — wso2-enterprise/wso2cloud-deployment#3409.

## Test plan

- [x] Unit tests: token detection, absolute `gh` path, helper wiring
- [x] Provision e2e: with `GITHUB_TOKEN` set, clone + push succeed and refresh is never called
- [ ] Merge after #413
- [ ] Release `0.6.0-rc5` and merge deploy pin #3409
- [ ] Cloud smoke: coding Job clones, commits, and pushes without the username prompt error