### PR TITLE
fix(deployments): pin locally-imported images against kubelet image GC

### DIFF
--- a/deployments/scripts/build-runner.sh
+++ b/deployments/scripts/build-runner.sh
@@ -38,6 +38,8 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/env.sh"
+# pin_node_image — keeps the imported tag out of kubelet's image GC.
+source "$SCRIPT_DIR/utils.sh"
 
 IMAGE="${AGENT_RUNNER_IMAGE:-aep-runner:dev}"
 WORKER_DIR="$SCRIPT_DIR/../../runners/remote-worker"
@@ -72,9 +74,23 @@ fi
 if [ "${SKIP_IMPORT:-0}" = "1" ]; then
     echo "⏭️  node import skipped (SKIP_IMPORT=1) — the caller owns it"
 elif command -v k3d &>/dev/null && k3d cluster list "$CLUSTER_NAME" &>/dev/null; then
-    k3d image import "$IMAGE" -c "$CLUSTER_NAME" \
-        && echo "✅ imported $IMAGE into k3d cluster '$CLUSTER_NAME'" \
-        || echo "⚠️  k3d image import failed; first dispatch may cold-pull"
+    if k3d image import "$IMAGE" -c "$CLUSTER_NAME"; then
+        # A successful import is not durable on its own: this tag is local-only and
+        # the largest image on the node, so kubelet's image GC evicts it between
+        # dispatches and the next Job has no registry to fall back to. pin_node_image
+        # both pins it and verifies it actually landed — `k3d image import` is known
+        # to flake and still exit 0, and that shows up here as exit 2 (image in no
+        # node), which is an import failure rather than a pinning one.
+        PIN_RC=0
+        pin_node_image "$IMAGE" || PIN_RC=$?
+        case "$PIN_RC" in
+            0) echo "✅ imported $IMAGE into k3d cluster '$CLUSTER_NAME' (verified in node containerd)" ;;
+            2) echo "⚠️  import reported success but did not land; first dispatch may cold-pull — re-run 'make build-runner'" ;;
+            *) echo "✅ imported $IMAGE into k3d cluster '$CLUSTER_NAME' (unpinned — see the warning above)" ;;
+        esac
+    else
+        echo "⚠️  k3d image import failed; first dispatch may cold-pull"
+    fi
 else
     echo "ℹ️  k3d cluster '$CLUSTER_NAME' not found — built the image only; setup-aep.sh imports it at cluster setup."
 fi

--- a/deployments/scripts/build-runner.sh
+++ b/deployments/scripts/build-runner.sh
@@ -74,22 +74,30 @@ fi
 if [ "${SKIP_IMPORT:-0}" = "1" ]; then
     echo "⏭️  node import skipped (SKIP_IMPORT=1) — the caller owns it"
 elif command -v k3d &>/dev/null && k3d cluster list "$CLUSTER_NAME" &>/dev/null; then
+    # A missing image is a FAILURE, not a warning: this tag is local-only, so a pod
+    # that cannot find it has no registry to fall back on and the dispatch is dead.
+    # Both callers already expect a non-zero exit here and turn it into their own
+    # message (setup-aep.sh's "dispatch stays disabled until fixed", setup.sh's
+    # background-build branch), so exiting non-zero is what makes those fire.
     if k3d image import "$IMAGE" -c "$CLUSTER_NAME"; then
-        # A successful import is not durable on its own: this tag is local-only and
-        # the largest image on the node, so kubelet's image GC evicts it between
-        # dispatches and the next Job has no registry to fall back to. pin_node_image
-        # both pins it and verifies it actually landed — `k3d image import` is known
-        # to flake and still exit 0, and that shows up here as exit 2 (image in no
-        # node), which is an import failure rather than a pinning one.
+        # A successful import is not durable on its own: an idle local-only tag is
+        # collected early by kubelet's image GC, and the next Job then has nothing to
+        # pull. pin_node_image both pins it and verifies it actually landed on every
+        # node — `k3d image import` is known to flake and still exit 0, which shows
+        # up here as exit 2 and is an import failure rather than a pinning one.
         PIN_RC=0
         pin_node_image "$IMAGE" || PIN_RC=$?
         case "$PIN_RC" in
             0) echo "✅ imported $IMAGE into k3d cluster '$CLUSTER_NAME' (verified in node containerd)" ;;
