### PR TITLE
SPA talks to its API through same-origin /api (nginx proxy)

### DIFF
--- a/runners/remote-worker/src/lib/workflow_skill.test.ts
+++ b/runners/remote-worker/src/lib/workflow_skill.test.ts
@@ -194,6 +194,7 @@ const REFERENCE_RULES: Record<string, string[]> = {
     "A `platform-resource` with no `wiring` is broken input",
     "**One that already exists is edited, never regenerated.**",
     "**A sibling SPA reaches a service through same-origin `/api`, not `external`.**",
+    "**Provider endpoint visibility:** a service a sibling SPA calls lists",
   ],
 };
 

--- a/runners/remote-worker/src/lib/workflow_skill.test.ts
+++ b/runners/remote-worker/src/lib/workflow_skill.test.ts
@@ -193,7 +193,7 @@ const REFERENCE_RULES: Record<string, string[]> = {
     "**Copy a `wiring` object verbatim**",
     "A `platform-resource` with no `wiring` is broken input",
     "**One that already exists is edited, never regenerated.**",
-    "**Every service component with dependents MUST list `external`.**",
+    "**A sibling SPA reaches a service through same-origin `/api`, not `external`.**",
   ],
 };
 

--- a/services/aep-api/internal/delivery/run/cycle.go
+++ b/services/aep-api/internal/delivery/run/cycle.go
@@ -159,20 +159,17 @@ func (l *loop) runCycle(ctx workflow.Context, kind string, anchorIssue int) (cyc
 // WAVE BY WAVE, then one CONVERGE — because the wiring between components splits
 // into two kinds that want opposite treatment (spec.HardConfigEdges).
 //
-// A HARD edge is an address the platform stamps into a component's own start-up
-// config: a web app reads API_BASE_URL out of window._env_ at module load and
-// throws without it. That address exists only once the provider has a rendered
-// binding, so a consumer promoted alongside its provider is published with a
-// config nothing could have filled — a blank page served to anyone who visits
-// before the repair. Hard edges therefore ORDER the deploy: each wave waits for
-// the last to serve, and every component's config is right the first time it is
-// written.
+// A HARD edge is an address the platform must have before the consumer can
+// serve a useful first byte: a web app's nginx reverse-proxies `/api` to a
+// sibling Service URL injected as pod env. That address exists only once the
+// provider has a rendered binding, so a SPA promoted alongside its API answers
+// `/api` with 502 until the Service exists. Hard edges therefore ORDER the
+// deploy: each wave waits for the last to serve.
 //
-// A SOFT edge runs the other way — a provider learning about its consumer. A
-// protected API's CORS allowlist is the project's SPA origins; an OIDC resource
-// wants the SPA's callback URL registered. Neither is needed before the consumer
-// serves, and requiring them would make the graph circular and unsatisfiable
-// (the SPA needs the API's address, the API needs the SPA's). So they are not
+// A SOFT edge runs the other way — a provider learning about its consumer. An
+// OIDC resource wants the SPA's callback URL registered. That is not needed
+// before the consumer serves, and requiring it would make the graph circular
+// (the SPA needs the API's address, the IdP needs the SPA's). So they are not
 // ordered at all: one converge at the end, when every address exists.
 //
 // The converge passes an EMPTY commit, and that is what makes it a converge and

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
@@ -345,7 +345,7 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
 		svc := svcWithCatalog(oc, rc, nil, cat)
 
-		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; got false (out=%v)", out)
 		}
@@ -401,7 +401,7 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
 		svc := svcWithCatalog(oc, rc, nil, cat)
 
-		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; got false (out=%v)", out)
 		}
@@ -450,7 +450,7 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		}}
 		svc := svcWithCatalog(oc, rc, nil, cat)
 
-		_, ready := svc.buildEnvValues(ctx, "acme", "proj", web, design)
+		_, ready := svc.buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true")
 		}
@@ -474,7 +474,7 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		cat := &fakeCatalog{markers: map[string]dependencies.TypeMarkers{}} // no markers for postgres
 		svc := svcWithCatalog(oc, rc, nil, cat)
 
-		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; got false (out=%v)", out)
 		}
@@ -501,7 +501,7 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
 		svc := svcWithCatalog(oc, rc, nil, cat)
 
-		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svc.buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; got false (out=%v)", out)
 		}
@@ -549,7 +549,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		web := componentNamed(t, design, "web")
 
 		oc := ocResolving(map[string]string{})
-		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; sibling API URL is not a window._env_ key; got false (out=%v)", out)
 		}
@@ -577,7 +577,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 				return nil, errors.New("oc: transient")
 			},
 		}
-		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true when sibling ListDeployments is unused; got false (out=%v)", out)
 		}
@@ -594,7 +594,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		web := componentNamed(t, design, "web")
 
 		oc := &ocmocks.ComponentClientMock{}
-		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; a non-service dep is skipped, not deferred")
 		}
@@ -613,7 +613,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		out, ready := svcWithCatalog(oc, nil, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svcWithCatalog(oc, nil, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when the resource client is unwired")
 		}
@@ -630,7 +630,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		rc := rcOutputs(authOutputs(), nil)
 		// No SetResourceCatalog → nil catalog.
-		out, ready := NewRuntimeConfigService(oc, rc, nil).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := NewRuntimeConfigService(oc, rc, nil).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when the catalog is unwired")
 		}
@@ -647,7 +647,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		rc := rcOutputs(authOutputs(), nil)
 		cat := &fakeCatalog{err: errors.New("oc: catalog unreachable")}
-		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when the catalog fetch fails")
 		}
@@ -666,7 +666,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		rc := rcOutputs(nil, nil) // binding has no status yet
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when the binding outputs are not ready")
 		}
@@ -685,7 +685,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		rc := rcOutputs(map[string]string{}, nil) // status present, zero outputs
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		_, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		_, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when the binding has zero outputs")
 		}
@@ -703,7 +703,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local", "web": "http://web.local"})
 		rc := rcOutputs(authOutputs(), errors.New("oc: patch failed"))
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; a failed callback registration is not a missing start-up value")
 		}
@@ -730,7 +730,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		oc := ocResolving(map[string]string{"api": "http://api.local"})
 		rc := rcOutputs(authOutputs(), nil)
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		out, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if !ready {
 			t.Fatalf("want ready=true; the SPA's own URL is not a value the SPA reads")
 		}
@@ -753,7 +753,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 			return nil, errors.New("oc down")
 		}
 		cat := &fakeCatalog{markers: authMarkers("thunder-app")}
