### PR TITLE
fix(secret-seeding): route OC SecretReferences to the org namespace

### DIFF
--- a/services/aep-api/internal/clients/secretmanagersvc/client.go
+++ b/services/aep-api/internal/clients/secretmanagersvc/client.go
@@ -162,10 +162,20 @@ func (c *secretManagementClient) requireOCClient() error {
 	return nil
 }
 
+// ocOrgNS resolves the OC SecretReference API namespace for a location.
+// When OCOrgName is set (the OC org name, e.g. "default"), it is used directly.
+// Otherwise, falls back to deriving the wc-* namespace from OrgBaseNamespace —
+// this is the legacy path; OC's ReleaseBinding controller cannot find refs placed
+// there, so callers should always set OCOrgName.
+func ocOrgNS(location SecretLocation) string {
+	if location.OCOrgName != "" {
+		return location.OCOrgName
+	}
+	return tenant.OrgBaseNamespace(location.OrgName)
+}
+
 func (c *secretManagementClient) upsertSecretReference(ctx context.Context, location SecretLocation, kvPath string, secretKeys []string) (string, error) {
-	// D-SR-namespace: OrgName is the org UUID; OC calls need the derived
-	// k8s base namespace (wc-<ouId8>-<sha256[:8]>), not the raw UUID.
-	orgNS := tenant.OrgBaseNamespace(location.OrgName)
+	orgNS := ocOrgNS(location)
 	name := location.SecretRefName()
 	req := CreateSecretReferenceRequest{
 		Namespace:       orgNS,
@@ -260,8 +270,7 @@ func (c *secretManagementClient) DeleteSecret(ctx context.Context, location Secr
 		if err := c.requireOCClient(); err != nil {
 			return err
 		}
-		orgNS := tenant.OrgBaseNamespace(location.OrgName)
-		if err := c.ocClient.DeleteSecretReference(ctx, orgNS, secretRefName); err != nil {
+		if err := c.ocClient.DeleteSecretReference(ctx, ocOrgNS(location), secretRefName); err != nil {
 			if !errors.Is(err, ErrNotFound) {
 				return fmt.Errorf("delete SecretReference: %w", err)
 			}

--- a/services/aep-api/internal/organization/secret_ref_writer.go
+++ b/services/aep-api/internal/organization/secret_ref_writer.go
@@ -108,6 +108,7 @@ func (w *SecretRefWriter) WriteAnthropic(ctx context.Context, ocOrgID string, ro
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: role.SecretRefEntity(),
 		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
 	}
@@ -152,6 +153,7 @@ func (w *SecretRefWriter) WriteGitHubPAT(ctx context.Context, ocOrgID string, pa
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: "github-pat",
 		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
 	}
@@ -201,6 +203,7 @@ func (w *SecretRefWriter) WriteExternalResourceSecret(ctx context.Context, ocOrg
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:     orgUUID,
+		OCOrgName:   ocOrgID,
 		ProjectName: projectName,
 		EntityName:  entityName,
 	}
@@ -272,6 +275,7 @@ func (w *SecretRefWriter) DeleteAnthropic(ctx context.Context, ocOrgID string, r
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: role.SecretRefEntity(),
 		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
 	}
@@ -320,6 +324,7 @@ func (w *SecretRefWriter) WritePublisher(ctx context.Context, ocOrgID, clientID,
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: "publisher",
 	}
 	secretRefName, err := w.client.CreateSecret(ctx, loc, map[string]string{
@@ -364,6 +369,7 @@ func (w *SecretRefWriter) DeletePublisher(ctx context.Context, ocOrgID string) e
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: "publisher",
 	}
 	refName := derefPreferString(row.SecretRefName, row.SMAPISecretRefName)
@@ -391,6 +397,7 @@ func (w *SecretRefWriter) DeleteGitHubPAT(ctx context.Context, ocOrgID string) e
 	}
 	loc := secretmanagersvc.SecretLocation{
 		OrgName:    orgUUID,
+		OCOrgName:  ocOrgID,
 		EntityName: "github-pat",
 		SecretKey:  secretmanagersvc.SecretKeyAPIKey,
 	}

--- a/services/aep-api/secretsprovider/types.go
+++ b/services/aep-api/secretsprovider/types.go
@@ -89,10 +89,16 @@ type OpenBaoAuth struct {
 // All segments are validated against `/` to prevent traversal +
 // path collisions.
 type SecretLocation struct {
-	// OrgName is the org UUID (ouId). The OpenChoreo org namespace is derived
-	// via tenant.OrgBaseNamespace at SecretReference authoring time — do not
-	// pass the derived `wc-…` namespace here. Required.
+	// OrgName is the org UUID (ouId). Used as the KV path segment in OpenBao
+	// (via OrgBaseNamespace). Required.
 	OrgName string
+
+	// OCOrgName is the OC org name (e.g. "default") used as the namespaceName
+	// in OC SecretReference API calls. When set, it overrides the derived
+	// OrgBaseNamespace(OrgName) for OC placement. Required when the caller
+	// routes SecretReferences through OC — omitting it falls back to the
+	// derived wc-* namespace, which OC's ReleaseBinding controller cannot find.
+	OCOrgName string
 
 	// ProjectName is the OC Project handle. Optional — empty for
 	// org-scoped credentials (Anthropic platform key, App webhook


### PR DESCRIPTION
> **Stacks on #435** — this PR contains only the one fix commit on top of `rework-secret-seeding`. Until #435 merges the diff will appear large; after merge it will reduce to the single commit below.

## Summary

- **Root cause**: `OrgBaseNamespace(ouId)` derives a `wc-*` namespace that OC's ReleaseBinding controller cannot look up. Every `SecretReference` written during stage-inputs was placed in the wrong namespace, so stages failed with `external resources: write secret … create SecretReference: internal server error`.
- **Fix**: Add `OCOrgName string` to `SecretLocation` (the OC org name, e.g. `"default"`). A new `ocOrgNS()` helper in the secretmanagersvc client uses it for OC SecretReference API calls while still using `OrgBaseNamespace(OrgName)` for the OpenBao KV path. All seven `SecretLocation` initialisations in `secret_ref_writer.go` now pass `OCOrgName`.
- No behaviour change for callers that leave `OCOrgName` empty — they fall back to the old derived namespace (backward-compatible).

## Changed files

| File | What changed |
|---|---|
| `secretsprovider/types.go` | Added `OCOrgName` field with doc comment |
| `internal/clients/secretmanagersvc/client.go` | `ocOrgNS()` helper; `upsertSecretReference` + `DeleteSecret` use it |
| `internal/organization/secret_ref_writer.go` | All 7 `SecretLocation{}` literals pass `OCOrgName: ocOrgID` |

## Test plan

- [x] Clean platform install with `aepctl platform install`
- [x] Create org + set Anthropic key → `WriteAnthropic` succeeds, SecretReference appears in `default` namespace
- [x] Create project + set GitHub PAT → `WriteGitHubPAT` succeeds
- [x] Add external resource → stage-inputs completes without "write secret" error
- [x] End-to-end run reached builds-green (ceramics-api deployed 1/1 Running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)