### PR TITLE
fix(ci): allow pre-release versions in release workflow version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           CGO_ENABLED: "0"
           VERSION: ${{ inputs.version }}
         run: |
-          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid version: $VERSION"; exit 1; }
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]] || { echo "invalid version: $VERSION"; exit 1; }
           go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
             -o aectl-${GOOS}-${GOARCH}${{ matrix.ext || '' }} .
 
@@ -265,7 +265,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           REPO: ${{ github.repository }}
         run: |
-          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid version: $VERSION"; exit 1; }
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]] || { echo "invalid version: $VERSION"; exit 1; }
           gh release create "ctl/v${VERSION}" \
             --title "AECTL v${VERSION}" \
             --notes "## AECTL v${VERSION}


### PR DESCRIPTION
## Summary

- The version regex `^[0-9]+\.[0-9]+\.[0-9]+$` in the release workflow rejected pre-release versions like `0.6.0-rc10`
- Extended it to `^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$` to accept an optional pre-release suffix
- Applies to both the build-binaries step and the create-release step

## Test plan

- [ ] Trigger the release workflow with version `0.6.0` — passes as before
- [ ] Trigger with `0.6.0-rc10` — now passes instead of failing
- [ ] Trigger with an invalid value like `abc` or `0.6` — still fails with "invalid version"

🤖 Generated with [Claude Code](https://claude.com/claude-code)