-            2) echo "⚠️  import reported success but did not land; first dispatch may cold-pull — re-run 'make build-runner'" ;;
+            2) echo "❌ import reported success but the image is not in the node — re-run 'make build-runner'"
+               exit 1 ;;
+            # Pinned-but-unlabelled: the image IS there, so dispatch works today. Not
+            # worth failing a build over — it only means GC can still evict it.
             *) echo "✅ imported $IMAGE into k3d cluster '$CLUSTER_NAME' (unpinned — see the warning above)" ;;
         esac
     else
-        echo "⚠️  k3d image import failed; first dispatch may cold-pull"
+        echo "❌ k3d image import failed — $IMAGE is not in the node and has no registry to pull from"
+        exit 1
     fi
 else
     echo "ℹ️  k3d cluster '$CLUSTER_NAME' not found — built the image only; setup-aep.sh imports it at cluster setup."

--- a/deployments/scripts/setup-aep.sh
+++ b/deployments/scripts/setup-aep.sh
@@ -567,7 +567,17 @@ docker build -t thunder-app-operator:local "${SCRIPT_DIR}/../single-cluster/reso
 k3d image import thunder-app-operator:local -c "${CLUSTER_NAME}"
 # pullPolicy=Never below means an image-GC eviction of this local-only tag is fatal
 # (ErrImageNeverPull, no registry to recover from) — pin it. See utils.sh.
-pin_node_image thunder-app-operator:local || true
+# Exit 2 means the import silently did not land, which `set -e` already treats as
+# fatal when the import command itself fails; the helm install below would otherwise
+# deploy an operator whose pod can never start. Exit 1 leaves the image usable but
+# collectible, which is a warning, not a reason to abort setup.
+PIN_RC=0
+pin_node_image thunder-app-operator:local || PIN_RC=$?
+if [ "$PIN_RC" = "2" ]; then
+    echo "❌ thunder-app-operator:local did not land in the node — the operator would"
+    echo "   stay ErrImageNeverPull (pullPolicy: Never, no registry). Re-run setup-aep.sh."
+    exit 1
+fi
 helm upgrade --install thunder-app-operator \
     "${SCRIPT_DIR}/../single-cluster/resource-types/thunder-app/operator/helm" \
     -n thunder-app-operator-system --create-namespace \

--- a/deployments/scripts/setup-aep.sh
+++ b/deployments/scripts/setup-aep.sh
@@ -565,6 +565,9 @@ echo ""
 echo "🔧 Building + installing thunder-app-operator..."
 docker build -t thunder-app-operator:local "${SCRIPT_DIR}/../single-cluster/resource-types/thunder-app/operator"
 k3d image import thunder-app-operator:local -c "${CLUSTER_NAME}"
+# pullPolicy=Never below means an image-GC eviction of this local-only tag is fatal
+# (ErrImageNeverPull, no registry to recover from) — pin it. See utils.sh.
+pin_node_image thunder-app-operator:local || true
 helm upgrade --install thunder-app-operator \
     "${SCRIPT_DIR}/../single-cluster/resource-types/thunder-app/operator/helm" \
     -n thunder-app-operator-system --create-namespace \

--- a/deployments/scripts/setup-observability.sh
+++ b/deployments/scripts/setup-observability.sh
@@ -269,13 +269,23 @@ if docker image inspect "$RCA_IMAGE" >/dev/null 2>&1; then
         echo "⚠️  import attempt ${attempt} did not land in the node (transient k3d flake) — retrying..."
     done
     if [ -n "$IMPORTED" ]; then
