### PR TITLE
feat(aep-api): allow disabling the platform-resource type catalog

### DIFF
--- a/services/aep-api/.env.example
+++ b/services/aep-api/.env.example
@@ -19,6 +19,11 @@ TEST_MODE=false
 # deployments/docker-compose.yml sets this true.
 PLAYGROUND_TOKEN_ENABLED=false
 
+# Gates ClusterResourceType catalog discovery. Default true (core capability).
+# Set false when the deployment offers no platform-resource catalog — List
+# returns [] without calling OpenChoreo. Local ships unset (enabled).
+#PLATFORM_RESOURCES_ENABLED=true
+
 # Git host provider (clients/<provider> behind gitrepo's ports). Only "github"
 # is supported today; boot fails on any other value.
 GIT_PROVIDER=github

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -921,7 +921,7 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	}
 	params.Deps.Ops = opsHandlers
 	params.MCPOrgEndpoints = orgEndpointCatalog
-	resourceTypeCatalog := dependencies.NewResourceTypeCatalog(resourceClient)
+	resourceTypeCatalog := dependencies.NewResourceTypeCatalog(resourceClient, cfg.PlatformResourcesEnabled)
 	params.MCPResourceTypes = resourceTypeCatalog
 	// params.Deps.Dependencies (the strict ListPlatformResourceTypes + provisioning
 	// ops) is assembled below, after provisioningSvc exists.

