### PR TITLE
fix(ci): correct platform release install instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,8 @@ jobs:
           ### Install
 
           \`\`\`bash
-          helm install aep oci://ghcr.io/wso2/aep/charts/aep-bootstrap \\
-            --version ${{ inputs.version }} -n wso2-aep --create-namespace
-
-          aectl platform install \\
-            --platform-version ${{ inputs.version }}
+          aectl platform config import --config <your-config-file>
+          aectl platform install --platform-version ${{ inputs.version }}
           \`\`\`
 
           ### Images


### PR DESCRIPTION
## Summary

- Removed reference to non-existent `aep-bootstrap` chart — the chart is `aep-platform` and `aectl platform install` handles the Helm install internally
- Added the required `aectl platform config import` step that must run before `aectl platform install`
- Removed the redundant standalone `helm install` line

## Test plan

- [ ] Trigger a platform release and verify the generated GitHub release notes show the correct two-step install flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)