### PR TITLE
fix(aectl): allow secrets to be injected via env vars in platform install

### DIFF
--- a/tools/aectl/cmd/init.go
+++ b/tools/aectl/cmd/init.go
@@ -154,12 +154,16 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		}
 		_, _ = fmt.Fprintln(os.Stdout, "Existing secrets verified — skipping provisioning.")
 	} else {
-		anthropicKey, err := readMaskedInput("Anthropic API key")
-		if err != nil {
-			return fmt.Errorf("read Anthropic API key: %w", err)
-		}
+		anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
 		if anthropicKey == "" {
-			return fmt.Errorf("an Anthropic API key is required")
+			var err error
+			anthropicKey, err = readMaskedInput("Anthropic API key")
+			if err != nil {
+				return fmt.Errorf("read Anthropic API key: %w", err)
+			}
+			if anthropicKey == "" {
+				return fmt.Errorf("an Anthropic API key is required")
+			}
 		}
 
 		if openBaoDirect && os.Getenv("AEP_OPENBAO_TOKEN") == "" {
@@ -172,15 +176,18 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET") == "" {
-			thunderSecret, err := readMaskedInput("Thunder admin client secret (Enter = use value from config)")
+		thunderSecret := os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET")
+		if thunderSecret == "" {
+			var err error
+			thunderSecret, err = readMaskedInput("Thunder admin client secret")
 			if err != nil {
 				return fmt.Errorf("read Thunder admin client secret: %w", err)
 			}
-			if thunderSecret != "" {
-				viper.Set("thunder.admin_client_secret", thunderSecret)
+			if thunderSecret == "" {
+				return fmt.Errorf("a Thunder admin client secret is required")
 			}
 		}
+		viper.Set("thunder.admin_client_secret", thunderSecret)
 
 		adminClientID := viper.GetString("thunder.admin_client_id")
 		adminClientSecret := viper.GetString("thunder.admin_client_secret")

--- a/tools/aectl/cmd/init.go
+++ b/tools/aectl/cmd/init.go
@@ -154,7 +154,7 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 		}
 		_, _ = fmt.Fprintln(os.Stdout, "Existing secrets verified — skipping provisioning.")
 	} else {
-		anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+		anthropicKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
 		if anthropicKey == "" {
 			var err error
 			anthropicKey, err = readMaskedInput("Anthropic API key")
@@ -176,7 +176,7 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		thunderSecret := os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET")
+		thunderSecret := strings.TrimSpace(os.Getenv("AEP_THUNDER_ADMIN_CLIENT_SECRET"))
 		if thunderSecret == "" {
 			var err error
 			thunderSecret, err = readMaskedInput("Thunder admin client secret")


### PR DESCRIPTION
## Summary

- `ANTHROPIC_API_KEY` env var now skips the Anthropic API key prompt in `aectl platform install`
- `AEP_THUNDER_ADMIN_CLIENT_SECRET` env var now skips the Thunder admin client secret prompt
- Thunder admin client secret no longer silently falls back to config — it errors if neither the env var nor the prompt provides a value (consistent with how the Anthropic key works)

Both secrets follow the same pattern: env var takes precedence → masked interactive prompt → hard error if still empty.

## Test plan

- [ ] Run `aectl platform install` without env vars set — both prompts appear as before
- [ ] Run with `ANTHROPIC_API_KEY=sk-... aectl platform install` — Anthropic prompt is skipped
- [ ] Run with `AEP_THUNDER_ADMIN_CLIENT_SECRET=... aectl platform install` — Thunder prompt is skipped
- [ ] Run with both env vars set — no secret prompts appear
- [ ] Run without env vars and leave Thunder secret blank at prompt — command errors with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)