### PR TITLE
fix(agents,aep-api): turn journal — rehydrate shows what the user sent, not the composed prompt

### DIFF
--- a/packages/agent-stream/src/contracts/sse-events.ts
+++ b/packages/agent-stream/src/contracts/sse-events.ts
@@ -417,6 +417,18 @@ export const TURN_KINDS = ["chat", "flow", "start", "plan"] as const;
 
 export type TurnKind = (typeof TURN_KINDS)[number];
 
+/**
+ * A turn's display record (#463): the raw client-sent instruction and the
+ * acting user. `author` mirrors the console's live author shape
+ * (`{id: email, displayName}`) so a rehydrated row is attributable — and
+ * self-vs-teammate distinguishable — exactly like a live one; it is omitted
+ * for M2M callers with no human identity.
+ */
+export interface TurnJournal {
+  text: string;
+  author?: { id: string; displayName: string };
+}
+
 /** The milestone a plan turn is scoped to, and which of its stories already have Tasks. */
 export interface PlanScope {
   phase: number;
@@ -484,7 +496,7 @@ export interface TurnRequest {
    * callers, evals) → no journal entry; the read falls back to the raw stored
    * message for that turn.
    */
-  journal?: { text: string; author?: string };
+  journal?: TurnJournal;
   /**
    * Room-scoped turn (#86 phase 4): join this collab room as a live Yjs peer,
    * read files from the doc, apply ops to the doc, commit nothing. Omitted →

--- a/packages/agent-stream/src/contracts/sse-events.ts
+++ b/packages/agent-stream/src/contracts/sse-events.ts
@@ -477,6 +477,15 @@ export interface TurnRequest {
    */
   mcp?: McpConfig;
   /**
+   * The turn's display record (#463): the raw client-sent instruction (exactly
+   * what the sender's UI rendered as the user bubble) plus a best-effort acting
+   * user. Journaled beside the transcript and served for user rows on the
+   * get-conversation read — never woven into the model prompt. Omitted (older
+   * callers, evals) → no journal entry; the read falls back to the raw stored
+   * message for that turn.
+   */
+  journal?: { text: string; author?: string };
+  /**
    * Room-scoped turn (#86 phase 4): join this collab room as a live Yjs peer,
    * read files from the doc, apply ops to the doc, commit nothing. Omitted →
    * the committed-truth snapshot turn (byte-identical to today).

--- a/packages/agent-stream/src/index.ts
+++ b/packages/agent-stream/src/index.ts
@@ -51,6 +51,7 @@ export type {
   TurnKind,
   PlanScope,
   PlanContextFile,
+  TurnJournal,
   WorkspaceRef,
   McpConfig,
   CollabConfig,

--- a/playground/src/ports/conversation-store.ts
+++ b/playground/src/ports/conversation-store.ts
@@ -74,7 +74,9 @@ export class FileConversationStore implements ConversationStore {
     return {
       id: raw.id,
       messages: raw.messages,
-      turns: raw.turns ?? [],
+      // Nested dates need the same revival as the top-level ones — JSON hands
+      // back ISO strings where the type says Date.
+      turns: (raw.turns ?? []).map((t) => ({ ...t, createdAt: new Date(t.createdAt) })),
       // A persisted "active" is always stale here (see module doc).
       status: raw.status === "active" ? "done" : raw.status,
       createdAt: new Date(raw.createdAt),

--- a/playground/src/ports/conversation-store.ts
+++ b/playground/src/ports/conversation-store.ts
@@ -37,6 +37,8 @@ import type { Conversation, ConversationStore } from "@aep/agents/store/conversa
 interface StoredConversation {
   id: string;
   messages: Conversation["messages"];
+  /** Turn journal (#463); absent in files written before it existed. */
+  turns?: Conversation["turns"];
   status: Conversation["status"];
   createdAt: string;
   updatedAt: string;
@@ -72,6 +74,7 @@ export class FileConversationStore implements ConversationStore {
     return {
       id: raw.id,
       messages: raw.messages,
+      turns: raw.turns ?? [],
       // A persisted "active" is always stale here (see module doc).
       status: raw.status === "active" ? "done" : raw.status,
       createdAt: new Date(raw.createdAt),
@@ -84,6 +87,7 @@ export class FileConversationStore implements ConversationStore {
     const stored: StoredConversation = {
       id: c.id,
       messages: c.messages,
+      turns: c.turns,
       status: c.status,
       createdAt: c.createdAt.toISOString(),
       updatedAt: c.updatedAt.toISOString(),

--- a/services/aep-api/internal/clients/agentsvc/client.go
+++ b/services/aep-api/internal/clients/agentsvc/client.go
@@ -192,10 +192,19 @@ type MCPBlock struct {
 }
 
 // JournalBlock is a turn's display record (#463): what the client sent,
-// verbatim, and who sent it.
+// verbatim, and who sent it. Author mirrors the console's live author shape
+// ({id: email, displayName}) so a rehydrated row is attributable — and
+// self-vs-teammate distinguishable — exactly like a live one; nil for callers
+// with no human identity (M2M tokens journal no author, never a bare subject).
 type JournalBlock struct {
-	Text   string `json:"text"`
-	Author string `json:"author,omitempty"`
+	Text   string         `json:"text"`
+	Author *JournalAuthor `json:"author,omitempty"`
+}
+
+// JournalAuthor is the acting user in the console's author shape.
+type JournalAuthor struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
 }
 
 // UpstreamError is a non-2xx pre-stream response from the agents service. The

--- a/services/aep-api/internal/clients/agentsvc/client.go
+++ b/services/aep-api/internal/clients/agentsvc/client.go
@@ -154,6 +154,13 @@ type TurnRequest struct {
 	// FROM the doc, and applies ops to the doc — nothing is committed to git.
 	// Wire shape pinned by @aep/agent-stream's CollabConfig.
 	Collab *CollabBlock `json:"collab,omitempty"`
+	// Journal, when set, is the turn's display record (#463): the raw
+	// client-sent instruction (exactly what the sender's UI rendered as the
+	// user bubble) plus the acting user's best-effort display identity. The
+	// agents service stores it beside the transcript and serves it for user
+	// rows on the get-conversation read — the composed model prompt never
+	// reaches a browser. Wire shape pinned by @aep/agent-stream's TurnRequest.
+	Journal *JournalBlock `json:"journal,omitempty"`
 	// WebSearch, when true, has the agents service register Anthropic's
 	// provider-executed web_search tool for this turn (external-dependency-
 	// discovery #252) — it lets the model verify a candidate external API/SDK
@@ -182,6 +189,13 @@ type CollabBlock struct {
 type MCPBlock struct {
 	URL   string `json:"url"`
 	Token string `json:"token"`
+}
+
+// JournalBlock is a turn's display record (#463): what the client sent,
+// verbatim, and who sent it.
+type JournalBlock struct {
+	Text   string `json:"text"`
+	Author string `json:"author,omitempty"`
 }
 
 // UpstreamError is a non-2xx pre-stream response from the agents service. The

--- a/services/aep-api/internal/spec/genai_component_test.go
+++ b/services/aep-api/internal/spec/genai_component_test.go
@@ -709,6 +709,11 @@ func Test202Flow_PreviewOnlyAndStreamReplays(t *testing.T) {
 	if sent.req.Turn.Kind != agentsvc.TurnKindChat || sent.req.Turn.Text != "tidy the requirements" {
 		t.Errorf("turn = %+v, want the user's text as a chat turn", sent.req.Turn)
 	}
+	// The journal (#463) carries the raw client-sent text — what the sender's
+	// UI rendered as the user bubble — so rehydrate shows the same thing.
+	if sent.req.Journal == nil || sent.req.Journal.Text != "tidy the requirements" {
+		t.Errorf("journal = %+v, want the raw instruction", sent.req.Journal)
+	}
 
 	// Stream replay: every non-manifest part + terminal + [DONE], id-stamped.
 	events, done, code := r.streamEvents(t, turnID, "", nil)

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -384,9 +384,9 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 		turn:             turnSpec,
 		target:           in.Target,
 		summary:          in.Instruction,
-		// Captured before the detached goroutine: the display identity reads
-		// the request's bearer, and the journal (#463) attributes the turn.
-		author: displayIdentityFrom(ctx),
+		// Captured before the detached goroutine: the identity reads the
+		// request's bearer, and the journal (#463) attributes the turn.
+		author: journalAuthorFrom(ctx),
 		repoRef:          ref,
 		baseRef:          baseRef,
 		skillsRef:        skillsRef,

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -384,6 +384,9 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 		turn:             turnSpec,
 		target:           in.Target,
 		summary:          in.Instruction,
+		// Captured before the detached goroutine: the display identity reads
+		// the request's bearer, and the journal (#463) attributes the turn.
+		author: displayIdentityFrom(ctx),
 		repoRef:          ref,
 		baseRef:          baseRef,
 		skillsRef:        skillsRef,

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -65,7 +65,8 @@ type turnJob struct {
 	nsConversationID string            // namespaced agents-service id
 	turn             agentsvc.TurnSpec // what this turn is FOR (the agents service composes the text)
 	target           string            // spec-bundle path this turn should write to, when pinned
-	summary          string            // raw user instruction (feed line subject)
+	summary          string            // raw user instruction (feed line subject + journal display, #463)
+	author           string            // acting user's display identity (journal attribution; "" = unknown)
 	repoRef          sourcecontrol.RepoRef
 	baseRef          string
 	skillsRef        string
@@ -125,6 +126,20 @@ func (s *Service) runTurn(ctx context.Context, job turnJob) {
 // SAME condition. A plain chat turn with no room does not qualify.
 func designOrCollabTurn(job turnJob) bool {
 	return job.flow == "design" || job.collabRoomID != ""
+}
+
+// journalFor is the turn's display record (#463): the raw client-sent
+// instruction — exactly what the sender's UI rendered as the user bubble —
+// plus the acting user. The agents service stores it beside the transcript;
+// its get-conversation read serves it for user rows so the composed prompt
+// never reaches a browser. A blank instruction (never sent by real clients)
+// journals nothing rather than an empty bubble.
+func journalFor(job turnJob) *agentsvc.JournalBlock {
+	text := strings.TrimSpace(job.summary)
+	if text == "" {
+		return nil
+	}
+	return &agentsvc.JournalBlock{Text: text, Author: job.author}
 }
 
 // mcpForTurn mints the per-turn MCP discovery block for design-generation turns
@@ -193,6 +208,7 @@ func (s *Service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		MCP:                    s.mcpForTurn(ctx, job),
 		WebSearch:              designOrCollabTurn(job),
 		Collab:                 collab,
+		Journal:                journalFor(job),
 	})
 	if err != nil {
 		slog.WarnContext(ctx, "genai: turn dispatch failed", "turn", job.turnID, "error", err)

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -38,6 +38,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/agentsvc"
 	"github.com/wso2/aep/aep-api/internal/contracts"
 	"github.com/wso2/aep/aep-api/internal/platform/agentfold"
+	"github.com/wso2/aep/aep-api/internal/platform/auth"
 	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
 )
 
@@ -66,7 +67,10 @@ type turnJob struct {
 	turn             agentsvc.TurnSpec // what this turn is FOR (the agents service composes the text)
 	target           string            // spec-bundle path this turn should write to, when pinned
 	summary          string            // raw user instruction (feed line subject + journal display, #463)
-	author           string            // acting user's display identity (journal attribution; "" = unknown)
+	// author is the acting user for the journal (#463), nil when the bearer
+	// carries no human identity — an M2M token journals no author rather than
+	// a bare subject claim.
+	author *agentsvc.JournalAuthor
 	repoRef          sourcecontrol.RepoRef
 	baseRef          string
 	skillsRef        string
@@ -140,6 +144,26 @@ func journalFor(job turnJob) *agentsvc.JournalBlock {
 		return nil
 	}
 	return &agentsvc.JournalBlock{Text: text, Author: job.author}
+}
+
+// journalAuthorFrom projects the request bearer onto the journal's author
+// shape, EMAIL-ANCHORED to match the console's live author identity
+// ({id: email, displayName}) — that equality is what lets a rehydrated row
+// read as "you" vs a teammate. No email means no attributable human (an M2M
+// token, or a minimal user token): journal no author, never a bare subject.
+func journalAuthorFrom(ctx context.Context) *agentsvc.JournalAuthor {
+	token := auth.GetAuthToken(ctx)
+	if token == "" {
+		return nil
+	}
+	name, email := parseDisplayIdentity("Bearer " + token)
+	if email == "" {
+		return nil
+	}
+	if name == "" {
+		name = email
+	}
+	return &agentsvc.JournalAuthor{ID: email, DisplayName: name}
 }
 
 // mcpForTurn mints the per-turn MCP discovery block for design-generation turns

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -139,11 +139,13 @@ func designOrCollabTurn(job turnJob) bool {
 // never reaches a browser. A blank instruction (never sent by real clients)
 // journals nothing rather than an empty bubble.
 func journalFor(job turnJob) *agentsvc.JournalBlock {
-	text := strings.TrimSpace(job.summary)
-	if text == "" {
+	// Trimming detects a blank instruction only — the journal carries the
+	// instruction VERBATIM (that is its contract; the sender's UI rendered
+	// exactly these bytes).
+	if strings.TrimSpace(job.summary) == "" {
 		return nil
 	}
-	return &agentsvc.JournalBlock{Text: text, Author: job.author}
+	return &agentsvc.JournalBlock{Text: job.summary, Author: job.author}
 }
 
 // journalAuthorFrom projects the request bearer onto the journal's author

--- a/services/agents/AGENTS.md
+++ b/services/agents/AGENTS.md
@@ -91,6 +91,14 @@ off the stream. The plan tool contract (inputs, results, error codes, the
   `mcp: { url, token }` bundle on the turn (aep-api in production; the playground in
   local dev). Absent → no discovery tools (byte-identical to today); malformed → a
   clean pre-stream 400.
+- **Turn journal** (optional, #463): the caller pushes
+  `journal: { text, author?: { id, displayName } }` — the raw client-sent
+  instruction + acting user, stored beside the transcript (never woven into
+  the prompt). `GET /conversations/:id` serves a DISPLAY projection, not the
+  raw transcript: user rows carry the journal text + author (a journal-less
+  turn falls back to its raw stored message); assistant/tool rows pass through.
+  The read is org-fenced like the turn POST (`X-Org-Id` must match the id's
+  org segment). Absent → no entry; malformed → a clean pre-stream 400.
 
 ## Test
 

--- a/services/agents/src/conversation/display-history.ts
+++ b/services/agents/src/conversation/display-history.ts
@@ -24,29 +24,26 @@
  * turn journal's raw client-sent text + author; assistant/tool rows pass
  * through untouched (the UI projects their text and question tool-calls).
  *
- * Pairing is TAIL-ANCHORED: a turn appends exactly one user message and one
- * journal entry in the same save, but pre-journal turns appended messages with
- * no entry — so the LAST n user messages pair with the n entries, and earlier
- * user messages fall back to their raw stored content (a presence check, never
- * prompt-convention parsing).
+ * Pairing is BY STATED INDEX: each entry carries the `messages` index of the
+ * user message its turn appended, stamped at the append site — so a turn with
+ * no entry (pre-journal history, an older caller mid-rolling-deploy) falls
+ * back to its raw stored content WITHOUT shifting any other turn's pairing.
  */
 
 import type { ModelMessage } from "ai";
-import type { Conversation } from "../store/conversation-store.js";
+import type { Conversation, TurnJournalEntry } from "../store/conversation-store.js";
 
 /** A transcript message as served on the wire: user rows may carry an author. */
-export type DisplayMessage = ModelMessage | { role: "user"; content: string; author?: string };
+export type DisplayMessage =
+  | ModelMessage
+  | { role: "user"; content: string; author?: TurnJournalEntry["author"] };
 
 export function projectDisplayHistory(conv: Conversation): DisplayMessage[] {
-  const turns = conv.turns ?? [];
-  const userCount = conv.messages.filter((m) => m.role === "user").length;
-  let userIndex = 0;
-  return conv.messages.map((m): DisplayMessage => {
+  const byIndex = new Map<number, TurnJournalEntry>();
+  for (const entry of conv.turns ?? []) byIndex.set(entry.messageIndex, entry);
+  return conv.messages.map((m, index): DisplayMessage => {
     if (m.role !== "user") return m;
-    // The i-th user message from the END pairs with the i-th entry from the
-    // END; a negative index (pre-journal turn) reads as undefined → raw.
-    const entry = turns[turns.length - userCount + userIndex];
-    userIndex++;
+    const entry = byIndex.get(index);
     if (!entry) return m;
     return {
       role: "user",

--- a/services/agents/src/conversation/display-history.ts
+++ b/services/agents/src/conversation/display-history.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Display projection of a conversation (#463). The stored transcript's user
+ * messages are COMPOSED MODEL PROMPTS (eager skill bodies + inlined files +
+ * framing) — correct as the model's memory, wrong as a chat bubble. The
+ * get-conversation read serves this projection instead: user rows carry the
+ * turn journal's raw client-sent text + author; assistant/tool rows pass
+ * through untouched (the UI projects their text and question tool-calls).
+ *
+ * Pairing is TAIL-ANCHORED: a turn appends exactly one user message and one
+ * journal entry in the same save, but pre-journal turns appended messages with
+ * no entry — so the LAST n user messages pair with the n entries, and earlier
+ * user messages fall back to their raw stored content (a presence check, never
+ * prompt-convention parsing).
+ */
+
+import type { ModelMessage } from "ai";
+import type { Conversation } from "../store/conversation-store.js";
+
+/** A transcript message as served on the wire: user rows may carry an author. */
+export type DisplayMessage = ModelMessage | { role: "user"; content: string; author?: string };
+
+export function projectDisplayHistory(conv: Conversation): DisplayMessage[] {
+  const turns = conv.turns ?? [];
+  const userCount = conv.messages.filter((m) => m.role === "user").length;
+  let userIndex = 0;
+  return conv.messages.map((m): DisplayMessage => {
+    if (m.role !== "user") return m;
+    // The i-th user message from the END pairs with the i-th entry from the
+    // END; a negative index (pre-journal turn) reads as undefined → raw.
+    const entry = turns[turns.length - userCount + userIndex];
+    userIndex++;
+    if (!entry) return m;
+    return {
+      role: "user",
+      content: entry.text,
+      ...(entry.author ? { author: entry.author } : {}),
+    };
+  });
+}

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -57,7 +57,7 @@ import {
 } from "../shared/model.js";
 import { loadMcpTools } from "../shared/mcp-client.js";
 import { turnTelemetry } from "../shared/telemetry.js";
-import type { Conversation, ConversationStore } from "../store/conversation-store.js";
+import type { Conversation, ConversationStore, TurnJournalEntry } from "../store/conversation-store.js";
 
 /** Thrown when a second turn starts for an id whose turn is still in flight (→ HTTP 409). */
 export class ConcurrentTurnError extends Error {
@@ -181,7 +181,7 @@ export interface RunConversationTurnInput {
    * the display source the get-conversation read serves for user rows. Absent
    * (older callers, evals) → no entry; the read falls back to the raw message.
    */
-  journal?: { kind: string; text: string; author?: string; turnId: string };
+  journal?: Omit<TurnJournalEntry, "messageIndex" | "createdAt">;
   store: ConversationStore;
   guard: TurnGuard;
   onEvent: (p: StreamPart) => void;
@@ -326,11 +326,13 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
     }
 
     // 7. persist the whole aggregate (history is append-only). The journal
-    //    entry (#463) commits in the same save as the transcript it describes:
-    //    a failed turn persists neither, so the nth-user-message ↔ nth-entry
-    //    pairing the read path relies on can never drift.
+    //    entry (#463) commits in the same save as the transcript it describes,
+    //    stamped with the INDEX of the user message this turn appended
+    //    (startLen — runTurn appends the prompt first): the display read pairs
+    //    entry↔message by that stated fact, so an un-journaled turn anywhere
+    //    in the history can never shift another turn's pairing.
     if (input.journal) {
-      conv.turns = [...(conv.turns ?? []), { ...input.journal, createdAt: new Date() }];
+      conv.turns = [...(conv.turns ?? []), { ...input.journal, messageIndex: startLen, createdAt: new Date() }];
     }
     await input.store.save(conv);
 

--- a/services/agents/src/conversation/run-conversation-turn.ts
+++ b/services/agents/src/conversation/run-conversation-turn.ts
@@ -91,7 +91,7 @@ const DIVERGENCE_NOTE =
 
 function freshConversation(id: string): Conversation {
   const now = new Date(); // store re-stamps on save; this is the lazy-create placeholder
-  return { id, messages: [], status: "active", createdAt: now, updatedAt: now };
+  return { id, messages: [], turns: [], status: "active", createdAt: now, updatedAt: now };
 }
 
 /**
@@ -175,6 +175,13 @@ export interface RunConversationTurnInput {
    * evals) → the manifest usage carries `model: ""`.
    */
   modelId?: string;
+  /**
+   * The turn's journal entry (#463): the raw client-sent instruction + acting
+   * user, appended to `conv.turns` alongside the transcript in the same save —
+   * the display source the get-conversation read serves for user rows. Absent
+   * (older callers, evals) → no entry; the read falls back to the raw message.
+   */
+  journal?: { kind: string; text: string; author?: string; turnId: string };
   store: ConversationStore;
   guard: TurnGuard;
   onEvent: (p: StreamPart) => void;
@@ -318,7 +325,13 @@ export async function runConversationTurn(input: RunConversationTurnInput): Prom
       );
     }
 
-    // 7. persist the whole aggregate (history is append-only)
+    // 7. persist the whole aggregate (history is append-only). The journal
+    //    entry (#463) commits in the same save as the transcript it describes:
+    //    a failed turn persists neither, so the nth-user-message ↔ nth-entry
+    //    pairing the read path relies on can never drift.
+    if (input.journal) {
+      conv.turns = [...(conv.turns ?? []), { ...input.journal, createdAt: new Date() }];
+    }
     await input.store.save(conv);
 
     // 8. terminal manifest (D14) — emitted LAST, only on full success (any

--- a/services/agents/src/server.ts
+++ b/services/agents/src/server.ts
@@ -59,6 +59,7 @@ import {
 import { composeInstruction, eagerSkillsFor, toolsetFor } from "./prompts/turn.js";
 import type { ConversationStore } from "./store/conversation-store.js";
 import { runConversationTurn, TurnGuard, ConcurrentTurnError } from "./conversation/run-conversation-turn.js";
+import { projectDisplayHistory } from "./conversation/display-history.js";
 import { joinRoom, type RoomPeer } from "./collab/room-peer.js";
 import type { SkillSource } from "./agents/main/skill-source.js";
 import { readSnapshot, loadSkillsFromSnapshot } from "./conversation/load-workspace.js";
@@ -90,6 +91,17 @@ function isMcpConfig(v: unknown): v is McpConfig {
   if (typeof v !== "object" || v === null) return false;
   const c = v as Record<string, unknown>;
   return typeof c.url === "string" && c.url !== "" && typeof c.token === "string" && c.token !== "";
+}
+
+/** Runtime guard for an untrusted `journal` value (#463). */
+function isJournal(v: unknown): v is { text: string; author?: string } {
+  if (typeof v !== "object" || v === null) return false;
+  const j = v as Record<string, unknown>;
+  return (
+    typeof j.text === "string" &&
+    j.text.trim() !== "" &&
+    (j.author === undefined || typeof j.author === "string")
+  );
 }
 
 function startSSE(res: Response): void {
@@ -144,6 +156,7 @@ export function createApp(deps: CreateAppDeps): Express {
       skills?: unknown;
       toolset?: unknown;
       mcp?: unknown;
+      journal?: unknown;
       collab?: unknown;
       webSearch?: unknown;
       eagerSkills?: unknown;
@@ -207,6 +220,7 @@ export function createApp(deps: CreateAppDeps): Express {
     // read the files and the lazy skill source from the mount.
     let files: Record<string, string>;
     let skillSource: SkillSource;
+    let turnId: string;
     try {
       const ws = resolveWorkspace({
         conversationIdParam: id,
@@ -216,6 +230,7 @@ export function createApp(deps: CreateAppDeps): Express {
       });
       files = readSnapshot(ws.snapshotDir);
       skillSource = loadSkillsFromSnapshot(ws.skillsSnapshotDir);
+      turnId = ws.turnId;
     } catch (err) {
       if (err instanceof WorkspaceRefError) {
         res.status(err.status).json({ error: err.message });
@@ -242,6 +257,17 @@ export function createApp(deps: CreateAppDeps): Express {
         return;
       }
       mcp = body.mcp;
+    }
+
+    // journal (#463): the turn's display record — raw client-sent text + acting
+    // user. Optional (older callers/evals journal nothing); malformed → clean 400.
+    let journal: { text: string; author?: string } | undefined;
+    if (body.journal !== undefined) {
+      if (!isJournal(body.journal)) {
+        res.status(400).json({ error: "journal must be { text: string, author?: string }" });
+        return;
+      }
+      journal = body.journal;
     }
 
     // collab (optional, #86 phase 4): a room-scoped turn. The room replaces
@@ -343,6 +369,7 @@ export function createApp(deps: CreateAppDeps): Express {
         skillSource,
         ...(toolset ? { toolset } : {}),
         ...(mcp ? { mcp } : {}),
+        ...(journal ? { journal: { ...journal, kind: turn.kind, turnId } } : {}),
         ...(eagerSkills ? { eagerSkills } : {}),
         webSearch: body.webSearch === true,
         ...(roomPeer ? { collabPeer: roomPeer } : {}),
@@ -388,10 +415,13 @@ export function createApp(deps: CreateAppDeps): Express {
       res.status(404).json({ error: "conversation not found" });
       return;
     }
-    // Raw ModelMessage[] — the UI projects tool parts to Changes client-side (§9).
+    // Display projection (#463): user rows carry the journal's raw client-sent
+    // text + author instead of the composed model prompt; assistant/tool rows
+    // pass through raw — the UI projects their text, question tool-calls, and
+    // Changes client-side (§9).
     res.json({
       status: conv.status,
-      messages: conv.messages,
+      messages: projectDisplayHistory(conv),
       createdAt: conv.createdAt,
       updatedAt: conv.updatedAt,
     });

--- a/services/agents/src/server.ts
+++ b/services/agents/src/server.ts
@@ -54,6 +54,7 @@ import {
   type McpConfig,
   type StreamPart,
   type Toolset,
+  type TurnJournal,
   type TurnSpec,
 } from "@aep/agent-stream";
 import { composeInstruction, eagerSkillsFor, toolsetFor } from "./prompts/turn.js";
@@ -63,7 +64,7 @@ import { projectDisplayHistory } from "./conversation/display-history.js";
 import { joinRoom, type RoomPeer } from "./collab/room-peer.js";
 import type { SkillSource } from "./agents/main/skill-source.js";
 import { readSnapshot, loadSkillsFromSnapshot } from "./conversation/load-workspace.js";
-import { resolveWorkspace, WorkspaceRefError } from "./shared/snapshot-path.js";
+import { conversationOrgId, resolveWorkspace, WorkspaceRefError } from "./shared/snapshot-path.js";
 import { createAuthMiddleware, type AgentsAuthConfig } from "./shared/auth.js";
 import { startKeepAlive } from "./shared/keepalive.js";
 import { config } from "./shared/config.js";
@@ -94,14 +95,14 @@ function isMcpConfig(v: unknown): v is McpConfig {
 }
 
 /** Runtime guard for an untrusted `journal` value (#463). */
-function isJournal(v: unknown): v is { text: string; author?: string } {
+function isJournal(v: unknown): v is TurnJournal {
   if (typeof v !== "object" || v === null) return false;
   const j = v as Record<string, unknown>;
-  return (
-    typeof j.text === "string" &&
-    j.text.trim() !== "" &&
-    (j.author === undefined || typeof j.author === "string")
-  );
+  if (typeof j.text !== "string" || j.text.trim() === "") return false;
+  if (j.author === undefined) return true;
+  if (typeof j.author !== "object" || j.author === null) return false;
+  const a = j.author as Record<string, unknown>;
+  return typeof a.id === "string" && a.id !== "" && typeof a.displayName === "string" && a.displayName !== "";
 }
 
 function startSSE(res: Response): void {
@@ -260,14 +261,21 @@ export function createApp(deps: CreateAppDeps): Express {
     }
 
     // journal (#463): the turn's display record — raw client-sent text + acting
-    // user. Optional (older callers/evals journal nothing); malformed → clean 400.
-    let journal: { text: string; author?: string } | undefined;
+    // user. Optional (older callers/evals journal nothing); malformed → clean
+    // 400. Rebuilt field-by-field: the body object is untrusted, and a spread
+    // would persist whatever extra keys a caller smuggled beside `text`.
+    let journal: TurnJournal | undefined;
     if (body.journal !== undefined) {
       if (!isJournal(body.journal)) {
-        res.status(400).json({ error: "journal must be { text: string, author?: string }" });
+        res.status(400).json({ error: "journal must be { text: string, author?: { id, displayName } }" });
         return;
       }
-      journal = body.journal;
+      journal = {
+        text: body.journal.text,
+        ...(body.journal.author
+          ? { author: { id: body.journal.author.id, displayName: body.journal.author.displayName } }
+          : {}),
+      };
     }
 
     // collab (optional, #86 phase 4): a room-scoped turn. The room replaces
@@ -369,7 +377,7 @@ export function createApp(deps: CreateAppDeps): Express {
         skillSource,
         ...(toolset ? { toolset } : {}),
         ...(mcp ? { mcp } : {}),
-        ...(journal ? { journal: { ...journal, kind: turn.kind, turnId } } : {}),
+        ...(journal ? { journal: { ...journal, turnId } } : {}),
         ...(eagerSkills ? { eagerSkills } : {}),
         webSearch: body.webSearch === true,
         ...(roomPeer ? { collabPeer: roomPeer } : {}),
@@ -410,7 +418,25 @@ export function createApp(deps: CreateAppDeps): Express {
   });
 
   app.get("/conversations/:id", requireAuth, async (req: Request, res: Response) => {
-    const conv = await deps.store.get(req.params.id as string);
+    // The same cross-tenant fence as the turn POST (§12): the id's org segment
+    // must equal the caller's X-Org-Id claim. The M2M token is shared, so
+    // without this any holder could read another org's thread — which now
+    // carries per-turn author identities (#463).
+    const id = req.params.id as string;
+    try {
+      const claim = req.header("x-org-id");
+      if (!claim || conversationOrgId(id) !== claim) {
+        res.status(403).json({ error: "conversation org does not match the caller's organization" });
+        return;
+      }
+    } catch (err) {
+      if (err instanceof WorkspaceRefError) {
+        res.status(err.status).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+    const conv = await deps.store.get(id);
     if (!conv) {
       res.status(404).json({ error: "conversation not found" });
       return;

--- a/services/agents/src/shared/snapshot-path.ts
+++ b/services/agents/src/shared/snapshot-path.ts
@@ -96,6 +96,16 @@ export interface ResolvedWorkspace {
 }
 
 /**
+ * The org segment of a namespaced conversation id — the get-conversation
+ * read's cross-tenant fence (#463): the same parse the turn POST fences with,
+ * so the two routes can never disagree on an id's org. Throws
+ * `WorkspaceRefError` (400) on a malformed id.
+ */
+export function conversationOrgId(id: string): string {
+  return parseConversationId(id).orgId;
+}
+
+/**
  * Parse a namespaced conversation id into its four segments, defensively.
  * Splitting on `--` FIRST guarantees no segment can smuggle a `--` through the
  * (dash-admitting) per-segment charsets.

--- a/services/agents/src/store/conversation-store.ts
+++ b/services/agents/src/store/conversation-store.ts
@@ -38,12 +38,20 @@ import type { ModelMessage } from "ai";
 export interface TurnJournalEntry {
   /** The BFF-minted turn id (WorkspaceRef.turnId). */
   turnId: string;
-  /** The TurnSpec kind the request declared (chat | flow | start | plan). */
-  kind: string;
   /** The raw client-sent instruction — exactly what the sender's UI rendered. */
   text: string;
-  /** Best-effort display identity of the acting user; absent for M2M callers. */
-  author?: string;
+  /**
+   * The acting user, in the console's live author shape ({id: email,
+   * displayName}); absent for M2M callers with no human identity.
+   */
+  author?: { id: string; displayName: string };
+  /**
+   * Index into `messages` of the user message this turn appended — stamped at
+   * write time (the append site knows it exactly), so the display read pairs
+   * entry↔message by position stated as fact, never inferred. Journal-less
+   * turns simply have no entry claiming their index.
+   */
+  messageIndex: number;
   createdAt: Date;
 }
 

--- a/services/agents/src/store/conversation-store.ts
+++ b/services/agents/src/store/conversation-store.ts
@@ -28,6 +28,25 @@
 
 import type { ModelMessage } from "ai";
 
+/**
+ * One turn's display record (#463): what the CLIENT sent, verbatim, plus who
+ * sent it — the source the get-conversation read serves for user rows, so the
+ * composed model prompt (skills, file dumps, framing) never reaches a browser.
+ * Journaled beside the transcript, never inside it: `messages` is the model's
+ * memory and the prompt-cache prefix, and its bytes must not change.
+ */
+export interface TurnJournalEntry {
+  /** The BFF-minted turn id (WorkspaceRef.turnId). */
+  turnId: string;
+  /** The TurnSpec kind the request declared (chat | flow | start | plan). */
+  kind: string;
+  /** The raw client-sent instruction — exactly what the sender's UI rendered. */
+  text: string;
+  /** Best-effort display identity of the acting user; absent for M2M callers. */
+  author?: string;
+  createdAt: Date;
+}
+
 export interface Conversation {
   /** Caller-supplied id (the BFF owns its id namespace). */
   id: string;
@@ -36,6 +55,13 @@ export interface Conversation {
    * (the wire is raw StreamPart, runTurn is ModelMessage-native), append-only.
    */
   messages: ModelMessage[];
+  /**
+   * The turn journal (#463), one entry per completed turn, in turn order. A
+   * turn appends exactly one user message to `messages`, so the nth user
+   * message pairs with the nth entry; pre-journal turns simply have no entry
+   * (the read path falls back to the raw message for those).
+   */
+  turns: TurnJournalEntry[];
   /** `awaiting-human` = the turn ended on a HITL question call (ask_question / ask_questions). */
   status: "active" | "awaiting-human" | "done";
   /** Store-owned timestamps. */

--- a/services/agents/src/store/postgres-store.ts
+++ b/services/agents/src/store/postgres-store.ts
@@ -52,7 +52,7 @@ const CREATE_TABLE = `CREATE TABLE IF NOT EXISTS conversations (
 // an every-boot ALTER queued behind a long transaction would stall every
 // reader on the table; the probe costs one catalog read instead.
 const TURNS_COLUMN_EXISTS = `SELECT 1 FROM information_schema.columns
-  WHERE table_name = 'conversations' AND column_name = 'turns'`;
+  WHERE table_schema = current_schema() AND table_name = 'conversations' AND column_name = 'turns'`;
 
 const ADD_TURNS_COLUMN = `ALTER TABLE conversations
   ADD COLUMN IF NOT EXISTS turns jsonb NOT NULL DEFAULT '[]'`;

--- a/services/agents/src/store/postgres-store.ts
+++ b/services/agents/src/store/postgres-store.ts
@@ -29,7 +29,7 @@
  */
 
 import type { ModelMessage } from "ai";
-import type { Conversation, ConversationStore } from "./conversation-store.js";
+import type { Conversation, ConversationStore, TurnJournalEntry } from "./conversation-store.js";
 
 /** The subset of a `pg.Pool`/`pg.Client` this store uses. */
 export interface Queryable {
@@ -39,20 +39,27 @@ export interface Queryable {
 const CREATE_TABLE = `CREATE TABLE IF NOT EXISTS conversations (
   id text PRIMARY KEY,
   messages jsonb NOT NULL,
+  turns jsonb NOT NULL DEFAULT '[]',
   status text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 )`;
 
-const SELECT_ONE = `SELECT id, messages, status, created_at, updated_at
+// Pre-journal deployments created the table without `turns` (#463); CREATE
+// TABLE IF NOT EXISTS never adds a column, so bootstrap alters idempotently.
+const ADD_TURNS_COLUMN = `ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS turns jsonb NOT NULL DEFAULT '[]'`;
+
+const SELECT_ONE = `SELECT id, messages, turns, status, created_at, updated_at
   FROM conversations WHERE id = $1`;
 
 // created_at is untouched on conflict (store-authoritative first-seen); only the
-// messages/status/updated_at advance.
-const UPSERT = `INSERT INTO conversations (id, messages, status, created_at, updated_at)
-  VALUES ($1, $2::jsonb, $3, now(), now())
+// messages/turns/status/updated_at advance.
+const UPSERT = `INSERT INTO conversations (id, messages, turns, status, created_at, updated_at)
+  VALUES ($1, $2::jsonb, $3::jsonb, $4, now(), now())
   ON CONFLICT (id) DO UPDATE
     SET messages = EXCLUDED.messages,
+        turns = EXCLUDED.turns,
         status = EXCLUDED.status,
         updated_at = now()`;
 
@@ -66,9 +73,19 @@ function asDate(value: unknown): Date {
 
 /** jsonb comes back already parsed by node-postgres; timestamptz comes back as a Date. */
 function rowToConversation(row: Record<string, unknown>): Conversation {
+  const turns = ((row.turns ?? []) as Array<Record<string, unknown>>).map(
+    (t): TurnJournalEntry => ({
+      turnId: String(t.turnId ?? ""),
+      kind: String(t.kind ?? ""),
+      text: String(t.text ?? ""),
+      ...(t.author ? { author: String(t.author) } : {}),
+      createdAt: asDate(t.createdAt),
+    }),
+  );
   return {
     id: String(row.id),
     messages: (row.messages ?? []) as ModelMessage[],
+    turns,
     status: row.status as Conversation["status"],
     createdAt: asDate(row.created_at),
     updatedAt: asDate(row.updated_at),
@@ -81,6 +98,7 @@ export class PostgresConversationStore implements ConversationStore {
   /** Idempotent schema bootstrap; safe to call on every startup. */
   async init(): Promise<void> {
     await this.db.query(CREATE_TABLE);
+    await this.db.query(ADD_TURNS_COLUMN);
   }
 
   async get(id: string): Promise<Conversation | null> {
@@ -90,7 +108,7 @@ export class PostgresConversationStore implements ConversationStore {
   }
 
   async save(c: Conversation): Promise<void> {
-    await this.db.query(UPSERT, [c.id, JSON.stringify(c.messages), c.status]);
+    await this.db.query(UPSERT, [c.id, JSON.stringify(c.messages), JSON.stringify(c.turns), c.status]);
   }
 
   /** Delete rows whose `updated_at` is older than `ttlMs`. Returns the count purged. */

--- a/services/agents/src/store/postgres-store.ts
+++ b/services/agents/src/store/postgres-store.ts
@@ -47,6 +47,13 @@ const CREATE_TABLE = `CREATE TABLE IF NOT EXISTS conversations (
 
 // Pre-journal deployments created the table without `turns` (#463); CREATE
 // TABLE IF NOT EXISTS never adds a column, so bootstrap alters idempotently.
+// The ALTER runs only when the probe says the column is missing: Postgres
+// takes the table's ACCESS EXCLUSIVE lock BEFORE evaluating IF NOT EXISTS, so
+// an every-boot ALTER queued behind a long transaction would stall every
+// reader on the table; the probe costs one catalog read instead.
+const TURNS_COLUMN_EXISTS = `SELECT 1 FROM information_schema.columns
+  WHERE table_name = 'conversations' AND column_name = 'turns'`;
+
 const ADD_TURNS_COLUMN = `ALTER TABLE conversations
   ADD COLUMN IF NOT EXISTS turns jsonb NOT NULL DEFAULT '[]'`;
 
@@ -73,15 +80,18 @@ function asDate(value: unknown): Date {
 
 /** jsonb comes back already parsed by node-postgres; timestamptz comes back as a Date. */
 function rowToConversation(row: Record<string, unknown>): Conversation {
-  const turns = ((row.turns ?? []) as Array<Record<string, unknown>>).map(
-    (t): TurnJournalEntry => ({
+  const turns = ((row.turns ?? []) as Array<Record<string, unknown>>).map((t): TurnJournalEntry => {
+    const author = t.author as { id?: unknown; displayName?: unknown } | undefined;
+    return {
       turnId: String(t.turnId ?? ""),
-      kind: String(t.kind ?? ""),
       text: String(t.text ?? ""),
-      ...(t.author ? { author: String(t.author) } : {}),
+      ...(author && typeof author.id === "string" && typeof author.displayName === "string"
+        ? { author: { id: author.id, displayName: author.displayName } }
+        : {}),
+      messageIndex: Number(t.messageIndex ?? -1),
       createdAt: asDate(t.createdAt),
-    }),
-  );
+    };
+  });
   return {
     id: String(row.id),
     messages: (row.messages ?? []) as ModelMessage[],
@@ -98,7 +108,8 @@ export class PostgresConversationStore implements ConversationStore {
   /** Idempotent schema bootstrap; safe to call on every startup. */
   async init(): Promise<void> {
     await this.db.query(CREATE_TABLE);
-    await this.db.query(ADD_TURNS_COLUMN);
+    const { rows } = await this.db.query(TURNS_COLUMN_EXISTS);
+    if (rows.length === 0) await this.db.query(ADD_TURNS_COLUMN);
   }
 
   async get(id: string): Promise<Conversation | null> {

--- a/services/agents/test/display-history.test.ts
+++ b/services/agents/test/display-history.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * `projectDisplayHistory` (#463): the get-conversation read serves the turn
+ * journal's raw client-sent text for user rows — never the composed model
+ * prompt — with a tail-anchored pairing so pre-journal turns fall back to
+ * their raw stored content.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { projectDisplayHistory } from "../src/conversation/display-history.js";
+import type { Conversation, TurnJournalEntry } from "../src/store/conversation-store.js";
+
+const PROMPT_1 = "The following skill guidance is ALREADY LOADED…\n\n## Skill: start\n\nExisting files:…\n\nInstruction: /start";
+const PROMPT_2 = "Existing files:…\n\nInstruction: Answers: …";
+
+function entry(turnId: string, text: string, author?: string): TurnJournalEntry {
+  return { turnId, kind: "chat", text, ...(author ? { author } : {}), createdAt: new Date("2026-01-01T00:00:00Z") };
+}
+
+function conv(messages: Conversation["messages"], turns: TurnJournalEntry[]): Conversation {
+  return {
+    id: "c1",
+    messages,
+    turns,
+    status: "done",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+test("user rows carry the journal text + author; assistant rows pass through", () => {
+  const out = projectDisplayHistory(
+    conv(
+      [
+        { role: "user", content: PROMPT_1 },
+        { role: "assistant", content: "made the PRD" },
+      ],
+      [entry("t1", "/start", "Admin")],
+    ),
+  );
+  assert.deepEqual(out[0], { role: "user", content: "/start", author: "Admin" });
+  assert.deepEqual(out[1], { role: "assistant", content: "made the PRD" });
+});
+
+test("pre-journal user rows fall back to their raw content (tail-anchored pairing)", () => {
+  const out = projectDisplayHistory(
+    conv(
+      [
+        { role: "user", content: PROMPT_1 }, // legacy turn: no entry
+        { role: "assistant", content: "a" },
+        { role: "user", content: PROMPT_2 }, // journaled turn
+        { role: "assistant", content: "b" },
+      ],
+      [entry("t2", "Answers: lunch at noon")],
+    ),
+  );
+  assert.equal((out[0] as { content: string }).content, PROMPT_1, "legacy turn stays raw");
+  assert.deepEqual(out[2], { role: "user", content: "Answers: lunch at noon" });
+});
+
+test("a journal-less conversation projects byte-identically", () => {
+  const messages: Conversation["messages"] = [
+    { role: "user", content: PROMPT_1 },
+    { role: "assistant", content: "a" },
+  ];
+  assert.deepEqual(projectDisplayHistory(conv(messages, [])), messages);
+});
+
+test("author is omitted, not empty, when the journal has none", () => {
+  const out = projectDisplayHistory(conv([{ role: "user", content: PROMPT_1 }], [entry("t1", "hi")]));
+  assert.deepEqual(out[0], { role: "user", content: "hi" });
+  assert.ok(!("author" in (out[0] as object)));
+});

--- a/services/agents/test/display-history.test.ts
+++ b/services/agents/test/display-history.test.ts
@@ -19,8 +19,8 @@
 /**
  * `projectDisplayHistory` (#463): the get-conversation read serves the turn
  * journal's raw client-sent text for user rows — never the composed model
- * prompt — with a tail-anchored pairing so pre-journal turns fall back to
- * their raw stored content.
+ * prompt — paired by each entry's stated messageIndex, so a journal-less turn
+ * anywhere in the history never shifts another turn's pairing.
  */
 
 import { test } from "node:test";
@@ -30,9 +30,16 @@ import type { Conversation, TurnJournalEntry } from "../src/store/conversation-s
 
 const PROMPT_1 = "The following skill guidance is ALREADY LOADED…\n\n## Skill: start\n\nExisting files:…\n\nInstruction: /start";
 const PROMPT_2 = "Existing files:…\n\nInstruction: Answers: …";
+const AUTHOR = { id: "sarah@example.com", displayName: "Sarah Perera" };
 
-function entry(turnId: string, text: string, author?: string): TurnJournalEntry {
-  return { turnId, kind: "chat", text, ...(author ? { author } : {}), createdAt: new Date("2026-01-01T00:00:00Z") };
+function entry(messageIndex: number, text: string, author?: TurnJournalEntry["author"]): TurnJournalEntry {
+  return {
+    turnId: `t${messageIndex}`,
+    text,
+    ...(author ? { author } : {}),
+    messageIndex,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+  };
 }
 
 function conv(messages: Conversation["messages"], turns: TurnJournalEntry[]): Conversation {
@@ -46,34 +53,54 @@ function conv(messages: Conversation["messages"], turns: TurnJournalEntry[]): Co
   };
 }
 
-test("user rows carry the journal text + author; assistant rows pass through", () => {
+test("user rows carry the journal text + author object; assistant rows pass through", () => {
   const out = projectDisplayHistory(
     conv(
       [
         { role: "user", content: PROMPT_1 },
         { role: "assistant", content: "made the PRD" },
       ],
-      [entry("t1", "/start", "Admin")],
+      [entry(0, "/start", AUTHOR)],
     ),
   );
-  assert.deepEqual(out[0], { role: "user", content: "/start", author: "Admin" });
+  assert.deepEqual(out[0], { role: "user", content: "/start", author: AUTHOR });
   assert.deepEqual(out[1], { role: "assistant", content: "made the PRD" });
 });
 
-test("pre-journal user rows fall back to their raw content (tail-anchored pairing)", () => {
+test("pre-journal user rows fall back to their raw content", () => {
   const out = projectDisplayHistory(
     conv(
       [
         { role: "user", content: PROMPT_1 }, // legacy turn: no entry
         { role: "assistant", content: "a" },
-        { role: "user", content: PROMPT_2 }, // journaled turn
+        { role: "user", content: PROMPT_2 }, // journaled turn at index 2
         { role: "assistant", content: "b" },
       ],
-      [entry("t2", "Answers: lunch at noon")],
+      [entry(2, "Answers: lunch at noon")],
     ),
   );
   assert.equal((out[0] as { content: string }).content, PROMPT_1, "legacy turn stays raw");
   assert.deepEqual(out[2], { role: "user", content: "Answers: lunch at noon" });
+});
+
+// A journal-less turn AFTER journaled ones (older caller mid-rolling-deploy)
+// must not shift earlier turns' pairing — the review's interleaving scenario.
+test("a journal-less turn between journaled turns shifts nothing", () => {
+  const out = projectDisplayHistory(
+    conv(
+      [
+        { role: "user", content: PROMPT_1 }, // journaled at index 0
+        { role: "assistant", content: "a" },
+        { role: "user", content: PROMPT_2 }, // journal-less (old replica)
+        { role: "assistant", content: "b" },
+        { role: "user", content: "raw 3" }, // journaled at index 4
+      ],
+      [entry(0, "/start", AUTHOR), entry(4, "add a returns policy")],
+    ),
+  );
+  assert.deepEqual(out[0], { role: "user", content: "/start", author: AUTHOR });
+  assert.equal((out[2] as { content: string }).content, PROMPT_2, "un-journaled turn stays raw, unshifted");
+  assert.deepEqual(out[4], { role: "user", content: "add a returns policy" });
 });
 
 test("a journal-less conversation projects byte-identically", () => {
@@ -85,7 +112,7 @@ test("a journal-less conversation projects byte-identically", () => {
 });
 
 test("author is omitted, not empty, when the journal has none", () => {
-  const out = projectDisplayHistory(conv([{ role: "user", content: PROMPT_1 }], [entry("t1", "hi")]));
+  const out = projectDisplayHistory(conv([{ role: "user", content: PROMPT_1 }], [entry(0, "hi")]));
   assert.deepEqual(out[0], { role: "user", content: "hi" });
   assert.ok(!("author" in (out[0] as object)));
 });

--- a/services/agents/test/memory-store.test.ts
+++ b/services/agents/test/memory-store.test.ts
@@ -25,6 +25,7 @@ function fresh(id: string): Conversation {
   return {
     id,
     messages: [{ role: "user", content: "hi" }],
+    turns: [],
     status: "active",
     createdAt: new Date("2020-01-01T00:00:00Z"),
     updatedAt: new Date("2020-01-01T00:00:00Z"),

--- a/services/agents/test/postgres-store.test.ts
+++ b/services/agents/test/postgres-store.test.ts
@@ -31,6 +31,7 @@ import { PostgresConversationStore, type Queryable } from "../src/store/postgres
 interface Row {
   id: string;
   messages: unknown;
+  turns: unknown;
   status: string;
   created_at: Date;
   updated_at: Date;
@@ -51,6 +52,7 @@ class FakePg implements Queryable {
     return {
       id: row.id,
       messages: JSON.parse(JSON.stringify(row.messages)),
+      turns: JSON.parse(JSON.stringify(row.turns)),
       status: row.status,
       created_at: new Date(row.created_at),
       updated_at: new Date(row.updated_at),
@@ -61,6 +63,7 @@ class FakePg implements Queryable {
     const verb = text.trimStart().split(/\s+/)[0]?.toUpperCase();
     switch (verb) {
       case "CREATE":
+      case "ALTER":
         return Promise.resolve({ rows: [] });
       case "SELECT": {
         const row = this.rows.get(String(params[0]));
@@ -72,7 +75,8 @@ class FakePg implements Queryable {
         this.rows.set(id, {
           id,
           messages: JSON.parse(String(params[1])),
-          status: String(params[2]),
+          turns: JSON.parse(String(params[2])),
+          status: String(params[3]),
           created_at: existing?.created_at ?? this.now(), // preserved on conflict
           updated_at: this.now(),
         });
@@ -105,6 +109,7 @@ function fresh(id: string): Conversation {
   return {
     id,
     messages: [{ role: "user", content: "hi" }],
+    turns: [],
     status: "active",
     createdAt: new Date("2020-01-01T00:00:00Z"), // ignored: the store owns timestamps
     updatedAt: new Date("2020-01-01T00:00:00Z"),

--- a/services/agents/test/run-conversation-turn.test.ts
+++ b/services/agents/test/run-conversation-turn.test.ts
@@ -79,18 +79,32 @@ test("lazy-creates, runs server-side execute, persists, status done", async () =
   assert.ok(stored.messages.some((m) => m.role === "tool"));
 });
 
-// The journal entry (#463) commits in the same save as the transcript, so the
-// nth-user-message ↔ nth-entry pairing the display read relies on never drifts.
-test("a journaled turn appends one entry beside the transcript", async () => {
+// The journal entry (#463) commits in the same save as the transcript, stamped
+// with the INDEX of the user message its turn appended — the fact the display
+// read pairs by.
+test("a journaled turn appends one entry stamped with its user message's index", async () => {
   const store = new InMemoryConversationStore();
   const guard = new TurnGuard();
+  const author = { id: "admin@example.com", displayName: "Admin" };
 
   await runConversationTurn({
     id: "conv-j",
     instruction: "rename the hello message",
     files: SEED_FILES,
     model: textModel("ok"),
-    journal: { kind: "chat", text: "rename the hello message", author: "Admin", turnId: "t-1" },
+    journal: { text: "rename the hello message", author, turnId: "t-1" },
+    store,
+    guard,
+    onEvent: () => {},
+  });
+  // A second journaled turn on the same conversation: its entry must point at
+  // ITS user message, not the first.
+  await runConversationTurn({
+    id: "conv-j",
+    instruction: "now shorten it",
+    files: SEED_FILES,
+    model: textModel("ok"),
+    journal: { text: "now shorten it", author, turnId: "t-2" },
     store,
     guard,
     onEvent: () => {},
@@ -98,12 +112,14 @@ test("a journaled turn appends one entry beside the transcript", async () => {
 
   const stored = await store.get("conv-j");
   assert.ok(stored);
-  assert.equal(stored.turns.length, 1);
+  assert.equal(stored.turns.length, 2);
   assert.equal(stored.turns[0]!.text, "rename the hello message");
-  assert.equal(stored.turns[0]!.author, "Admin");
+  assert.deepEqual(stored.turns[0]!.author, author);
   assert.equal(stored.turns[0]!.turnId, "t-1");
-  assert.equal(stored.turns[0]!.kind, "chat");
-  assert.equal(stored.messages.filter((m) => m.role === "user").length, stored.turns.length);
+  for (const entry of stored.turns) {
+    assert.equal(stored.messages[entry.messageIndex]?.role, "user", "messageIndex points at the turn's user message");
+  }
+  assert.ok(stored.turns[1]!.messageIndex > stored.turns[0]!.messageIndex);
 });
 
 // An un-journaled turn (older caller, eval) stores no entry — the read path

--- a/services/agents/test/run-conversation-turn.test.ts
+++ b/services/agents/test/run-conversation-turn.test.ts
@@ -79,6 +79,51 @@ test("lazy-creates, runs server-side execute, persists, status done", async () =
   assert.ok(stored.messages.some((m) => m.role === "tool"));
 });
 
+// The journal entry (#463) commits in the same save as the transcript, so the
+// nth-user-message ↔ nth-entry pairing the display read relies on never drifts.
+test("a journaled turn appends one entry beside the transcript", async () => {
+  const store = new InMemoryConversationStore();
+  const guard = new TurnGuard();
+
+  await runConversationTurn({
+    id: "conv-j",
+    instruction: "rename the hello message",
+    files: SEED_FILES,
+    model: textModel("ok"),
+    journal: { kind: "chat", text: "rename the hello message", author: "Admin", turnId: "t-1" },
+    store,
+    guard,
+    onEvent: () => {},
+  });
+
+  const stored = await store.get("conv-j");
+  assert.ok(stored);
+  assert.equal(stored.turns.length, 1);
+  assert.equal(stored.turns[0]!.text, "rename the hello message");
+  assert.equal(stored.turns[0]!.author, "Admin");
+  assert.equal(stored.turns[0]!.turnId, "t-1");
+  assert.equal(stored.turns[0]!.kind, "chat");
+  assert.equal(stored.messages.filter((m) => m.role === "user").length, stored.turns.length);
+});
+
+// An un-journaled turn (older caller, eval) stores no entry — the read path
+// falls back to the raw message for it.
+test("a journal-less turn appends no entry", async () => {
+  const store = new InMemoryConversationStore();
+  const guard = new TurnGuard();
+  await runConversationTurn({
+    id: "conv-nj",
+    instruction: "hello",
+    files: SEED_FILES,
+    model: textModel("ok"),
+    store,
+    guard,
+    onEvent: () => {},
+  });
+  const stored = await store.get("conv-nj");
+  assert.equal(stored?.turns.length, 0);
+});
+
 test("append-only across turns (resume on the same id)", async () => {
   const store = new InMemoryConversationStore();
   const guard = new TurnGuard();

--- a/services/agents/test/server.test.ts
+++ b/services/agents/test/server.test.ts
@@ -171,20 +171,32 @@ test("POST streams raw StreamPart frames + [DONE], runs execute, persists", asyn
   }
 });
 
-test("GET rehydrates the aggregate; 404 for an unknown id", async () => {
+test("GET rehydrates the aggregate; org-fenced; 404 for an unknown id", async () => {
   const root = makeMountRoot({ [REQUIREMENTS]: "# Req\n" });
   const { baseUrl, close } = await boot(mockModel([{ kind: "text", text: "ok" }]), root);
   try {
     const token = await mintToken();
     await (await fetch(`${baseUrl}/conversations/${WS_CONV}/turns`, turnPost(wsBody(), { token, org: WS_ORG }))).text();
 
-    const got = await fetch(`${baseUrl}/conversations/${WS_CONV}`, { headers: { Authorization: `Bearer ${token}` } });
+    const headers = { Authorization: `Bearer ${token}`, "X-Org-Id": WS_ORG };
+    const got = await fetch(`${baseUrl}/conversations/${WS_CONV}`, { headers });
     assert.equal(got.status, 200);
     const body = (await got.json()) as { status: string; messages: unknown[] };
     assert.equal(body.status, "done");
     assert.ok(Array.isArray(body.messages) && body.messages.length >= 2);
 
-    const missing = await fetch(`${baseUrl}/conversations/does-not-exist`, { headers: { Authorization: `Bearer ${token}` } });
+    // The read carries the same cross-tenant fence as the turn POST (#463):
+    // the shared M2M token alone must not read another org's thread.
+    const noOrg = await fetch(`${baseUrl}/conversations/${WS_CONV}`, { headers: { Authorization: `Bearer ${token}` } });
+    assert.equal(noOrg.status, 403);
+    const wrongOrg = await fetch(`${baseUrl}/conversations/${WS_CONV}`, {
+      headers: { Authorization: `Bearer ${token}`, "X-Org-Id": "other-org" },
+    });
+    assert.equal(wrongOrg.status, 403);
+    const malformed = await fetch(`${baseUrl}/conversations/does-not-exist`, { headers });
+    assert.equal(malformed.status, 400);
+
+    const missing = await fetch(`${baseUrl}/conversations/${WS_CONV.replace(/conv1$/, "conv9")}`, { headers });
     assert.equal(missing.status, 404);
   } finally {
     await close();


### PR DESCRIPTION
Closes #463.

## Problem

A conversation's stored user messages are **composed model prompts** — eager skill bodies (#335) + inlined files + framing — correct as the model's memory, wrong as a chat bubble. Since the thread became project-owned (#430), rehydrate rebuilds bubbles from that store, so opening a project after `/start` rendered the entire start skill (~9.5KB) as the user's bubble, and form answers rendered with their `Existing files: … Instruction: …` framing. Root cause analysis on the issue.

## Design (grilled, recorded on #463)

**The transcript stays byte-frozen** — it is the prompt-cache prefix and the model's memory; display never reads it for user rows again. Beside it, the conversation row gains a **turn journal** (`turns` JSONB, same UPSERT, same TTL lifecycle): one entry per turn holding the **verbatim client-sent instruction** — exactly what the sender's UI rendered live — plus the acting user and the index of the user message the turn appended.

- **Agents service**: `TurnRequest` gains optional `journal {text, author?: {id, displayName}}` (named `TurnJournal` contract type in `@aep/agent-stream`); the entry commits in the same save as the transcript, stamped with its message index. `GET /conversations/:id` now serves a **display projection**: user rows carry journal text + author, paired by stated index (a journal-less turn falls back to its raw message without shifting anyone else); assistant/tool rows pass through, so question cards and answered-ness detection are untouched. The read gains the turn POST's **cross-tenant org fence**.
- **BFF**: every spec turn sends the journal — text is the verbatim instruction, author is **email-anchored** from the request bearer (`{id: email, displayName}`, matching the console's live identity shape) and omitted entirely for bearers with no email, so M2M callers never journal a bare subject claim. This also makes multi-user attribution real: nothing set `author` on history before.
- **Console**: zero changes — the live path already renders the sent text, so live and rehydrated bubbles are byte-identical by construction (including `/start`, whose bubble is the `/start` command both live and rehydrated).
- **Collab**: room-scoped turns run the same path/store and journal identically; a teammate's turn — which only ever renders via rehydrate — now shows the bubble its author saw, with their name.

**No backfill by design**: pre-fix threads render their raw stored text until abandoned; there is no runtime prompt-convention parsing anywhere. Existing tables get the `turns` column via a probe-gated idempotent `ALTER` (catalog check first — no ACCESS EXCLUSIVE queueing on healthy boots).

## Review

`/code-review` ran on the branch; all ten surviving findings were fixed in the second commit — most notably: author served as an object (attribution was otherwise dead on arrival against the console's `mapAuthor`), index-stamped pairing (the tail-anchored version leaked the composed prompt when a journal-less turn interleaved), field-by-field journal construction (no persisted smuggled keys), and the org fence on the read.

## Proof of real execution

Diagnosed against the live local stack: `GET /projects/fright-forwarding/agents/{id}/messages` showed the first user message as the 9,487-char composed prompt beginning "The following skill guidance is ALREADY LOADED… ## Skill: start…" — the exact bubble content reported. The fix's projection is pinned by tests reproducing that shape (`services/agents/test/display-history.test.ts`), plus fence/interleaving/journal-append suites: agents 246/246, full monorepo `make build` / `test` (33 tasks + all Go) / `typecheck` / knip / both deadcode gates / license all green.

Note for deployment/testing: old threads keep their raw rendering until new turns land (accepted in the design); local testing needs `docker compose build aep-api agents` + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)