### PR TITLE
fix(aep-api): author SecretReferences in the Workload control-plane namespace

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -334,3 +334,11 @@ what keeps the two write paths from racing (only one writer to committed truth w
 a room is open).
 _Avoid_: dry-run, preview turn (a room-mode turn's edits are real, just landed by the
 committer rather than the turn).
+
+## Secrets
+
+**SecretReference**:
+An OpenChoreo CR that names a vault path for a secret. It lives in the same
+control-plane namespace as the Workload that consumes it. The vault path's
+`wc-…` segment (`OrgBaseNamespace`) is a storage key, not that namespace.
+_Avoid_: treating OrgBaseNamespace as the SecretReference CR namespace.

--- a/deployments/scripts/setup-aep.sh
+++ b/deployments/scripts/setup-aep.sh
@@ -892,13 +892,16 @@ EOF
 echo "✅ .env file generated at $(realpath "$ENV_FILE")"
 
 # ──────────────────────────────────────────────────────────────────────────
-# Local-only: pre-create the default org's base namespace `wc-<…>` that
-# SecretReference CRs land in during Connect (OpenBao-direct provider writes
-# KV; the high-level client authors the SecretReference into this NS).
+# Local-only: pre-create the default org's vault-path namespace `wc-<…>`
+# (`tenant.OrgBaseNamespace(ouId)`). Vault keys are
+# `user-app-secrets/<this-ns>/<secretRefName>`. OpenBao-direct SecretReference
+# CRs do *not* land here — they go in the OC org control-plane namespace
+# (`default`), same as Workload/ReleaseBinding. This Namespace object is
+# still created so leftover pre-fix CRs (and any other wc-… lookups) do not
+# fail with `namespaces wc-… not found`.
 #
 # On cloud, `ou-service` creates this NS at org-onboard time. Locally
-# there is no equivalent. Without this NS, Connect's secrets-delivery
-# path fails (`namespaces wc-… not found`).
+# there is no equivalent.
 #
 # Derives the NS deterministically from Thunder's ouId for the default
 # org (= `wc-<ouId8>-<sha256(ouId)[:8]>`), matching

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,9 +14,11 @@
 The OpenChoreo control-plane namespace minted **once per organization** when
 the org subscribes to a product. Created by wso2cloud's `ou` service
 (`backend/core/internal/ou/util/namespace.go::GenerateNamespaceName`) via the
-OC CP API. All OC CRs the platform authors for an org (Project, Component,
-Workload, ReleaseBinding, SecretReference) live here, on cluster
-`cloud-dp-oc-cp`.
+OC CP API. Project, Component, Workload, and ReleaseBinding CRs live here on
+cluster `cloud-dp-oc-cp`. Local OSS uses the OC org handle (`default`) as
+this CP namespace. The `wc-…` string is *also* the vault path segment
+(`OrgBaseNamespace`); that is not automatically the SecretReference CR
+namespace — see SecretReference.
 
 ### `org-env NS` (DP) — `wc-<orgUUID8>-<orgHash8>-<env>`
 The data-plane namespace minted **once per (org, env)** by wso2cloud's `ou`
@@ -60,10 +62,17 @@ handle).
 ## Secrets
 
 ### `SecretReference`
-An OpenChoreo CR (`openchoreo.dev/v1alpha1`) authored in the **org NS** (CP)
-that points at a KV path in the central secret backend. ESO materializes it
-into a K8s `Secret` in the consuming-plane NS. Only the reference (KV path)
-crosses plane boundaries; the value never does.
+An OpenChoreo CR (`openchoreo.dev/v1alpha1`) that points at a KV path in the
+central secret backend. It **must live in the same control-plane namespace
+as the Workload/ReleaseBinding that `secretKeyRef`s it** — OpenChoreo
+ReleaseBinding collect looks up the CR in `releaseBinding.Namespace`, not
+in the vault path. On local OSS that CP namespace is the OC org handle
+(`default`); on cloud it is the org NS. `OrgBaseNamespace` (`wc-…`) is
+only the vault path segment (`user-app-secrets/<wc-…>/<name>`). Do not
+author the CR into `wc-…` unless that is also the Workload's CP
+namespace. ESO materializes the reference into a K8s `Secret` in the
+consuming-plane NS. Only the reference (KV path) crosses plane boundaries;
+the value never does.
 
 ### `GitSecret`
 An OpenChoreo CR for build credentials, bound to `ClusterWorkflowPlane/default`
@@ -87,7 +96,9 @@ AEP selects one secrets provider per process (no fallback chain):
 - **Local / OSS:** in-process OpenBao-direct provider when `OPENBAO_ADDR` (and
   `OPENBAO_TOKEN`) are set. The provider writes KV only
   (`ManagesSecretReferences()=false`); the high-level client authors
-  `SecretReference` CRs via OpenChoreo. See `services/aep-api/design/composition-seam.md`.
+  `SecretReference` CRs via OpenChoreo into the Workload control-plane
+  namespace (not the vault `wc-…` segment). See
+  `services/aep-api/design/composition-seam.md`.
 
 ### `OpenBao`
 HashiCorp Vault fork. Local/OSS secret KV backend behind the

--- a/services/aep-api/design/composition-seam.md
+++ b/services/aep-api/design/composition-seam.md
@@ -49,7 +49,9 @@ One seam, two providers, no stub:
   provider when `OPENBAO_ADDR` (and `OPENBAO_TOKEN`) are set. The provider writes
   KV; the high-level client authors `SecretReference` CRs via OpenChoreo when
   `ManagesSecretReferences()` is false. Those CRs go in the Workload's
-  control-plane namespace (not the vault `wc-…` path segment).
+  control-plane namespace (not the vault `wc-…` path segment). Disconnect
+  also best-effort deletes a leftover CR of the same name from `wc-…`
+  (pre-fix authoring); NotFound is ignored.
 - **Overlay / cloud** — overlay `main` injects its own provider (sm-api HTTP
   client) through `Options.SecretsProvider`. That client lives outside the
   public module; OSS CI does not exercise it. Coverage is the overlay's unit

--- a/services/aep-api/design/composition-seam.md
+++ b/services/aep-api/design/composition-seam.md
@@ -48,7 +48,8 @@ One seam, two providers, no stub:
 - **OSS / local** — `NewOSSOptions` constructs the in-process OpenBao-direct
   provider when `OPENBAO_ADDR` (and `OPENBAO_TOKEN`) are set. The provider writes
   KV; the high-level client authors `SecretReference` CRs via OpenChoreo when
-  `ManagesSecretReferences()` is false.
+  `ManagesSecretReferences()` is false. Those CRs go in the Workload's
+  control-plane namespace (not the vault `wc-…` path segment).
 - **Overlay / cloud** — overlay `main` injects its own provider (sm-api HTTP
   client) through `Options.SecretsProvider`. That client lives outside the
   public module; OSS CI does not exercise it. Coverage is the overlay's unit

--- a/services/aep-api/internal/clients/openchoreo/secret_reference_client.go
+++ b/services/aep-api/internal/clients/openchoreo/secret_reference_client.go
@@ -44,8 +44,8 @@ func NewSecretReferenceClient(cfg Config) secretmanagersvc.OpenChoreoSecretRefer
 	return &secretReferenceClient{oc: oc}
 }
 
