### PR TITLE
fix(console): rejoin the collab room from scratch after a post-sync drop

### DIFF
--- a/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
+++ b/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+// A doc must never outlive the connection that filled it. The collab server
+// unloads a room on last-leave and reseeds a NEW Y.Doc from git HEAD on the
+// next join; markdown files are top-level Y.XmlFragments with no key to
+// converge on, so a reconnect carrying this doc's already-seeded fragments
+// merges them with the fresh seed's independent items and the file comes back
+// doubled. These tests pin the rejoin-from-scratch behavior that prevents it.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as Y from "yjs";
+import { useCollabSpec } from "./useCollabSpec";
+
+interface FakeConfig {
+  document: Y.Doc;
+  onSynced: () => void;
+  onStatus: (data: { status: string }) => void;
+}
+
+const instances: FakeConfig[] = [];
+
+vi.mock("@hocuspocus/provider", () => {
+  class FakeProvider {
+    document: Y.Doc;
+    awareness = { on: () => {}, off: () => {}, getStates: () => new Map() };
+    constructor(config: FakeConfig) {
+      this.document = config.document;
+      instances.push(config);
+    }
+    setAwarenessField() {}
+    on() {}
+    off() {}
+    attach() {}
+    destroy() {}
+    sendStateless() {}
+  }
+  return { HocuspocusProvider: FakeProvider };
+});
+
+vi.mock("../../../auth/token", () => ({
+  getAccessToken: vi.fn(async () => "token"),
+  renewAccessToken: vi.fn(async () => "token"),
+  subscribeAccessTokenRefresh: vi.fn(() => () => {}),
+}));
+
+const USER = { name: "Ada", email: "ada@example.com" };
+
+function renderCollab() {
+  return renderHook(() => useCollabSpec("proj1", USER, "acme"));
+}
+
+describe("useCollabSpec — rejoin from scratch after a post-sync drop", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("drops the synced doc and joins with a fresh one", async () => {
+    renderCollab();
+    expect(instances).toHaveLength(1);
+    const firstDoc = instances[0]!.document;
+
+    // Server state has landed — this doc now carries seeded fragments.
+    act(() => instances[0]!.onSynced());
+    // Websocket drops. The server unloads the room and will reseed from HEAD.
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(instances).toHaveLength(2);
+    expect(instances[1]!.document).not.toBe(firstDoc);
+  });
+
+  it("keeps the doc when the drop happens before the first sync", async () => {
+    renderCollab();
+    // Never synced: the doc is still empty, so it can carry nothing back into
+    // a reseeded room. The provider's own retry handles this case.
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(instances).toHaveLength(1);
+  });
+
+  it("rebuilds once per drop, not once per disconnect event", async () => {
+    renderCollab();
+    act(() => instances[0]!.onSynced());
+    act(() => {
+      instances[0]!.onStatus({ status: "disconnected" });
+      instances[0]!.onStatus({ status: "disconnected" });
+      instances[0]!.onStatus({ status: "disconnected" });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(instances).toHaveLength(2);
+  });
+
+  it("does not resurrect the room after unmount", async () => {
+    const { unmount } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(instances).toHaveLength(1);
+  });
+});

--- a/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
+++ b/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
@@ -34,17 +34,30 @@ interface FakeConfig {
   document: Y.Doc;
   onSynced: () => void;
   onStatus: (data: { status: string }) => void;
+  onAuthenticationFailed: (data: { reason: string }) => void;
 }
 
-const instances: FakeConfig[] = [];
+/** A recorded room: the hook's callbacks plus what it did to the provider. */
+interface FakeRoom extends FakeConfig {
+  disconnectCalls: number;
+}
+
+const instances: FakeRoom[] = [];
 
 vi.mock("@hocuspocus/provider", () => {
   class FakeProvider {
     document: Y.Doc;
+    room: FakeRoom;
     awareness = { on: () => {}, off: () => {}, getStates: () => new Map() };
     constructor(config: FakeConfig) {
       this.document = config.document;
-      instances.push(config);
+      this.room = { ...config, disconnectCalls: 0 };
+      instances.push(this.room);
+    }
+    // The real provider's websocket re-arms its own reconnect on close; the
+    // hook calls this to silence it before rebuilding.
+    disconnect() {
+      this.room.disconnectCalls += 1;
     }
     setAwarenessField() {}
     on() {}
@@ -133,5 +146,120 @@ describe("useCollabSpec — rejoin from scratch after a post-sync drop", () => {
     });
 
     expect(instances).toHaveLength(1);
+  });
+
+  // The old provider's websocket re-arms a reconnect from its own `onClose`,
+  // on the same 1s delay as the rebuild. If that socket reopens before React
+  // commits the teardown it carries the seeded fragments back into a reseeded
+  // room — the doubling this all exists to prevent. So the drop must silence
+  // the old provider immediately, not merely outrace it.
+  it("silences the old provider before the rebuild is even due", () => {
+    renderCollab();
+    act(() => instances[0]!.onSynced());
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+
+    expect(instances[0]!.disconnectCalls).toBe(1);
+    expect(instances).toHaveLength(1); // still only armed, not yet rebuilt
+  });
+});
+
+// A rejected bearer is the one drop a rebuild must not answer: the fresh
+// provider would present the same token and be rejected again. The server
+// closes the socket right after rejecting, so the rejection and the close
+// arrive in either order — both must end offline and stay there.
+describe("useCollabSpec — an authentication failure is terminal", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("cancels a rebuild the preceding drop already queued", async () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+    act(() => instances[0]!.onAuthenticationFailed({ reason: "expired" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(instances).toHaveLength(1);
+    expect(result.current.status).toBe("offline");
+  });
+
+  it("blocks a rebuild the following drop would have queued", async () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    act(() => instances[0]!.onAuthenticationFailed({ reason: "expired" }));
+    act(() => instances[0]!.onStatus({ status: "disconnected" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(instances).toHaveLength(1);
+    expect(result.current.status).toBe("offline");
+  });
+});
+
+// A rebuild costs the server a room load and a git seed. A pod that
+// accepts-then-drops must not be held at one of those per second, per tab.
+describe("useCollabSpec — rebuilds back off while drops keep coming", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  /** Sync the newest room, then drop it. */
+  const syncThenDrop = () => {
+    const room = instances[instances.length - 1]!;
+    act(() => room.onSynced());
+    act(() => room.onStatus({ status: "disconnected" }));
+  };
+
+  it("doubles the delay when a session drops again right after syncing", async () => {
+    renderCollab();
+    syncThenDrop();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(2);
+
+    // Second drop with no healthy session in between: 2s, not 1s.
+    syncThenDrop();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(3);
+  });
+
+  it("starts over after a session that held", async () => {
+    renderCollab();
+    syncThenDrop();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(2);
+
+    // This one stays synced past the reset window, so it was healthy: the
+    // next drop is back to the base delay instead of the doubled one.
+    act(() => instances[1]!.onSynced());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    act(() => instances[1]!.onStatus({ status: "disconnected" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(3);
   });
 });

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -89,6 +89,14 @@ const FLUSH_TIMEOUT_MS = 30_000;
 // there; this only stops a server that accepts-then-drops from spinning a
 // full resync per round-trip.
 const REBUILD_DELAY_MS = 1_000;
+// …and the ceiling once that delay doubles per consecutive rebuild. A rebuild
+// costs the SERVER a room load and a git seed, so a crash-looping collab pod
+// must not be held at one per second by every open tab.
+const REBUILD_MAX_DELAY_MS = 30_000;
+// A session that stayed synced this long was healthy, so the next drop starts
+// the backoff over. Without it, a server that syncs before each drop would
+// reset the count every round and never back off at all.
+const REBUILD_RESET_MS = 30_000;
 
 const PEER_COLORS = [
   "#e57373", "#64b5f6", "#81c784", "#ffb74d",
@@ -124,6 +132,10 @@ export function useCollabSpec(
   // needs a rebuild — see `scheduleRebuild`.
   const syncedRef = useRef(false);
   const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Consecutive rebuilds with no healthy session between them, and when the
+  // live one last synced — together they set the backoff (see `scheduleRebuild`).
+  const rebuildAttemptsRef = useRef(0);
+  const syncedAtRef = useRef(0);
   // Last-seen file-path set (serialized) so we re-render the list only when a
   // file is added/removed/created — not on every keystroke within a file.
   const pathKeyRef = useRef("");
@@ -158,13 +170,35 @@ export function useCollabSpec(
     // are lost, which is the same content the server already discarded when it
     // unloaded the room. Before the first sync the doc is still empty and can
     // carry nothing back, so the provider's own retry is left to do its job.
+    //
+    // A rejected bearer is the one drop this must NOT answer: the rebuild would
+    // present the same token and be rejected again, so `authFailed` latches for
+    // the life of this provider.
+    let authFailed = false;
     const scheduleRebuild = () => {
-      if (!syncedRef.current || rebuildTimerRef.current) return;
+      if (authFailed || !syncedRef.current || rebuildTimerRef.current) return;
       syncedRef.current = false;
-      rebuildTimerRef.current = setTimeout(() => {
-        rebuildTimerRef.current = null;
-        setEpoch((e) => e + 1);
-      }, REBUILD_DELAY_MS);
+      // Silence the OLD provider's own retry first. Its websocket re-arms a
+      // reconnect from `onClose` on the same 1s delay as ours, so a socket that
+      // reopens before React commits the teardown would carry this doc's
+      // already-seeded fragments into the room the server just reseeded — the
+      // exact doubling the rebuild exists to prevent. The doc is being thrown
+      // away regardless, so there is nothing to lose by closing it now.
+      provider.disconnect();
+      // Back off while drops keep coming, and start over once a session has
+      // held long enough to count as healthy.
+      const attempt =
+        Date.now() - syncedAtRef.current >= REBUILD_RESET_MS
+          ? 0
+          : rebuildAttemptsRef.current;
+      rebuildAttemptsRef.current = attempt + 1;
+      rebuildTimerRef.current = setTimeout(
+        () => {
+          rebuildTimerRef.current = null;
+          setEpoch((e) => e + 1);
+        },
+        Math.min(REBUILD_DELAY_MS * 2 ** attempt, REBUILD_MAX_DELAY_MS),
+      );
     };
 
     const provider = new HocuspocusProvider({
@@ -174,6 +208,7 @@ export function useCollabSpec(
       token: async () => (await getAccessToken()) ?? "",
       onSynced: () => {
         syncedRef.current = true;
+        syncedAtRef.current = Date.now();
         setStatus("connected");
       },
       onStatus: ({ status: s }) => {
@@ -182,8 +217,19 @@ export function useCollabSpec(
           scheduleRebuild();
         }
       },
-      // Terminal: a rejected bearer will be rejected again on a rebuild.
-      onAuthenticationFailed: () => setStatus("offline"),
+      // Terminal: a rejected bearer will be rejected again on a rebuild. The
+      // server closes the socket right after rejecting, and the provider emits
+      // the rejection and the close in either order, so this both latches the
+      // flag and cancels a bump the close already queued. The room stays
+      // offline until something else remounts the hook.
+      onAuthenticationFailed: () => {
+        authFailed = true;
+        if (rebuildTimerRef.current) {
+          clearTimeout(rebuildTimerRef.current);
+          rebuildTimerRef.current = null;
+        }
+        setStatus("offline");
+      },
     });
     providerRef.current = provider;
 

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -84,6 +84,12 @@ export interface CollabSpec {
 // git op before the build is blocked on a hung reply.
 const FLUSH_TIMEOUT_MS = 30_000;
 
+// Settle time before rebuilding the room after a post-sync drop (see
+// `scheduleRebuild`). The fresh provider retries on its own backoff from
+// there; this only stops a server that accepts-then-drops from spinning a
+// full resync per round-trip.
+const REBUILD_DELAY_MS = 1_000;
+
 const PEER_COLORS = [
   "#e57373", "#64b5f6", "#81c784", "#ffb74d",
   "#ba68c8", "#4dd0e1", "#f06292", "#aed581",
@@ -109,8 +115,15 @@ export function useCollabSpec(
   const [peers, setPeers] = useState<CollabPeer[]>([]);
   const [version, setVersion] = useState(0);
   const [flushError, setFlushError] = useState<string | null>(null);
+  // Bumped to rebuild the Y.Doc + provider after a post-sync drop; it is an
+  // effect dependency, so a bump tears the old room down and joins fresh.
+  const [epoch, setEpoch] = useState(0);
   const docRef = useRef<Y.Doc | null>(null);
   const providerRef = useRef<HocuspocusProvider | null>(null);
+  // True once this doc has taken server state. Only a drop AFTER that point
+  // needs a rebuild — see `scheduleRebuild`.
+  const syncedRef = useRef(false);
+  const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Last-seen file-path set (serialized) so we re-render the list only when a
   // file is added/removed/created — not on every keystroke within a file.
   const pathKeyRef = useRef("");
@@ -123,19 +136,53 @@ export function useCollabSpec(
   useEffect(() => {
     const doc = new Y.Doc();
     docRef.current = doc;
+    syncedRef.current = false;
+    pathKeyRef.current = "";
     setDocReady(true);
+    setStatus("connecting");
     // Stable across this effect — captured so the cleanup doesn't read a ref
     // that could have moved (react-hooks/exhaustive-deps).
     const flushes = pendingFlushes.current;
+
+    // A doc must never outlive the connection that filled it. The server
+    // treats git as the durable truth: it unloads a room on last-leave and
+    // RESEEDS a brand-new Y.Doc from HEAD on the next join. Markdown files are
+    // top-level Y.XmlFragments, which have no key to converge on — so a
+    // reconnect that carried this doc's already-seeded fragments back would
+    // merge them with the fresh seed's independent items and the file would
+    // come back DOUBLED (non-md files hide the bug: they are Y.Map entries,
+    // where a colliding key resolves last-writer-wins).
+    //
+    // So on a drop that happens after we synced, throw the doc away and rejoin
+    // from scratch — the server's copy is authoritative. Unsynced local edits
+    // are lost, which is the same content the server already discarded when it
+    // unloaded the room. Before the first sync the doc is still empty and can
+    // carry nothing back, so the provider's own retry is left to do its job.
+    const scheduleRebuild = () => {
+      if (!syncedRef.current || rebuildTimerRef.current) return;
+      syncedRef.current = false;
+      rebuildTimerRef.current = setTimeout(() => {
+        rebuildTimerRef.current = null;
+        setEpoch((e) => e + 1);
+      }, REBUILD_DELAY_MS);
+    };
+
     const provider = new HocuspocusProvider({
       url: collabWsUrl(),
       name: `spec-${orgHandle}-${projectName}`,
       document: doc,
       token: async () => (await getAccessToken()) ?? "",
-      onSynced: () => setStatus("connected"),
-      onStatus: ({ status: s }) => {
-        if (s === "disconnected") setStatus("offline");
+      onSynced: () => {
+        syncedRef.current = true;
+        setStatus("connected");
       },
+      onStatus: ({ status: s }) => {
+        if (s === "disconnected") {
+          setStatus("offline");
+          scheduleRebuild();
+        }
+      },
+      // Terminal: a rejected bearer will be rejected again on a rebuild.
       onAuthenticationFailed: () => setStatus("offline"),
     });
     providerRef.current = provider;
@@ -242,6 +289,13 @@ export function useCollabSpec(
 
     provider.attach();
     return () => {
+      // A rebuild already consumed its timer; this covers unmount and a
+      // project/org switch, where a pending bump must not resurrect the room.
+      if (rebuildTimerRef.current) {
+        clearTimeout(rebuildTimerRef.current);
+        rebuildTimerRef.current = null;
+      }
+      syncedRef.current = false;
       unsubscribeToken();
       doc.off("afterAllTransactions", onDocChange);
       awareness?.off("change", onAwareness);
@@ -255,7 +309,7 @@ export function useCollabSpec(
       docRef.current = null;
       providerRef.current = null;
     };
-  }, [projectName, user.name, user.email, orgHandle]);
+  }, [projectName, user.name, user.email, orgHandle, epoch]);
 
   return useMemo(
     () => ({
@@ -310,6 +364,9 @@ export function useCollabSpec(
           provider.sendStateless(JSON.stringify({ type: "flush", id }));
         }),
     }),
+    // A rebuild always moves `status` (offline → connecting → connected), so
+    // the refs are re-read and consumers holding a fragment from the discarded
+    // doc are handed the new one. No `epoch` dependency is needed for that.
     [status, peers, version, user.name, docReady, flushError],
   );
 }


### PR DESCRIPTION
## The bug

A markdown spec file comes back **doubled** after the collab websocket drops and reconnects.

The doc outlived the connection that filled it. The collab server treats git as the durable truth: it unloads a room on last-leave and reseeds a brand-new `Y.Doc` from HEAD on the next join. `useCollabSpec` built its `Y.Doc` once per project and kept it, so the provider's own reconnect carried the already-seeded doc back into a freshly reseeded room.

Markdown files are top-level `Y.XmlFragment`s — no key to converge on — so the two seedings merge as disjoint sets of inserts and the file's content appears twice. Non-md files hid the bug: they are `Y.Map` entries, where a colliding key resolves last-writer-wins.

## The fix

A drop that happens **after** we synced now throws the doc away and rejoins from scratch — the server's copy is authoritative.

- `epoch` is an effect dependency, so bumping it tears the old room down and joins with a fresh `Y.Doc` + provider.
- `syncedRef` gates it: before the first sync the doc is still empty and can carry nothing back, so the provider's own retry is left to do its job.
- A 1s settle window (`REBUILD_DELAY_MS`) plus the timer guard keeps a server that accepts-then-drops from spinning a full resync per round-trip.
- Cleanup clears a pending bump, so unmount or an org/project switch cannot resurrect the room.
- `onAuthenticationFailed` deliberately stays terminal — a rejected bearer will be rejected again on a rebuild.

The memoized return needs no `epoch` dependency: a rebuild always moves `status` (offline → connecting → connected), so consumers holding a fragment from the discarded doc are handed the new one.

**Known and accepted:** unsynced local edits are lost on a rebuild. That is the same content the server already discarded when it unloaded the room.

## Tests

`useCollabSpec.test.tsx` mocks `HocuspocusProvider` and records every constructed instance, pinning the four behaviors:

- a post-sync drop rebuilds with a *different* doc,
- a pre-sync drop does **not** rebuild,
- three disconnect events produce one rebuild,
- unmount cancels a pending rebuild.

## Proof of execution

New suite:

```
$ pnpm exec vitest run src/features/spec/collab/useCollabSpec.test.tsx
 ✓ useCollabSpec — rejoin from scratch after a post-sync drop (4)
   ✓ drops the synced doc and joins with a fresh one
   ✓ keeps the doc when the drop happens before the first sync
   ✓ rebuilds once per drop, not once per disconnect event
   ✓ does not resurrect the room after unmount

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Whole spec feature, on this branch rebased onto current `main`:

```
$ pnpm exec vitest run src/features/spec

 Test Files  18 passed (18)
      Tests  144 passed (144)
   Duration  12.55s
```

`eslint` is clean on both changed files.

### Unrelated, flagged not fixed

`pnpm exec tsc --noEmit` on `apps/console` currently fails on `main` as well, in `features/settings`, `features/validation`, `features/builds` and `src/mocks` — `codingLlm`, `credentialKind` and a `"revalidate"` run kind are missing from the generated contract types (looks like generated output is behind the API). Nothing in `features/spec/collab` is affected, and this PR neither causes nor addresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
