### PR TITLE
fix(release): build and publish thunder-app-operator image on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           - name: console
             dockerfile: apps/console/Dockerfile
             context: .
+          - name: thunder-app-operator
+            dockerfile: deployments/single-cluster/resource-types/thunder-app/operator/Dockerfile
+            context: deployments/single-cluster/resource-types/thunder-app/operator
 
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +148,9 @@ jobs:
           yq -i '.console.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
           yq -i '.console.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
           yq -i '.codingAgentRunner.image = "${{ env.IMAGE_PREFIX }}/remote-worker:${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '."thunder-app-operator".image.repository = "${{ env.IMAGE_PREFIX }}/thunder-app-operator"' /tmp/platform/values.yaml
+          yq -i '."thunder-app-operator".image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '."thunder-app-operator".image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
 
           helm package /tmp/platform --destination /tmp/charts
 
@@ -191,7 +197,8 @@ jobs:
           - \`ghcr.io/wso2/aep/collab:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/aep-mcp-server:${{ inputs.version }}\`
           - \`ghcr.io/wso2/aep/remote-worker:${{ inputs.version }}\`
-          - \`ghcr.io/wso2/aep/console:${{ inputs.version }}\`"
+          - \`ghcr.io/wso2/aep/console:${{ inputs.version }}\`
+          - \`ghcr.io/wso2/aep/thunder-app-operator:${{ inputs.version }}\`"
 
   # ─── CTL: build CLI binaries ─────────────────────────────────────────────────
   build-ctl-binaries:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,30 +126,34 @@ jobs:
               --username ${{ github.actor }} --password-stdin
 
       - name: Package platform chart
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]] || { echo "invalid version: $VERSION"; exit 1; }
+
           helm dependency update deployments/helm-charts/platform
           cp -r deployments/helm-charts/platform /tmp/platform
 
-          yq -i '.version = "${{ inputs.version }}"' /tmp/platform/Chart.yaml
-          yq -i '.appVersion = "${{ inputs.version }}"' /tmp/platform/Chart.yaml
-          yq -i '.aepApi.image.repository = "${{ env.IMAGE_PREFIX }}/aep-api"' /tmp/platform/values.yaml
-          yq -i '.aepApi.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.version = strenv(VERSION)' /tmp/platform/Chart.yaml
+          yq -i '.appVersion = strenv(VERSION)' /tmp/platform/Chart.yaml
+          yq -i '.aepApi.image.repository = strenv(IMAGE_PREFIX) + "/aep-api"' /tmp/platform/values.yaml
+          yq -i '.aepApi.image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '.aepApi.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
-          yq -i '.aepAgents.image.repository = "${{ env.IMAGE_PREFIX }}/agents"' /tmp/platform/values.yaml
-          yq -i '.aepAgents.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.aepAgents.image.repository = strenv(IMAGE_PREFIX) + "/agents"' /tmp/platform/values.yaml
+          yq -i '.aepAgents.image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '.aepAgents.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
-          yq -i '.collab.image.repository = "${{ env.IMAGE_PREFIX }}/collab"' /tmp/platform/values.yaml
-          yq -i '.collab.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.collab.image.repository = strenv(IMAGE_PREFIX) + "/collab"' /tmp/platform/values.yaml
+          yq -i '.collab.image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '.collab.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
-          yq -i '.aepMcpServer.image.repository = "${{ env.IMAGE_PREFIX }}/aep-mcp-server"' /tmp/platform/values.yaml
-          yq -i '.aepMcpServer.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.aepMcpServer.image.repository = strenv(IMAGE_PREFIX) + "/aep-mcp-server"' /tmp/platform/values.yaml
+          yq -i '.aepMcpServer.image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '.aepMcpServer.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
-          yq -i '.console.image.repository = "${{ env.IMAGE_PREFIX }}/console"' /tmp/platform/values.yaml
-          yq -i '.console.image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.console.image.repository = strenv(IMAGE_PREFIX) + "/console"' /tmp/platform/values.yaml
+          yq -i '.console.image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '.console.image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
-          yq -i '.codingAgentRunner.image = "${{ env.IMAGE_PREFIX }}/remote-worker:${{ inputs.version }}"' /tmp/platform/values.yaml
-          yq -i '."thunder-app-operator".image.repository = "${{ env.IMAGE_PREFIX }}/thunder-app-operator"' /tmp/platform/values.yaml
-          yq -i '."thunder-app-operator".image.tag = "${{ inputs.version }}"' /tmp/platform/values.yaml
+          yq -i '.codingAgentRunner.image = strenv(IMAGE_PREFIX) + "/remote-worker:" + strenv(VERSION)' /tmp/platform/values.yaml
+          yq -i '."thunder-app-operator".image.repository = strenv(IMAGE_PREFIX) + "/thunder-app-operator"' /tmp/platform/values.yaml
+          yq -i '."thunder-app-operator".image.tag = strenv(VERSION)' /tmp/platform/values.yaml
           yq -i '."thunder-app-operator".image.pullPolicy = "IfNotPresent"' /tmp/platform/values.yaml
 
           helm package /tmp/platform --destination /tmp/charts


### PR DESCRIPTION
## Summary

- `thunder-app-operator` was missing from the release workflow's image build matrix
- Its chart defaults to `repository: thunder-app-operator, tag: local` which only works in local k3d dev (image is imported directly into nodes)
- On real clusters this caused `ImagePullBackOff` because the image doesn't exist in any registry

## Changes

- Added `thunder-app-operator` to the `build-push-images` matrix — builds and pushes `ghcr.io/wso2/aep/thunder-app-operator:<version>` to GHCR on release
- Added `yq` overrides in the chart packaging step to pin the image repo/tag/pullPolicy in `values.yaml` so the published image is used on install
- Added the image to the release notes

## Test plan

- [ ] Trigger a release and confirm `thunder-app-operator` image appears in GHCR at the correct tag
- [ ] Run `aectl platform install --platform-version <version>` and confirm the operator pod starts without `ImagePullBackOff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)