-        echo "✅ imported $RCA_IMAGE into k3d-$CLUSTER_NAME (verified in node containerd)"
         # The patched tag is built locally and exists in no registry, so an image-GC
         # eviction would be unrecoverable — pin it (see pin_node_image in utils.sh).
-        pin_node_image "$RCA_IMAGE" || true
-    else
-        echo "⚠️  k3d import failed twice — switching to registry-direct: the cluster"
-        echo "    will pull ${RCA_IMAGE_PULL} from Docker Hub instead."
+        # It also re-verifies on EVERY server/agent node, where _rca_image_in_node
+        # above only checks server-0: exit 2 means the import landed on some nodes
+        # but not all, so fall through to the registry-direct path rather than
+        # deploying a pod that cannot start wherever the image is missing.
+        PIN_RC=0
+        pin_node_image "$RCA_IMAGE" || PIN_RC=$?
+        if [ "$PIN_RC" = "2" ]; then
+            IMPORTED=""
+        else
+            echo "✅ imported $RCA_IMAGE into k3d-$CLUSTER_NAME (verified in node containerd)"
+        fi
+    fi
+    if [ -z "$IMPORTED" ]; then
+        echo "⚠️  k3d import did not land on every node — switching to registry-direct:"
+        echo "    the cluster will pull ${RCA_IMAGE_PULL} from Docker Hub instead."
         RCA_IMAGE_REPO="${RCA_IMAGE_PULL%%:*}"
         RCA_IMAGE_TAG="${RCA_IMAGE_PULL##*:}"
     fi

--- a/deployments/scripts/setup-observability.sh
+++ b/deployments/scripts/setup-observability.sh
@@ -270,6 +270,9 @@ if docker image inspect "$RCA_IMAGE" >/dev/null 2>&1; then
     done
     if [ -n "$IMPORTED" ]; then
         echo "✅ imported $RCA_IMAGE into k3d-$CLUSTER_NAME (verified in node containerd)"
+        # The patched tag is built locally and exists in no registry, so an image-GC
+        # eviction would be unrecoverable — pin it (see pin_node_image in utils.sh).
+        pin_node_image "$RCA_IMAGE" || true
     else
         echo "⚠️  k3d import failed twice — switching to registry-direct: the cluster"
         echo "    will pull ${RCA_IMAGE_PULL} from Docker Hub instead."

--- a/deployments/scripts/utils.sh
+++ b/deployments/scripts/utils.sh
@@ -438,8 +438,10 @@ EOF
 # sits in ImagePullBackOff (or ErrImageNeverPull under `pullPolicy: Never`) until
 # someone re-imports by hand. kubelet's imageGCManager collects unused images once
 # the node's image filesystem crosses its high threshold — 85%, freeing down to
-# 80% — largest and coldest first, which is exactly what these tags are between
-# uses. The thresholds are kubelet defaults; nothing in
+# 80% — least recently used first (it sorts byLastUsedAndDetected, NOT by size),
+# and keeps going until it has freed enough bytes. An idle local-only tag is
+# therefore taken early, and a large one frees a big chunk of the target in one
+# go. The thresholds are kubelet defaults; nothing in
 # deployments/k3d-local-config.yaml currently sets them (it could, by the same
 # --kubelet-arg mechanism it already uses for eviction-hard).
 #
@@ -451,20 +453,28 @@ EOF
 # An import REPLACES the containerd record, so this belongs in the import path —
 # a one-off `ctr label` does not survive the next import.
 #
+# The contract is ALL-OR-NOTHING across the cluster's server/agent nodes, because a
+# pod is scheduled to one of them and a partial result is a bug on whichever node
+# was missed. Anything less than complete is reported as a failure, never as a
+# qualified success.
+#
 # Usage: pin_node_image <repo:tag>
