### PR TITLE
feat(aepctl): config-first platform install with validation and secret reuse

### DIFF
--- a/tools/aepctl/cmd/config_validate.go
+++ b/tools/aepctl/cmd/config_validate.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wso2/aep/aepctl/internal/config"
+	k8s "github.com/wso2/aep/aepctl/internal/kubernetes"
+)
+
+var configTestFile string
+
+var configTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Validate a local config file or the cluster ConfigMap",
+	Long: `Checks that all required keys are present and that values have the
+correct type and format.
+
+Validate a local file before importing:
+  aep platform config test --config ~/aepctl-configs/defaults.yaml
+
+Validate what is currently in the cluster:
+  aep platform config test`,
+	RunE: runConfigTest,
+}
+
+func init() {
+	configCmd.AddCommand(configTestCmd)
+	configTestCmd.Flags().StringVar(&configTestFile, "config", "", "path to local config YAML file to validate (omit to validate the cluster ConfigMap)")
+}
+
+func runConfigTest(cmd *cobra.Command, args []string) error {
+	var errs []string
+
+	if configTestFile != "" {
+		errs = config.ValidateFile(configTestFile)
+	} else {
+		ctx := context.Background()
+		client, err := k8s.NewClient(kubeconfig)
+		if err != nil {
+			return fmt.Errorf("connect to cluster: %w", err)
+		}
+		const aepNamespace = "wso2-aep"
+		if _, err := config.LoadFromCluster(ctx, client, aepNamespace); err != nil {
+			return fmt.Errorf("load cluster config: %w", err)
+		}
+		errs = config.ValidateLoaded()
+	}
+
+	if len(errs) > 0 {
+		_, _ = fmt.Fprintln(os.Stderr, "Config validation failed:")
+		for _, e := range errs {
+			_, _ = fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		return fmt.Errorf("config is invalid — fix the errors above")
+	}
+
+	_, _ = fmt.Fprintln(os.Stdout, "Config is valid.")
+	return nil
+}

--- a/tools/aepctl/cmd/configure.go
+++ b/tools/aepctl/cmd/configure.go
@@ -42,46 +42,20 @@ var configImportFile string
 var configImportCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Apply a local config file to the in-cluster aep-cli-config ConfigMap",
-	Long: `Reads a local YAML config file and upserts the aep-cli-config ConfigMap
-in the wso2-aep namespace. Use this to set or update AEP configuration
-without re-running aep platform install.
+	Long: `Reads a local YAML config file, validates it, and writes all recognised
+config keys to the aep-cli-config ConfigMap in the wso2-aep namespace.
+Creates the namespace if it does not yet exist.
 
-Only keys present in the file are written; existing keys not in the file
-are left untouched. thunder.admin_client_secret is intentionally ignored
-— it is managed by OpenBao/ESO and never stored in the ConfigMap.
+This command must be run before 'aep platform install'. All config values
+for the install must come from this ConfigMap — no hardcoded defaults are
+used at install time.
 
-Example config file:
+All keys from the file are written; keys absent from the file are stored
+as empty (their zero value). thunder.admin_client_secret is intentionally
+ignored — it is managed by OpenBao/ESO and never stored in the ConfigMap.
 
-  thunder:
-    url: http://thunder-service.thunder.svc.cluster.local:8090
-    public_url: https://thunder.example.com
-    admin_client_id: openchoreo-system-app
-    namespace: thunder
-    config_map: thunder-config-map
-    deployment: thunder-deployment
-
-  oc:
-    api_url: http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080
-    system_namespace: openchoreo-control-plane
-    org_namespace: default
-    local_org_provisioning:
-      enabled: false
-
-  platform:
-    workspaces:
-      access_mode: ReadWriteMany
-
-  codingagent:
-    openbao_direct:
-      enabled: false
-
-  openbao:
-    addr: http://openbao.openbao.svc.cluster.local:8200
-
-  webhook:
-    delivery_url: https://webhook.example.com
-    local_smee:
-      enabled: false`,
+Start from the defaults template:
+  aep platform config import --config ~/aepctl-configs/defaults.yaml`,
 	RunE: runConfigImport,
 }
 