-		_, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web, design)
+		_, ready := svcWithCatalog(oc, rc, nil, cat).buildEnvValues(ctx, "acme", "proj", web)
 		if ready {
 			t.Fatalf("want ready=false when GetBinding errors")
 		}

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_emit_test.go
@@ -505,8 +505,17 @@ func Test_buildEnvValues_genericEmission(t *testing.T) {
 		if !ready {
 			t.Fatalf("want ready=true; got false (out=%v)", out)
 		}
-		if out["API_BASE_URL"] != "http://api.local" || out["API_URL"] != "http://api.local" {
-			t.Errorf("service-URL keys drifted: %v", out)
+		if _, ok := out["API_BASE_URL"]; ok {
+			t.Errorf("API_BASE_URL must not be emitted; browser uses same-origin /api; out=%v", out)
+		}
+		if _, ok := out["API_URL"]; ok {
+			t.Errorf("API_URL must not be emitted; pod env is for nginx only; out=%v", out)
+		}
+		if len(out) != 0 {
+			t.Errorf("want empty env map for a webapp with only a sibling service dep; got %v", out)
+		}
+		if n := len(oc.ListDeploymentsCalls()); n != 0 {
+			t.Errorf("ListDeployments must not be called for a sibling service dep; got %d", n)
 		}
 		if cat.calls != 0 {
 			t.Errorf("catalog must NOT be read when there is no platform-resource dep; got %d", cat.calls)
@@ -529,7 +538,7 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		"components/api/design.json": serviceComponentMd(),
 	}
 
-	t.Run("unresolved service dep gates emission (ready=false)", func(t *testing.T) {
+	t.Run("unresolved sibling service dep does not gate emission", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]string{
 			spec.DesignRootFile:          rootDesignMd(),
@@ -541,15 +550,18 @@ func Test_buildEnvValues_defers(t *testing.T) {
 
 		oc := ocResolving(map[string]string{})
 		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
-		if ready {
-			t.Fatalf("want ready=false when a required service dep has no resolved URL; got true (out=%v)", out)
+		if !ready {
+			t.Fatalf("want ready=true; sibling API URL is not a window._env_ key; got false (out=%v)", out)
 		}
 		if _, ok := out["API_BASE_URL"]; ok {
-			t.Errorf("API_BASE_URL must be absent when the dep is unresolved; out=%v", out)
+			t.Errorf("API_BASE_URL must be absent; out=%v", out)
+		}
+		if n := len(oc.ListDeploymentsCalls()); n != 0 {
+			t.Errorf("ListDeployments must not be called for a sibling service dep; got %d", n)
 		}
 	})
 
-	t.Run("ListDeployments error on a service dep gates emission", func(t *testing.T) {
+	t.Run("ListDeployments is not consulted for a sibling service dep", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]string{
 			spec.DesignRootFile:          rootDesignMd(),
@@ -561,12 +573,13 @@ func Test_buildEnvValues_defers(t *testing.T) {
 
 		oc := &ocmocks.ComponentClientMock{
 			ListDeploymentsFunc: func(context.Context, string, string, string) (*gen.DeploymentList, error) {
+				t.Errorf("ListDeployments must not be called for sibling service deps")
 				return nil, errors.New("oc: transient")
 			},
 		}
-		_, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
-		if ready {
-			t.Fatalf("want ready=false on a transient OC error for a required dep; got true")
+		out, ready := NewRuntimeConfigService(oc, nil, nil).buildEnvValues(ctx, "acme", "proj", web, design)
+		if !ready {
+			t.Fatalf("want ready=true when sibling ListDeployments is unused; got false (out=%v)", out)
 		}
 	})
 
@@ -721,9 +734,6 @@ func Test_buildEnvValues_defers(t *testing.T) {
 		if !ready {
 			t.Fatalf("want ready=true; the SPA's own URL is not a value the SPA reads")
 		}
-		if out["API_BASE_URL"] != "http://api.local" {
-			t.Errorf("the backend address the bundle reads is missing; out=%v", out)
-		}
 		if out["USER_AUTH_CLIENT_ID"] == nil {
 			t.Errorf("the OIDC client_id the bundle reads is missing; out=%v", out)
 		}
@@ -842,8 +852,6 @@ func Test_FilesForComponent(t *testing.T) {
 		}
 		for _, want := range []string{
 			"window._env_ = {",
-			`API_BASE_URL: "http://api.local/todo"`,
-			`API_URL: "http://api.local/todo"`,
 			`USER_AUTH_CLIENT_ID: "web-cid"`,
 			`USER_AUTH_ISSUER: "http://thunder.local"`,
 			`USER_AUTH_JWKS_URL: "http://thunder.local/jwks"`,
@@ -852,6 +860,9 @@ func Test_FilesForComponent(t *testing.T) {
 			if !strings.Contains(f.Value, want) {
 				t.Errorf("emitted env-config.js missing %q\ngot:\n%s", want, f.Value)
 			}
+		}
+		if strings.Contains(f.Value, "API_BASE_URL") || strings.Contains(f.Value, "API_URL:") {
+			t.Errorf("sibling API public URLs must not appear in env-config.js:\n%s", f.Value)
 		}
 		if strings.Contains(f.Value, "THUNDER_") {
 			t.Errorf("no legacy THUNDER_* key must appear in env-config.js:\n%s", f.Value)
@@ -884,20 +895,27 @@ func Test_FilesForComponent(t *testing.T) {
 		}
 	})
 
-	t.Run("not-ready (unresolved service dep) defers the write", func(t *testing.T) {
+	t.Run("unresolved sibling service dep still writes env-config.js", func(t *testing.T) {
 		t.Parallel()
 		oc := ocResolving(map[string]string{})
 		svc := NewRuntimeConfigService(oc, nil, storeWith(webAndAPI("")))
 
 		files, ready, err := svc.FilesForComponent(ctx, "acme", "proj", "web")
 		if err != nil {
-			t.Fatalf("FilesForComponent should not error when not ready; got %v", err)
+			t.Fatalf("FilesForComponent: %v", err)
 		}
-		// ready=false is what tells the deploy stage to leave the binding's files
-		// UNMANAGED. A partially populated window._env_ is worse than a stale one:
-		// the SPA's src/env.ts throws on it at module load.
-		if ready || len(files) != 0 {
-			t.Errorf("want ready=false and no files; got ready=%v files=%d", ready, len(files))
+		if !ready {
+			t.Fatalf("want ready=true when only a sibling service dep is unresolved; got false")
+		}
+		if len(files) != 1 {
+			t.Fatalf("want 1 file when only a sibling service dep is unresolved; got %d", len(files))
+		}
+		val := files[0].Value
+		if !strings.Contains(val, "window._env_ = {") {
+			t.Errorf("want an env-config.js write; got %q", val)
+		}
+		if strings.Contains(val, "API_BASE_URL") {
+			t.Errorf("API_BASE_URL must not appear:\n%s", val)
 		}
 	})
 

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
@@ -368,7 +368,7 @@ func renderEnvConfigJS(values map[string]interface{}) string {
 		}
 		b.WriteString("  ")
 		// JS-side keys are bare identifiers — safe to emit unquoted since
-		// upperSnakeKey returns only [A-Z0-9_].
+		// ocname.EnvVarName returns only [A-Z0-9_].
 		b.WriteString(k)
 		b.WriteString(": ")
 		b.Write(raw)
@@ -388,30 +388,4 @@ func sortedKeys(m map[string]interface{}) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-// upperSnakeKey converts a component name (kebab- or camelCase) into the
-// upper-snake form used as a `window._env_` key prefix. Drops any chars
-// outside [A-Za-z0-9_] so the result is a safe JS identifier.
-func upperSnakeKey(name string) string {
-	var b strings.Builder
-	prevAlnum := false
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z':
-			b.WriteRune(r - 'a' + 'A')
-			prevAlnum = true
-		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prevAlnum = true
-		case r == '-' || r == '_':
-			if prevAlnum {
-				b.WriteRune('_')
-			}
-			prevAlnum = false
-		default:
-			prevAlnum = false
-		}
-	}
-	return strings.TrimRight(b.String(), "_")
 }

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
@@ -103,9 +103,10 @@ func (s *RuntimeConfigService) SetResourceCatalog(c resourceMarkerCatalog) {
 // than in a follow-up patch that had to wait for the binding to exist.
 //
 // `ready` is false when a required key could not be populated yet — typically a
-// dependency URL that resolves only once a sibling is serving. The caller must
-// then leave the field unmanaged: a partially populated window._env_ is worse
-// than a stale one, because the SPA's src/env.ts throws on it at module load.
+// platform-resource binding whose outputs are not yet resolved, or a transient
+// OC error on that path. The caller must then leave the field unmanaged: a
+// partially populated window._env_ is worse than a stale one, because the
+// SPA's src/env.ts throws on it at module load.
 // A non-web-app component wants no files at all, which is (nil, true).
 func (s *RuntimeConfigService) FilesForComponent(ctx context.Context, orgID, projectID, componentName string) ([]openchoreo.WorkflowFileVar, bool, error) {
 	if s == nil {
@@ -153,10 +154,6 @@ func (s *RuntimeConfigService) FilesForComponent(ctx context.Context, orgID, pro
 }
 
 // buildEnvValues assembles the map that becomes `window._env_`.
-//   - `API_BASE_URL` — first sibling service dep's external URL (the
-//     conventional name for the primary backend).
-//   - `<UPPER_SNAKE_NAME>_URL` — every dep, keyed by component name. Lets
-//     a SPA with multiple backends address each one explicitly.
 //   - `<DEP>_<OUTPUT>` — every platform-resource dependency's resolved binding
 //     outputs, keyed generically (resources.EnvVarName — the same convention
 //     wiring.go injects pod env vars with). No resource-type name is hardcoded:
@@ -165,66 +162,19 @@ func (s *RuntimeConfigService) FilesForComponent(ctx context.Context, orgID, pro
 //     dependency's provisioned binding outputs (resolved by OC); the BFF never
 //     calls the upstream from this path.
 //
-// buildEnvValues returns the map + a `ready` flag, where ready means "every key
-// the SPA needs to START is present" — a sibling backend's address, a platform
-// resource's outputs. The caller must NOT write a partial env-config.js on
-// `!ready`: src/env.ts throws on a missing key at module load, so half a file is
-// worse than the stale one the pod already has.
+// Sibling service URLs are NOT emitted. The browser calls same-origin `/api`
+// (SPA nginx reverse-proxies to the pod env `<DEP>_URL` OpenChoreo injects).
+// Public gateway URLs in window._env_ were the old SPA-reachability workaround.
 //
-// The SPA's OWN external URL is deliberately NOT one of those keys. It exists
-// only once the SPA has a rendered binding, so requiring it before the SPA's
-// first write is a demand the SPA cannot satisfy until it has already been
-// deployed — and the one thing that needs it (registering the callback URL with
-// an OIDC dependency) is not read by the bundle at all. See layerPlatformResources.
+// buildEnvValues returns the map + a `ready` flag. The flag is false
+// when a required key couldn't be populated yet (transient OC error,
+// SPA URL not yet resolved for an OIDC consumer-URL patch, etc.). The
+// caller must NOT write a partial env-config.js on `!ready` — see
+// FilesForComponent.
 func (s *RuntimeConfigService) buildEnvValues(ctx context.Context, orgID, projectID string, webapp *spec.DesignComponent, design *spec.DesignFile) (out map[string]interface{}, ready bool) {
+	_ = design // sibling component index is no longer used for window._env_
 	out = map[string]interface{}{}
 	ready = true
-
-	// The same edge rule the deploy stage orders its waves by. Sharing it is what
-	// makes the order honest: every dependency this loop needs a URL for is one the
-	// scheduler has already waited for within this cycle, so a deferral here means
-	// the provider is outside the cycle and not yet deployed at all.
-	var firstServiceURL string
-	for _, dep := range spec.HardProvidersFor(design, webapp.Name) {
-		k8sName := k8sname.ToK8sName(dep)
-		list, err := s.componentClient.ListDeployments(ctx, orgID, projectID, k8sName)
-		if err != nil {
-			// Transient OC failure on a required dep. Mark not-ready so
-			// the caller skips the write and preserves the previously
-			// valid env-config.js for the pod.
-			slog.WarnContext(ctx, "runtime_config: ListDeployments error for dep; deferring",
-				"projectID", projectID, "component", webapp.Name, "dep", dep, "error", err)
-			ready = false
-			continue
-		}
-		if list == nil {
-			// A required dep with no deployment list is not resolvable
-			// yet — defer rather than ship an incomplete env-config.js.
-			ready = false
-			continue
-		}
-		url := ""
-		for _, d := range list.Items {
-			if d.EndpointURL != "" {
-				url = strings.TrimRight(d.EndpointURL, "/")
-				break
-			}
-		}
-		if url == "" {
-			// Dep not yet deployed — not an error, but we don't have a
-			// URL for it. Defer rather than ship a window._env_ that
-			// will throw at module load.
-			ready = false
-			continue
-		}
-		out[upperSnakeKey(dep)+"_URL"] = url
-		if firstServiceURL == "" {
-			firstServiceURL = url
-		}
-	}
-	if firstServiceURL != "" {
-		out["API_BASE_URL"] = firstServiceURL
-	}
 
 	// Layer every platform-resource dependency's binding outputs generically.
 	// No resource-type name is hardcoded — an OIDC dependency and a database

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service.go
@@ -138,7 +138,7 @@ func (s *RuntimeConfigService) FilesForComponent(ctx context.Context, orgID, pro
 		return nil, true, nil
 	}
 
-	envValues, ready := s.buildEnvValues(ctx, orgID, projectID, match, design)
+	envValues, ready := s.buildEnvValues(ctx, orgID, projectID, match)
 	if !ready {
 		slog.InfoContext(ctx, "runtime_config: required keys not yet ready; deferring env-config.js",
 			"orgID", orgID, "projectID", projectID, "component", componentName, "keys", sortedKeys(envValues))
@@ -162,17 +162,15 @@ func (s *RuntimeConfigService) FilesForComponent(ctx context.Context, orgID, pro
 //     dependency's provisioned binding outputs (resolved by OC); the BFF never
 //     calls the upstream from this path.
 //
-// Sibling service URLs are NOT emitted. The browser calls same-origin `/api`
-// (SPA nginx reverse-proxies to the pod env `<DEP>_URL` OpenChoreo injects).
-// Public gateway URLs in window._env_ were the old SPA-reachability workaround.
+// Sibling service URLs are not emitted. The browser calls same-origin `/api`;
+// SPA nginx reverse-proxies to the pod env `<DEP>_URL` OpenChoreo injects.
 //
 // buildEnvValues returns the map + a `ready` flag. The flag is false
 // when a required key couldn't be populated yet (transient OC error,
 // SPA URL not yet resolved for an OIDC consumer-URL patch, etc.). The
 // caller must NOT write a partial env-config.js on `!ready` — see
 // FilesForComponent.
-func (s *RuntimeConfigService) buildEnvValues(ctx context.Context, orgID, projectID string, webapp *spec.DesignComponent, design *spec.DesignFile) (out map[string]interface{}, ready bool) {
-	_ = design // sibling component index is no longer used for window._env_
+func (s *RuntimeConfigService) buildEnvValues(ctx context.Context, orgID, projectID string, webapp *spec.DesignComponent) (out map[string]interface{}, ready bool) {
 	out = map[string]interface{}{}
 	ready = true
 
@@ -237,8 +235,8 @@ func platformResourceDeps(c *spec.DesignComponent) []spec.Dependency {
 //
 // All-or-nothing at the write level: any not-ready dependency sets ready=false,
 // and the caller then skips the whole write — a deferring dependency contributes
-// NO keys of its own, and sibling deps' keys already in `out` are never shipped
-// because the write is gated. The SPA is thus never handed a partial window._env_.
+// NO keys of its own, and keys already in `out` are never shipped because the
+// write is gated. The SPA is thus never handed a partial window._env_.
 func (s *RuntimeConfigService) layerPlatformResources(ctx context.Context, orgID, projectID string, webapp *spec.DesignComponent, deps []spec.Dependency, out map[string]interface{}) bool {
 	if s.resourceClient == nil {
 		slog.WarnContext(ctx, "runtime_config: resourceClient not wired; deferring platform-resource outputs",

--- a/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service_test.go
+++ b/services/aep-api/internal/dependencies/runtimeconfig/runtime_config_service_test.go
@@ -61,25 +61,3 @@ func Test_renderEnvConfigJS(t *testing.T) {
 		prev = i
 	}
 }
-
-// Test_upperSnakeKey — kebab-case + dash + camelCase normalise to safe
-// JS identifier prefixes.
-func Test_upperSnakeKey(t *testing.T) {
-	cases := []struct{ in, want string }{
-		{"todo-api", "TODO_API"},
-		{"todo_api", "TODO_API"},
-		{"TodoApi", "TODOAPI"},
-		{"todo--api", "TODO_API"},
-		{"--todo-api--", "TODO_API"},
-		{"", ""},
-		{"a", "A"},
-		{"a-b-c", "A_B_C"},
-		{"todo-api-v2", "TODO_API_V2"},
-	}
-	for _, c := range cases {
-		got := upperSnakeKey(c.in)
-		if got != c.want {
-			t.Errorf("upperSnakeKey(%q) = %q; want %q", c.in, got, c.want)
-		}
-	}
-}

--- a/services/aep-api/internal/projects/api_traits.go
+++ b/services/aep-api/internal/projects/api_traits.go
@@ -71,31 +71,7 @@ func APIConfigurationInstanceName(componentName, endpointName string) string {
 // function returns nil + a tombstone entry to strip any previously-set
 // config.
 //
-// `allowedOrigins` lists the SPA hostnames the gateway should
-// echo on CORS preflight. Empty/nil falls back to the trait schema's
-// default of `["*"]` (wildcard). Either way `allowedHeaders` stays `["*"]`
-// and `allowCredentials` stays false:
-//
-//   - Bearer auth does NOT need `allowCredentials`. That flag governs
-//     cookies, TLS client certs and browser-managed HTTP auth; an
-//     `Authorization` header set by JS is an ordinary header and only has to
-//     appear in `Access-Control-Allow-Headers`. Every SPA this platform
-//     generates keeps its token in localStorage and the gateway strips
-//     `authorization` before the upstream, so no cookie ever rides the API
-//     call.
-//   - Credentials-off is what makes the header wildcard legal — the WSO2
-//     platform forbids `*` combined with credentials and answers such a
-//     preflight with NO CORS headers at all, which browsers report as a
-//     blanket CORS failure.
-//   - `["*"]` rather than a fixed list because the gateway REFLECTS the
-//     requested header names back. A generated client sending anything the
-//     list did not anticipate (the gateway-injected `X-User-*` identity
-//     headers, `If-Match`, `X-Request-Id`) otherwise gets the same
-//     all-or-nothing blackout: the browser blocks the request before it is
-//     ever sent, so nothing reaches the access log to diagnose.
-//
-// Empty/nil `allowedOrigins` is the production path (schema default `["*"]`).
-// The `len(allowedOrigins) > 0` branch stays for tests / any future caller.
+// CORS omits `allowedOrigins` so the trait schema default `["*"]` applies.
 //
 // `configs` is keyed by trait instance name; the value is the parameters
 // block that lands at `ReleaseBinding.spec.traitEnvironmentConfigs[<inst>]`.
@@ -108,7 +84,7 @@ func APIConfigurationInstanceName(componentName, endpointName string) string {
 // is no longer hardcoded, so a component whose workload names its endpoint
 // something other than "http" still renders (previously deploy rendering failed
 // with `workload.endpoints["http"]: no such key`).
-func DesiredAPIConfigurationTraitWithIssuers(componentName, endpointName string, enabled bool, issuers []string, allowedOrigins []string) (traits []openchoreo.ComponentTrait, configs map[string]map[string]interface{}) {
+func DesiredAPIConfigurationTraitWithIssuers(componentName, endpointName string, enabled bool, issuers []string) (traits []openchoreo.ComponentTrait, configs map[string]map[string]interface{}) {
 	endpointName = strings.TrimSpace(endpointName)
 	if endpointName == "" {
 		endpointName = spec.DefaultEndpointName
@@ -135,16 +111,6 @@ func DesiredAPIConfigurationTraitWithIssuers(componentName, endpointName string,
 	}
 	cors := map[string]interface{}{
 		"enabled": true,
-	}
-	if len(allowedOrigins) > 0 {
-		originsIface := make([]interface{}, 0, len(allowedOrigins))
-		for _, o := range allowedOrigins {
-			originsIface = append(originsIface, o)
-		}
-		cors["allowedOrigins"] = originsIface
-		cors["allowedMethods"] = []interface{}{"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
-		cors["allowedHeaders"] = []interface{}{"*"}
-		cors["allowCredentials"] = false
 	}
 	configs = map[string]map[string]interface{}{
 		inst: {

--- a/services/aep-api/internal/projects/api_traits.go
+++ b/services/aep-api/internal/projects/api_traits.go
@@ -94,8 +94,8 @@ func APIConfigurationInstanceName(componentName, endpointName string) string {
 //     all-or-nothing blackout: the browser blocks the request before it is
 //     ever sent, so nothing reaches the access log to diagnose.
 //
-// Origins stay pinned to the sibling SPA list — this widens headers, never
-// the origin, and CORS constrains browsers only (curl was never gated).
+// Empty/nil `allowedOrigins` is the production path (schema default `["*"]`).
+// The `len(allowedOrigins) > 0` branch stays for tests / any future caller.
 //
 // `configs` is keyed by trait instance name; the value is the parameters
 // block that lands at `ReleaseBinding.spec.traitEnvironmentConfigs[<inst>]`.

--- a/services/aep-api/internal/projects/api_traits_test.go
+++ b/services/aep-api/internal/projects/api_traits_test.go
@@ -135,25 +135,6 @@ func keysOfAny[T any](m map[string]T) []string {
 	return out
 }
 
-// Test_originFromEndpointURL — extracts scheme://authority from a
-// ListDeployments-shaped URL with trailing path/query/fragment.
-func Test_originFromEndpointURL(t *testing.T) {
-	cases := []struct{ in, want string }{
-		{"http://host.example:19080/", "http://host.example:19080"},
-		{"http://host.example:19080", "http://host.example:19080"},
-		{"http://host.example:19080/path/here", "http://host.example:19080"},
-		{"https://host.example/abc?q=1", "https://host.example"},
-		{"", ""},
-		{"not-a-url", ""},
-	}
-	for _, c := range cases {
-		got := originFromEndpointURL(c.in)
-		if got != c.want {
-			t.Errorf("originFromEndpointURL(%q) = %q; want %q", c.in, got, c.want)
-		}
-	}
-}
-
 // desiredAPIConfigurationTraitForTest is the no-issuers, no-origins shape these
 // table tests exercise. A test helper rather than a production shim: the only
 // production caller is DesiredDeploymentFor, which always has both to pass.

--- a/services/aep-api/internal/projects/api_traits_test.go
+++ b/services/aep-api/internal/projects/api_traits_test.go
@@ -135,9 +135,9 @@ func keysOfAny[T any](m map[string]T) []string {
 	return out
 }
 
-// desiredAPIConfigurationTraitForTest is the no-issuers, no-origins shape these
-// table tests exercise. A test helper rather than a production shim: the only
-// production caller is DesiredDeploymentFor, which always has both to pass.
+// desiredAPIConfigurationTraitForTest is the no-issuers shape these table
+// tests exercise. Production (DesiredDeploymentFor) passes issuers when the
+// org has a BYO-IDP profile.
 func desiredAPIConfigurationTraitForTest(componentName, endpointName string, enabled bool) ([]openchoreo.ComponentTrait, map[string]map[string]interface{}) {
-	return DesiredAPIConfigurationTraitWithIssuers(componentName, endpointName, enabled, nil, nil)
+	return DesiredAPIConfigurationTraitWithIssuers(componentName, endpointName, enabled, nil)
 }

--- a/services/aep-api/internal/projects/deployment_service.go
+++ b/services/aep-api/internal/projects/deployment_service.go
@@ -119,21 +119,14 @@ func (s *DeploymentService) Deploy(ctx context.Context, orgID, projectID string,
 		return nil, nil
 	}
 
-	// Resolved ONCE for the pass: both are project-wide facts, and asking per
+	// Resolved ONCE for the pass: a project-wide fact, and asking per
 	// component would issue the same reads N times for the same answer.
 	issuers := s.resolveIssuers(ctx, orgID, design)
-	origins, originsErr := s.siblingSPAOrigins(ctx, orgID, projectID, design)
-	if originsErr != nil {
-		// A partial allowlist silently blocks the missing SPA's preflight, so a
-		// transient lookup failure must fail the pass rather than commit a CORS
-		// list that is wrong in a way nothing will report.
-		return nil, fmt.Errorf("deployment: sibling SPA origins: %w", originsErr)
-	}
 
 	out := make([]delivery.ComponentDeploy, 0, len(components))
 	var failures []error
 	for _, name := range components {
-		outcome, derr := s.deployOne(ctx, orgID, projectID, name, commitSHA, design, issuers, origins)
+		outcome, derr := s.deployOne(ctx, orgID, projectID, name, commitSHA, design, issuers)
 		out = append(out, outcome)
 		if derr != nil {
 			failures = append(failures, fmt.Errorf("component %q: %w", name, derr))
@@ -208,7 +201,7 @@ func (s *DeploymentService) Converge(ctx context.Context, orgID, projectID strin
 
 // deployOne cuts the release and writes the binding for a single component.
 func (s *DeploymentService) deployOne(ctx context.Context, orgID, projectID, componentName, commitSHA string,
-	design *spec.DesignFile, issuers, origins []string) (delivery.ComponentDeploy, error) {
+	design *spec.DesignFile, issuers []string) (delivery.ComponentDeploy, error) {
 	outcome := delivery.ComponentDeploy{Component: componentName, Environment: openchoreo.DevEnvironmentName}
 
 	comp := findDesignComponent(design, componentName)
@@ -238,14 +231,13 @@ func (s *DeploymentService) deployOne(ctx context.Context, orgID, projectID, com
 	}
 
 	desired := DesiredDeploymentFor(DeploymentInputs{
-		Component:      *comp,
-		ComponentName:  componentName,
-		Environment:    openchoreo.DevEnvironmentName,
-		ReleaseName:    releaseName,
-		Issuers:        issuers,
-		AllowedOrigins: origins,
-		EnvVars:        s.envVarsFor(ctx, orgID, projectID, componentName),
-		Files:          s.filesFor(ctx, orgID, projectID, componentName),
+		Component:     *comp,
+		ComponentName: componentName,
+		Environment:   openchoreo.DevEnvironmentName,
+		ReleaseName:   releaseName,
+		Issuers:       issuers,
+		EnvVars:       s.envVarsFor(ctx, orgID, projectID, componentName),
+		Files:         s.filesFor(ctx, orgID, projectID, componentName),
 	})
 	if err := s.components.ApplyReleaseBinding(ctx, orgID, projectID, desired.Binding); err != nil {
 		return outcome, fmt.Errorf("apply release binding: %w", permanentIfMissing(err))
@@ -404,65 +396,6 @@ func (s *DeploymentService) DeleteComponentCascade(ctx context.Context, orgID, p
 	slog.InfoContext(ctx, "deployment: component deleted; OC RenderedRelease finalizer GCs trait resources",
 		"orgID", orgID, "projectID", projectID, "componentName", componentName)
 	return nil
-}
-
-// siblingSPAOrigins returns the external origins of every web-app component in
-// the project — the CORS allowlist a protected API's gateway echoes.
-//
-// A transient lookup failure is returned, never swallowed: a partial allowlist
-// commits a CORS list that blocks the missing SPA's preflight, and a browser
-// reports that as a blanket failure with nothing in the access log to diagnose.
-// A SPA that simply has not deployed yet contributes nothing and is picked up by
-// the converge pass once it is Ready.
-func (s *DeploymentService) siblingSPAOrigins(ctx context.Context, orgID, projectID string, design *spec.DesignFile) ([]string, error) {
-	if s.components == nil || design == nil {
-		return nil, nil
-	}
-	origins := make([]string, 0, len(design.Components))
-	seen := make(map[string]struct{}, len(design.Components))
-	for _, c := range design.Components {
-		if c.ComponentType != spec.ComponentTypeWebApplication {
-			continue
-		}
-		list, err := s.components.ListDeployments(ctx, orgID, projectID, k8sname.ToK8sName(c.Name))
-		if err != nil {
-			return nil, fmt.Errorf("list deployments for %q: %w", c.Name, err)
-		}
-		if list == nil {
-			continue
-		}
-		for _, d := range list.Items {
-			origin := originFromEndpointURL(d.EndpointURL)
-			if origin == "" {
-				continue
-			}
-			if _, ok := seen[origin]; ok {
-				continue
-			}
-			seen[origin] = struct{}{}
-			origins = append(origins, origin)
-		}
-	}
-	return origins, nil
-}
-
-// originFromEndpointURL extracts scheme+host+port from a deployment URL.
-// Returns "" when parsing fails — callers skip empty origins.
-func originFromEndpointURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	const sep = "://"
-	i := strings.Index(u, sep)
-	if i < 0 {
-		return ""
-	}
-	rest := u[i+len(sep):]
-	end := strings.IndexAny(rest, "/?#")
-	if end < 0 {
-		return u
-	}
-	return u[:i+len(sep)+end]
 }
 
 // resolveIssuers ensures the org's publisher app exists and returns the issuer

--- a/services/aep-api/internal/projects/deployment_service_test.go
+++ b/services/aep-api/internal/projects/deployment_service_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/wso2/aep/aep-api/internal/spec/artifactstest"
 )
 
-// UNIT tier for DeploymentService.Deploy + siblingSPAOrigins — the promote the
-// run supervisor drives once a cycle's builds are green. The two seams are
+// UNIT tier for DeploymentService.Deploy — the promote the run supervisor
+// drives once a cycle's builds are green. The two seams are
 // doubled at the process boundary: the openchoreo.ComponentClient (generated
 // moq — ListDeployments to read a web-app's external URL, EnsureRelease and
 // ApplyReleaseBinding to promote) and the artifacts store (the REAL
@@ -189,26 +189,56 @@ func TestDeploy_ReleaseNameIsDerivedFromTheCommit(t *testing.T) {
 	}
 }
 
-// A protected API's CORS allowlist has to carry its sibling SPA's origin, and
-// the deploy is where that gets resolved.
-func TestDeploy_ProtectedAPICarriesSiblingSPAOrigin(t *testing.T) {
+// Protected APIs use trait-default wildcard CORS; deploy must not list web-app
+// deployments to build a sibling origin allowlist.
+func TestDeploy_ProtectedAPIUsesTraitDefaultCORS(t *testing.T) {
 	t.Parallel()
 	files := map[string]string{
-		spec.DesignRootFile:          traitRootMd(),
-		"components/api/design.json": endUserServiceMd("api"),
-		"components/web/design.json": webAppMd("web"),
+		spec.DesignRootFile:           traitRootMd(),
+		"components/api/design.json":  endUserServiceMd("api"),
+		"components/s2s/design.json":  serviceToServiceMd("s2s"),
+		"components/web/design.json":  webAppMd("web"),
 	}
 	oc := ocDeployments(map[string]string{"web": "http://web.local/app/"})
 	svc := NewDeploymentService(oc, traitStoreWith(files))
 
-	if _, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api"}, "abc123def456"); err != nil {
+	if _, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api", "s2s"}, "abc123def456"); err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
-	cfg := oc.ApplyReleaseBindingCalls()[0].In.TraitEnvironmentConfigs[APIConfigurationInstanceName("api", "http")]
-	cors, _ := cfg["cors"].(map[string]interface{})
-	origins, _ := cors["allowedOrigins"].([]interface{})
-	if len(origins) != 1 || origins[0] != "http://web.local" {
-		t.Errorf("allowedOrigins = %v, want the sibling SPA origin", origins)
+	for _, c := range oc.ListDeploymentsCalls() {
+		if c.ComponentName == "web" {
+			t.Errorf("deploy must not list web-app deployments for CORS; SPA uses same-origin /api")
+		}
+	}
+
+	traitCORSForDeploy := func(component string) map[string]interface{} {
+		t.Helper()
+		inst := APIConfigurationInstanceName(component, "http")
+		for _, call := range oc.ApplyReleaseBindingCalls() {
+			if call.In.ComponentName != component {
+				continue
+			}
+			cfg, ok := call.In.TraitEnvironmentConfigs[inst]
+			if !ok {
+				t.Fatalf("component %q carries no api-configuration config", component)
+			}
+			cors, _ := cfg["cors"].(map[string]interface{})
+			return cors
+		}
+		t.Fatalf("no binding write for component %q", component)
+		return nil
+	}
+
+	apiCORS := traitCORSForDeploy("api")
+	if _, ok := apiCORS["allowedOrigins"]; ok {
+		t.Errorf("end-user API must use trait-default wildcard CORS, not sibling origins; got %+v", apiCORS)
+	}
+	if got := apiCORS["enabled"]; got != true {
+		t.Errorf("cors.enabled = %v; want true", got)
+	}
+	s2sCORS := traitCORSForDeploy("s2s")
+	if _, ok := s2sCORS["allowedOrigins"]; ok {
+		t.Errorf("service-to-service API must not advertise SPA origins; got %+v", s2sCORS)
 	}
 }
 
@@ -367,127 +397,3 @@ func TestDeploymentState_FreshBindingIsPendingNotFailed(t *testing.T) {
 	}
 }
 
-// --- siblingSPAOrigins --------------------------------------------------------
-
-func Test_siblingSPAOrigins(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	t.Run("collects each web-app origin, trims path, dedups", func(t *testing.T) {
-		t.Parallel()
-		files := map[string]string{
-			spec.DesignRootFile:           traitRootMd(),
-			"components/web1/design.json": webAppMd("web1"),
-			"components/web2/design.json": webAppMd("web2"),
-			"components/api/design.json":  endUserServiceMd("api"),
-		}
-		design := traitReadDesign(t, files)
-		oc := ocDeployments(map[string]string{
-			"web1": "http://web1.local/todo/",    // path trimmed → scheme+host
-			"web2": "http://web2.local:8080/app", // port preserved
-		})
-		svc := NewDeploymentService(oc, traitStoreWith(files))
-
-		got, err := svc.siblingSPAOrigins(ctx, "acme", "proj", design)
-		if err != nil {
-			t.Fatalf("siblingSPAOrigins: %v", err)
-		}
-		want := map[string]bool{"http://web1.local": true, "http://web2.local:8080": true}
-		if len(got) != 2 {
-			t.Fatalf("want 2 origins; got %v", got)
-		}
-		for _, o := range got {
-			if !want[o] {
-				t.Errorf("unexpected origin %q; want one of %v", o, want)
-			}
-		}
-		// The service component is never consulted for origins — only web-apps.
-		for _, c := range oc.ListDeploymentsCalls() {
-			if c.ComponentName == "api" {
-				t.Errorf("siblingSPAOrigins must not list the service component's deployments")
-			}
-		}
-	})
-
-	t.Run("web-app with no deployment yet contributes nothing", func(t *testing.T) {
-		t.Parallel()
-		files := map[string]string{
-			spec.DesignRootFile:          traitRootMd(),
-			"components/web/design.json": webAppMd("web"),
-		}
-		design := traitReadDesign(t, files)
-		oc := ocDeployments(map[string]string{}) // web → empty list
-		svc := NewDeploymentService(oc, traitStoreWith(files))
-		got, err := svc.siblingSPAOrigins(ctx, "acme", "proj", design)
-		if err != nil {
-			t.Fatalf("siblingSPAOrigins: %v", err)
-		}
-		if len(got) != 0 {
-			t.Errorf("undeployed SPA should contribute no origins; got %v", got)
-		}
-	})
-
-	t.Run("duplicate deployment URLs dedup to one origin", func(t *testing.T) {
-		t.Parallel()
-		files := map[string]string{
-			spec.DesignRootFile:          traitRootMd(),
-			"components/web/design.json": webAppMd("web"),
-		}
-		design := traitReadDesign(t, files)
-		oc := &mocks.ComponentClientMock{
-			ListDeploymentsFunc: func(context.Context, string, string, string) (*gen.DeploymentList, error) {
-				return &gen.DeploymentList{Items: []gen.Deployment{
-					{EndpointURL: "http://web.local/a"},
-					{EndpointURL: "http://web.local/b"}, // same origin
-				}}, nil
-			},
-		}
-		svc := NewDeploymentService(oc, traitStoreWith(files))
-		got, err := svc.siblingSPAOrigins(ctx, "acme", "proj", design)
-		if err != nil {
-			t.Fatalf("siblingSPAOrigins: %v", err)
-		}
-		if len(got) != 1 || got[0] != "http://web.local" {
-			t.Errorf("same-origin deployments must dedup; got %v", got)
-		}
-	})
-
-	t.Run("transient ListDeployments error surfaces (no partial allowlist)", func(t *testing.T) {
-		t.Parallel()
-		files := map[string]string{
-			spec.DesignRootFile:          traitRootMd(),
-			"components/web/design.json": webAppMd("web"),
-		}
-		design := traitReadDesign(t, files)
-		oc := &mocks.ComponentClientMock{
-			ListDeploymentsFunc: func(context.Context, string, string, string) (*gen.DeploymentList, error) {
-				return nil, errors.New("oc: transient")
-			},
-		}
-		svc := NewDeploymentService(oc, traitStoreWith(files))
-		if _, err := svc.siblingSPAOrigins(ctx, "acme", "proj", design); err == nil {
-			t.Fatalf("a sibling lookup error must surface — a partial CORS allowlist would silently block the missing SPA")
-		}
-	})
-
-	t.Run("no web-apps yields empty slice, nil error", func(t *testing.T) {
-		t.Parallel()
-		files := map[string]string{
-			spec.DesignRootFile:          traitRootMd(),
-			"components/api/design.json": endUserServiceMd("api"),
-		}
-		design := traitReadDesign(t, files)
-		oc := &mocks.ComponentClientMock{} // ListDeployments must never be called
-		svc := NewDeploymentService(oc, traitStoreWith(files))
-		got, err := svc.siblingSPAOrigins(ctx, "acme", "proj", design)
-		if err != nil {
-			t.Fatalf("siblingSPAOrigins: %v", err)
-		}
-		if len(got) != 0 {
-			t.Errorf("want empty origins with no web-apps; got %v", got)
-		}
-		if len(oc.ListDeploymentsCalls()) != 0 {
-			t.Errorf("ListDeployments must not be called when there are no web-apps; got %d", len(oc.ListDeploymentsCalls()))
-		}
-	})
-}

--- a/services/aep-api/internal/projects/deployment_spec.go
+++ b/services/aep-api/internal/projects/deployment_spec.go
@@ -91,13 +91,11 @@ type DeploymentInputs struct {
 func DesiredDeploymentFor(in DeploymentInputs) DesiredDeployment {
 	apiEnabled := spec.ResolveAPISecurityEnabled(in.Component)
 
-	// CORS: leave allowedOrigins unset so the api-configuration trait schema
-	// default ["*"] applies (OpenChoreo / WSO2 default). Sibling SPA origin
-	// pinning was an AEP override for browser→gateway calls; the SPA now
-	// same-origin proxies via nginx, so that allowlist is unused. Do not set
-	// cors.enabled false — that would be a new deny-all, not an undo.
+	// CORS: omit allowedOrigins so the api-configuration trait schema default
+	// ["*"] applies. Do not set cors.enabled false — that would deny all
+	// origins, including curl-from-the-gateway clients.
 	traits, configs := DesiredAPIConfigurationTraitWithIssuers(
-		in.ComponentName, in.Component.EndpointName(), apiEnabled, in.Issuers, nil)
+		in.ComponentName, in.Component.EndpointName(), apiEnabled, in.Issuers)
 
 	// Appended to the SAME slice/map: `spec.traits` is replaced wholesale on
 	// write, so emitting the alert rule separately would clobber the

--- a/services/aep-api/internal/projects/deployment_spec.go
+++ b/services/aep-api/internal/projects/deployment_spec.go
@@ -70,9 +70,6 @@ type DeploymentInputs struct {
 	// Issuers pins JWT validation to an org's own IDP; empty trusts any
 	// cluster-configured keymanager.
 	Issuers []string
-	// AllowedOrigins is the sibling-SPA CORS allowlist. Empty falls back to the
-	// trait schema's wildcard.
-	AllowedOrigins []string
 	// EnvVars are the user's component config (the DB is their canonical
 	// record). Nil means "not managed by this write" — see
 	// openchoreo.ReleaseBindingDesired.
@@ -94,18 +91,13 @@ type DeploymentInputs struct {
 func DesiredDeploymentFor(in DeploymentInputs) DesiredDeployment {
 	apiEnabled := spec.ResolveAPISecurityEnabled(in.Component)
 
-	// Sibling-SPA origins are for BROWSER callers only. A service-to-service API
-	// has no browser caller, and handing it the project's SPA origins would widen
-	// its CORS surface for nothing — so the allowlist is dropped here rather than
-	// at the point it was gathered, which keeps the gathering one project-wide
-	// read instead of one per component.
-	origins := in.AllowedOrigins
-	if !apiEnabled || spec.ResolveAPISecurityCallerKind(in.Component) != "end-user" {
-		origins = nil
-	}
-
+	// CORS: leave allowedOrigins unset so the api-configuration trait schema
+	// default ["*"] applies (OpenChoreo / WSO2 default). Sibling SPA origin
+	// pinning was an AEP override for browser→gateway calls; the SPA now
+	// same-origin proxies via nginx, so that allowlist is unused. Do not set
+	// cors.enabled false — that would be a new deny-all, not an undo.
 	traits, configs := DesiredAPIConfigurationTraitWithIssuers(
-		in.ComponentName, in.Component.EndpointName(), apiEnabled, in.Issuers, origins)
+		in.ComponentName, in.Component.EndpointName(), apiEnabled, in.Issuers, nil)
 
 	// Appended to the SAME slice/map: `spec.traits` is replaced wholesale on
 	// write, so emitting the alert rule separately would clobber the

--- a/services/aep-api/internal/projects/deployment_spec_test.go
+++ b/services/aep-api/internal/projects/deployment_spec_test.go
@@ -55,7 +55,6 @@ func TestDesiredDeploymentFor(t *testing.T) {
 	t.Parallel()
 
 	const inst = "api-http"
-	origins := []string{"http://web.local"}
 
 	cases := []struct {
 		name string
@@ -64,7 +63,7 @@ func TestDesiredDeploymentFor(t *testing.T) {
 		wantAPITrait bool
 		// wantJWT: the binding carries a jwtAuth config for it.
 		wantJWT bool
-		// wantOrigins: the sibling SPA allowlist is applied.
+		// wantOrigins: allowedOrigins is explicitly set (non-production path).
 		wantOrigins bool
 	}{
 		{
@@ -72,15 +71,13 @@ func TestDesiredDeploymentFor(t *testing.T) {
 			body: svcJSON("api", "", ""),
 		},
 		{
-			name:         "end-user-required is protected and browser-facing",
+			name:         "end-user-required uses trait-default wildcard CORS",
 			body:         svcJSON("api", "end-user-required", ""),
 			wantAPITrait: true,
 			wantJWT:      true,
-			wantOrigins:  true,
+			wantOrigins:  false,
 		},
 		{
-			// A service-to-service API has no browser caller, so handing it the
-			// project's SPA origins would widen its CORS surface for nothing.
 			name:         "service-required is protected but takes no SPA origins",
 			body:         svcJSON("api", "service-required", ""),
 			wantAPITrait: true,
@@ -93,11 +90,10 @@ func TestDesiredDeploymentFor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := DesiredDeploymentFor(DeploymentInputs{
-				Component:      designComponent(t, tc.body),
-				ComponentName:  "api",
-				Environment:    openchoreo.DevEnvironmentName,
-				ReleaseName:    "rel-1",
-				AllowedOrigins: origins,
+				Component:     designComponent(t, tc.body),
+				ComponentName: "api",
+				Environment:   openchoreo.DevEnvironmentName,
+				ReleaseName:   "rel-1",
 			})
 
 			hasTrait := false

--- a/services/aep-api/internal/projects/deployment_spec_test.go
+++ b/services/aep-api/internal/projects/deployment_spec_test.go
@@ -63,8 +63,6 @@ func TestDesiredDeploymentFor(t *testing.T) {
 		wantAPITrait bool
 		// wantJWT: the binding carries a jwtAuth config for it.
 		wantJWT bool
-		// wantOrigins: allowedOrigins is explicitly set (non-production path).
-		wantOrigins bool
 	}{
 		{
 			name: "unprotected service gets no api-configuration trait",
@@ -75,14 +73,12 @@ func TestDesiredDeploymentFor(t *testing.T) {
 			body:         svcJSON("api", "end-user-required", ""),
 			wantAPITrait: true,
 			wantJWT:      true,
-			wantOrigins:  false,
 		},
 		{
 			name:         "service-required is protected but takes no SPA origins",
 			body:         svcJSON("api", "service-required", ""),
 			wantAPITrait: true,
 			wantJWT:      true,
-			wantOrigins:  false,
 		},
 	}
 
@@ -117,9 +113,8 @@ func TestDesiredDeploymentFor(t *testing.T) {
 				t.Errorf("protected component carries no jwtAuth: %+v", cfg)
 			}
 			cors, _ := cfg["cors"].(map[string]interface{})
-			_, gotOrigins := cors["allowedOrigins"]
-			if gotOrigins != tc.wantOrigins {
-				t.Errorf("allowedOrigins present = %v, want %v (%+v)", gotOrigins, tc.wantOrigins, cors)
+			if _, ok := cors["allowedOrigins"]; ok {
+				t.Errorf("allowedOrigins must be omitted (trait default wildcard); got %+v", cors)
 			}
 		})
 	}

--- a/services/aep-api/internal/spec/README.md
+++ b/services/aep-api/internal/spec/README.md
@@ -106,12 +106,12 @@ the genai turn engine (runner/broker/sweeper), and the files / design / skills s
 - **Single write-authority** over the git spec-content store and its `v<N>` tags — every save/tag/discard
   runs through this domain's gitfs Workspace engine; no other domain writes spec content.
 - **One authority for which wiring edges are HARD** (`wiring_edges.go`). A hard edge is an address the
-  platform stamps into a component's own start-up config — today a web app's sibling *services*, whose
-  URLs land in `env-config.js`. Both consumers read the same rule: `dependencies` composes the file, and
-  `projects` orders the deploy waves around it, so they can never disagree about which addresses are
-  needed. Everything else is soft (it flows consumer→provider: CORS origins, an OIDC callback) and orders
-  nothing. Deliberately NOT hard: service→service, which OpenChoreo resolves through its own connection
-  mechanism — ordering it would refuse two services that call each other. ADR-0019.
+  platform must have before a component can serve its first useful byte — today a web app's sibling
+  *services*, whose cluster Service URLs are injected as pod env for nginx (`<DEP>_URL`). `projects`
+  orders the deploy waves around that rule. Everything else is soft (it flows consumer→provider: an
+  OIDC callback) and orders nothing. Deliberately NOT hard: service→service, which OpenChoreo resolves
+  through its own connection mechanism — ordering it would refuse two services that call each other.
+  ADR-0019.
 - **`CRTType` is a projection, not a re-export.** design-save reads the dependencies resource-type catalog
   through the `resourceTypeCatalog` port in spec's OWN vocabulary (`CRTType`), mapped by a root
   adapter — the spec domain names the dependencies domain nowhere.

--- a/services/aep-api/internal/spec/README.md
+++ b/services/aep-api/internal/spec/README.md
@@ -42,7 +42,7 @@ the genai turn engine (runner/broker/sweeper), and the files / design / skills s
 | `resourceTypeCatalog` (returns `CRTType`) | needs | `dependencies` — the PE-authored CRT markers + declared outputs, projected at the root |
 | `AnthropicKeyResolver` · git-token `Resolver` | needs | `platform/secrets` — per-org keys + sealed git tokens |
 | `ArtifactService` · `ArtifactStore` · `SplitFrontmatter` | offers | `delivery` / `projects` / `dependencies` — design reads, spec-save, status snapshots |
-| `HardConfigEdges` · `HardProvidersFor` | offers | `projects` (deploy order) / `dependencies` (runtime-config compose) — which sibling addresses a component cannot start without |
+| `HardConfigEdges` | offers | `projects` (deploy order) — which sibling addresses a component cannot start without |
 | `DescriptorWriter` | offers | `projects` — stamps `specs/.agentic-engineer.toml` into a repo at project create |
 | `CredentialsRefreshService`-adjacent turn/tag reads | offers | delivery/build (SpecTagger, validation criteria) |
 

--- a/services/aep-api/internal/spec/api_security.go
+++ b/services/aep-api/internal/spec/api_security.go
@@ -34,20 +34,3 @@ func ResolveAPISecurityEnabled(comp DesignComponent) bool {
 	}
 	return false
 }
-
-// ResolveAPISecurityCallerKind returns the auth flavor for sibling-CORS
-// gating. Only `end-user-required` APIs should advertise SPA origins in
-// their CORS allowlist (service-to-service APIs have no browser caller).
-// Returns "" when API security is not enabled.
-func ResolveAPISecurityCallerKind(comp DesignComponent) string {
-	if comp.ExposesAPI == nil {
-		return ""
-	}
-	switch strings.ToLower(strings.TrimSpace(comp.ExposesAPI.Auth)) {
-	case "end-user-required":
-		return "end-user"
-	case "service-required":
-		return "service"
-	}
-	return ""
-}

--- a/services/aep-api/internal/spec/entity_api_security_test.go
+++ b/services/aep-api/internal/spec/entity_api_security_test.go
@@ -41,25 +41,3 @@ func TestResolveAPISecurityEnabled(t *testing.T) {
 		})
 	}
 }
-
-func TestResolveAPISecurityCallerKind(t *testing.T) {
-	cases := []struct {
-		name    string
-		exposes *ExposesAPI
-		want    string
-	}{
-		{"nil block", nil, ""},
-		{"none", &ExposesAPI{Auth: "none"}, ""},
-		{"end-user-required", &ExposesAPI{Auth: "end-user-required"}, "end-user"},
-		{"service-required", &ExposesAPI{Auth: "service-required"}, "service"},
-		{"unrecognised", &ExposesAPI{Auth: "yes"}, ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := ResolveAPISecurityCallerKind(DesignComponent{ExposesAPI: c.exposes})
-			if got != c.want {
-				t.Fatalf("got %q, want %q", got, c.want)
-			}
-		})
-	}
-}

--- a/services/aep-api/internal/spec/wiring_edges.go
+++ b/services/aep-api/internal/spec/wiring_edges.go
@@ -73,25 +73,6 @@ func HardConfigEdges(design *DesignFile) map[string][]string {
 	return out
 }
 
-// HardProvidersFor is HardConfigEdges for ONE consumer — what the composer wants,
-// since it is filling in a single component's file and has no use for the rest of
-// the project's edges.
-//
-// Both spellings run the same rule (hardProvidersOf), which is the point: the
-// composer that needs an address and the planner that orders around it must never
-// be able to disagree about which addresses are needed.
-func HardProvidersFor(design *DesignFile, componentName string) []string {
-	if design == nil {
-		return nil
-	}
-	for _, c := range design.Components {
-		if c.Name == componentName {
-			return hardProvidersOf(c, componentsByName(design))
-		}
-	}
-	return nil
-}
-
 func componentsByName(design *DesignFile) map[string]DesignComponent {
 	out := make(map[string]DesignComponent, len(design.Components))
 	for _, c := range design.Components {

--- a/services/aep-api/internal/spec/wiring_edges.go
+++ b/services/aep-api/internal/spec/wiring_edges.go
@@ -23,17 +23,15 @@ package spec
 // the component can serve its first byte, versus which it can supply afterwards.
 //
 //	HARD  the provider's address is stamped into the consumer's own start-up
-//	      configuration. A web app's `window._env_` is the case that exists: the
-//	      bundle reads API_BASE_URL at module load and throws without it, so a
-//	      SPA published before its backend has an address is a blank page. Hard
-//	      edges ORDER the deploy, and they must form a DAG.
+//	      configuration. A web app's nginx reverse-proxy is the case that
+//	      exists: OpenChoreo injects the sibling Service URL as pod env
+//	      `<DEP>_URL`, and `/api` 502s until that Service exists. Hard edges
+//	      ORDER the deploy, and they must form a DAG.
 //
 //	SOFT  the fact flows the other way — a provider learning about its consumer.
-//	      A protected API's CORS allowlist is the project's SPA origins; an OIDC
-//	      resource needs the SPA's callback URL registered. Neither is needed
-//	      before the consumer serves, only before a later browser call or login.
-//	      Soft edges order NOTHING and are free to cycle, which is exactly what
-//	      they do: the SPA needs the API's address, and the API needs the SPA's.
+//	      An OIDC resource needs the SPA's callback URL registered. That is not
+//	      needed before the consumer serves, only before a later login. Soft
+//	      edges order NOTHING and are free to cycle.
 //
 // Collapsing the two is what makes the wiring look circular and therefore
 // unsolvable. Separated, the hard half is a DAG the deploy can walk in waves and
@@ -51,11 +49,10 @@ package spec
 // consumer name. Both sides are DESIGN names (the caller maps to k8s names if
 // it addresses OpenChoreo with them).
 //
-// It is the single authority for that rule. runtimeconfig composes the file
-// these edges exist for, and projects orders the deploy by them; a second
-// spelling would let the writer and the scheduler disagree about which component
-// blocks which — the failure mode being a SPA the scheduler thinks is
-// independent, published with a config the composer could not fill.
+// It is the single authority for that rule. projects orders the deploy by
+// these edges so a SPA is not published before the sibling Service nginx
+// will proxy to. A second spelling would let the writer and the scheduler
+// disagree about which component blocks which.
 //
 // Components named as dependencies but absent from the design are skipped: an
 // edge to a component that does not exist cannot be waited for.
@@ -83,11 +80,11 @@ func componentsByName(design *DesignFile) map[string]DesignComponent {
 
 // hardProvidersOf lists one component's hard providers in declaration order.
 //
-// Today the only consumer that carries a stamped address is a web app, and the
-// only providers whose address is stamped are its sibling SERVICES — a peer web
+// Today the only consumer that needs a sibling address at start-up is a web
+// app: nginx reverse-proxies `/api` to that sibling's Service URL. A peer web
 // app is not called over HTTP, so its URL is nothing to wait for. When a second
 // stamped-config shape appears (a worker handed a queue's address, say) it is
-// added here, and both the composer and the deploy order follow it at once.
+// added here, and the deploy order follows it.
 func hardProvidersOf(c DesignComponent, byName map[string]DesignComponent) []string {
 	if c.ComponentType != ComponentTypeWebApplication {
 		return nil

--- a/services/aep-api/internal/spec/wiring_edges_test.go
+++ b/services/aep-api/internal/spec/wiring_edges_test.go
@@ -46,7 +46,7 @@ func TestHardConfigEdges(t *testing.T) {
 		design *DesignFile
 		want   map[string][]string
 	}{{
-		name:   "a web app's sibling service is hard — its address lands in window._env_",
+		name:   "a web app's sibling service is hard — nginx needs its Service URL",
 		design: &DesignFile{Components: []DesignComponent{edgeWebApp("shop-web", "shop-api"), edgeService("shop-api")}},
 		want:   map[string][]string{"shop-web": {"shop-api"}},
 	}, {

--- a/skills/aep/references/component-contract.md
+++ b/skills/aep/references/component-contract.md
@@ -79,14 +79,13 @@ its contract instead.
   write on a blank page. Change what the issue asks and no more — a diff wider
   than its issue is likelier to break something that was green.
 - **A loaded skill outranks your training data.** Where a skill states a
-  convention ("use `modernc.org/sqlite`", "read `window._env_.X_URL`"), it is
+  convention ("use `modernc.org/sqlite`", "read `window._env_.<DEP>_CLIENT_ID`"), it is
   authoritative — never re-derive one from memory.
 - **CORS belongs to the gateway** for a service whose design sets `exposesAPI`:
   the gateway attaches a filter to every `visibility: external` route, and your
-  own middleware on top of it breaks the response. The one exception is a service
-  with **no** `exposesAPI` that a sibling web app's browser calls directly — that
-  one serves CORS itself, and your stack skill has the wrapper. Web apps never
-  add CORS.
+  own middleware on top of it breaks the response. A sibling web-app does **not**
+  call this service from the browser; it same-origin proxies via nginx (`react-webapp`).
+  Unmanaged services therefore do not serve CORS for the SPA. Web apps never add CORS.
 - **Never commit build output, dependency directories or local env files.** The
   repo-root `.gitignore` covers them; your stack skill names its own.
 

--- a/skills/aep/references/component-contract.md
+++ b/skills/aep/references/component-contract.md
@@ -82,8 +82,7 @@ its contract instead.
   convention ("use `modernc.org/sqlite`", "read `window._env_.<DEP>_CLIENT_ID`"), it is
   authoritative — never re-derive one from memory.
 - **CORS belongs to the gateway** for a service whose design sets `exposesAPI`:
-  the gateway attaches a filter to every `visibility: external` route, and your
-  own middleware on top of it breaks the response.
+  the gateway attaches a filter to every `visibility: external` route.
 - **Never commit build output, dependency directories or local env files.** The
   repo-root `.gitignore` covers them; your stack skill names its own.
 

--- a/skills/aep/references/component-contract.md
+++ b/skills/aep/references/component-contract.md
@@ -83,9 +83,7 @@ its contract instead.
   authoritative — never re-derive one from memory.
 - **CORS belongs to the gateway** for a service whose design sets `exposesAPI`:
   the gateway attaches a filter to every `visibility: external` route, and your
-  own middleware on top of it breaks the response. A sibling web-app does **not**
-  call this service from the browser; it same-origin proxies via nginx (`react-webapp`).
-  Unmanaged services therefore do not serve CORS for the SPA. Web apps never add CORS.
+  own middleware on top of it breaks the response.
 - **Never commit build output, dependency directories or local env files.** The
   repo-root `.gitignore` covers them; your stack skill names its own.
 

--- a/skills/aep/references/workload-and-wiring.md
+++ b/skills/aep/references/workload-and-wiring.md
@@ -69,6 +69,7 @@ endpoints:
     port: 9090
     basePath: /                 # optional; root path for API services
     visibility:
+      - project
       - external
 
 dependencies:                    # what you resolved above — omit a half you have none of
@@ -108,16 +109,19 @@ configurations:
 OpenChoreo connections may only use `project` or `namespace`; `external` on a
 *dependency* is rejected. Same project → consumer `visibility: project`. Other
 project → `visibility: namespace` plus `project:` (and the provider must already
-list `namespace` / be org-published).
+list `namespace` / be org-published). That "not `external`" is the SPA's
+**dependency** entry only — not the service's own `endpoints[].visibility`.
 
 The SPA browser calls `/api` on its own host; nginx in the SPA pod reverse-proxies
 to the project Service URL injected as `<DEP_NAME>_URL`. That pod env var is not
 a `window._env_` key.
 
-**Provider endpoint visibility for now:** a service a sibling SPA calls lists
+**Provider endpoint visibility:** a service a sibling SPA calls lists
 `visibility: [project, external]` — `project` for the nginx hop, `external` so
-the API remains curl-able on the public gateway. The SPA must not fetch that
-public URL. Org-published services still add `namespace` as below.
+the API remains curl-able on the public gateway. Write both YAML list items.
+A single-item `project` list is wrong even when the SPA uses `/api`, and
+`design.json` `exposure: intranet` does not drop `external`. The SPA must not
+fetch that public URL. Org-published services still add `namespace` as below.
 
 **Org-published services.** If the component's `design.json` sets
 `exposesAPI.orgPublished: true`, components in OTHER projects consume it — also

--- a/skills/aep/references/workload-and-wiring.md
+++ b/skills/aep/references/workload-and-wiring.md
@@ -104,11 +104,20 @@ configurations:
 | `internal` | across all namespaces in the cluster |
 | `external` | public internet via the ingress gateway |
 
-**Every service component with dependents MUST list `external`.** That is what
-makes the deployed URL reachable from a dependent SPA's browser, and what lets
-the platform resolve the URL into a dependent's runtime config. Omit it and
-nothing errors: the dependent's config is never written, and its
-`<DEP_NAME>_URL` arrives empty.
+**A sibling SPA reaches a service through same-origin `/api`, not `external`.**
+OpenChoreo connections may only use `project` or `namespace`; `external` on a
+*dependency* is rejected. Same project → consumer `visibility: project`. Other
+project → `visibility: namespace` plus `project:` (and the provider must already
+list `namespace` / be org-published).
+
+The SPA browser calls `/api` on its own host; nginx in the SPA pod reverse-proxies
+to the project Service URL injected as `<DEP_NAME>_URL`. That pod env var is not
+a `window._env_` key.
+
+**Provider endpoint visibility for now:** a service a sibling SPA calls lists
+`visibility: [project, external]` — `project` for the nginx hop, `external` so
+the API remains curl-able on the public gateway. The SPA must not fetch that
+public URL. Org-published services still add `namespace` as below.
 
 **Org-published services.** If the component's `design.json` sets
 `exposesAPI.orgPublished: true`, components in OTHER projects consume it — also

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -84,5 +84,5 @@ inbound `Authorization` header verbatim — never re-issue or mint a token.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| CORS error in the browser when calling this API | The service ships its own CORS middleware (doubled headers), or its `workload.yaml` lacks `visibility: external` | Remove the middleware; confirm `visibility: external`. |
+| CORS error in the browser when calling this API | The SPA is fetching the public gateway URL, or this service ships its own CORS middleware (doubled headers) | Point the SPA at same-origin `"/api"` (`react-webapp`); remove service CORS middleware. |
 | Every protected request 401s in tests | Test calls carry no `X-User-Id` — in production the gateway sets it | Set `X-User-Id` directly on the request in tests; don't try to mint a JWT. |

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -84,5 +84,5 @@ inbound `Authorization` header verbatim — never re-issue or mint a token.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| CORS error in the browser when calling this API | The SPA is fetching the public gateway URL, or this service ships its own CORS middleware (doubled headers) | Point the SPA at same-origin `"/api"` (`react-webapp`); remove service CORS middleware. |
+| CORS error in the browser when calling this API | This service ships its own CORS middleware (doubled headers) | Remove the middleware. |
 | Every protected request 401s in tests | Test calls carry no `X-User-Id` — in production the gateway sets it | Set `X-User-Id` directly on the request in tests; don't try to mint a JWT. |

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -51,7 +51,7 @@ gateway gives you: stamp it on every row this service creates, and gate every
 per-user query on it.
 
 **CORS.** The `api-configuration` ClusterTrait attaches an Envoy CORS filter per
-`visibility: external` HTTPRoute, so a managed API must not add its own.
+`visibility: external` HTTPRoute.
 
 **Document the injected header.** In the OpenAPI you author for a protected
 service, list `X-User-Id` under `parameters` so consumers know it is

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -29,11 +29,7 @@ download a toolchain and will not compile C.
    ```
    Commit the `go.sum` this produces. A stdlib-only service produces none —
    correct and expected; never hand-write one.
-4. **Check CORS**, if a web-app calls this service directly (see Constraints):
-   `curl -i -X OPTIONS <one endpoint>` returns `204` **and** shows
-   `Access-Control-Allow-Origin`. Serving the raw mux is an incomplete task —
-   the deployed web-app fails every fetch.
-5. **PR** — only once step 3 exits 0 and step 4 (when it applies) passed.
+4. **PR** — only once step 3 exits 0.
 
 ## Constraints
 
@@ -65,9 +61,9 @@ NULL DEFAULT '{}'`) 500s at runtime. Normalize before insert
 or middleware chains. Not Gin/Echo/Fiber — large dep trees, little gain at
 5–20 endpoints.
 
-**CORS.** Only when this service has no `exposesAPI` and a browser calls it
-directly — wrapper below. A managed API relies on the gateway; adding your own
-doubles the headers.
+**Never add CORS middleware.** A sibling SPA calls this service through that
+SPA's same-origin `/api` proxy, not from the browser to this host. A managed
+API (`exposesAPI`) gets CORS on the gateway; adding your own doubles the headers.
 
 **Upstreams.** `url.JoinPath(base, "path")`, never `base + "/path"` — an
 injected address can end in `/`.
@@ -119,25 +115,6 @@ import "github.com/jackc/pgx/v5/pgxpool"
 pool, err := pgxpool.New(ctx, os.Getenv("<DB_URL_ENV_VAR>"))
 ```
 
-CORS wrapper — headers on every response, `OPTIONS` answered with 204:
-
-```go
-func withCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-// serve it: http.ListenAndServe(":9090", withCORS(mux))
-```
-
 ## Pitfalls
 
 | Symptom | Cause | Fix |
@@ -150,6 +127,5 @@ func withCORS(next http.Handler) http.Handler {
 | `checksum mismatch … SECURITY ERROR` at build | `go.sum` stale or hand-edited | `go mod tidy` locally; commit the result |
 | Build fails `COPY go.mod go.sum ./ … go.sum: no such file or directory` | Dockerfile names `go.sum`, stdlib-only service has none | `COPY go.mod ./` only |
 | Pod won't start; `panic: listen tcp :8080` | Wrong port | Listen on 9090 |
-| Every browser call to the service fails, curl works | Raw mux served with no CORS wrapper | Wrap in `withCORS`; verify `OPTIONS` → 204 |
 | `POST` to an injected upstream returns `405` (or a `301` then a `GET`) | Address ended in `/`, so `base + "/path"` built `//path`; `ServeMux` 301s to the clean path and the client re-issues it as `GET` | `url.JoinPath(base, "path")` |
 | Create/POST 500s only when an optional list field is omitted (`[]` works) | Nil slice bound as `NULL` into a `NOT NULL` array column; its `DEFAULT` skipped because the INSERT lists it | Normalize nil→empty, or omit the column |

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -65,6 +65,12 @@ or middleware chains. Not Gin/Echo/Fiber — large dep trees, little gain at
 SPA's same-origin `/api` proxy, not from the browser to this host. A managed
 API (`exposesAPI`) gets CORS on the gateway; adding your own doubles the headers.
 
+**Endpoint visibility.** A service a sibling SPA calls lists **both**
+`project` and `external` on its own HTTP endpoint — `project` for the nginx
+hop, `external` so the API stays curl-able on the public gateway. The SPA
+must not fetch that public URL; its *dependency* entry is `project` only.
+`design.json` `exposure: intranet` does not drop `external`.
+
 **Upstreams.** `url.JoinPath(base, "path")`, never `base + "/path"` — an
 injected address can end in `/`.
 
@@ -85,6 +91,18 @@ injected address can end in `/`.
 ├── Dockerfile
 └── workload.yaml
 ```
+
+`workload.yaml` HTTP endpoint when a sibling SPA calls this service:
+
+```yaml
+    visibility:
+      - project
+      - external
+```
+
+**Done when:** both list items are present. A single-item `project` list is
+wrong even though the SPA uses `/api`. Never put `external` on a
+*dependency* entry.
 
 `Dockerfile` — multi-stage, pinned builder, slim runtime:
 
@@ -129,3 +147,4 @@ pool, err := pgxpool.New(ctx, os.Getenv("<DB_URL_ENV_VAR>"))
 | Pod won't start; `panic: listen tcp :8080` | Wrong port | Listen on 9090 |
 | `POST` to an injected upstream returns `405` (or a `301` then a `GET`) | Address ended in `/`, so `base + "/path"` built `//path`; `ServeMux` 301s to the clean path and the client re-issues it as `GET` | `url.JoinPath(base, "path")` |
 | Create/POST 500s only when an optional list field is omitted (`[]` works) | Nil slice bound as `NULL` into a `NOT NULL` array column; its `DEFAULT` skipped because the INSERT lists it | Normalize nil→empty, or omit the column |
+| API reachable via SPA `/api` but not curl-able on the public gateway | Provider `visibility` is only `project` (misread "not `external`" as the endpoint list) | List both `- project` and `- external` on the service's own endpoint |

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -61,10 +61,6 @@ NULL DEFAULT '{}'`) 500s at runtime. Normalize before insert
 or middleware chains. Not Gin/Echo/Fiber — large dep trees, little gain at
 5–20 endpoints.
 
-**Never add CORS middleware.** A sibling SPA calls this service through that
-SPA's same-origin `/api` proxy, not from the browser to this host. A managed
-API (`exposesAPI`) gets CORS on the gateway; adding your own doubles the headers.
-
 **Upstreams.** `url.JoinPath(base, "path")`, never `base + "/path"` — an
 injected address can end in `/`.
 

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -65,12 +65,6 @@ or middleware chains. Not Gin/Echo/Fiber — large dep trees, little gain at
 SPA's same-origin `/api` proxy, not from the browser to this host. A managed
 API (`exposesAPI`) gets CORS on the gateway; adding your own doubles the headers.
 
-**Endpoint visibility.** A service a sibling SPA calls lists **both**
-`project` and `external` on its own HTTP endpoint — `project` for the nginx
-hop, `external` so the API stays curl-able on the public gateway. The SPA
-must not fetch that public URL; its *dependency* entry is `project` only.
-`design.json` `exposure: intranet` does not drop `external`.
-
 **Upstreams.** `url.JoinPath(base, "path")`, never `base + "/path"` — an
 injected address can end in `/`.
 

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -59,9 +59,9 @@ is `undefined` at module load. Use these exact spellings:
 | `<NAME>` (any) | you declared it in `workload.yaml` `configurations.env` | app-config default, per-env override possible |
 
 There is **no** `API_BASE_URL` and **no** `<UPSTREAM>_URL` in `window._env_` for
-a sibling service. Those used to be public gateway URLs. The sibling lives at
-**same-origin** `/api` (extra siblings: `/api/<component-name>/`). OpenChoreo
-still injects `<DEP>_URL` as a **pod** env var; only the nginx drop-in reads it.
+a sibling service. The sibling lives at **same-origin** `/api` (extra siblings:
+`/api/<component-name>/`). OpenChoreo still injects `<DEP>_URL` as a **pod**
+env var; only the nginx drop-in reads it.
 
 **Throw on a missing key, never default it.** No `?? ""`, no `|| ''`, for keys
 this table says are set. A silent fallback hides a missing OIDC issuer. Do not
@@ -200,7 +200,7 @@ import type { paths } from "./generated/todo-api";
 export const todoApi = createClient<paths>({ baseUrl: "/api" });
 
 // extra sibling:
-// export const otherApi = createClient<paths>({ baseUrl: "/api/other-api" });
+// export const otherApi = createClient<paths>({ baseUrl: "/api/other-api/" });
 ```
 
 **Done when:** no `env.API_BASE_URL`, no `env.TODO_API_URL`, no

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -10,17 +10,18 @@ metadata:
 # React Webapp
 
 A web-app on this platform: a Vite + TS SPA built to static files, served by
-stock `nginx:alpine`. The image is **byte-identical across every environment** —
-per-env values (API URLs, OIDC config, flags) arrive at request time in
-`window._env_`, never at build time.
+stock `nginx:alpine`. The image is **byte-identical across every environment**.
+Per-env values the **browser** needs (OIDC config, flags) arrive at request time
+in `window._env_`, never at build time. Sibling API addresses are **not**
+browser config — they are pod env for nginx.
 
 ## Development flow
 
-1. **Scaffold** per Layout.
+1. **Scaffold** per Layout, including the nginx drop-in copy in step 1 of Layout.
 2. **Implement** — `src/env.ts` first (every other module reads config through
    it), then generate `src/generated/` from each dependency's OpenAPI contract,
-   then `src/api.ts`, then pages. Every rule under Constraints is a runtime
-   failure if broken, not a style preference.
+   then `src/api.ts` with **same-origin** `baseUrl`, then pages. Every rule under
+   Constraints is a runtime failure if broken, not a style preference.
 3. **Verify** — from the app path:
    ```bash
    npm install                   # regenerates package-lock.json
@@ -53,28 +54,31 @@ is `undefined` at module load. Use these exact spellings:
 
 | Key | Set when | Meaning |
 |---|---|---|
-| `API_BASE_URL` | this web-app has a `component`-kind `dependencies` entry on a service sibling | external gateway URL of the primary upstream service in this project |
-| `<UPSTREAM>_URL` | this web-app depends on `<upstream>` (a `component`-kind entry) | external gateway URL of that sibling (`<UPSTREAM>` = component name in `UPPER_SNAKE_CASE`, e.g. `todo-api` → `TODO_API_URL`) |
-| `<NAME>_URL` | `dependencies` include an `external`-kind entry `<name>` | external gateway URL of that external upstream API (same convention, e.g. `employee-api` → `EMPLOYEE_API_URL`) |
+| `<NAME>_URL` | `dependencies` include an `external`-kind entry `<name>` | URL of that **external** upstream (browser may call it). Not used for a sibling `component`-kind service. |
 | `<DEP>_*` | this web-app declares an auth `platform-resource` dependency named `<dep>` | OIDC config (`<DEP>_CLIENT_ID`, `<DEP>_ISSUER`, `<DEP>_JWKS_URL`, `<DEP>_SCOPES`), `<DEP>` = UPPER_SNAKE of the dependency name (`user-auth` → `USER_AUTH_*`) — owned by `thunder-authentication` |
 | `<NAME>` (any) | you declared it in `workload.yaml` `configurations.env` | app-config default, per-env override possible |
 
-**Throw on a missing key, never default it.** No `?? ""`, no `|| ''`. A silent
-fallback turns every fetch into a relative URL against the SPA's own nginx,
-which answers `405` on a `POST` — a bug that looks like a backend fault.
+There is **no** `API_BASE_URL` and **no** `<UPSTREAM>_URL` in `window._env_` for
+a sibling service. Those used to be public gateway URLs. The sibling lives at
+**same-origin** `/api` (extra siblings: `/api/<component-name>/`). OpenChoreo
+still injects `<DEP>_URL` as a **pod** env var; only the nginx drop-in reads it.
+
+**Throw on a missing key, never default it.** No `?? ""`, no `|| ''`, for keys
+this table says are set. A silent fallback hides a missing OIDC issuer. Do not
+declare sibling API URL keys on `Env` just to throw — they are not emitted.
 
 **Served at host root.** Each web-app gets its **own** gateway hostname, so the
 stock Vite default is correct: **do NOT set `base`**. Asset URLs, any react-router
 `basename`, and any OAuth `redirect_uri` are plain root paths (`/assets/…`,
 `/callback`). Services ARE path-routed, under `/<project>-<component>-http` on a
-shared gateway — copying that prefix into `base` 404s every asset (nginx serves
-`index.html` instead, so the browser gets HTML for a module script) and the page
-renders blank.
+shared gateway — copying that prefix into `base` 404s every asset.
 
-**Static nginx only.** No `proxy_pass`, no `/oidc/` block, no `envsubst`, no
-`/etc/nginx/templates/`, no `NGINX_ENVSUBST_*`, no custom
-`/docker-entrypoint.d/` script. The platform-mounted `/env-config.js` is served
-by the same static config as plain JS.
+**Same-origin API proxy.** Nginx reverse-proxies `location /api/` to the primary
+sibling's project Service URL. Copy the assets in Layout; do not hand-write a
+different `proxy_pass`, do not add `/oidc/` (token endpoint stays cross-origin;
+`thunder-authentication`), do not copy `apps/console/docker-entrypoint.sh`.
+Keep the official `nginx:alpine` `ENTRYPOINT`. The only extra file is
+`/docker-entrypoint.d/15-aep-api-proxy.sh`.
 
 **Auth.** If the component declares an auth `platform-resource` dependency, add
 `src/auth.ts` and attach `Authorization: Bearer <token>` to every API call —
@@ -89,10 +93,8 @@ for a `component`-kind dependency, or
 `specs/design/components/<this-app>/dependencies/<dep-name>.openapi.yaml` for an
 `external`-kind one — project-root paths, sibling to this app's own folder.
 Generate types from it and call through `openapi-fetch`'s typed client (Layout);
-don't hand-write request/response shapes, they drift from the real contract the
-moment it changes. Commit `src/generated/` — the per-component Docker build's
-context is this app's own folder alone, so unlike a monorepo-wide `gen` step
-there is no later stage that can reach the sibling spec to regenerate it.
+don't hand-write request/response shapes. Commit `src/generated/` — the
+per-component Docker build's context is this app's own folder alone.
 
 ## Layout
 
@@ -111,13 +113,36 @@ there is no later stage that can reach the sibling spec to regenerate it.
 │   ├── auth.ts           # only with an auth dependency — see thunder-authentication
 │   └── pages/
 ├── nginx/
-│   └── default.conf
+│   ├── default.conf      # copied from the skill assets, then /api locations kept
+│   └── 15-aep-api-proxy.sh
 └── Dockerfile
 ```
 
+**Copy the nginx assets first.** From the App Path:
+
+```bash
+mkdir -p nginx
+cp "$AEP_SKILLS_DIR/react-webapp/assets/nginx-default.conf" nginx/default.conf
+cp "$AEP_SKILLS_DIR/react-webapp/assets/15-aep-api-proxy.sh" nginx/15-aep-api-proxy.sh
+```
+
+If `$AEP_SKILLS_DIR` is unset, copy from `assets/` next to this skill's `SKILL.md`
+(the BFF mirrors that directory to `.claude/skills/react-webapp/`).
+
+Then in `nginx/15-aep-api-proxy.sh` only: change `API_URL="${TODO_API_URL:-}"` so
+`TODO_API_URL` is the UPPER_SNAKE `_URL` of the **primary** component-kind
+dependency (`todo-api` → `TODO_API_URL`). Do not invent a second name.
+
+**Done when:** `nginx/default.conf` contains `location /api/` and
+`proxy_pass http://$api_backend`; the drop-in script's `API_URL=` line uses that
+primary `<DEP>_URL`; there is no `/oidc/` location.
+
+Extra component-kind siblings: add one `location /api/<component-name>/` block
+each (same `proxy_pass` pattern, rewrite stripping that prefix) and a matching
+`sed` of `__<NAME>_BACKEND__` from that sibling's `<DEP>_URL`. Primary stays `/api`.
+
 `index.html` — the `env-config.js` tag is **synchronous** and comes BEFORE the
-bundle. No `async`, no `defer`, no `type="module"` on it; that is what guarantees
-`window._env_` is populated before any ES module evaluates.
+bundle. No `async`, no `defer`, no `type="module"` on it.
 
 ```html
 <head>
@@ -129,13 +154,13 @@ bundle. No `async`, no `defer`, no `type="module"` on it; that is what guarantee
 </body>
 ```
 
-`src/env.ts` — typed read, throwing if the file never loaded:
+`src/env.ts` — typed read, throwing if the file never loaded. Declare only keys
+from the table above that this app actually has (OIDC / `configurations.env` /
+external-kind URLs). Example with no browser API URL:
 
 ```ts
 type Env = {
-  API_BASE_URL: string;
-  // ...one <UPSTREAM>_URL per component-kind dependency, plus the <DEP>_* OIDC
-  // keys if this SPA declares an auth dependency.
+  // USER_AUTH_* only if this SPA declares that auth dependency
 };
 
 declare global {
@@ -154,8 +179,7 @@ export const env: Env = window._env_;
 ```
 
 `src/generated/<component-name>.ts` — one run per dependency, before writing
-`api.ts`. `openapi-typescript` is a devDependency (codegen only, no runtime
-footprint); `openapi-fetch` is a regular dependency (it ships in the bundle):
+`api.ts`:
 
 ```bash
 npx openapi-typescript ../specs/design/components/<component-name>/openapi.yaml \
@@ -166,43 +190,25 @@ npx openapi-typescript ../specs/design/components/<component-name>/openapi.yaml 
 `../specs/design/components/<this-app>/dependencies/<dep-name>.openapi.yaml`
 instead.) Re-run and commit the diff whenever the upstream spec changes.
 
-`src/api.ts` — resolve the upstream URL at module top level, so a missing key
-throws at load rather than at the first click; the client is typed end-to-end
-against the generated file, so a path or method typo is a compile error, not a
-runtime 404:
+`src/api.ts` — **same-origin** `baseUrl`. OpenAPI paths stay as designed
+(`/hello`, `/todos`); nginx strips `/api` before proxying.
 
 ```ts
 import createClient from "openapi-fetch";
 import type { paths } from "./generated/todo-api";
-import { env } from "./env";
 
-const BASE_URL = env.TODO_API_URL; // or env.API_BASE_URL for the primary upstream
-if (!BASE_URL) {
-  throw new Error("TODO_API_URL not set in window._env_");
-}
+export const todoApi = createClient<paths>({ baseUrl: "/api" });
 
-export const todoApi = createClient<paths>({ baseUrl: BASE_URL });
-
-// call sites use the typed client directly, e.g.:
-// const { data, error } = await todoApi.GET("/todos");
+// extra sibling:
+// export const otherApi = createClient<paths>({ baseUrl: "/api/other-api" });
 ```
 
-`nginx/default.conf` — pure static:
+**Done when:** no `env.API_BASE_URL`, no `env.TODO_API_URL`, no
+`window._env_` key used as an API host.
 
-```nginx
-server {
-    listen 9090;
-    server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-```
-
-`Dockerfile` — multi-stage build onto stock `nginx:alpine`:
+`Dockerfile` — multi-stage onto stock `nginx:alpine`. **Do not set `ENTRYPOINT`**
+— the image already runs `/docker-entrypoint.sh`, which runs
+`/docker-entrypoint.d/*.sh` then execs `CMD`.
 
 ```dockerfile
 FROM node:20-alpine AS builder
@@ -215,19 +221,27 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY nginx/15-aep-api-proxy.sh /docker-entrypoint.d/15-aep-api-proxy.sh
+RUN chmod +x /docker-entrypoint.d/15-aep-api-proxy.sh
 EXPOSE 9090
 CMD ["nginx", "-g", "daemon off;"]
 ```
 
+**Done when:** Dockerfile COPYs the drop-in to `/docker-entrypoint.d/` and has
+no `ENTRYPOINT` line.
+
 `workload.yaml` follows your prompt — as given when it carries one, else per the
-component contract. Any default it declares under `configurations.env` arrives as
-a `window._env_` entry (see Config above).
+component contract. Consumer connection to the sibling: `visibility: project`,
+`envBindings.address: <DEP_NAME>_URL` (pod, for nginx). Any default under
+`configurations.env` arrives as a `window._env_` entry.
 
 ## Pitfalls
 
 | Symptom | Cause | Fix |
 |---|---|---|
 | SPA throws on load: `window._env_ not set` | `/env-config.js` failed to load — path wrong, 404, or the `<script>` was `defer`/`async` | Make the tag synchronous in `<head>`, BEFORE the bundle's `<script type="module">`. |
-| `nginx: [emerg] host not found in upstream "thunder-service..."` at pod start | Legacy `/oidc/` proxy block in `nginx/default.conf` | Delete the block. The browser posts cross-origin. |
+| `nginx: [emerg] host not found in upstream "…"` at pod start | Literal `proxy_pass http://hostname` (startup DNS) or leftover `/oidc/` block | Use the asset conf (`proxy_pass http://$api_backend`) and the drop-in; delete `/oidc/`. |
+| Browser CORS error calling the sibling API | `baseUrl` is the public gateway URL or `window._env_.API_BASE_URL` | `baseUrl: "/api"`. |
+| `/api` 502, SPA otherwise fine | API pod down, or drop-in left `TODO_API_URL` when the dep is named something else | Align `API_URL="${…}"` with `envBindings.address`; 502 while the API is down is expected. |
 | Types in `src/generated/*` don't match the live service | Upstream `openapi.yaml` changed since last generation | Re-run the `openapi-typescript` command and commit the diff. |
-| Docker build succeeds but ships stale/hand-written shapes, or fails `ENOENT ../specs/...` | `src/generated/` wasn't committed — the per-component build context is this app's folder alone, `specs/` isn't reachable from it | Generate and commit `src/generated/` before PR; never rely on a build-time regen step. |
+| Docker build succeeds but ships stale/hand-written shapes, or fails `ENOENT ../specs/...` | `src/generated/` wasn't committed — the per-component build context is this app's folder alone | Generate and commit `src/generated/` before PR. |

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -235,6 +235,11 @@ component contract. Consumer connection to the sibling: `visibility: project`,
 `envBindings.address: <DEP_NAME>_URL` (pod, for nginx). Any default under
 `configurations.env` arrives as a `window._env_` entry.
 
+**Done when:** this app's dependency on the sibling is `visibility: project`
+(never `external`). The sibling *service's* own endpoint lists both
+`project` and `external` — that file is the Go (or other backend) skill's
+to write; do not strip `external` from it because this SPA uses `/api`.
+
 ## Pitfalls
 
 | Symptom | Cause | Fix |

--- a/skills/react-webapp/assets/15-aep-api-proxy.sh
+++ b/skills/react-webapp/assets/15-aep-api-proxy.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Runs from official nginx:alpine /docker-entrypoint.d/ *before* nginx starts.
+# Do not exec nginx here; the image ENTRYPOINT does that.
+
+set -e
+
+CONF=/etc/nginx/conf.d/default.conf
+
+DNS_RESOLVERS="$(awk '/^nameserver/ {print $2}' /etc/resolv.conf | tr '\n' ' ' | sed 's/ $//')"
+if [ -z "$DNS_RESOLVERS" ]; then
+    echo "aep-api-proxy: no nameservers in /etc/resolv.conf; /api will 502"
+    DNS_RESOLVERS="127.0.0.11"
+fi
+sed -i "s|__DNS_RESOLVERS__|${DNS_RESOLVERS}|g" "$CONF"
+
+# Primary sibling address. After copy, the coding agent sets this to the
+# UPPER_SNAKE `_URL` of the primary component-kind dependency
+# (todo-api → TODO_API_URL). OpenChoreo injects it on the pod.
+API_URL="${TODO_API_URL:-}"
+API_BACKEND="$(echo "${API_URL}" | sed 's|^https\{0,1\}://||' | sed 's|/.*||')"
+if [ -z "$API_BACKEND" ]; then
+    echo "aep-api-proxy: primary *_URL unset; /api will 502 until OpenChoreo injects it"
+    API_BACKEND="127.0.0.1:9"
+fi
+sed -i "s|__API_BACKEND__|${API_BACKEND}|g" "$CONF"

--- a/skills/react-webapp/assets/nginx-default.conf
+++ b/skills/react-webapp/assets/nginx-default.conf
@@ -1,0 +1,29 @@
+server {
+    listen 9090;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Request-time DNS so nginx starts if the sibling API Service is not up yet
+    # (browser /api then 502s; the pod does not crash-loop).
+    resolver __DNS_RESOLVERS__ valid=10s ipv6=off;
+
+    location /api/ {
+        set $api_backend __API_BACKEND__;
+        rewrite ^/api/(.*) /$1 break;
+        proxy_pass http://$api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -70,7 +70,7 @@ and serve the route at `/callback`. Post-sign-in landing is
 **Token endpoint is cross-origin.** The browser posts straight to
 `<DEP>_ISSUER/oauth2/token`; discovery is
 `<DEP>_ISSUER/.well-known/openid-configuration`. Nothing is proxied same-origin,
-which is why `react-webapp` keeps nginx purely static.
+which is why `react-webapp` does not proxy `/oidc/` — nginx only reverse-proxies sibling APIs under `/api`.
 
 **Persist the session and renew silently.** The OAuth client is provisioned with
 the `refresh_token` grant alongside `authorization_code` + PKCE, so an expiring
@@ -161,7 +161,7 @@ on every visit. `currentUser()` already renews silently.
 ```ts
 export async function listTodos() {
   const token = await getAccessToken();
-  const res = await fetch(`${env.API_BASE_URL}/todos`, {
+  const res = await fetch(`/api/todos`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (res.status === 401) { await signIn(); return []; }


### PR DESCRIPTION
## Problem

A generated fullstack app is a browser SPA plus a backend API in the same OpenChoreo project.

OpenChoreo can only inject **in-cluster** Service URLs (`*.svc.cluster.local`) into the **pod**. The browser cannot reach those. Skills previously worked around that by putting the API's **public gateway URL** in `window._env_.API_BASE_URL` and requiring `visibility: external` plus CORS. That is flaky: the gateway URL is not always ready, CORS allowlists drift, and OpenChoreo rejects `external` on a *dependency* connection.

## What this PR does

The browser calls a path on the SPA's own host. Nginx in the SPA pod reverse-proxies that path to the project-level Service URL OpenChoreo already injects as pod env (`TODO_API_URL` / `<DEP>_URL`). The API gateway is not on this hop.

```mermaid
flowchart LR
  Browser["Browser"] -->|"GET /api/hello<br/>same origin"| Nginx["SPA nginx<br/>(public)"]
  Nginx -->|"proxy_pass<br/>pod env TODO_API_URL"| API["API pod :9090<br/>project Service"]
```

| Before | After |
|---|---|
| Browser fetches `https://…openchoreoapis…/…-http/hello` | Browser fetches `/api/hello` on the SPA host |
| `window._env_.API_BASE_URL` = public gateway URL | No sibling API URL in `window._env_` |
| CORS allowlist of sibling SPA origins | Gateway CORS stays at trait default `["*"]`; SPA hop needs no CORS |
| Go services wrapped in `withCORS` | No service CORS middleware for the SPA |

Provider endpoints still list `[project, external]`: `project` for nginx, `external` so the API remains curl-able on the public gateway. The SPA must not fetch that public URL.

Auth / JWT-in-service is out of scope. The OIDC token endpoint stays cross-origin (no `/oidc/` proxy).

## Changes

- **Platform:** stop writing sibling API public URLs into `env-config.js`; stop pinning API CORS to sibling SPA origins.
- **Skills:** `react-webapp` copies an nginx drop-in (`location /api/` + official `nginx:alpine` ENTRYPOINT). `go` / `api-management` / `thunder-authentication` stop teaching CORS/`API_BASE_URL` workarounds.

## Test plan

- [x] `go test` in `runtimeconfig`, `projects`, `spec`, `delivery/run`
- [x] `make -C services/aep-api deadcode-check`
- [x] Playground coding run: SPA Dockerfile copies `/docker-entrypoint.d/15-aep-api-proxy.sh` (no custom `ENTRYPOINT`); `src/api.ts` uses `baseUrl: "/api"`; no `withCORS`; API `workload.yaml` has `[project, external]`; SPA dependency is `visibility: project`
- [x] Local k3d + agent-browser: SPA origin `GET /api/hello` → 200, no CORS, no fetch to a gateway API host or `*.svc.cluster.local`. API scaled to 0 → SPA still 200, `/api/hello` 502