-#   0 — pinned on at least one node
-#   1 — the image is there but the label could not be applied
-#   2 — the image is on no node, i.e. the import did not land (k3d image import is
-#       known to flake and still exit 0; see the RCA import in
-#       setup-observability.sh). Callers should treat this as an import failure,
-#       not a pinning failure.
+#   0 — every eligible node has the image and it is pinned there
+#   1 — every node has it, but the label could not be applied somewhere; the image
+#       is usable, it is just still collectible
+#   2 — at least one eligible node is missing the image (or there are no eligible
+#       nodes), i.e. the import did not land. `k3d image import` is known to flake
+#       and still exit 0 — see the RCA import in setup-observability.sh — so
+#       callers should treat this as an import failure, not a pinning failure.
 pin_node_image() {
-    local image="$1" found=0 pinned=0 node ref
+    local image="$1" nodes eligible=0 found=0 pinned=0 node ref
     # Every server/agent node: `k3d image import` loads into all of them, so
     # pinning only the first would leave the eviction reproducible on whichever
     # node the pod happens to land on. The loadbalancer node runs no containerd.
-    for node in $(k3d node list --no-headers 2>/dev/null \
-        | awk -v c="$CLUSTER_NAME" '$3 == c && ($2 == "server" || $2 == "agent") { print $1 }'); do
+    nodes="$(k3d node list --no-headers 2>/dev/null \
+        | awk -v c="$CLUSTER_NAME" '$3 == c && ($2 == "server" || $2 == "agent") { print $1 }')"
+    for node in $nodes; do
+        eligible=$((eligible + 1))
         # A local tag lands as docker.io/library/<repo>:<tag>; a registry-qualified
         # name keeps its host. Match the WHOLE ref against both forms — a substring
         # match would happily select <repo>:<tag>-debug and pin the wrong record.
@@ -475,15 +485,19 @@ pin_node_image() {
         docker exec "$node" ctr -n k8s.io images label \
             "$ref" io.cri-containerd.pinned=pinned >/dev/null 2>&1 && pinned=$((pinned + 1))
     done
-    if [ "$found" -eq 0 ]; then
-        echo "⚠️  $image is in no node's containerd — the import did not land"
+    if [ "$eligible" -eq 0 ]; then
+        echo "⚠️  no server/agent node found for cluster '$CLUSTER_NAME' — cannot pin $image"
         return 2
     fi
-    if [ "$pinned" -eq 0 ]; then
-        echo "⚠️  could not pin $image — kubelet image GC may evict this local-only tag"
+    if [ "$found" -lt "$eligible" ]; then
+        echo "⚠️  $image is missing from $((eligible - found))/$eligible node(s) — the import did not land"
+        return 2
+    fi
+    if [ "$pinned" -lt "$found" ]; then
+        echo "⚠️  could not pin $image on $((found - pinned))/$found node(s) — kubelet image GC may evict this local-only tag"
         return 1
     fi
-    echo "📌 pinned $image against kubelet image GC ($pinned node(s))"
+    echo "📌 pinned $image against kubelet image GC ($pinned/$eligible node(s))"
     return 0
 }
 

--- a/deployments/scripts/utils.sh
+++ b/deployments/scripts/utils.sh
@@ -431,6 +431,64 @@ EOF
 
 
 # ----------------------------------------------------------------------------
+# Locally-imported images
+# ----------------------------------------------------------------------------
+# An image that was IMPORTED into the node rather than pulled has no registry
+# behind it, so a kubelet eviction is unrecoverable: the next pod that needs it
+# sits in ImagePullBackOff (or ErrImageNeverPull under `pullPolicy: Never`) until
+# someone re-imports by hand. kubelet's imageGCManager collects unused images once
+# the node's image filesystem crosses its high threshold — 85%, freeing down to
+# 80% — largest and coldest first, which is exactly what these tags are between
+# uses. The thresholds are kubelet defaults; nothing in
+# deployments/k3d-local-config.yaml currently sets them (it could, by the same
+# --kubelet-arg mechanism it already uses for eviction-hard).
+#
+# Labelling the image `io.cri-containerd.pinned=pinned` is containerd's own way of
+# saying an image has no upstream to recover from: CRI reports it as
+# `pinned: true` and the kubelet skips it when collecting. Verify with
+#   docker exec k3d-<cluster>-server-0 crictl inspecti <repo>:<tag> | grep pinned
+#
+# An import REPLACES the containerd record, so this belongs in the import path —
+# a one-off `ctr label` does not survive the next import.
+#
+# Usage: pin_node_image <repo:tag>
+#   0 — pinned on at least one node
+#   1 — the image is there but the label could not be applied
+#   2 — the image is on no node, i.e. the import did not land (k3d image import is
+#       known to flake and still exit 0; see the RCA import in
+#       setup-observability.sh). Callers should treat this as an import failure,
+#       not a pinning failure.
+pin_node_image() {
+    local image="$1" found=0 pinned=0 node ref
+    # Every server/agent node: `k3d image import` loads into all of them, so
+    # pinning only the first would leave the eviction reproducible on whichever
+    # node the pod happens to land on. The loadbalancer node runs no containerd.
+    for node in $(k3d node list --no-headers 2>/dev/null \
+        | awk -v c="$CLUSTER_NAME" '$3 == c && ($2 == "server" || $2 == "agent") { print $1 }'); do
+        # A local tag lands as docker.io/library/<repo>:<tag>; a registry-qualified
+        # name keeps its host. Match the WHOLE ref against both forms — a substring
+        # match would happily select <repo>:<tag>-debug and pin the wrong record.
+        ref="$(docker exec "$node" ctr -n k8s.io images ls -q 2>/dev/null \
+            | grep -m1 -Fx -e "$image" -e "docker.io/library/$image" || true)"
+        [ -n "$ref" ] || continue
+        found=$((found + 1))
+        docker exec "$node" ctr -n k8s.io images label \
+            "$ref" io.cri-containerd.pinned=pinned >/dev/null 2>&1 && pinned=$((pinned + 1))
+    done
+    if [ "$found" -eq 0 ]; then
+        echo "⚠️  $image is in no node's containerd — the import did not land"
+        return 2
+    fi
+    if [ "$pinned" -eq 0 ]; then
+        echo "⚠️  could not pin $image — kubelet image GC may evict this local-only tag"
+        return 1
+    fi
+    echo "📌 pinned $image against kubelet image GC ($pinned node(s))"
+    return 0
+}
+
+
+# ----------------------------------------------------------------------------
 # Public URL handling
 # ----------------------------------------------------------------------------
 # .env carries two canonical fields:

--- a/runners/AGENTS.md
+++ b/runners/AGENTS.md
@@ -190,3 +190,17 @@ into the runner pod at `/app/skills` for live skill edits (see
   critical path) and imports it in `setup-aep.sh`; `PREBUILD_RUNNER=0` reverts
   to a serial build. The build is skipped when the tag exists, so use
   `FORCE=1 make build-runner` after changing the Dockerfile or `src/`.
+- **The imported tag is pinned in containerd** — `build-runner.sh` calls
+  `pin_node_image` (`deployments/scripts/utils.sh`) after a successful
+  `k3d image import`. `aep-runner:dev` is local-only, so there is no registry to
+  re-pull from, yet it is the largest and coldest image on the k3d node: exactly
+  what kubelet's imageGCManager evicts first once the node's image filesystem
+  crosses its high threshold (85%, freeing down to 80%), which leaves the next
+  dispatch in `ImagePullBackOff` with nothing to recover from. The same helper
+  covers the other local-only imports (`thunder-app-operator:local`, the patched
+  RCA image). It doubles as import verification: an image in no node's containerd
+  means the import silently did not land. Verify a pin from the host with
+  `docker exec k3d-openchoreo-server-0 crictl inspecti aep-runner:dev` →
+  `"pinned": true` (there is no host-side `crictl`). An import replaces the
+  containerd record, so the pin has to live in the import path, not in a manual
+  step.

--- a/runners/AGENTS.md
+++ b/runners/AGENTS.md
@@ -193,10 +193,12 @@ into the runner pod at `/app/skills` for live skill edits (see
 - **The imported tag is pinned in containerd** — `build-runner.sh` calls
   `pin_node_image` (`deployments/scripts/utils.sh`) after a successful
   `k3d image import`. `aep-runner:dev` is local-only, so there is no registry to
-  re-pull from, yet it is the largest and coldest image on the k3d node: exactly
-  what kubelet's imageGCManager evicts first once the node's image filesystem
-  crosses its high threshold (85%, freeing down to 80%), which leaves the next
-  dispatch in `ImagePullBackOff` with nothing to recover from. The same helper
+  re-pull from, and it sits idle between dispatches: kubelet's imageGCManager
+  collects least-recently-used images first (it sorts `byLastUsedAndDetected`, not
+  by size) once the node's image filesystem crosses its high threshold (85%,
+  freeing down to 80%), so an idle runner tag goes early and its size means one
+  eviction covers much of the target. That leaves the next dispatch in
+  `ImagePullBackOff` with nothing to recover from. The same helper
   covers the other local-only imports (`thunder-app-operator:local`, the patched
   RCA image). It doubles as import verification: an image in no node's containerd
   means the import silently did not land. Verify a pin from the host with


### PR DESCRIPTION
Closes #471.

## What

`pin_node_image` in `deployments/scripts/utils.sh` labels an imported image
`io.cri-containerd.pinned=pinned` on every server/agent node of the cluster. Called
from all three local-only import paths:

| Path | Image | Why it cannot recover |
|---|---|---|
| `build-runner.sh` | `aep-runner:dev` | local-only tag; both task kinds dispatch on it |
| `setup-aep.sh` | `thunder-app-operator:local` | installed `pullPolicy: Never` → `ErrImageNeverPull` |
| `setup-observability.sh` | patched RCA tag | built locally, exists in no registry |

That label is containerd's own declaration that an image has no upstream to recover
from: CRI reports it as `pinned: true` and the kubelet skips pinned images when
collecting. It lives in the import path because an import **replaces** the containerd
record, so a one-off `ctr label` does not survive the next build.

The helper doubles as import verification. `k3d image import` is known to flake
transiently and still exit 0 (already documented at `setup-observability.sh`), so
"image in no node's containerd" returns exit 2 and is reported as an import that did
not land — not as a pinning failure. Getting that wrong would print `✅ imported`
followed by a GC warning while the real problem was a missing image.

Pinning covers **all three** rather than just the runner on purpose: GC frees down to
80% regardless, so removing only the largest image from the menu makes it take the
siblings instead. That is not hypothetical — see proof 3.

## Why

An image imported into the k3d node has no registry behind it, so a kubelet eviction
is unrecoverable. kubelet's imageGCManager collects unused images once the node's
image filesystem crosses its high threshold (85%, freeing to 80%), largest and coldest
first — exactly what `aep-runner:dev` is between dispatches.

The symptom is silent: no container ever starts, so the run emits **no logs**, and with
`backoffLimit=0` the Job stays `Running` until `activeDeadlineSeconds` (7200) expires.
It reads as a hung run rather than a failed one. Third occurrence of this for the
runner tag (2026-07-24, 07-27, 08-14); a pin once existed in the since-deleted
`build-validation-runner.sh` (`f4113e3d`) and was lost when that script was
consolidated.

Full analysis in #471.

## Proof of real execution

All against the live local cluster (`k3d-openchoreo-server-0`). There is no shell test
harness in this repo (knip is TS-only, golangci-lint Go-only), so verification is by
live run.

**1. The bug.** kubelet evicting the image 6 minutes after a successful import:

```
I0814 05:40:29 image_gc_manager.go:487] "Removing image to free bytes"
  imageID="sha256:46a7105d05d9fc0a1f8779d2507b9f93979e4fbb8cbf9f69ae7bcbc1750b4d3b"
  size=1864369542
```

`46a7105d…` is the digest from that build's own `exporting config sha256:` line. The
validation Job scheduled 2h later:

```
Failed to pull image "aep-runner:dev": failed to resolve reference
"docker.io/library/aep-runner:dev": pull access denied, repository does not exist
or may require authorization: insufficient_scope: authorization failed
```

Pod pending 63 min, Job `Running 0/1`, no logs at all.

**2. Recovery confirms the mechanism.** Re-import + pin → the pod reached `Running` on
kubelet's next sync with no pod delete (`backoffLimit=0` means deleting it would have
failed the Job) → Job `Complete 1/1`, turn-journal logs streaming.

