### PR TITLE
fix(skills): compile Ballerina services at image build so they start on a read-only rootfs

### DIFF
--- a/skills/ballerina/SKILL.md
+++ b/skills/ballerina/SKILL.md
@@ -64,11 +64,21 @@ Derive the distribution root with `bal home`, never a hardcoded version; both ro
 
 ## Dockerfile
 
+`Dockerfile` — multi-stage, pinned Ballerina builder, JRE runtime:
+
 ```dockerfile
-FROM ballerina/ballerina:2201.13.5 
+FROM ballerina/ballerina:2201.13.5 AS builder
 WORKDIR /src
 COPY --chown=ballerina:troupe . .
-ENTRYPOINT ["bal", "run"]
+RUN bal build && mv target/bin/*.jar /tmp/service.jar
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /tmp/service.jar /app/service.jar
+EXPOSE 9090
+ENTRYPOINT ["java", "-jar", "/app/service.jar"]
 ```
 
-`--chown` is required, not stylistic: `COPY` always lands files as `root:root` regardless of the base image's `USER` directive, but the container runs as the non-root `ballerina` user. Without it, `bal run` fails writing `target/`/`Dependencies.toml` and the pod crash-loops.
+`--chown` is required, not stylistic: `COPY` always lands files as `root:root` regardless of the base image's `USER` directive, but the builder runs as the non-root `ballerina` user. Without it, `bal build` cannot write `target/`.
+
+The dataplane root filesystem is read-only. `bal run` writes `/.ballerina` and `target/` at start, which crash-loops the pod (`FileSystemException: /.ballerina: Read-only file system`). The runtime entrypoint is the jar the builder produced. The jar is moved to `/tmp/service.jar` so the runtime `COPY` has a stable path regardless of the package name.


### PR DESCRIPTION
## Summary

OpenChoreo runs user workloads with a **read-only root filesystem**. The Ballerina stack skill told the coding agent to ship this Dockerfile:

```dockerfile
FROM ballerina/ballerina:2201.13.5
WORKDIR /src
COPY --chown=ballerina:troupe . .
ENTRYPOINT ["bal", "run"]
```

`bal run` is a toolchain, not a server: at startup it tries to create `/.ballerina/bal-tools.toml`. That write fails, the pod crash-loops, the ReleaseBinding never stays Ready, and the public URL returns **503**. Go services already avoid this by compiling in the image build and starting a binary at runtime.

This change updates `skills/ballerina/SKILL.md` to the same shape: `bal build` in a pinned Ballerina builder, then `java -jar` on `eclipse-temurin:21-jre`. The skill now states the read-only-rootfs constraint next to `--chown`, which is why agents copy the new Dockerfile instead of inventing `HOME=/tmp` or asking the platform for extra volumes.

Existing generated apps are unchanged; the next coding-agent run on a Ballerina component is enough.

Fixes https://github.com/wso2/labs-agentic-engineer/issues/454

## Test plan

- [x] Old skill Dockerfile (`ENTRYPOINT ["bal", "run"]`) under `docker run --read-only --user 65534`: exits 1 with `FileSystemException: /.ballerina: Read-only file system`
- [x] New skill Dockerfile, same flags: `GET /hello` → 200 `{"message":"Hello, World!"}` (no `/tmp` mount)
- [x] Playground coding run on a one-endpoint hello Ballerina service (`skillsPinned: ["ballerina"]`): agent wrote the new Dockerfile verbatim
- [x] Image built from that generated `hello-api/`: `GET /hello` → 200 under `--read-only --user 65534`
- [ ] Optional on a full OpenChoreo dataplane: ReleaseBinding `Ready: True`, public URL 200 (playground does not deploy)