--- a/services/aep-api/internal/config/config.go
+++ b/services/aep-api/internal/config/config.go
@@ -58,6 +58,15 @@ type Config struct {
 	// local dev. Read from PLAYGROUND_TOKEN_ENABLED.
 	PlaygroundTokenEnabled bool
 
+	// PlatformResourcesEnabled gates discovery of cluster-scoped platform
+	// resource types (ResourceTypeCatalog.List → OC ListClusterResourceTypes).
+	// Defaults TRUE: platform resources are a core capability; deployments that
+	// offer no platform-resource catalog must opt out explicitly
+	// (PLATFORM_RESOURCES_ENABLED=false). Unlike PlaygroundTokenEnabled /
+	// AutoMergeCodingPRs (opt-in extras that default false), this is an
+	// opt-out. Read from PLATFORM_RESOURCES_ENABLED.
+	PlatformResourcesEnabled bool
+
 	// AutoMergeCodingPRs gates auto-merge of coding-agent pull requests: when
 	// true, a coding-agent PR is squash-merged the moment it opens, removing the
 	// human review gate and letting the path-based build fan-out deploy the fix

--- a/services/aep-api/internal/config/config_loader.go
+++ b/services/aep-api/internal/config/config_loader.go
@@ -53,6 +53,8 @@ func Load() (Config, error) {
 		LocalOpenBaoRepairEnabled: r.readOptionalBool("LOCAL_OPENBAO_REPAIR", false),
 		DeploymentTier:            r.readOptionalString("DEPLOYMENT_TIER", "dev"),
 		PlaygroundTokenEnabled:    r.readOptionalBool("PLAYGROUND_TOKEN_ENABLED", false),
+		// Default true: core capability, opt-out (unlike other booleans here which are opt-in extras).
+		PlatformResourcesEnabled: r.readOptionalBool("PLATFORM_RESOURCES_ENABLED", true),
 		AutoMergeCodingPRs:        r.readOptionalBool("AUTO_MERGE_CODING_PRS", false),
 		TenantGateMode:            r.readOptionalString("TENANT_GATE_MODE", "enforce"),
 		OAuthStateSigningKey:      r.readOptionalString("OAUTH_STATE_SIGNING_KEY", ""),

--- a/services/aep-api/internal/dependencies/README.md
+++ b/services/aep-api/internal/dependencies/README.md
@@ -102,4 +102,9 @@ slices.
 - **The wire quirks the contract-first cutover pinned stay pinned**: wrong-kind → 400, not-found/
   not-registered → 404, in-use → 409, provision-failure → 502; get-dependency-status and list-access-requests
   return their empty-but-present shapes; a nil service 503s (the surface exists with the feature unwired).
+- **Platform-resource catalog may be disabled.** When `PLATFORM_RESOURCES_ENABLED=false`,
+  `ResourceTypeCatalog.List` returns an empty slice without calling OpenChoreo. HTTP
+  `GET .../platform-resource-types`, MCP `list_platform_resource_types`, and design-save
+  marker/wiring stamping all degrade off that empty catalog (no separate API signal).
+  Any future entry point that discovers platform resource types must honor the same flag.
 - Platform-wide rules (tenant gate, secrets fence, feature-free domains) → [../../README.md](../../README.md).

--- a/services/aep-api/internal/dependencies/platform_catalog.go
+++ b/services/aep-api/internal/dependencies/platform_catalog.go
@@ -50,18 +50,27 @@ type PlatformResourceType struct {
 
 // ResourceTypeCatalog lists installed cluster-scoped ClusterResourceTypes
 // (read-only). AEP NEVER authors these — it only discovers them (the cluster
-// PE installs them out-of-band).
-type ResourceTypeCatalog struct{ rc openchoreo.ResourceClient }
+// PE installs them out-of-band). When enabled is false, List returns an empty
+// slice without calling OpenChoreo (deployments with no platform-resource catalog).
+type ResourceTypeCatalog struct {
+	rc      openchoreo.ResourceClient
+	enabled bool
+}
 
 // NewResourceTypeCatalog wires the read-only discovery over the OC client.
-func NewResourceTypeCatalog(rc openchoreo.ResourceClient) *ResourceTypeCatalog {
-	return &ResourceTypeCatalog{rc: rc}
+// Pass enabled=false to disable catalog discovery (empty list, no OC call).
+func NewResourceTypeCatalog(rc openchoreo.ResourceClient, enabled bool) *ResourceTypeCatalog {
+	return &ResourceTypeCatalog{rc: rc, enabled: enabled}
 }
 
 // List returns the installed ClusterResourceTypes sorted by name, projecting
 // each to its architect-facing slice (name, description, parameter
-// properties, output names).
+// properties, output names). When the catalog is disabled, returns an empty
+// slice without calling OpenChoreo.
 func (c *ResourceTypeCatalog) List(ctx context.Context) ([]PlatformResourceType, error) {
+	if !c.enabled {
+		return []PlatformResourceType{}, nil
+	}
 	cts, err := c.rc.ListClusterResourceTypes(ctx)
 	if err != nil {
 		return nil, err

--- a/services/aep-api/internal/dependencies/platform_catalog_test.go
+++ b/services/aep-api/internal/dependencies/platform_catalog_test.go
@@ -46,7 +46,7 @@ func TestResourceTypeCatalog_List(t *testing.T) {
 		},
 	}
 
-	got, err := NewResourceTypeCatalog(rc).List(context.Background())
+	got, err := NewResourceTypeCatalog(rc, true).List(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestResourceTypeCatalog_ListError(t *testing.T) {
 			return nil, errors.New("OC down")
 		},
 	}
-	if _, err := NewResourceTypeCatalog(rc).List(context.Background()); err == nil {
+	if _, err := NewResourceTypeCatalog(rc, true).List(context.Background()); err == nil {
 		t.Fatal("want the client error surfaced")
 	}
 }
@@ -112,7 +112,7 @@ func TestResourceTypeCatalog_List_ProjectsMarkers(t *testing.T) {
 		},
 	}
 
-	got, err := NewResourceTypeCatalog(rc).List(context.Background())
+	got, err := NewResourceTypeCatalog(rc, true).List(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestResourceTypeCatalog_MarkersByName(t *testing.T) {
 		},
 	}
 
-	got, err := NewResourceTypeCatalog(rc).MarkersByName(context.Background())
+	got, err := NewResourceTypeCatalog(rc, true).MarkersByName(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,52 @@ func TestResourceTypeCatalog_MarkersByNameError(t *testing.T) {
 			return nil, errors.New("OC down")
 		},
 	}
-	if _, err := NewResourceTypeCatalog(rc).MarkersByName(context.Background()); err == nil {
+	if _, err := NewResourceTypeCatalog(rc, true).MarkersByName(context.Background()); err == nil {
 		t.Fatal("want the client error surfaced")
+	}
+}
+
+func TestResourceTypeCatalog_List_FlagOff_NoOCCall(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ListClusterResourceTypesFunc: func(_ context.Context) ([]openchoreo.ResourceType, error) {
+			t.Fatal("ListClusterResourceTypes must not be called when platform resources are disabled")
+			return nil, nil
+		},
+	}
+
+	got, err := NewResourceTypeCatalog(rc, false).List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty catalog when disabled, got %+v", got)
+	}
+	if n := len(rc.ListClusterResourceTypesCalls()); n != 0 {
+		t.Fatalf("want 0 OC calls, got %d", n)
+	}
+}
+
+func TestResourceTypeCatalog_List_FlagOn_Unchanged(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ListClusterResourceTypesFunc: func(_ context.Context) ([]openchoreo.ResourceType, error) {
+			return []openchoreo.ResourceType{
+				{Metadata: openchoreo.OCObjectMeta{Name: "postgres-cnpg"}},
+			}, nil
+		},
+	}
+
+	got, err := NewResourceTypeCatalog(rc, true).List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "postgres-cnpg" {
+		t.Fatalf("want postgres-cnpg, got %+v", got)
+	}
+	if n := len(rc.ListClusterResourceTypesCalls()); n != 1 {
+		t.Fatalf("want 1 OC call, got %d", n)
 	}
 }


### PR DESCRIPTION
## Summary

Some deployments do not install OpenChoreo **cluster resource types** (the catalog behind Settings → Resources and the MCP tool `list_platform_resource_types`). On those deployments, listing the catalog calls OpenChoreo and surfaces errors instead of a quiet empty state.

This PR adds an env flag so those deployments can turn catalog discovery off:

- **`PLATFORM_RESOURCES_ENABLED`** (default **`true`**)
- When **`false`**, `ResourceTypeCatalog.List` returns an empty list and **does not** call OpenChoreo.
- Existing consumers keep working with no API change: the HTTP list endpoint, the MCP tool, and design-save marker/wiring stamping all see an empty catalog and show the console’s normal empty state.

Default is `true` because platform resources are a core local/dev capability; only deployments without a catalog should set `false`.

**Unchanged:** external-dependency and org-service provisioning, OpenAPI contracts, and the console UI (no new screens or fields).

## Test plan

- [x] Unit tests: flag off → empty list and zero OpenChoreo calls; flag on → previous behavior
- [x] `make test`, `make lint`, `make typecheck`, `make license-check`, and `make -C services/aep-api deadcode-check`
- [x] Local with flag **unset** (enabled): cluster still has the three seeded types (`postgres`, `postgres-cnpg`, `thunder-app`)
- [x] Local with `PLATFORM_RESOURCES_ENABLED=false` (temporary, then removed):
  - MCP `list_platform_resource_types` returns `{"resourceTypes":[]}` with no error
  - Settings → Resources shows the plain “No platform resources” empty state (no error toast)
- [ ] Full external-dependency E2E on this workstation is blocked by a pre-existing OpenChoreo client-credentials failure (`invalid_client`), unrelated to this PR

## Proof

**Units**

```
ok  github.com/wso2/aep/aep-api/internal/dependencies  (TestResourceTypeCatalog_*)
ok  github.com/wso2/aep/aep-api/internal/config
```

**Flag disabled — MCP**

```json
{"resourceTypes":[]}
```

**Flag disabled — console**

Settings → Resources → Platform Resources: “No platform resources” / “No platform resource types are installed…” — no error toast.

**Flag enabled — cluster types present**

```
clusterresourcetype.openchoreo.dev/postgres
clusterresourcetype.openchoreo.dev/postgres-cnpg
clusterresourcetype.openchoreo.dev/thunder-app
```

**Repo gates:** `make test`, `make lint`, `make typecheck`, `make license-check`, `make -C services/aep-api deadcode-check` — pass.