**3. The pin holds under live GC pressure**, and the siblings show why they are
included. The node sat at 86% with GC retrying every 5 minutes:

```
I0814 09:15:35 image_gc_manager.go:383] "Disk usage on image filesystem is over the
  high threshold..." usage=86 highThreshold=85 amountToFree=5913531187 lowThreshold=80
```

Through that loop the pinned `aep-runner:dev` stayed present, while the
then-unpinned `thunder-app-operator:local` was evicted out from under a `Running`
Deployment — it would have failed `ErrImageNeverPull` on its next restart.

**4. `build-runner.sh` end to end** (unpinned first, then a real run):

```
before:     "pinned": false,
...
📌 pinned aep-runner:dev against kubelet image GC (1 node(s))
✅ imported aep-runner:dev into k3d cluster 'openchoreo' (verified in node containerd)
after:      "pinned": true,
```

**5. The sibling call path** — the exact two commands `setup-aep.sh` now runs, which
also repaired the eviction from proof 3:

```
$ k3d image import thunder-app-operator:local -c openchoreo
Successfully imported 1 image(s) into 1 cluster(s)
$ pin_node_image thunder-app-operator:local
📌 pinned thunder-app-operator:local against kubelet image GC (1 node(s))
rc=0
$ docker exec k3d-openchoreo-server-0 crictl inspecti thunder-app-operator:local | grep pinned
    "pinned": true,
```