-func (c *secretReferenceClient) GetSecretReference(ctx context.Context, orgNS, name string) (*secretmanagersvc.SecretReference, error) {
-	resp, err := c.oc.GetSecretReferenceWithResponse(ctx, orgNS, name)
+func (c *secretReferenceClient) GetSecretReference(ctx context.Context, cpNS, name string) (*secretmanagersvc.SecretReference, error) {
+	resp, err := c.oc.GetSecretReferenceWithResponse(ctx, cpNS, name)
 	if err != nil {
 		return nil, fmt.Errorf("get secret reference: %w", err)
 	}
@@ -60,9 +60,9 @@ func (c *secretReferenceClient) GetSecretReference(ctx context.Context, orgNS, n
 	return secretReferenceToModel(resp.JSON200), nil
 }
 
-func (c *secretReferenceClient) CreateSecretReference(ctx context.Context, orgNS string, req secretmanagersvc.CreateSecretReferenceRequest) (*secretmanagersvc.SecretReference, error) {
+func (c *secretReferenceClient) CreateSecretReference(ctx context.Context, cpNS string, req secretmanagersvc.CreateSecretReferenceRequest) (*secretmanagersvc.SecretReference, error) {
 	body := buildSecretReferenceBody(req)
-	resp, err := c.oc.CreateSecretReferenceWithResponse(ctx, orgNS, body)
+	resp, err := c.oc.CreateSecretReferenceWithResponse(ctx, cpNS, body)
 	if err != nil {
 		return nil, fmt.Errorf("create secret reference: %w", err)
 	}
@@ -78,9 +78,9 @@ func (c *secretReferenceClient) CreateSecretReference(ctx context.Context, orgNS
 	return secretReferenceToModel(resp.JSON201), nil
 }
 
-func (c *secretReferenceClient) UpdateSecretReference(ctx context.Context, orgNS, name string, req secretmanagersvc.CreateSecretReferenceRequest) (*secretmanagersvc.SecretReference, error) {
+func (c *secretReferenceClient) UpdateSecretReference(ctx context.Context, cpNS, name string, req secretmanagersvc.CreateSecretReferenceRequest) (*secretmanagersvc.SecretReference, error) {
 	body := buildSecretReferenceBody(req)
-	resp, err := c.oc.UpdateSecretReferenceWithResponse(ctx, orgNS, name, body)
+	resp, err := c.oc.UpdateSecretReferenceWithResponse(ctx, cpNS, name, body)
 	if err != nil {
 		return nil, fmt.Errorf("update secret reference: %w", err)
 	}
@@ -96,8 +96,8 @@ func (c *secretReferenceClient) UpdateSecretReference(ctx context.Context, orgNS
 	return secretReferenceToModel(resp.JSON200), nil
 }
 
-func (c *secretReferenceClient) DeleteSecretReference(ctx context.Context, orgNS, name string) error {
-	resp, err := c.oc.DeleteSecretReferenceWithResponse(ctx, orgNS, name)
+func (c *secretReferenceClient) DeleteSecretReference(ctx context.Context, cpNS, name string) error {
+	resp, err := c.oc.DeleteSecretReferenceWithResponse(ctx, cpNS, name)
 	if err != nil {
 		return fmt.Errorf("delete secret reference: %w", err)
 	}

--- a/services/aep-api/internal/clients/secretmanagersvc/client.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client.go
@@ -210,7 +210,20 @@ func (c *secretManagementClient) upsertSecretReference(ctx context.Context, loca
 	return name, nil
 }
 
+func (c *secretManagementClient) requireOpenBaoDirectRefs(location SecretLocation) error {
+	if err := c.requireOCClient(); err != nil {
+		return err
+	}
+	_, err := secretReferenceCPNamespace(location)
+	return err
+}
+
 func (c *secretManagementClient) CreateSecret(ctx context.Context, location SecretLocation, data map[string]string) (string, error) {
+	if !c.managesRefs() {
+		if err := c.requireOpenBaoDirectRefs(location); err != nil {
+			return "", err
+		}
+	}
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return "", fmt.Errorf("marshal secret data: %w", err)
@@ -223,9 +236,6 @@ func (c *secretManagementClient) CreateSecret(ctx context.Context, location Secr
 	if c.managesRefs() {
 		return secretRef, nil
 	}
-	if err := c.requireOCClient(); err != nil {
-		return "", err
-	}
 	keys := make([]string, 0, len(data))
 	for k := range data {
 		keys = append(keys, k)
@@ -234,6 +244,11 @@ func (c *secretManagementClient) CreateSecret(ctx context.Context, location Secr
 }
 
 func (c *secretManagementClient) PatchSecret(ctx context.Context, location SecretLocation, data map[string]string, keysToDelete []string) (string, error) {
+	if !c.managesRefs() {
+		if err := c.requireOpenBaoDirectRefs(location); err != nil {
+			return "", err
+		}
+	}
 	patch := make(map[string]any, len(data)+len(keysToDelete))
 	for k, v := range data {
 		patch[k] = v
@@ -253,9 +268,6 @@ func (c *secretManagementClient) PatchSecret(ctx context.Context, location Secre
 	if c.managesRefs() {
 		return secretRef, nil
 	}
-	if err := c.requireOCClient(); err != nil {
-		return "", err
-	}
 	info, err := c.lowLevelClient.GetSecret(ctx, location)
 	if err != nil {
 		return "", fmt.Errorf("get secret keys after patch: %w", err)
@@ -264,14 +276,16 @@ func (c *secretManagementClient) PatchSecret(ctx context.Context, location Secre
 }
 
 func (c *secretManagementClient) DeleteSecret(ctx context.Context, location SecretLocation, secretRefName string) error {
+	if !c.managesRefs() {
+		if err := c.requireOpenBaoDirectRefs(location); err != nil {
+			return err
+		}
+	}
 	metadata := &SecretMetadata{ManagedBy: c.managedBy}
 	if err := c.lowLevelClient.DeleteSecret(ctx, location, metadata); err != nil {
 		return fmt.Errorf("delete secret: %w", err)
 	}
 	if !c.managesRefs() {
-		if err := c.requireOCClient(); err != nil {
-			return err
-		}
 		orgNS, nsErr := secretReferenceCPNamespace(location)
 		if nsErr != nil {
 			return nsErr

--- a/services/aep-api/internal/clients/secretmanagersvc/client.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client.go
@@ -37,8 +37,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/wso2/aep/aep-api/internal/platform/tenant"
+	"strings"
 )
 
 const (
@@ -162,10 +161,23 @@ func (c *secretManagementClient) requireOCClient() error {
 	return nil
 }
 
+// secretReferenceCPNamespace is the k8s namespace OpenChoreo ReleaseBinding
+// collect uses (Workload/ReleaseBinding ns). Vault paths stay on
+// tenant.OrgBaseNamespace(OrgName); mixing the two is the
+// startup_failed:no_pod_scheduled failure mode.
+func secretReferenceCPNamespace(location SecretLocation) (string, error) {
+	ns := strings.TrimSpace(location.ControlPlaneNamespace)
+	if ns == "" {
+		return "", fmt.Errorf("SecretLocation.ControlPlaneNamespace is required to author SecretReferences")
+	}
+	return ns, nil
+}
+
 func (c *secretManagementClient) upsertSecretReference(ctx context.Context, location SecretLocation, kvPath string, secretKeys []string) (string, error) {
-	// D-SR-namespace: OrgName is the org UUID; OC calls need the derived
-	// k8s base namespace (wc-<ouId8>-<sha256[:8]>), not the raw UUID.
-	orgNS := tenant.OrgBaseNamespace(location.OrgName)
+	orgNS, err := secretReferenceCPNamespace(location)
+	if err != nil {
+		return "", err
+	}
 	name := location.SecretRefName()
 	req := CreateSecretReferenceRequest{
 		Namespace:       orgNS,
@@ -260,7 +272,10 @@ func (c *secretManagementClient) DeleteSecret(ctx context.Context, location Secr
 		if err := c.requireOCClient(); err != nil {
 			return err
 		}
-		orgNS := tenant.OrgBaseNamespace(location.OrgName)
+		orgNS, nsErr := secretReferenceCPNamespace(location)
+		if nsErr != nil {
+			return nsErr
+		}
 		if err := c.ocClient.DeleteSecretReference(ctx, orgNS, secretRefName); err != nil {
 			if !errors.Is(err, ErrNotFound) {
 				return fmt.Errorf("delete SecretReference: %w", err)

--- a/services/aep-api/internal/clients/secretmanagersvc/client.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client.go
@@ -37,7 +37,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+
+	"github.com/wso2/aep/aep-api/internal/platform/tenant"
 )
 
 const (
@@ -53,23 +54,25 @@ const (
 )
 
 // ErrNotFound is returned by OpenChoreoSecretReferenceClient lookups when
-// no SecretReference exists for (orgNS, name). Distinct from
+// no SecretReference exists for (cpNS, name). Distinct from
 // ErrSecretNotFound (which is about the KV value itself).
 var ErrNotFound = errors.New("not found")
 
 // ErrConflict is returned by Create when a SecretReference with the same
-// (orgNS, name) already exists, signalling a race with another writer.
+// (cpNS, name) already exists, signalling a race with another writer.
 var ErrConflict = errors.New("conflict")
 
 // OpenChoreoSecretReferenceClient is the small slice of the OC client
 // that this package needs. It covers SecretReference CRUD only; the
 // GitSecret CRUD lives elsewhere. Implementations are expected to map
 // ErrNotFound / ErrConflict on the namespaced errors they return.
+// cpNS is the Workload/ReleaseBinding control-plane namespace, not the
+// vault OrgBaseNamespace.
 type OpenChoreoSecretReferenceClient interface {
-	GetSecretReference(ctx context.Context, orgNS, name string) (*SecretReference, error)
-	CreateSecretReference(ctx context.Context, orgNS string, req CreateSecretReferenceRequest) (*SecretReference, error)
-	UpdateSecretReference(ctx context.Context, orgNS, name string, req CreateSecretReferenceRequest) (*SecretReference, error)
-	DeleteSecretReference(ctx context.Context, orgNS, name string) error
+	GetSecretReference(ctx context.Context, cpNS, name string) (*SecretReference, error)
+	CreateSecretReference(ctx context.Context, cpNS string, req CreateSecretReferenceRequest) (*SecretReference, error)
+	UpdateSecretReference(ctx context.Context, cpNS, name string, req CreateSecretReferenceRequest) (*SecretReference, error)
+	DeleteSecretReference(ctx context.Context, cpNS, name string) error
 }
 
 // CreateSecretReferenceRequest mirrors the field set the cluster-gateway
@@ -161,26 +164,14 @@ func (c *secretManagementClient) requireOCClient() error {
 	return nil
 }
 
-// secretReferenceCPNamespace is the k8s namespace OpenChoreo ReleaseBinding
-// collect uses (Workload/ReleaseBinding ns). Vault paths stay on
-// tenant.OrgBaseNamespace(OrgName); mixing the two is the
-// startup_failed:no_pod_scheduled failure mode.
-func secretReferenceCPNamespace(location SecretLocation) (string, error) {
-	ns := strings.TrimSpace(location.ControlPlaneNamespace)
-	if ns == "" {
-		return "", fmt.Errorf("SecretLocation.ControlPlaneNamespace is required to author SecretReferences")
-	}
-	return ns, nil
-}
-
 func (c *secretManagementClient) upsertSecretReference(ctx context.Context, location SecretLocation, kvPath string, secretKeys []string) (string, error) {
-	orgNS, err := secretReferenceCPNamespace(location)
+	cpNS, err := location.CPNamespace()
 	if err != nil {
 		return "", err
 	}
 	name := location.SecretRefName()
 	req := CreateSecretReferenceRequest{
-		Namespace:       orgNS,
+		Namespace:       cpNS,
 		Name:            name,
 		ProjectName:     location.ProjectName,
 		ComponentName:   location.EntityName,
@@ -188,14 +179,14 @@ func (c *secretManagementClient) upsertSecretReference(ctx context.Context, loca
 		SecretKeys:      secretKeys,
 		RefreshInterval: c.refreshInterval,
 	}
-	_, getErr := c.ocClient.GetSecretReference(ctx, orgNS, name)
+	_, getErr := c.ocClient.GetSecretReference(ctx, cpNS, name)
 	if getErr != nil {
 		if !errors.Is(getErr, ErrNotFound) {
 			return "", fmt.Errorf("check SecretReference: %w", getErr)
 		}
-		if _, createErr := c.ocClient.CreateSecretReference(ctx, orgNS, req); createErr != nil {
+		if _, createErr := c.ocClient.CreateSecretReference(ctx, cpNS, req); createErr != nil {
 			if errors.Is(createErr, ErrConflict) {
-				if _, updateErr := c.ocClient.UpdateSecretReference(ctx, orgNS, name, req); updateErr != nil {
+				if _, updateErr := c.ocClient.UpdateSecretReference(ctx, cpNS, name, req); updateErr != nil {
 					return "", fmt.Errorf("update after create conflict: %w", updateErr)
 				}
 			} else {
@@ -203,7 +194,7 @@ func (c *secretManagementClient) upsertSecretReference(ctx context.Context, loca
 			}
 		}
 	} else {
-		if _, updateErr := c.ocClient.UpdateSecretReference(ctx, orgNS, name, req); updateErr != nil {
+		if _, updateErr := c.ocClient.UpdateSecretReference(ctx, cpNS, name, req); updateErr != nil {
 			return "", fmt.Errorf("update SecretReference: %w", updateErr)
 		}
 	}
@@ -214,7 +205,7 @@ func (c *secretManagementClient) requireOpenBaoDirectRefs(location SecretLocatio
 	if err := c.requireOCClient(); err != nil {
 		return err
 	}
-	_, err := secretReferenceCPNamespace(location)
+	_, err := location.CPNamespace()
 	return err
 }
 
@@ -286,15 +277,27 @@ func (c *secretManagementClient) DeleteSecret(ctx context.Context, location Secr
 		return fmt.Errorf("delete secret: %w", err)
 	}
 	if !c.managesRefs() {
-		orgNS, nsErr := secretReferenceCPNamespace(location)
-		if nsErr != nil {
-			return nsErr
+		cpNS, err := location.CPNamespace()
+		if err != nil {
+			return err
 		}
-		if err := c.ocClient.DeleteSecretReference(ctx, orgNS, secretRefName); err != nil {
-			if !errors.Is(err, ErrNotFound) {
-				return fmt.Errorf("delete SecretReference: %w", err)
+		if err := c.deleteSecretReference(ctx, cpNS, secretRefName); err != nil {
+			return fmt.Errorf("delete SecretReference: %w", err)
+		}
+		// Pre-fix OpenBao-direct authored CRs into OrgBaseNamespace.
+		// Best-effort sweep so disconnect does not leave an inert CR.
+		if oldNS := tenant.OrgBaseNamespace(location.OrgName); oldNS != "" && oldNS != cpNS {
+			if err := c.deleteSecretReference(ctx, oldNS, secretRefName); err != nil {
+				return fmt.Errorf("delete leftover SecretReference: %w", err)
 			}
 		}
+	}
+	return nil
+}
+
+func (c *secretManagementClient) deleteSecretReference(ctx context.Context, ns, name string) error {
+	if err := c.ocClient.DeleteSecretReference(ctx, ns, name); err != nil && !errors.Is(err, ErrNotFound) {
+		return err
 	}
 	return nil
 }

--- a/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
@@ -111,6 +111,15 @@ func testLocation() SecretLocation {
 	}
 }
 
+// testLocationWithCP is the OpenBao-direct authoring case: vault path is
+// derived from the org UUID, but the SecretReference CR must land in the
+// OC control-plane namespace (same ns as Workload/ReleaseBinding).
+func testLocationWithCP() SecretLocation {
+	loc := testLocation()
+	loc.ControlPlaneNamespace = "default"
+	return loc
+}
+
 func newClientForTest(t *testing.T, p Provider, oc OpenChoreoSecretReferenceClient) SecretManagementClient {
 	t.Helper()
 	c, err := NewSecretManagementClientWithConfig(SecretManagementClientConfig{
@@ -127,10 +136,11 @@ func newClientForTest(t *testing.T, p Provider, oc OpenChoreoSecretReferenceClie
 
 // ---- gating tests ----------------------------------------------------------
 
-func TestCreateSecret_ManagesRefsFalse_AuthorsSRWithOrgBaseNamespace(t *testing.T) {
-	loc := testLocation()
-	wantNS := tenant.OrgBaseNamespace(loc.OrgName)
-	vaultPath := "user-app-secrets/" + wantNS + "/" + loc.SecretRefName()
+func TestCreateSecret_ManagesRefsFalse_AuthorsSRInControlPlaneNamespace(t *testing.T) {
+	loc := testLocationWithCP()
+	vaultNS := tenant.OrgBaseNamespace(loc.OrgName)
+	wantCRNS := loc.ControlPlaneNamespace
+	vaultPath := "user-app-secrets/" + vaultNS + "/" + loc.SecretRefName()
 
 	oc := &recordingOCClient{getErr: ErrNotFound}
 	p := &stubProvider{
@@ -151,11 +161,14 @@ func TestCreateSecret_ManagesRefsFalse_AuthorsSRWithOrgBaseNamespace(t *testing.
 		t.Fatalf("expected 1 CreateSecretReference, got %d (gets=%d updates=%d)", len(oc.creates), len(oc.gets), len(oc.updates))
 	}
 	call := oc.creates[0]
-	if call.orgNS != wantNS {
-		t.Fatalf("Create orgNS = %q, want OrgBaseNamespace %q (not raw UUID)", call.orgNS, wantNS)
+	if call.orgNS != wantCRNS {
+		t.Fatalf("Create orgNS = %q, want control-plane ns %q", call.orgNS, wantCRNS)
 	}
-	if call.req.Namespace != wantNS {
-		t.Fatalf("req.Namespace = %q, want %q", call.req.Namespace, wantNS)
+	if call.req.Namespace != wantCRNS {
+		t.Fatalf("req.Namespace = %q, want %q", call.req.Namespace, wantCRNS)
+	}
+	if call.orgNS == vaultNS {
+		t.Fatalf("CR namespace %q must not be the vault OrgBaseNamespace", call.orgNS)
 	}
 	if call.req.KVPath != vaultPath {
 		t.Fatalf("req.KVPath = %q, want %q", call.req.KVPath, vaultPath)
@@ -168,7 +181,31 @@ func TestCreateSecret_ManagesRefsFalse_AuthorsSRWithOrgBaseNamespace(t *testing.
 	}
 	// Guard: never pass the raw UUID as the k8s namespace.
 	if strings.Contains(call.orgNS, "eeeeeeeeeeee") || call.orgNS == loc.OrgName {
-		t.Fatalf("orgNS must be OrgBaseNamespace, got raw-looking %q", call.orgNS)
+		t.Fatalf("orgNS must not be the raw org UUID, got %q", call.orgNS)
+	}
+}
+
+func TestCreateSecret_ManagesRefsFalse_RequiresControlPlaneNamespace(t *testing.T) {
+	loc := testLocation() // no ControlPlaneNamespace
+	vaultNS := tenant.OrgBaseNamespace(loc.OrgName)
+	vaultPath := "user-app-secrets/" + vaultNS + "/" + loc.SecretRefName()
+
+	oc := &recordingOCClient{getErr: ErrNotFound}
+	p := &stubProvider{
+		client:      &stubSecretsClient{pushPath: vaultPath},
+		managesRefs: false,
+	}
+	c := newClientForTest(t, p, oc)
+
+	_, err := c.CreateSecret(context.Background(), loc, map[string]string{"api-key": "sk-test"})
+	if err == nil {
+		t.Fatal("expected error when ControlPlaneNamespace is empty")
+	}
+	if !strings.Contains(err.Error(), "ControlPlaneNamespace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(oc.creates)+len(oc.updates) != 0 {
+		t.Fatalf("must not author a SecretReference without ControlPlaneNamespace; creates=%d updates=%d", len(oc.creates), len(oc.updates))
 	}
 }
 
@@ -214,9 +251,9 @@ func TestCreateSecret_ManagesRefsFalse_RequiresOCClient(t *testing.T) {
 }
 
 func TestPatchSecret_ManagesRefsFalse_AuthorsSR(t *testing.T) {
-	loc := testLocation()
-	wantNS := tenant.OrgBaseNamespace(loc.OrgName)
-	vaultPath := "user-app-secrets/" + wantNS + "/" + loc.SecretRefName()
+	loc := testLocationWithCP()
+	wantNS := loc.ControlPlaneNamespace
+	vaultPath := "user-app-secrets/" + tenant.OrgBaseNamespace(loc.OrgName) + "/" + loc.SecretRefName()
 
 	oc := &recordingOCClient{getErr: ErrNotFound}
 	p := &stubProvider{
@@ -261,9 +298,9 @@ func TestPatchSecret_ManagesRefsTrue_SkipsOC(t *testing.T) {
 	}
 }
 
-func TestDeleteSecret_ManagesRefsFalse_DeletesSRWithOrgBaseNamespace(t *testing.T) {
-	loc := testLocation()
-	wantNS := tenant.OrgBaseNamespace(loc.OrgName)
+func TestDeleteSecret_ManagesRefsFalse_DeletesSRInControlPlaneNamespace(t *testing.T) {
+	loc := testLocationWithCP()
+	wantNS := loc.ControlPlaneNamespace
 	refName := loc.SecretRefName()
 
 	oc := &recordingOCClient{}
@@ -317,9 +354,9 @@ func TestDeleteSecret_ManagesRefsFalse_RequiresOCClient(t *testing.T) {
 }
 
 func TestCreateSecret_ManagesRefsFalse_UpdateWhenExists(t *testing.T) {
-	loc := testLocation()
-	wantNS := tenant.OrgBaseNamespace(loc.OrgName)
-	vaultPath := "user-app-secrets/" + wantNS + "/" + loc.SecretRefName()
+	loc := testLocationWithCP()
+	wantNS := loc.ControlPlaneNamespace
+	vaultPath := "user-app-secrets/" + tenant.OrgBaseNamespace(loc.OrgName) + "/" + loc.SecretRefName()
 
 	oc := &recordingOCClient{} // get succeeds → update path
 	p := &stubProvider{

--- a/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
@@ -27,20 +27,26 @@ import (
 // ---- test doubles ----------------------------------------------------------
 
 type stubSecretsClient struct {
-	pushPath   string
-	patchPath  string
-	deleteErr  error
-	info       *SecretInfo
-	getInfoErr error
+	pushPath    string
+	patchPath   string
+	deleteErr   error
+	info        *SecretInfo
+	getInfoErr  error
+	pushCalls   int
+	patchCalls  int
+	deleteCalls int
 }
 
 func (s *stubSecretsClient) PushSecret(_ context.Context, _ SecretLocation, _ []byte, _ *SecretMetadata) (string, error) {
+	s.pushCalls++
 	return s.pushPath, nil
 }
 func (s *stubSecretsClient) PatchSecret(_ context.Context, _ SecretLocation, _ []byte, _ *SecretMetadata) (string, error) {
+	s.patchCalls++
 	return s.patchPath, nil
 }
 func (s *stubSecretsClient) DeleteSecret(_ context.Context, _ SecretLocation, _ *SecretMetadata) error {
+	s.deleteCalls++
 	return s.deleteErr
 }
 func (s *stubSecretsClient) GetSecret(_ context.Context, _ SecretLocation) (*SecretInfo, error) {
@@ -196,6 +202,7 @@ func TestCreateSecret_ManagesRefsFalse_RequiresControlPlaneNamespace(t *testing.
 		managesRefs: false,
 	}
 	c := newClientForTest(t, p, oc)
+	low := p.client.(*stubSecretsClient)
 
 	_, err := c.CreateSecret(context.Background(), loc, map[string]string{"api-key": "sk-test"})
 	if err == nil {
@@ -203,6 +210,9 @@ func TestCreateSecret_ManagesRefsFalse_RequiresControlPlaneNamespace(t *testing.
 	}
 	if !strings.Contains(err.Error(), "ControlPlaneNamespace") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if low.pushCalls != 0 {
+		t.Fatalf("must not PushSecret without ControlPlaneNamespace; pushes=%d", low.pushCalls)
 	}
 	if len(oc.creates)+len(oc.updates) != 0 {
 		t.Fatalf("must not author a SecretReference without ControlPlaneNamespace; creates=%d updates=%d", len(oc.creates), len(oc.updates))
@@ -295,6 +305,47 @@ func TestPatchSecret_ManagesRefsTrue_SkipsOC(t *testing.T) {
 	}
 	if len(oc.gets)+len(oc.creates)+len(oc.updates) != 0 {
 		t.Fatal("expected no OC calls")
+	}
+}
+
+func TestDeleteSecret_ManagesRefsFalse_RequiresControlPlaneNamespace(t *testing.T) {
+	loc := testLocation()
+	oc := &recordingOCClient{}
+	low := &stubSecretsClient{}
+	p := &stubProvider{client: low, managesRefs: false}
+	c := newClientForTest(t, p, oc)
+
+	err := c.DeleteSecret(context.Background(), loc, loc.SecretRefName())
+	if err == nil {
+		t.Fatal("expected error when ControlPlaneNamespace is empty")
+	}
+	if !strings.Contains(err.Error(), "ControlPlaneNamespace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if low.deleteCalls != 0 {
+		t.Fatalf("must not DeleteSecret without ControlPlaneNamespace; deletes=%d", low.deleteCalls)
+	}
+	if len(oc.deletes) != 0 {
+		t.Fatalf("must not delete SecretReference without ControlPlaneNamespace; oc.deletes=%d", len(oc.deletes))
+	}
+}
+
+func TestPatchSecret_ManagesRefsFalse_RequiresControlPlaneNamespace(t *testing.T) {
+	loc := testLocation()
+	oc := &recordingOCClient{getErr: ErrNotFound}
+	low := &stubSecretsClient{patchPath: "user-app-secrets/x/y"}
+	p := &stubProvider{client: low, managesRefs: false}
+	c := newClientForTest(t, p, oc)
+
+	_, err := c.PatchSecret(context.Background(), loc, map[string]string{"k": "v"}, nil)
+	if err == nil {
+		t.Fatal("expected error when ControlPlaneNamespace is empty")
+	}
+	if !strings.Contains(err.Error(), "ControlPlaneNamespace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if low.patchCalls != 0 {
+		t.Fatalf("must not PatchSecret without ControlPlaneNamespace; patches=%d", low.patchCalls)
 	}
 }
 

--- a/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client_manages_refs_test.go
@@ -85,28 +85,28 @@ type recordingOCClient struct {
 }
 
 type createCall struct {
-	orgNS string
-	req   CreateSecretReferenceRequest
+	cpNS string
+	req  CreateSecretReferenceRequest
 }
 
-func (r *recordingOCClient) GetSecretReference(_ context.Context, orgNS, name string) (*SecretReference, error) {
-	r.gets = append(r.gets, [2]string{orgNS, name})
+func (r *recordingOCClient) GetSecretReference(_ context.Context, cpNS, name string) (*SecretReference, error) {
+	r.gets = append(r.gets, [2]string{cpNS, name})
 	if r.getErr != nil {
 		return nil, r.getErr
 	}
-	return &SecretReference{Namespace: orgNS, Name: name}, nil
+	return &SecretReference{Namespace: cpNS, Name: name}, nil
 }
-func (r *recordingOCClient) CreateSecretReference(_ context.Context, orgNS string, req CreateSecretReferenceRequest) (*SecretReference, error) {
-	r.creates = append(r.creates, createCall{orgNS: orgNS, req: req})
-	return &SecretReference{Namespace: orgNS, Name: req.Name}, nil
+func (r *recordingOCClient) CreateSecretReference(_ context.Context, cpNS string, req CreateSecretReferenceRequest) (*SecretReference, error) {
+	r.creates = append(r.creates, createCall{cpNS: cpNS, req: req})
+	return &SecretReference{Namespace: cpNS, Name: req.Name}, nil
 }
-func (r *recordingOCClient) UpdateSecretReference(_ context.Context, orgNS, name string, req CreateSecretReferenceRequest) (*SecretReference, error) {
-	r.updates = append(r.updates, createCall{orgNS: orgNS, req: req})
+func (r *recordingOCClient) UpdateSecretReference(_ context.Context, cpNS, name string, req CreateSecretReferenceRequest) (*SecretReference, error) {
+	r.updates = append(r.updates, createCall{cpNS: cpNS, req: req})
 	_ = name
-	return &SecretReference{Namespace: orgNS, Name: req.Name}, nil
+	return &SecretReference{Namespace: cpNS, Name: req.Name}, nil
 }
-func (r *recordingOCClient) DeleteSecretReference(_ context.Context, orgNS, name string) error {
-	r.deletes = append(r.deletes, [2]string{orgNS, name})
+func (r *recordingOCClient) DeleteSecretReference(_ context.Context, cpNS, name string) error {
+	r.deletes = append(r.deletes, [2]string{cpNS, name})
 	return nil
 }
 
@@ -167,14 +167,14 @@ func TestCreateSecret_ManagesRefsFalse_AuthorsSRInControlPlaneNamespace(t *testi
 		t.Fatalf("expected 1 CreateSecretReference, got %d (gets=%d updates=%d)", len(oc.creates), len(oc.gets), len(oc.updates))
 	}
 	call := oc.creates[0]
-	if call.orgNS != wantCRNS {
-		t.Fatalf("Create orgNS = %q, want control-plane ns %q", call.orgNS, wantCRNS)
+	if call.cpNS != wantCRNS {
+		t.Fatalf("Create cpNS = %q, want control-plane ns %q", call.cpNS, wantCRNS)
 	}
 	if call.req.Namespace != wantCRNS {
 		t.Fatalf("req.Namespace = %q, want %q", call.req.Namespace, wantCRNS)
 	}
-	if call.orgNS == vaultNS {
-		t.Fatalf("CR namespace %q must not be the vault OrgBaseNamespace", call.orgNS)
+	if call.cpNS == vaultNS {
+		t.Fatalf("CR namespace %q must not be the vault OrgBaseNamespace", call.cpNS)
 	}
 	if call.req.KVPath != vaultPath {
 		t.Fatalf("req.KVPath = %q, want %q", call.req.KVPath, vaultPath)
@@ -186,8 +186,8 @@ func TestCreateSecret_ManagesRefsFalse_AuthorsSRInControlPlaneNamespace(t *testi
 		t.Fatalf("req.SecretKeys = %v", call.req.SecretKeys)
 	}
 	// Guard: never pass the raw UUID as the k8s namespace.
-	if strings.Contains(call.orgNS, "eeeeeeeeeeee") || call.orgNS == loc.OrgName {
-		t.Fatalf("orgNS must not be the raw org UUID, got %q", call.orgNS)
+	if strings.Contains(call.cpNS, "eeeeeeeeeeee") || call.cpNS == loc.OrgName {
+		t.Fatalf("cpNS must not be the raw org UUID, got %q", call.cpNS)
 	}
 }
 
@@ -286,8 +286,8 @@ func TestPatchSecret_ManagesRefsFalse_AuthorsSR(t *testing.T) {
 	if len(oc.creates) != 1 {
 		t.Fatalf("expected 1 create, got %d", len(oc.creates))
 	}
-	if oc.creates[0].orgNS != wantNS {
-		t.Fatalf("orgNS = %q, want %q", oc.creates[0].orgNS, wantNS)
+	if oc.creates[0].cpNS != wantNS {
+		t.Fatalf("cpNS = %q, want %q", oc.creates[0].cpNS, wantNS)
 	}
 }
 
@@ -364,11 +364,15 @@ func TestDeleteSecret_ManagesRefsFalse_DeletesSRInControlPlaneNamespace(t *testi
 	if err := c.DeleteSecret(context.Background(), loc, refName); err != nil {
 		t.Fatalf("DeleteSecret: %v", err)
 	}
-	if len(oc.deletes) != 1 {
-		t.Fatalf("expected 1 delete, got %d", len(oc.deletes))
+	oldNS := tenant.OrgBaseNamespace(loc.OrgName)
+	if len(oc.deletes) != 2 {
+		t.Fatalf("expected CP-ns + leftover OrgBaseNamespace deletes, got %d: %v", len(oc.deletes), oc.deletes)
 	}
 	if oc.deletes[0][0] != wantNS || oc.deletes[0][1] != refName {
-		t.Fatalf("delete call = %v, want [%s %s]", oc.deletes[0], wantNS, refName)
+		t.Fatalf("first delete = %v, want [%s %s]", oc.deletes[0], wantNS, refName)
+	}
+	if oc.deletes[1][0] != oldNS || oc.deletes[1][1] != refName {
+		t.Fatalf("leftover delete = %v, want [%s %s]", oc.deletes[1], oldNS, refName)
 	}
 }
 
@@ -423,8 +427,8 @@ func TestCreateSecret_ManagesRefsFalse_UpdateWhenExists(t *testing.T) {
 	if len(oc.updates) != 1 || len(oc.creates) != 0 {
 		t.Fatalf("expected update-only; creates=%d updates=%d", len(oc.creates), len(oc.updates))
 	}
-	if oc.updates[0].orgNS != wantNS {
-		t.Fatalf("update orgNS = %q, want %q", oc.updates[0].orgNS, wantNS)
+	if oc.updates[0].cpNS != wantNS {
+		t.Fatalf("update cpNS = %q, want %q", oc.updates[0].cpNS, wantNS)
 	}
 }
 

--- a/services/aep-api/internal/clients/secretmanagersvc/providers/openbao/client.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/providers/openbao/client.go
@@ -32,7 +32,7 @@ type Client struct {
 }
 
 // vaultPath builds user-app-secrets/{OrgBaseNamespace(orgUUID)}/{SecretRefName}.
-// location.OrgName is the org UUID today (D-SR-namespace).
+// location.OrgName is the org UUID (vault path only; CR namespace is ControlPlaneNamespace).
 func vaultPath(location secretsprovider.SecretLocation) string {
 	ns := tenant.OrgBaseNamespace(location.OrgName)
 	name := location.SecretRefName()

--- a/services/aep-api/internal/delivery/codingagent/design/oc-job-dispatch.md
+++ b/services/aep-api/internal/delivery/codingagent/design/oc-job-dispatch.md
@@ -17,7 +17,11 @@ The chain is **Component → Workload (per-cycle env + secret-env refs) →
 GenerateRelease → ReleaseBinding** on the project's `development` environment.
 OC renders the `batch/v1 Job` into the project's `dp-…` release namespace and
 materialises the cycle's ExternalSecrets from the org's secret store — the
-platform writes no secret material, only references.
+platform writes no secret material, only references. SecretReference CRs that
+a Workload `secretKeyRef`s must live in the same control-plane namespace as
+that Workload/ReleaseBinding (locally the OC org, e.g. `default`); the vault
+path stays `user-app-secrets/<org-base-ns>/<name>` and is a different
+namespace from the CR.
 
 ## The type is per-org, and it is the billing key
 

--- a/services/aep-api/internal/organization/secret_ref_writer.go
+++ b/services/aep-api/internal/organization/secret_ref_writer.go
@@ -106,7 +106,12 @@ func (w *SecretRefWriter) WriteAnthropic(ctx context.Context, ocOrgID string, ro
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: anthropic upload: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, role.SecretRefEntity(), secretmanagersvc.SecretKeyAPIKey, "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            role.SecretRefEntity(),
+		SecretKey:             secretmanagersvc.SecretKeyAPIKey,
+	}
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		secretmanagersvc.SecretKeyAPIKey: apiKey,
 	})
@@ -146,7 +151,12 @@ func (w *SecretRefWriter) WriteGitHubPAT(ctx context.Context, ocOrgID string, pa
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: github-pat upload: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, "github-pat", secretmanagersvc.SecretKeyAPIKey, "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            "github-pat",
+		SecretKey:             secretmanagersvc.SecretKeyAPIKey,
+	}
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		secretmanagersvc.SecretKeyAPIKey: pat,
 	})
@@ -191,7 +201,12 @@ func (w *SecretRefWriter) WriteExternalResourceSecret(ctx context.Context, ocOrg
 	if err != nil {
 		return "", "", fmt.Errorf("secret-ref writer: external-resource secret upload (%s): %w", entityName, err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, entityName, "", projectName)
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		ProjectName:           projectName,
+		EntityName:            entityName,
+	}
 	secretRefName, err = w.client.CreateSecret(ctx, loc, data)
 	if err != nil {
 		return "", "", fmt.Errorf("secret-ref writer: external-resource secret upload (%s): %w", entityName, err)
@@ -217,19 +232,6 @@ func orgUUIDForSecretLocation(ctx context.Context) (string, error) {
 		return "", errors.New("no ouId claim in JWT context")
 	}
 	return claims.OuId, nil
-}
-
-// secretLocation builds a SecretLocation whose vault path is keyed by
-// orgUUID and whose SecretReference CR lands in the OC control-plane
-// namespace (ocOrgID).
-func secretLocation(ocOrgID, orgUUID, entityName, secretKey, projectName string) secretmanagersvc.SecretLocation {
-	return secretmanagersvc.SecretLocation{
-		OrgName:               orgUUID,
-		ControlPlaneNamespace: ocOrgID,
-		ProjectName:           projectName,
-		EntityName:            entityName,
-		SecretKey:             secretKey,
-	}
 }
 
 // resolveVaultKey reconstructs the actual Vault KV key from the
@@ -271,7 +273,12 @@ func (w *SecretRefWriter) DeleteAnthropic(ctx context.Context, ocOrgID string, r
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete anthropic secret: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, role.SecretRefEntity(), secretmanagersvc.SecretKeyAPIKey, "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            role.SecretRefEntity(),
+		SecretKey:             secretmanagersvc.SecretKeyAPIKey,
+	}
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete anthropic secret: %w", err)
@@ -315,7 +322,11 @@ func (w *SecretRefWriter) WritePublisher(ctx context.Context, ocOrgID, clientID,
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: publisher upload: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, "publisher", "", "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            "publisher",
+	}
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		PublisherSecretFieldClientID:     clientID,
 		PublisherSecretFieldClientSecret: clientSecret,
@@ -356,7 +367,11 @@ func (w *SecretRefWriter) DeletePublisher(ctx context.Context, ocOrgID string) e
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete publisher secret: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, "publisher", "", "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            "publisher",
+	}
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete publisher secret: %w", err)
@@ -380,7 +395,12 @@ func (w *SecretRefWriter) DeleteGitHubPAT(ctx context.Context, ocOrgID string) e
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete github-pat secret: %w", err)
 	}
-	loc := secretLocation(ocOrgID, orgUUID, "github-pat", secretmanagersvc.SecretKeyAPIKey, "")
+	loc := secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		EntityName:            "github-pat",
+		SecretKey:             secretmanagersvc.SecretKeyAPIKey,
+	}
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete github-pat secret: %w", err)

--- a/services/aep-api/internal/organization/secret_ref_writer.go
+++ b/services/aep-api/internal/organization/secret_ref_writer.go
@@ -106,11 +106,7 @@ func (w *SecretRefWriter) WriteAnthropic(ctx context.Context, ocOrgID string, ro
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: anthropic upload: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: role.SecretRefEntity(),
-		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
-	}
+	loc := secretLocation(ocOrgID, orgUUID, role.SecretRefEntity(), secretmanagersvc.SecretKeyAPIKey, "")
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		secretmanagersvc.SecretKeyAPIKey: apiKey,
 	})
@@ -150,11 +146,7 @@ func (w *SecretRefWriter) WriteGitHubPAT(ctx context.Context, ocOrgID string, pa
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: github-pat upload: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: "github-pat",
-		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
-	}
+	loc := secretLocation(ocOrgID, orgUUID, "github-pat", secretmanagersvc.SecretKeyAPIKey, "")
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		secretmanagersvc.SecretKeyAPIKey: pat,
 	})
@@ -199,11 +191,7 @@ func (w *SecretRefWriter) WriteExternalResourceSecret(ctx context.Context, ocOrg
 	if err != nil {
 		return "", "", fmt.Errorf("secret-ref writer: external-resource secret upload (%s): %w", entityName, err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:     orgUUID,
-		ProjectName: projectName,
-		EntityName:  entityName,
-	}
+	loc := secretLocation(ocOrgID, orgUUID, entityName, "", projectName)
 	secretRefName, err = w.client.CreateSecret(ctx, loc, data)
 	if err != nil {
 		return "", "", fmt.Errorf("secret-ref writer: external-resource secret upload (%s): %w", entityName, err)
@@ -219,16 +207,29 @@ func (w *SecretRefWriter) WriteExternalResourceSecret(ctx context.Context, ocOrg
 }
 
 // orgUUIDForSecretLocation returns the Thunder ouId that must populate
-// SecretLocation.OrgName. OpenBao-direct and upsertSecretReference both
-// hash OrgName via tenant.OrgBaseNamespace; the OC org handle (ocOrgID,
-// e.g. "default") produces a different wc-* namespace than the ouId that
-// setup-aep.sh pre-creates and that resolveVaultKey stamps into the DB.
+// SecretLocation.OrgName. The vault KV path hashes OrgName via
+// tenant.OrgBaseNamespace; SecretReference CRs are authored into
+// ControlPlaneNamespace (the OC org handle, e.g. "default") so
+// ReleaseBinding collect can find them.
 func orgUUIDForSecretLocation(ctx context.Context) (string, error) {
 	claims := jwtassertion.GetTokenClaims(ctx)
 	if claims == nil || strings.TrimSpace(claims.OuId) == "" {
 		return "", errors.New("no ouId claim in JWT context")
 	}
 	return claims.OuId, nil
+}
+
+// secretLocation builds a SecretLocation whose vault path is keyed by
+// orgUUID and whose SecretReference CR lands in the OC control-plane
+// namespace (ocOrgID).
+func secretLocation(ocOrgID, orgUUID, entityName, secretKey, projectName string) secretmanagersvc.SecretLocation {
+	return secretmanagersvc.SecretLocation{
+		OrgName:               orgUUID,
+		ControlPlaneNamespace: ocOrgID,
+		ProjectName:           projectName,
+		EntityName:            entityName,
+		SecretKey:             secretKey,
+	}
 }
 
 // resolveVaultKey reconstructs the actual Vault KV key from the
@@ -270,11 +271,7 @@ func (w *SecretRefWriter) DeleteAnthropic(ctx context.Context, ocOrgID string, r
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete anthropic secret: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: role.SecretRefEntity(),
-		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
-	}
+	loc := secretLocation(ocOrgID, orgUUID, role.SecretRefEntity(), secretmanagersvc.SecretKeyAPIKey, "")
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete anthropic secret: %w", err)
@@ -318,10 +315,7 @@ func (w *SecretRefWriter) WritePublisher(ctx context.Context, ocOrgID, clientID,
 	if err != nil {
 		return "", fmt.Errorf("secret-ref writer: publisher upload: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: "publisher",
-	}
+	loc := secretLocation(ocOrgID, orgUUID, "publisher", "", "")
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
 		PublisherSecretFieldClientID:     clientID,
 		PublisherSecretFieldClientSecret: clientSecret,
@@ -362,10 +356,7 @@ func (w *SecretRefWriter) DeletePublisher(ctx context.Context, ocOrgID string) e
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete publisher secret: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: "publisher",
-	}
+	loc := secretLocation(ocOrgID, orgUUID, "publisher", "", "")
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete publisher secret: %w", err)
@@ -389,11 +380,7 @@ func (w *SecretRefWriter) DeleteGitHubPAT(ctx context.Context, ocOrgID string) e
 	if err != nil {
 		return fmt.Errorf("secret-ref writer: delete github-pat secret: %w", err)
 	}
-	loc := secretmanagersvc.SecretLocation{
-		OrgName:    orgUUID,
-		EntityName: "github-pat",
-		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
-	}
+	loc := secretLocation(ocOrgID, orgUUID, "github-pat", secretmanagersvc.SecretKeyAPIKey, "")
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
 	if err := w.client.DeleteSecret(ctx, loc, refName); err != nil {
 		return fmt.Errorf("secret-ref writer: delete github-pat secret: %w", err)

--- a/services/aep-api/internal/organization/secret_ref_writer_test.go
+++ b/services/aep-api/internal/organization/secret_ref_writer_test.go
@@ -173,7 +173,7 @@ func TestSecretRefWriter_WriteAnthropic(t *testing.T) {
 			t.Fatalf("want exactly 1 CreateSecret call, got %d", len(fake.createCalls))
 		}
 		call := fake.createCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "anthropic", SecretKey: secretmanagersvc.SecretKeyAPIKey}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "anthropic", SecretKey: secretmanagersvc.SecretKeyAPIKey}
 		if call.loc != wantLoc {
 			t.Fatalf("SecretLocation = %+v; want %+v", call.loc, wantLoc)
 		}
@@ -272,7 +272,7 @@ func TestSecretRefWriter_WriteExternalResourceSecret(t *testing.T) {
 			t.Fatalf("want exactly 1 CreateSecret call, got %d", len(fake.createCalls))
 		}
 		call := fake.createCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ProjectName: "weatherproj", EntityName: "extres-openweather-development"}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", ProjectName: "weatherproj", EntityName: "extres-openweather-development"}
 		if call.loc != wantLoc {
 			t.Fatalf("SecretLocation = %+v; want %+v", call.loc, wantLoc)
 		}
@@ -350,7 +350,7 @@ func TestSecretRefWriter_WriteGitHubPAT(t *testing.T) {
 			t.Fatalf("want exactly 1 CreateSecret call, got %d", len(fake.createCalls))
 		}
 		call := fake.createCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "github-pat", SecretKey: secretmanagersvc.SecretKeyAPIKey}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "github-pat", SecretKey: secretmanagersvc.SecretKeyAPIKey}
 		if call.loc != wantLoc {
 			t.Fatalf("SecretLocation = %+v; want %+v", call.loc, wantLoc)
 		}
@@ -425,7 +425,7 @@ func TestSecretRefWriter_WritePublisher(t *testing.T) {
 			t.Fatalf("want exactly 1 CreateSecret call, got %d", len(fake.createCalls))
 		}
 		call := fake.createCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "publisher"}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "publisher"}
 		if call.loc != wantLoc {
 			t.Fatalf("SecretLocation = %+v; want %+v", call.loc, wantLoc)
 		}
@@ -538,7 +538,7 @@ func TestSecretRefWriter_DeleteAnthropic_DB(t *testing.T) {
 			t.Fatalf("want 1 DeleteSecret call, got %d", len(fake.deleteCalls))
 		}
 		call := fake.deleteCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "anthropic", SecretKey: secretmanagersvc.SecretKeyAPIKey}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "anthropic", SecretKey: secretmanagersvc.SecretKeyAPIKey}
 		if call.loc != wantLoc || call.secretRefName != "acme-anthropic-secrets" {
 			t.Fatalf("DeleteSecret called with loc=%+v ref=%q; want loc=%+v ref=%q", call.loc, call.secretRefName, wantLoc, "acme-anthropic-secrets")
 		}
@@ -650,7 +650,7 @@ func TestSecretRefWriter_DeletePublisher_DB(t *testing.T) {
 		}
 		call := fake.deleteCalls[0]
 		// Publisher location has no SecretKey (whole record addressed).
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "publisher"}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "publisher"}
 		if call.loc != wantLoc || call.secretRefName != "acme-publisher-secrets" {
 			t.Fatalf("DeleteSecret called with loc=%+v ref=%q; want loc=%+v ref=%q", call.loc, call.secretRefName, wantLoc, "acme-publisher-secrets")
 		}
@@ -765,7 +765,7 @@ func TestSecretRefWriter_DeleteGitHubPAT_DB(t *testing.T) {
 			t.Fatalf("want 1 DeleteSecret call, got %d", len(fake.deleteCalls))
 		}
 		call := fake.deleteCalls[0]
-		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", EntityName: "github-pat", SecretKey: secretmanagersvc.SecretKeyAPIKey}
+		wantLoc := secretmanagersvc.SecretLocation{OrgName: "ou-acme-uuid", ControlPlaneNamespace: "acme", EntityName: "github-pat", SecretKey: secretmanagersvc.SecretKeyAPIKey}
 		if call.loc != wantLoc || call.secretRefName != "acme-github-pat-secrets" {
 			t.Fatalf("DeleteSecret called with loc=%+v ref=%q; want loc=%+v ref=%q", call.loc, call.secretRefName, wantLoc, "acme-github-pat-secrets")
 		}

--- a/services/aep-api/internal/platform/tenant/namespace.go
+++ b/services/aep-api/internal/platform/tenant/namespace.go
@@ -23,21 +23,21 @@ import (
 	"strings"
 )
 
-// OrgBaseNamespace returns the org's base namespace name matching
+// OrgBaseNamespace returns the vault path segment matching
 // wso2cloud's `ou.util.GenerateNamespaceName` (= the same shape
 // secret-manager-api derives server-side from the JWT's orgUUID claim):
 //
 //	wc-<first-8-chars-of-cleaned-uuid>-<8-char-sha256-hex>
 //
-// SM-API uses this as the namespace it writes SecretReference CRs into;
-// the BFF must compute the same value when reconstructing the Vault
-// path for ExternalSecret.spec.data[].remoteRef.key (Vault path shape:
-// `<vaultPathPrefix>/<orgNS>/<secretRefName>`). Deterministic — same
-// orgUUID always produces the same name.
+// Used only as the middle segment of
+// `<vaultPathPrefix>/<orgNS>/<secretRefName>` (ExternalSecret remoteRef.key).
+// It is not the OpenChoreo SecretReference CR namespace on the OpenBao-direct
+// path — those CRs must live in the Workload/ReleaseBinding control-plane
+// namespace (`SecretLocation.ControlPlaneNamespace`). Cloud SM-API overlay
+// may still author CRs into this name; OSS must not.
 //
 // Home rationale (§4.0/§6.10c): this `wc-` derivation is a pure, gorm-free
-// tenancy primitive consumed by the credentials domain (the SM-API
-// SecretReference writer and the OpenBao provider's vault-path builder). It
+// tenancy primitive consumed by the credentials domain (vault-path builders). It
 // lives here in platform/tenant so no feature has to import another for it —
 // the only genuine parallel implementation is the external cloud SM-API + the
 // local stub, reconciled by a byte-parity contract test (§8), not a shared

--- a/services/aep-api/secretsprovider/provider_test.go
+++ b/services/aep-api/secretsprovider/provider_test.go
@@ -69,6 +69,26 @@ func TestProviderInterfaces_CompileAssert(t *testing.T) {
 	var _ secretsprovider.SecretsClient = stubClient{}
 }
 
+func TestSecretLocation_CPNamespace(t *testing.T) {
+	loc := secretsprovider.SecretLocation{
+		OrgName:               "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		ControlPlaneNamespace: "default",
+		EntityName:            "anthropic",
+	}
+	got, err := loc.CPNamespace()
+	if err != nil {
+		t.Fatalf("CPNamespace: %v", err)
+	}
+	if got != "default" {
+		t.Fatalf("got %q, want default", got)
+	}
+
+	empty := secretsprovider.SecretLocation{OrgName: loc.OrgName, EntityName: loc.EntityName}
+	if _, err := empty.CPNamespace(); err == nil {
+		t.Fatal("expected error when ControlPlaneNamespace is empty")
+	}
+}
+
 func TestSecretLocation_KVPath(t *testing.T) {
 	loc := secretsprovider.SecretLocation{
 		OrgName:    "acme",

--- a/services/aep-api/secretsprovider/types.go
+++ b/services/aep-api/secretsprovider/types.go
@@ -133,6 +133,18 @@ func sanitizeSegment(s string) (string, error) {
 	return s, nil
 }
 
+// CPNamespace is the OpenChoreo control-plane namespace where a
+// SecretReference CR must be authored — the same namespace as the
+// Workload/ReleaseBinding that will secretKeyRef it. Distinct from
+// tenant.OrgBaseNamespace(OrgName), which is only the vault path segment.
+func (l SecretLocation) CPNamespace() (string, error) {
+	ns := strings.TrimSpace(l.ControlPlaneNamespace)
+	if ns == "" {
+		return "", fmt.Errorf("SecretLocation.ControlPlaneNamespace is required to author SecretReferences")
+	}
+	return ns, nil
+}
+
 // KVPath builds the KV-store path from non-empty segments.
 //
 // Shapes (each ends with EntityName, optionally suffixed by SecretKey):

--- a/services/aep-api/secretsprovider/types.go
+++ b/services/aep-api/secretsprovider/types.go
@@ -89,10 +89,19 @@ type OpenBaoAuth struct {
 // All segments are validated against `/` to prevent traversal +
 // path collisions.
 type SecretLocation struct {
-	// OrgName is the org UUID (ouId). The OpenChoreo org namespace is derived
-	// via tenant.OrgBaseNamespace at SecretReference authoring time — do not
-	// pass the derived `wc-…` namespace here. Required.
+	// OrgName is the org UUID (ouId). Used to derive the vault KV path
+	// via tenant.OrgBaseNamespace (`user-app-secrets/<wc-…>/<name>`).
+	// Do not pass the derived `wc-…` namespace here. Required.
 	OrgName string
+
+	// ControlPlaneNamespace is the OpenChoreo k8s namespace where the
+	// SecretReference CR must be authored — the same namespace as the
+	// Workload/ReleaseBinding that will secretKeyRef it (locally the OC
+	// org handle, e.g. "default"). Distinct from OrgBaseNamespace, which
+	// is only the vault path segment. Required when the OpenBao-direct
+	// path authors SecretReferences via the OC API; unused when the
+	// provider manages SecretReferences itself.
+	ControlPlaneNamespace string
 
 	// ProjectName is the OC Project handle. Optional — empty for
 	// org-scoped credentials (Anthropic platform key, App webhook


### PR DESCRIPTION
## Summary
- OpenChoreo ReleaseBinding collect looks up SecretReference CRs in the Workload/ReleaseBinding control-plane namespace. The OpenBao-direct path was authoring those CRs into the vault `wc-…` namespace instead, so coding-agent Jobs never rendered (`startup_failed:no_pod_scheduled`).
- Vault paths stay `user-app-secrets/<OrgBaseNamespace(ouId)>/<name>`. Only the CR namespace changes. Providers that manage SecretReferences themselves (SM-API overlay) are unchanged.
- Connect writers now pass the OC org handle as `ControlPlaneNamespace`.

## Test plan
- [x] `go test` `secretmanagersvc`, `organization`, `secretsprovider` (failing tests first: CR ns must equal control-plane ns and must not equal OrgBaseNamespace; empty ControlPlaneNamespace errors)
- [ ] Local rebuild of `aep-api`: after Connect/resync, `anthropic-secrets` and `github-pat-secrets` SecretReferences exist in the OC org namespace (same ns as the coding-agent Component), not only in `wc-…`
- [ ] Coding-agent dispatch: Job/pod schedules; per-run ExternalSecret SecretSynced in the project's `dp-…` namespace
- [ ] SM-API overlay path still skips OC SecretReference CRUD (`ManagesSecretReferences=true`)