@@ -95,8 +69,16 @@ func init() {
 func runConfigImport(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Read the local file into a standalone viper instance so it does not
-	// interfere with the global viper used by the rest of the CLI.
+	// Validate the file before touching the cluster. Fail fast on errors.
+	if errs := config.ValidateFile(configImportFile); len(errs) > 0 {
+		_, _ = fmt.Fprintln(os.Stderr, "Config file validation failed:")
+		for _, e := range errs {
+			_, _ = fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		return fmt.Errorf("fix the errors above and re-run import")
+	}
+
+	// Re-read the file into an isolated viper to collect values.
 	fv := viper.New()
 	fv.SetConfigFile(configImportFile)
 	if err := fv.ReadInConfig(); err != nil {
@@ -107,15 +89,12 @@ func runConfigImport(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(os.Stderr, "warning: thunder.admin_client_secret is managed by OpenBao/ESO — ignoring")
 	}
 
-	// Collect only the keys that are explicitly set in the file.
-	data := make(map[string]string)
+	// Write ALL recognised keys. Keys absent from the file are stored as empty
+	// string (their zero value). This ensures the ConfigMap is always complete
+	// and ValidateLoaded can distinguish "never imported" from "explicitly empty".
+	data := make(map[string]string, len(config.ConfigMapKeys))
 	for _, k := range config.ConfigMapKeys {
-		if fv.IsSet(k) {
-			data[k] = fv.GetString(k)
-		}
-	}
-	if len(data) == 0 {
-		return fmt.Errorf("no recognised config keys found in %s", configImportFile)
+		data[k] = fv.GetString(k)
 	}
 
 	client, err := k8s.NewClient(kubeconfig)
@@ -125,8 +104,10 @@ func runConfigImport(cmd *cobra.Command, args []string) error {
 
 	const aepNamespace = "wso2-aep"
 	if err := ensureNamespace(ctx, client, aepNamespace); err != nil {
-		return err
+		return fmt.Errorf("ensure namespace %s: %w", aepNamespace, err)
 	}
+
+
 	existing, err := client.CoreV1().ConfigMaps(aepNamespace).Get(ctx, config.ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -144,12 +125,7 @@ func runConfigImport(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("create %s: %w", config.ConfigMapName, err)
 		}
 	} else {
-		if existing.Data == nil {
-			existing.Data = make(map[string]string)
-		}
-		for k, v := range data {
-			existing.Data[k] = v
-		}
+		existing.Data = data
 		_, err = client.CoreV1().ConfigMaps(aepNamespace).Update(ctx, existing, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("update %s: %w", config.ConfigMapName, err)
@@ -161,9 +137,11 @@ func runConfigImport(cmd *cobra.Command, args []string) error {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	_, _ = fmt.Fprintf(os.Stdout, "Applied %d key(s) to %s/%s:\n", len(keys), aepNamespace, config.ConfigMapName)
+	_, _ = fmt.Fprintf(os.Stdout, "Wrote %d key(s) to %s/%s:\n", len(keys), aepNamespace, config.ConfigMapName)
 	for _, k := range keys {
-		_, _ = fmt.Fprintf(os.Stdout, "  %s\n", k)
+		_, _ = fmt.Fprintf(os.Stdout, "  %s = %s\n", k, data[k])
 	}
+	_, _ = fmt.Fprintln(os.Stdout, "\nRun 'aep platform install' to apply.")
 	return nil
 }
+

--- a/tools/aepctl/cmd/init.go
+++ b/tools/aepctl/cmd/init.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,29 +53,33 @@ const (
 )
 
 var (
-	initPlatformChart        string
-	initPlatformVersion      string
-	initPlatformRelease      string
-	initPlatformNamespace    string
-	initConsoleURL           string
-	initAPIURL               string
-	initWorkspacesAccessMode string
-	initBuildPlaneNamespace  string
-	initRegistryService      string
-	initOCNamespace          string
-	initSkipOCVersionCheck   bool
-	initOpenBaoDirect        bool
+	initPlatformChart       string
+	initPlatformVersion     string
+	initPlatformRelease     string
+	initPlatformNamespace   string
+	initConsoleURL          string
+	initAPIURL              string
+	initBuildPlaneNamespace string
+	initRegistryService     string
+	initOCNamespace         string
+	initSkipOCVersionCheck  bool
+	initOpenBaoDirect       bool
+	initReuseSecrets        bool
 )
 
 var initCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Provision OpenBao secrets, install the platform, and configure Thunder",
 	Long: `Full AEP platform installation in one command:
-  1. Seeds all platform secrets into OpenChoreo's built-in OpenBao instance
-  2. Installs or upgrades the platform Helm chart (idempotent)
-  3. Waits for all platform pods to be ready
-  4. Registers AEP OAuth clients in Thunder
-  5. Writes cluster config to the aep-cli-config ConfigMap`,
+  1. Validates the cluster config (imported via 'aep platform config import')
+  2. Seeds all platform secrets into OpenChoreo's built-in OpenBao instance
+  3. Installs or upgrades the platform Helm chart (idempotent)
+  4. Waits for all platform pods to be ready
+  5. Registers AEP OAuth clients in Thunder
+
+Run 'aep platform config import --config <file>' before this command.
+All configuration values are read from the imported ConfigMap — no
+hardcoded defaults are used.`,
 	RunE: runAEPInit,
 }
 
@@ -88,26 +91,35 @@ func init() {
 	initCmd.Flags().StringVar(&initPlatformNamespace, "namespace", "wso2-aep", "Kubernetes namespace")
 	initCmd.Flags().StringVar(&initConsoleURL, "console-url", "http://console.openchoreo.localhost:8080", "Public URL of the AEP console")
 	initCmd.Flags().StringVar(&initAPIURL, "api-url", "http://api.openchoreo.localhost:8080", "Public URL of the AEP API")
-	initCmd.Flags().StringVar(&initWorkspacesAccessMode, "workspaces-access-mode", "", "PVC access mode for the shared workspaces volume (ReadWriteOnce; override for local k3d)")
-	_ = viper.BindPFlag("platform.workspaces.access_mode", initCmd.Flags().Lookup("workspaces-access-mode"))
 	initCmd.Flags().StringVar(&initBuildPlaneNamespace, "build-plane-namespace", "openchoreo-workflow-plane", "Namespace of the OpenChoreo build/workflow plane (must already exist, incl. its image registry)")
 	initCmd.Flags().StringVar(&initRegistryService, "registry-service", "registry", "Name of the build-plane image registry Service (the coding-agent build pushes/pulls here)")
 	initCmd.Flags().StringVar(&initOCNamespace, "oc-namespace", "", "Namespace where OpenChoreo control-plane is installed (overrides config)")
 	_ = viper.BindPFlag("oc.system_namespace", initCmd.Flags().Lookup("oc-namespace"))
 	initCmd.Flags().BoolVar(&initSkipOCVersionCheck, "skip-oc-version-check", false, "Skip the OpenChoreo minimum version check (not recommended)")
-	initCmd.Flags().String("oc-api-url", "", "In-cluster URL of the OpenChoreo platform API")
+	initCmd.Flags().String("oc-api-url", "", "In-cluster URL of the OpenChoreo platform API (overrides config)")
 	_ = viper.BindPFlag("oc.api_url", initCmd.Flags().Lookup("oc-api-url"))
-	initCmd.Flags().String("webhook-delivery-url", "", "Public URL registered on each repo's webhook (e.g. https://webhook.example.com/api/v1/webhooks/github)")
+	initCmd.Flags().String("webhook-delivery-url", "", "Public URL registered on each repo's webhook (overrides config)")
 	_ = viper.BindPFlag("webhook.delivery_url", initCmd.Flags().Lookup("webhook-delivery-url"))
 	initCmd.Flags().BoolVar(&initOpenBaoDirect, "openbao-direct", false, "Enable OpenBao-direct secrets delivery — injects OPENBAO_ADDR/TOKEN into aep-api (required for local/OSS installs)")
 	_ = viper.BindPFlag("codingagent.openbao_direct.enabled", initCmd.Flags().Lookup("openbao-direct"))
 	initCmd.Flags().String("openbao-addr", "", "In-cluster URL of the OpenBao service (overrides config)")
 	_ = viper.BindPFlag("openbao.addr", initCmd.Flags().Lookup("openbao-addr"))
+	initCmd.Flags().BoolVar(&initReuseSecrets, "reuse-secrets", false, "Skip secret prompts and reuse secrets already seeded in OpenBao (for reinstall or upgrade)")
 	registerThunderFlags(initCmd)
 }
 
 func runAEPInit(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+
+	// Pre-flight: all config values must come from the imported ConfigMap.
+	// PersistentPreRunE has already loaded it; fail fast if any required key is missing.
+	if errs := config.ValidateLoaded(); len(errs) > 0 {
+		_, _ = fmt.Fprintln(os.Stderr, "Missing or invalid config. Run 'aep platform config import --config <file>' first:")
+		for _, e := range errs {
+			_, _ = fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		return fmt.Errorf("config validation failed")
+	}
 
 	if _, err := exec.LookPath("helm"); err != nil {
 		return fmt.Errorf("helm is required but was not found in PATH\nInstall it from https://helm.sh/docs/intro/install/ and try again")
@@ -118,14 +130,9 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("connect to cluster: %w", err)
 	}
 
-	_, cmErr := k8sClient.CoreV1().ConfigMaps(initPlatformNamespace).Get(ctx, config.ConfigMapName, metav1.GetOptions{})
-	if cmErr == nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: existing %s found — re-running install will overwrite it.\n", config.ConfigMapName)
-		_, _ = fmt.Fprintf(os.Stderr, "  Export your config first with: aep platform config export\n")
-	}
-
+	ocNamespace := viper.GetString("oc.system_namespace")
 	if !initSkipOCVersionCheck {
-		if err := checkOCVersion(ctx, k8sClient, viper.GetString("oc.system_namespace"), minOCVersion); err != nil {
+		if err := checkOCVersion(ctx, k8sClient, ocNamespace, minOCVersion); err != nil {
 			return err
 		}
 	}
@@ -134,40 +141,48 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// 1. Prompt for secrets.
-	anthropicKey, err := readMaskedInput("Anthropic API key")
-	if err != nil {
-		return fmt.Errorf("read Anthropic API key: %w", err)
-	}
-	if anthropicKey == "" {
-		return fmt.Errorf("an Anthropic API key is required")
-	}
-
 	openBaoDirect := viper.GetBool("codingagent.openbao_direct.enabled")
-	if openBaoDirect && os.Getenv("AEP_OPENBAO_TOKEN") == "" {
-		obToken, err := readMaskedInput("OpenBao token (Enter = use default \"root\")")
-		if err != nil {
-			return fmt.Errorf("read OpenBao token: %w", err)
-		}
-		if obToken != "" {
-			viper.Set("openbao.token", obToken)
-		}
-	}
 
-	if os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET") == "" {
-		thunderSecret, err := readMaskedInput("Thunder admin client secret (Enter = use Thunder default)")
+	// 1. Secrets: either reuse existing OpenBao secrets or prompt + provision fresh ones.
+	if initReuseSecrets {
+		_, _ = fmt.Fprintln(os.Stdout, "Verifying existing OpenBao secrets...")
+		if err := verifyOpenBaoSecrets(ctx); err != nil {
+			return fmt.Errorf("reuse-secrets verification failed: %w\nRemove --reuse-secrets to run a fresh install", err)
+		}
+		_, _ = fmt.Fprintln(os.Stdout, "Existing secrets verified — skipping provisioning.")
+	} else {
+		anthropicKey, err := readMaskedInput("Anthropic API key")
 		if err != nil {
-			return fmt.Errorf("read Thunder admin client secret: %w", err)
+			return fmt.Errorf("read Anthropic API key: %w", err)
 		}
-		if thunderSecret != "" {
-			viper.Set("thunder.admin_client_secret", thunderSecret)
+		if anthropicKey == "" {
+			return fmt.Errorf("an Anthropic API key is required")
 		}
-	}
 
-	// 2. Provision OpenBao — seed all platform secrets into OC's built-in instance.
-	_, _ = fmt.Fprintln(os.Stdout, "Provisioning OpenBao secrets...")
-	if err := provisionOpenBao(ctx, anthropicKey); err != nil {
-		return fmt.Errorf("provision OpenBao: %w", err)
+		if openBaoDirect && os.Getenv("AEP_OPENBAO_TOKEN") == "" {
+			obToken, err := readMaskedInput("OpenBao token (Enter = use default \"root\")")
+			if err != nil {
+				return fmt.Errorf("read OpenBao token: %w", err)
+			}
+			if obToken != "" {
+				viper.Set("openbao.token", obToken)
+			}
+		}
+
+		if os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET") == "" {
+			thunderSecret, err := readMaskedInput("Thunder admin client secret (Enter = use value from config)")
+			if err != nil {
+				return fmt.Errorf("read Thunder admin client secret: %w", err)
+			}
+			if thunderSecret != "" {
+				viper.Set("thunder.admin_client_secret", thunderSecret)
+			}
+		}
+
+		_, _ = fmt.Fprintln(os.Stdout, "Provisioning OpenBao secrets...")
+		if err := provisionOpenBao(ctx, anthropicKey); err != nil {
+			return fmt.Errorf("provision OpenBao: %w", err)
+		}
 	}
 
 	// 3. Install the platform chart.
@@ -231,10 +246,7 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 5. Load the generated Thunder system-client secret from the ESO-synced
-	// aep-thunder-secrets Secret. aep init skips the PersistentPreRunE loader,
-	// so without this step doThunderSetup would fall back to the hardcoded
-	// viper default instead of the secret that was actually seeded. SetDefault
-	// means an explicit --thunder-admin-client-secret flag still takes precedence.
+	// aep-thunder-secrets Secret so doThunderSetup uses the actual seeded secret.
 	if err := config.LoadThunderSecretFromCluster(ctx, k8sClient, initPlatformNamespace); err != nil {
 		return fmt.Errorf("load Thunder secret: %w", err)
 	}
@@ -250,11 +262,6 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		initConsoleURL,
 	); err != nil {
 		return err
-	}
-
-	// 7. Persist non-sensitive config into the in-cluster ConfigMap.
-	if err := writeClusterConfig(ctx, k8sClient, initPlatformNamespace); err != nil {
-		return fmt.Errorf("write cluster config: %w", err)
 	}
 
 	_, _ = fmt.Fprintln(os.Stdout, "\nAEP is ready. Open the console to get started.")
@@ -374,6 +381,65 @@ func provisionOpenBao(ctx context.Context, anthropicKey string) error {
 	return nil
 }
 
+// verifyOpenBaoSecrets confirms all required secret paths exist in OpenBao.
+// Used by --reuse-secrets to ensure a previous install seeded everything before
+// skipping the provisioning step.
+func verifyOpenBaoSecrets(ctx context.Context) error {
+	pfCmd, err := openbao.PortForward(ctx, ocOpenBaoNamespace, ocOpenBaoRelease, kubeconfig)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = pfCmd.Process.Kill() }()
+
+	baseURL := "http://localhost:" + openbao.LocalPort
+	if err := openbao.WaitForReachable(ctx, baseURL, 30*time.Second); err != nil {
+		return fmt.Errorf("OpenBao not reachable: %w", err)
+	}
+
+	saToken, err := openbao.GetSAToken(ctx, ocOpenBaoNamespace, ocOpenBaoSA, kubeconfig)
+	if err != nil {
+		return err
+	}
+	token, err := openbao.KubernetesLogin(ctx, baseURL, ocWriteRole, saToken)
+	if err != nil {
+		return err
+	}
+
+	required := []string{
+		"aep/anthropic-api-key",
+		"aep/postgres-password",
+		"aep/task-signing-key",
+		"aep/oauth-state-key",
+		"aep/agents-jwt-secret",
+		"aep/webhook-secret",
+		"aep/opensearch-username",
+		"aep/opensearch-password",
+		"aep/thunder-clients/oc-workload-publisher",
+		"aep/thunder-clients/oc-observer-reader",
+		"aep/thunder-clients/aep-api-client",
+		"aep/thunder-clients/bff-git-service",
+		"aep/thunder-clients/bff-remote-worker",
+		"aep/thunder-clients/local-dev-seeder",
+		"aep/thunder-clients/system-client",
+		"aep/thunder-clients/openchoreo-rca-agent",
+	}
+
+	var missing []string
+	for _, path := range required {
+		_, status, err := openbao.Req(ctx, "GET", baseURL, token, "/v1/secret/data/"+path, nil)
+		if err != nil {
+			return fmt.Errorf("check secret %s: %w", path, err)
+		}
+		if status == 404 {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("the following secrets are not in OpenBao:\n  %s", strings.Join(missing, "\n  "))
+	}
+	return nil
+}
+
 // deleteOrphanedResources removes cluster resources that may have been created
 // by legacy setup scripts (setup-aep.sh) without Helm ownership labels. Helm
 // refuses to adopt them on install, so we delete and let the chart recreate.
@@ -401,33 +467,6 @@ func deleteOrphanedResources(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-func writeClusterConfig(ctx context.Context, client *kubernetes.Clientset, namespace string) error {
-	data := make(map[string]string, len(config.ConfigMapKeys))
-	for _, k := range config.ConfigMapKeys {
-		data[k] = viper.GetString(k)
-	}
-
-	existing, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, config.ConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("get %s: %w", config.ConfigMapName, err)
-		}
-		_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      config.ConfigMapName,
-				Namespace: namespace,
-				Labels:    map[string]string{"app.kubernetes.io/managed-by": "aepctl"},
-			},
-			Data: data,
-		}, metav1.CreateOptions{})
-		return err
-	}
-
-	existing.Data = data
-	_, err = client.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{})
-	return err
 }
 
 func checkOCVersion(ctx context.Context, client *kubernetes.Clientset, namespace, minVersion string) error {

--- a/tools/aepctl/internal/config/config.go
+++ b/tools/aepctl/internal/config/config.go
@@ -19,6 +19,8 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -52,54 +54,106 @@ var ConfigMapKeys = []string{
 	"webhook.local_smee.enabled",
 }
 
-// Init sets viper defaults and env-var bindings. Config is no longer read from
-// a local file — it is loaded from the cluster ConfigMap by LoadFromCluster,
-// called in root's PersistentPreRunE for every command except `aep init`.
+// keyKind describes the expected type of a config value for validation.
+type keyKind int
+
+const (
+	kindString keyKind = iota
+	kindBool
+	kindURL
+	kindEnum
+)
+
+type configKeyMeta struct {
+	required   bool
+	kind       keyKind
+	enumValues []string // only for kindEnum
+}
+
+// keyRegistry maps each ConfigMapKey to its validation metadata.
+var keyRegistry = map[string]configKeyMeta{
+	"thunder.namespace":                 {required: true, kind: kindString},
+	"thunder.url":                       {required: true, kind: kindURL},
+	"thunder.config_map":                {required: true, kind: kindString},
+	"thunder.deployment":                {required: true, kind: kindString},
+	"thunder.admin_client_id":           {required: true, kind: kindString},
+	"thunder.public_url":                {required: true, kind: kindURL},
+	"oc.api_url":                        {required: true, kind: kindURL},
+	"oc.system_namespace":               {required: true, kind: kindString},
+	"oc.org_namespace":                  {required: false, kind: kindString},
+	"oc.local_org_provisioning.enabled": {required: false, kind: kindBool},
+	"platform.workspaces.access_mode":   {required: false, kind: kindEnum, enumValues: []string{"", "ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"}},
+	"codingagent.openbao_direct.enabled": {required: false, kind: kindBool},
+	"openbao.addr":                      {required: false, kind: kindURL},
+	"webhook.delivery_url":              {required: false, kind: kindURL},
+	"webhook.local_smee.enabled":        {required: false, kind: kindBool},
+}
+
+// Init sets env-var bindings. All config values must come from the cluster
+// ConfigMap loaded by LoadFromCluster — no hardcoded defaults are set here.
 func Init() {
 	viper.SetEnvPrefix("AEP")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
+}
 
-	// Platform install defaults.
-	// platform.workspaces.access_mode: PVC access mode for the shared git workspaces
-	// volume. Empty means use the chart default (ReadWriteMany).
-	viper.SetDefault("platform.workspaces.access_mode", "")
+// ValidateFile reads the YAML at path into an isolated viper instance and
+// returns one error string per invalid or missing required key. Empty slice
+// means the file is valid.
+func ValidateFile(path string) []string {
+	fv := viper.New()
+	fv.SetConfigFile(path)
+	if err := fv.ReadInConfig(); err != nil {
+		return []string{fmt.Sprintf("cannot read config file: %s", err)}
+	}
+	return validateViper(fv)
+}
 
-	// OpenChoreo platform API defaults.
-	viper.SetDefault("oc.api_url", "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080")
-	viper.SetDefault("oc.system_namespace", "openchoreo-control-plane")
-	viper.SetDefault("oc.local_org_provisioning.enabled", false)
-	viper.SetDefault("oc.org_namespace", "default")
+// ValidateLoaded checks the currently resolved global viper state (populated
+// after LoadFromCluster) and returns one error string per invalid or missing
+// required key.
+func ValidateLoaded() []string {
+	return validateViper(viper.GetViper())
+}
 
-	// Coding-agent secrets delivery.
-	// codingagent.openbao_direct.enabled: injects OPENBAO_ADDR/TOKEN into
-	// aep-api for direct OpenBao secrets delivery. Required for local/OSS
-	// installs; production overlays inject a managed SecretsProvider instead.
-	viper.SetDefault("codingagent.openbao_direct.enabled", false)
-
-	// OpenBao address — used when codingagent.openbao_direct.enabled=true.
-	viper.SetDefault("openbao.addr", "http://openbao.openbao.svc.cluster.local:8200")
-	// openbao.token is intentionally absent from ConfigMapKeys — it is a
-	// credential and must be supplied via AEP_OPENBAO_TOKEN env var or
-	// prompted interactively. The default "root" applies to local dev only.
-	viper.SetDefault("openbao.token", "root")
-
-	// GitHub webhook delivery.
-	// webhook.delivery_url: registered on each repo's webhook. Set to the real
-	// public HTTPS URL of aep-api's /api/v1/webhooks/github in production.
-	// webhook.local_smee.enabled: deploys an in-cluster smee-client — off by
-	// default in production; use a real ingress + public delivery_url instead.
-	viper.SetDefault("webhook.delivery_url", "")
-	viper.SetDefault("webhook.local_smee.enabled", false)
-
-	// Thunder defaults — also overridable via AEP_THUNDER_* env vars.
-	viper.SetDefault("thunder.namespace", "thunder")
-	viper.SetDefault("thunder.url", "http://thunder-service.thunder.svc.cluster.local:8090")
-	viper.SetDefault("thunder.config_map", "thunder-config-map")
-	viper.SetDefault("thunder.deployment", "thunder-deployment")
-	viper.SetDefault("thunder.admin_client_id", "aep-system-client")
-	viper.SetDefault("thunder.admin_client_secret", "aep-system-client-secret")
-	viper.SetDefault("thunder.public_url", "http://thunder.openchoreo.localhost:8080")
+func validateViper(v *viper.Viper) []string {
+	var errs []string
+	for _, k := range ConfigMapKeys {
+		meta, ok := keyRegistry[k]
+		if !ok {
+			continue
+		}
+		val := v.GetString(k)
+		if meta.required && val == "" {
+			errs = append(errs, fmt.Sprintf("%s: required but not set", k))
+			continue
+		}
+		if val == "" {
+			continue // optional + empty → skip further checks
+		}
+		switch meta.kind {
+		case kindBool:
+			if _, err := strconv.ParseBool(val); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: invalid boolean value %q", k, val))
+			}
+		case kindURL:
+			if _, err := url.ParseRequestURI(val); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: not a valid URL: %q", k, val))
+			}
+		case kindEnum:
+			valid := false
+			for _, ev := range meta.enumValues {
+				if val == ev {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				errs = append(errs, fmt.Sprintf("%s: invalid value %q — must be one of %v", k, val, meta.enumValues))
+			}
+		}
+	}
+	return errs
 }
 
 // LoadFromCluster reads the aep-cli-config ConfigMap from the given namespace

--- a/tools/aepctl/internal/config/config.go
+++ b/tools/aepctl/internal/config/config.go
@@ -137,8 +137,9 @@ func validateViper(v *viper.Viper) []string {
 				errs = append(errs, fmt.Sprintf("%s: invalid boolean value %q", k, val))
 			}
 		case kindURL:
-			if _, err := url.ParseRequestURI(val); err != nil {
-				errs = append(errs, fmt.Sprintf("%s: not a valid URL: %q", k, val))
+			parsed, err := url.ParseRequestURI(val)
+			if err != nil || parsed.Host == "" {
+				errs = append(errs, fmt.Sprintf("%s: not a valid absolute URL (must include scheme and host): %q", k, val))
 			}
 		case kindEnum:
 			valid := false


### PR DESCRIPTION
## Summary

- Eliminates all hardcoded defaults from `aep platform install`. Every config value (URLs, namespaces, booleans) must now come from an explicitly imported ConfigMap — no silent fallbacks.
- Adds `aep platform config test` command to validate a local YAML file or the live cluster ConfigMap before importing.
- Hardens `aep platform config import` to validate before writing, create the `wso2-aep` namespace if absent, and do a full replace of all keys (not a merge).
- Adds `--reuse-secrets` flag to `aep platform install` so reinstalls and upgrades skip secret prompts and OpenBao provisioning, verifying existing secrets instead.

## New workflow

```sh
# 1. Validate your config file
aep platform config test --config ~/aepctl-configs/defaults.yaml

# 2. Import to cluster (creates wso2-aep namespace if needed)
aep platform config import --config ~/aepctl-configs/defaults.yaml

# 3. Install (reads ConfigMap; no hardcoded defaults)
aep platform install

# On reinstall/upgrade — skip prompts, reuse existing OpenBao secrets
aep platform install --reuse-secrets
```

## Changes by file

| File | Change |
|------|--------|
| `internal/config/config.go` | `Init()` no longer calls `viper.SetDefault`; added `keyRegistry` with per-key validation metadata; added `ValidateFile` and `ValidateLoaded` |
| `cmd/config_validate.go` | **New** — `aep platform config test` command |
| `cmd/configure.go` | Validates before writing; creates namespace; writes all keys (full replace) |
| `cmd/init.go` | Removed `skipClusterConfig`; pre-flight `ValidateLoaded`; added `--reuse-secrets`; removed `writeClusterConfig` |

## Test plan

- [ ] `aep platform config test --config defaults.yaml` → "Config is valid."
- [ ] Remove a required key (`thunder.url`) → test prints `thunder.url: required but not set`, exits 1
- [ ] Set an invalid access mode → test prints enum error
- [ ] `aep platform config import` on a cluster with no `wso2-aep` namespace → creates namespace + ConfigMap
- [ ] `aep platform install` with no ConfigMap → fails immediately with "Run 'aep platform config import...' first"
- [ ] `aep platform install` after import → proceeds normally
- [ ] `aep platform install --reuse-secrets` with secrets in OpenBao → skips prompts
- [ ] `aep platform install --reuse-secrets` with missing secrets → lists missing paths and exits 1

🤖 Generated with [Claude Code](https://claude.ai/claude-code)