**6. Whole-ref match, with a decoy ref that sorts first.** A substring match picks the
wrong containerd record — pinning a decoy while the image the Job actually uses stays
collectible:

```
$ ctr -n k8s.io images ls -q | grep aep-runner
docker.io/aep-runner:dev-debug
docker.io/library/aep-runner:dev

$ ... | grep -m1 -F "aep-runner:dev"                    # substring
docker.io/aep-runner:dev-debug                          # ← wrong record

$ ... | grep -m1 -Fx -e "aep-runner:dev" -e "docker.io/library/aep-runner:dev"
docker.io/library/aep-runner:dev                        # ← correct
```

**7. Failure paths:**

```
$ pin_node_image no-such-image:nope
⚠️  no-such-image:nope is in no node's containerd — the import did not land
rc=2
```

**8. Gates.** `bash -n` clean on all four scripts; `make license-check` passes. No Go
or TypeScript touched, so `make test` has nothing to exercise here.

## Docs

`runners/AGENTS.md` gains the pin to the runner-image section — what the import path
guarantees, that the same helper covers the other local-only tags, and how to verify
(`docker exec k3d-openchoreo-server-0 crictl inspecti aep-runner:dev` → `"pinned": true`;
there is no host-side `crictl`).

## Deliberately not covered

**Node disk pressure itself**, which is what triggers GC. This makes eviction
impossible for images that cannot recover from it; it does not stop the node filling
up. A node above 85% still thrashes GC every 5 minutes over everything unpinned.
Raising `image-gc-high-threshold` via `--kubelet-arg` in
`deployments/k3d-local-config.yaml` is reachable by the same mechanism that file
already uses for `eviction-hard`, but it needs a cluster recreate to apply and still
evicts once the node genuinely fills — so it is a separate call, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
