### PR TITLE
fix(helm): default workspaces PVC to ReadWriteOnce

### DIFF
--- a/deployments/helm-charts/platform/templates/workspaces-pvc.yaml
+++ b/deployments/helm-charts/platform/templates/workspaces-pvc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: wso2-aep
 spec:
   accessModes:
-    - {{ .Values.workspaces.accessMode | default "ReadWriteMany" }}
+    - {{ .Values.workspaces.accessMode | default "ReadWriteOnce" }}
   {{- if .Values.workspaces.storageClassName }}
   storageClassName: {{ .Values.workspaces.storageClassName | quote }}
   {{- end }}


### PR DESCRIPTION
## Summary
- The workspaces PVC template defaulted to `ReadWriteMany` when `values.workspaces.accessMode` was omitted. `values.yaml` already sets `ReadWriteOnce`; the template fallback did not.
- Aligns the template default with the RWX-declined decision so a chart render cannot recreate an RWX volume by leaving the value unset.

## Test plan
- [ ] `grep -n ReadWriteMany deployments/helm-charts/platform/templates/workspaces-pvc.yaml` is empty
- [ ] `values.yaml` still has `accessMode: "ReadWriteOnce"`
- [ ] Local helm template of the platform chart still emits `ReadWriteOnce`