### PR TITLE
docs(console): grill from either end, integrate on the branch, ship by merge

### DIFF
--- a/.agents/skills/console-feature/SKILL.md
+++ b/.agents/skills/console-feature/SKILL.md
@@ -1,149 +1,129 @@
 ---
 name: console-feature
-description: Drive a console feature through the issue-driven cycle — grill the idea, create the issue from the outcome, build, ship — with a checkpoint at each stage.
-disable-model-invocation: true
-argument-hint: <feature idea in plain words, or an existing issue number to resume>
+description: Drive a console (frontend) feature through its issue-driven cycle, grilled before any code. Use when the user wants a console feature built or changed, or names an existing console feature issue; bug fixes and polish are exempt.
+argument-hint: <feature idea in plain words, or an existing issue number>
 ---
 
 # Console feature cycle
 
-Orchestrate the console's issue-driven feature flow. This skill is the
-**entry point for frontend feature work**: an idea goes through it — grilled
-first, then written up as an issue, then built — never straight into code.
-The **spec** is `apps/console/design/development-flow.md` — read it first and
-follow its rules and template; this skill only sequences the steps and
-checkpoints.
+The **entry point for frontend feature work**: a feature goes through this
+skill — grilled first, then built. It takes either end — a raw **idea** (no
+issue yet), or an **issue number** for one already open.
 
-Non-negotiables (from the spec):
+`apps/console/design/development-flow.md` is the **spec**: it defines every
+stage, every rule, and the issue template. **Read it now**, before anything
+else. This skill carries only what the spec doesn't — which mode to route
+into, where each pause sits, and the commands to run. Console work requires
+`gh` auth.
 
-- **Grill before the issue exists.** The interview happens on the raw idea;
-  the issue is created from its outcome, with the decisions in the body. Do
-  not open an issue to "have somewhere to grill".
-- Every `gh issue` / `gh pr` command gets `--repo wso2/labs-agentic-engineer`
-  — issues and PRs live upstream, never in forks. `gh` auth is required.
-- Closed issues and merged PRs are frozen history: never edit or push to
-  them. ADRs are the current truth.
-- `packages/contracts/api/v1/openapi.yaml` is the **source of truth** for
-  the API (issue #76): editing it *is* the contract change. Regenerate with
-  the console-scoped gen (`pnpm --filter @aep/console gen`), not root
-  `make gen`.
-- Stopping at any checkpoint is a normal exit, not a failure. Tell the user
-  they can pick the feature back up with `/console-feature <issue-number>`
-  once the issue exists — and that stopping mid-grilling means starting the
-  interview over, since nothing is recorded yet.
+Stopping at any pause is a normal exit, not a failure. Say that the feature
+resumes with `/console-feature <issue-number>`; a stop mid-interview restarts
+it, since nothing is recorded until the issue or the comment exists.
 
-## Checkpoint classes
+## On silence
 
-Three kinds of pause, with different behavior when the user doesn't answer:
+Three kinds of pause, each named for what it does when the user doesn't
+answer:
 
-- **Hard-wait** — every grilling question and the issue-draft confirmation.
-  User input is the entire point: on timeout, re-ask and wait. Never answer
-  a grilling question on the user's behalf.
-- **Auto-proceed** — the recording stages (ADR graduation, handshake issue,
-  PRD in-flight). They only transcribe decisions the user already made:
-  offer the checkpoint, and on timeout proceed.
-- **Hard gate** — Build and Ship. On timeout or anything short of a clear
-  yes, stop the session cleanly and print the resume command. Never build
-  or ship on silence.
+- **Re-ask** — every interview question, and the issue-draft confirmation.
+  User input is the whole point: ask again and wait. Answering a grilling
+  question on the user's behalf voids the interview.
+- **Auto-proceed** — the recording pauses (decisions comment, ADR
+  graduation, handshake issue). They transcribe decisions the user already
+  made: offer, and on silence proceed.
+- **Halt** — Build and Ship. On silence, or anything short of a clear yes,
+  end the session cleanly and print the resume command.
 
-## Parse the arguments
+## Route on the argument
 
-- A bare number (`42`, `#42`) or issue URL → **resume mode**.
-- Anything else → **new-feature mode**, treating the text as the feature
-  idea.
-- No arguments → ask the user what the feature is, then new-feature mode.
+- A bare number (`42`, `#42`) or an issue URL → **issue mode**.
+- Anything else → **idea mode**, the text being the feature idea.
+- Nothing → ask which of the two they have, then the matching mode.
 
-## New-feature mode
+## The interview
 
-1. **Gather context.** Read `apps/console/PRD.md` and the ADRs in
-   `apps/console/design/decisions/`. If the idea overlaps existing work,
-   check `gh issue list --repo wso2/labs-agentic-engineer --label console
-   --label feature` (add `--state closed` for history). The feature must fit
-   the product picture or explicitly change it.
-2. **Grill the idea** (hard-wait per question). Run the `grill-me` skill on
-   the idea itself — no issue exists yet. If it isn't invocable in this
-   session, conduct the interview yourself in its spirit: relentless rounds
-   of pointed questions (AskUserQuestion) attacking the walkthrough's weak
-   points and every unknown until each is decided — never answer one on the
-   user's behalf, and on a timeout re-ask rather than defaulting. Keep the
-   running outcome (decided / why / rejected) as you go; it becomes the
-   issue's Decisions section.
-3. **Draft the issue.** Fill the feature-issue body template from the spec
-   (Problem / Users / Experience walkthrough / Scope / Decisions / Contract
-   changes / States to design / Open questions) from the grilling outcome —
-   the walkthrough is the decided version, and Open questions is normally
-   empty because the interview closed them. Show the user the full draft —
-   title and body — and get an explicit yes before creating anything
-   (**hard-wait**).
+First read `apps/console/PRD.md` and the ADRs in
+`apps/console/design/decisions/` — the interview is only as sharp as the
+product picture behind it.
+
+Run the `grill-me` skill on the subject — the raw idea in idea mode, the
+issue as written in issue mode. If it isn't invocable in this session, run
+the interview yourself in its spirit: relentless rounds of pointed questions
+(AskUserQuestion) attacking the walkthrough's weak points, ending only when
+**every unknown is decided**. Every question is a **re-ask** pause.
+
+Keep the running outcome — decided / why / rejected — as you go. Where it
+gets written down is the one thing the two modes don't share, and spec step 1
+says which goes where.
+
+## Idea mode (no issue yet)
+
+1. **Check for overlap.** Where the idea touches existing work, `gh issue
+   list --repo wso2/labs-agentic-engineer --label console --label feature`
+   (`--state closed` for history).
+2. **Grill the idea.** Nothing is written down until step 4.
+3. **Draft the issue** (**re-ask**). Fill the spec's issue template from the
+   interview outcome. Show the user the full draft — title and body — and
+   get an explicit yes.
 4. **Create it.** `gh issue create --repo wso2/labs-agentic-engineer
-   --label console --label feature` with the agreed title and body. Print
-   the issue number, URL, and final body.
-5. Continue to the stage walk below, starting at **ADR graduation**.
+   --label console --label feature`, with the agreed title and body.
+5. Continue to the stage walk at **ADR graduation**.
 
-## Resume mode
+## Issue mode (the issue exists)
 
-1. Fetch the issue and its comments:
-   `gh issue view <n> --repo wso2/labs-agentic-engineer --comments`.
-   If it's **closed**, stop: the feature shipped (or was abandoned); a
-   follow-up needs a new issue.
-2. Check for the feature's PR:
-   `gh pr list --repo wso2/labs-agentic-engineer --search "<n>" --state all`.
-   - PR **merged** → the build round is frozen; new requests become a new
-     issue referencing this one. Say so and stop (or offer to draft the
-     follow-up issue).
-   - PR **open** → feedback lives on the PR; enter the Build stage's
-     feedback loop.
-3. Otherwise detect the furthest completed stage — ADR in
-   `apps/console/design/decisions/`? handshake issue open? in-flight line in
-   `apps/console/PRD.md`? contract change, mocks, UI landed? — report what
-   you detected, and continue the stage walk from the next incomplete
-   stage. If the body has no Decisions section (a pre-grill-first issue, or
-   one opened by hand), grill it now and edit the section in before going
-   further.
+Covers both an issue someone filed by hand and a feature this skill started
+earlier; step 3 tells them apart.
+
+1. **Fetch it**, comments included: `gh issue view <n> --repo
+   wso2/labs-agentic-engineer --comments`. **Closed** → the feature shipped
+   or was abandoned, and a follow-up needs its own issue: say so and stop.
+   Anything that isn't a console feature (a bug, a chore, another component)
+   is exempt from this cycle: say so and stop.
+2. **Find its PR**: `gh pr list --repo wso2/labs-agentic-engineer --search
+   "<n>" --state all`.
+   - **Merged** → frozen; further requests become a new issue referencing
+     this one. Say so and stop, or offer to draft it.
+   - **Open** → feedback lives on the PR; enter the Build stage's feedback
+     loop.
+3. **Is it grilled?** Yes if the body has a filled Decisions section, or a
+   decisions comment exists. If not, grill it now, before anything else:
+   - Read the discussion already on the issue — it is part of the subject,
+     and points settled there get confirmed rather than re-litigated.
+   - Run the interview on the issue as written.
+   - **Post the decisions comment** (**auto-proceed**), showing it first.
+   - Edit the body for whatever the interview changed, per spec step 1, and
+     add the `console` and `feature` labels if the filer didn't.
+4. **Detect the furthest completed stage** — ADR in
+   `apps/console/design/decisions/`? contract change, mocks, UI, PRD entry
+   on the feature branch? handshake issue open, and have its backend changes
+   landed on that branch? — report what you found, then continue the stage
+   walk from the next incomplete stage.
 
 ## Stage walk
 
-Work through the stages in order, honoring each one's checkpoint class.
-Throughout: while the issue is **open**, edit the body in place
-(`gh issue edit`) so it always reflects the current shape of the feature,
-Decisions included.
+Each stage **runs the spec's step of the same number** (flow steps 4–7) —
+read what to do there. What follows is only the pause, the completion
+criterion, and the commands. Keep the issue body current with
+`gh issue edit` while it is open.
 
-1. **ADR graduation** (auto-proceed). Apply the spec's ADR rule: a decision
-   earns an ADR in `apps/console/design/decisions/ADR-NNNN-*.md` only if it
-   sets a cross-feature convention, changes the PRD, or rejects a
-   re-proposable approach. Feature-local choices stay in the issue's
-   Decisions section.
-2. **BE handshake** (auto-proceed) — only if the issue's Contract changes
-   section is non-empty. Open a separate `aep-api` issue whose body is the
-   request: the proposed spec diff, rationale, link to the feature issue.
-   The handshake issue must **exist before Build**; explicit BE agreement
-   is required **before Ship**, not before Build (mock-mode FE work can't
-   break anyone).
-3. **PRD in-flight** (auto-proceed). Add one line + issue link to the **In
-   flight** section of `apps/console/PRD.md`.
-4. **Build** (hard gate to enter).
-   - Contract diff in `packages/contracts/api/v1/openapi.yaml` (the source
-     of truth) → `pnpm --filter @aep/console gen` → typed MSW mocks covering
-     the scenarios from the issue's Decisions section → UI in mock mode
-     (`VITE_API_MODE=mock`). Use the `oxygen-ui` skill for all UI work;
-     follow `apps/console/design/design-system.md` and
-     `apps/console/design/api-guidelines.md`.
-   - **PR.** Push a feature branch upstream and open the PR against the
-     working branch. Save UI screenshots to a local folder, print their
-     paths, and ask the user to drag-and-drop them into the PR — never push
-     screenshots to a git branch. Then post a comment on the feature issue
-     linking the PR and redirecting all further feedback to the PR — the
-     issue stops collecting comments once a PR exists.
-   - **Feedback loop.** Review comments on the PR re-enter this stage:
-     implement, verify, push. Before *every* push, check
-     `gh pr view --json state` — if the PR merged meanwhile, do not push to
-     its branch; further changes need a new issue (and its own PR). Contract
-     deltas discovered here go to the handshake issue; spec-level changes to
-     the feature also update the issue body.
-5. **Ship** (hard gate to enter; entry condition: the BE handshake issue is
-   agreed and implemented). **Validate the feature** — the validation
-   procedure is defined by the user; ask how they want to validate until
-   the flow spec defines it. Then move the PRD in-flight line into the
-   feature inventory (linking the issue + any ADRs), amend affected PRD
-   sections, and close the issue. A feature PR without the PRD update is
-   incomplete.
+1. **ADR graduation** (**auto-proceed**). Test **every** decision the issue
+   carries against the spec's three-part rule — the ones that fail it stay
+   with the issue.
+2. **Build the frontend on mocks** (**halt** to enter). Use the `oxygen-ui`
+   skill for all UI work. Save screenshots to a local folder, print the
+   paths, and ask the user to drag-and-drop them into the PR. Review
+   comments re-enter this stage: implement,
+   verify, push, checking `gh pr view --json state` before *every* push so a
+   PR that merged meanwhile is never pushed to. Ends on the user confirming
+   the feature in mock mode (**halt**) — that confirmation is what unlocks
+   the handshake.
+3. **BE handshake** (**auto-proceed**) — only if the issue's Contract
+   changes section is non-empty. Open the `aep-api` issue per spec step 6,
+   then stop and tell the user the feature waits on it: Ship can't start
+   until the backend changes are on the branch.
+4. **Ship** (**halt** to enter; entry condition: backend changes are on the
+   feature branch, or the feature changed no contract). The user's
+   confirmation from the local-setup test is what unlocks the merge. Before
+   merging, check that the PR carries the PRD entry and closes **both**
+   issues. The merge is the last act — anything found afterwards is a new
+   issue.

--- a/.agents/skills/console-feature/SKILL.md
+++ b/.agents/skills/console-feature/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: console-feature
-description: Drive a console feature through the issue-driven cycle — create the issue, grill it, record decisions, build, ship — with a checkpoint at each stage.
+description: Drive a console feature through the issue-driven cycle — grill the idea, create the issue from the outcome, build, ship — with a checkpoint at each stage.
 disable-model-invocation: true
 argument-hint: <feature idea in plain words, or an existing issue number to resume>
 ---
 
 # Console feature cycle
 
-Orchestrate the console's issue-driven feature flow. The **spec** is
-`apps/console/design/development-flow.md` — read it first and follow its
-rules and template; this skill only sequences the steps and checkpoints.
+Orchestrate the console's issue-driven feature flow. This skill is the
+**entry point for frontend feature work**: an idea goes through it — grilled
+first, then written up as an issue, then built — never straight into code.
+The **spec** is `apps/console/design/development-flow.md` — read it first and
+follow its rules and template; this skill only sequences the steps and
+checkpoints.
 
 Non-negotiables (from the spec):
 
+- **Grill before the issue exists.** The interview happens on the raw idea;
+  the issue is created from its outcome, with the decisions in the body. Do
+  not open an issue to "have somewhere to grill".
 - Every `gh issue` / `gh pr` command gets `--repo wso2/labs-agentic-engineer`
   — issues and PRs live upstream, never in forks. `gh` auth is required.
 - Closed issues and merged PRs are frozen history: never edit or push to
@@ -22,19 +28,20 @@ Non-negotiables (from the spec):
   the console-scoped gen (`pnpm --filter @aep/console gen`), not root
   `make gen`.
 - Stopping at any checkpoint is a normal exit, not a failure. Tell the user
-  they can pick the feature back up with `/console-feature <issue-number>`.
+  they can pick the feature back up with `/console-feature <issue-number>`
+  once the issue exists — and that stopping mid-grilling means starting the
+  interview over, since nothing is recorded yet.
 
 ## Checkpoint classes
 
 Three kinds of pause, with different behavior when the user doesn't answer:
 
-- **Hard-wait** — the issue-draft confirmation and every grilling question.
+- **Hard-wait** — every grilling question and the issue-draft confirmation.
   User input is the entire point: on timeout, re-ask and wait. Never answer
   a grilling question on the user's behalf.
-- **Auto-proceed** — the recording stages (decisions comment, ADR
-  graduation, handshake issue, PRD in-flight). They only transcribe
-  decisions the user already made: offer the checkpoint, and on timeout
-  proceed.
+- **Auto-proceed** — the recording stages (ADR graduation, handshake issue,
+  PRD in-flight). They only transcribe decisions the user already made:
+  offer the checkpoint, and on timeout proceed.
 - **Hard gate** — Build and Ship. On timeout or anything short of a clear
   yes, stop the session cleanly and print the resume command. Never build
   or ship on silence.
@@ -53,15 +60,25 @@ Three kinds of pause, with different behavior when the user doesn't answer:
    check `gh issue list --repo wso2/labs-agentic-engineer --label console
    --label feature` (add `--state closed` for history). The feature must fit
    the product picture or explicitly change it.
-2. **Draft the issue.** Fill the feature-issue body template from the spec
-   (Problem / Users / Experience walkthrough / Scope / Contract changes /
-   States to design / Open questions). Show the user the full draft — title
-   and body — and get an explicit yes before creating anything
+2. **Grill the idea** (hard-wait per question). Run the `grill-me` skill on
+   the idea itself — no issue exists yet. If it isn't invocable in this
+   session, conduct the interview yourself in its spirit: relentless rounds
+   of pointed questions (AskUserQuestion) attacking the walkthrough's weak
+   points and every unknown until each is decided — never answer one on the
+   user's behalf, and on a timeout re-ask rather than defaulting. Keep the
+   running outcome (decided / why / rejected) as you go; it becomes the
+   issue's Decisions section.
+3. **Draft the issue.** Fill the feature-issue body template from the spec
+   (Problem / Users / Experience walkthrough / Scope / Decisions / Contract
+   changes / States to design / Open questions) from the grilling outcome —
+   the walkthrough is the decided version, and Open questions is normally
+   empty because the interview closed them. Show the user the full draft —
+   title and body — and get an explicit yes before creating anything
    (**hard-wait**).
-3. **Create it.** `gh issue create --repo wso2/labs-agentic-engineer
+4. **Create it.** `gh issue create --repo wso2/labs-agentic-engineer
    --label console --label feature` with the agreed title and body. Print
    the issue number, URL, and final body.
-4. Continue to the stage walk below, starting at **Grill**.
+5. Continue to the stage walk below, starting at **ADR graduation**.
 
 ## Resume mode
 
@@ -76,41 +93,38 @@ Three kinds of pause, with different behavior when the user doesn't answer:
      follow-up issue).
    - PR **open** → feedback lives on the PR; enter the Build stage's
      feedback loop.
-3. Otherwise detect the furthest completed stage — decisions comment
-   posted? in-flight line in `apps/console/PRD.md`? contract change,
-   mocks, UI landed? — report what you detected, and continue the stage
-   walk from the next incomplete stage.
+3. Otherwise detect the furthest completed stage — ADR in
+   `apps/console/design/decisions/`? handshake issue open? in-flight line in
+   `apps/console/PRD.md`? contract change, mocks, UI landed? — report what
+   you detected, and continue the stage walk from the next incomplete
+   stage. If the body has no Decisions section (a pre-grill-first issue, or
+   one opened by hand), grill it now and edit the section in before going
+   further.
 
 ## Stage walk
 
 Work through the stages in order, honoring each one's checkpoint class.
+Throughout: while the issue is **open**, edit the body in place
+(`gh issue edit`) so it always reflects the current shape of the feature,
+Decisions included.
 
-1. **Grill** (hard-wait per question). Run the `grill-me` skill on the
-   issue. If it isn't invocable in this session, conduct the interview
-   yourself in its spirit: relentless rounds of pointed questions
-   (AskUserQuestion) attacking the walkthrough's weak points and every Open
-   question until each is decided — never answer one on the user's behalf,
-   and on a timeout re-ask rather than defaulting. While the issue is open,
-   edit the body in place (`gh issue edit`) so it always reflects the
-   current shape of the feature.
-2. **Decisions comment** (auto-proceed). Post the grilling outcome as a
-   comment on the issue: what was decided, why, what was rejected.
-3. **ADR graduation** (auto-proceed). Apply the spec's ADR rule: a decision
+1. **ADR graduation** (auto-proceed). Apply the spec's ADR rule: a decision
    earns an ADR in `apps/console/design/decisions/ADR-NNNN-*.md` only if it
    sets a cross-feature convention, changes the PRD, or rejects a
-   re-proposable approach. Feature-local choices stay in the issue.
-4. **BE handshake** (auto-proceed) — only if the issue's Contract changes
+   re-proposable approach. Feature-local choices stay in the issue's
+   Decisions section.
+2. **BE handshake** (auto-proceed) — only if the issue's Contract changes
    section is non-empty. Open a separate `aep-api` issue whose body is the
    request: the proposed spec diff, rationale, link to the feature issue.
    The handshake issue must **exist before Build**; explicit BE agreement
    is required **before Ship**, not before Build (mock-mode FE work can't
    break anyone).
-5. **PRD in-flight** (auto-proceed). Add one line + issue link to the **In
+3. **PRD in-flight** (auto-proceed). Add one line + issue link to the **In
    flight** section of `apps/console/PRD.md`.
-6. **Build** (hard gate to enter).
+4. **Build** (hard gate to enter).
    - Contract diff in `packages/contracts/api/v1/openapi.yaml` (the source
      of truth) → `pnpm --filter @aep/console gen` → typed MSW mocks covering
-     the scenarios from the decisions comment → UI in mock mode
+     the scenarios from the issue's Decisions section → UI in mock mode
      (`VITE_API_MODE=mock`). Use the `oxygen-ui` skill for all UI work;
      follow `apps/console/design/design-system.md` and
      `apps/console/design/api-guidelines.md`.
@@ -126,7 +140,7 @@ Work through the stages in order, honoring each one's checkpoint class.
      its branch; further changes need a new issue (and its own PR). Contract
      deltas discovered here go to the handshake issue; spec-level changes to
      the feature also update the issue body.
-7. **Ship** (hard gate to enter; entry condition: the BE handshake issue is
+5. **Ship** (hard gate to enter; entry condition: the BE handshake issue is
    agreed and implemented). **Validate the feature** — the validation
    procedure is defined by the user; ask how they want to validate until
    the flow spec defines it. Then move the PRD in-flight line into the

--- a/.agents/skills/console-feature/SKILL.md
+++ b/.agents/skills/console-feature/SKILL.md
@@ -124,6 +124,6 @@ criterion, and the commands. Keep the issue body current with
 4. **Ship** (**halt** to enter; entry condition: backend changes are on the
    feature branch, or the feature changed no contract). The user's
    confirmation from the local-setup test is what unlocks the merge. Before
-   merging, check that the PR carries the PRD entry and closes **both**
-   issues. The merge is the last act — anything found afterwards is a new
-   issue.
+   merging, check that the PR carries the PRD entry and closes the feature
+   issue — plus the handshake issue, if stage 3 opened one. The merge is the
+   last act: anything found afterward is a new issue.

--- a/apps/console/AGENTS.md
+++ b/apps/console/AGENTS.md
@@ -10,16 +10,16 @@ React SPA console for AEP. Vite + TypeScript + Oxygen UI, talking to the
 > mention Oxygen UI by name.
 
 > [!IMPORTANT]
-> Before implementing a frontend feature, use the `/console-feature` skill —
-> pass it the idea in plain words. It runs a grilling session, creates the
-> GitHub issue from the outcome, and then implements from there. Don't
-> freestyle a feature straight into code.
+> Frontend features go through the `console-feature` skill — it grills first,
+> then drives the build. A feature request goes into that cycle, not straight
+> into code, and an ungrilled issue gets grilled before it gets built.
 
 **Read before working on any feature:**
 
 - `PRD.md` — the living product picture: what exists, what's planned.
-- `design/development-flow.md` — the feature cycle (grilling → feature issue
-  → build → ship → PRD update). Follow it; don't freestyle features.
+- `design/development-flow.md` — **the** spec for the feature cycle: every
+  stage, every rule, the feature-issue template. Follow it; don't freestyle
+  features.
 - `design/design-system.md` — Oxygen UI conventions and which skills to use.
 - `design/api-guidelines.md` — data fetching, error handling, user feedback,
   and the mock layer. Three rules are non-negotiable; the rest is judgment
@@ -43,15 +43,11 @@ React SPA console for AEP. Vite + TypeScript + Oxygen UI, talking to the
 
 ## Feature docs (issue-driven — ADR-0001)
 
-- **A feature is a GitHub issue** (labels `console` + `feature`): body = the
-  feature doc, including the **Decisions** section from the grilling that
-  preceded it. The issue is created *after* the interview, never before it.
-  Requires `gh` auth.
+- **A feature is a GitHub issue** (labels `console` + `feature`): the body is
+  the feature doc, and nothing is built ungrilled. Requires `gh` auth.
 - **`design/decisions/` ADRs are the current truth** — read them FIRST for
   context, then `gh issue list --repo wso2/labs-agentic-engineer --label
   console --label feature` (closed issues are frozen history, never edited;
   issues live upstream, not in forks).
-- Durable decisions graduate from the issue's Decisions section to ADRs (rule
-  in `design/development-flow.md` step 4).
 
 Commands are the uniform verbs from the root `Makefile` (`make build`, etc.).

--- a/apps/console/AGENTS.md
+++ b/apps/console/AGENTS.md
@@ -9,11 +9,17 @@ React SPA console for AEP. Vite + TypeScript + Oxygen UI, talking to the
 > `oxygen-ui` skill before writing or editing UI code, even when the request does not
 > mention Oxygen UI by name.
 
+> [!IMPORTANT]
+> Before implementing a frontend feature, use the `/console-feature` skill —
+> pass it the idea in plain words. It runs a grilling session, creates the
+> GitHub issue from the outcome, and then implements from there. Don't
+> freestyle a feature straight into code.
+
 **Read before working on any feature:**
 
 - `PRD.md` — the living product picture: what exists, what's planned.
-- `design/development-flow.md` — the feature cycle (feature doc → grilling →
-  decisions → build → ship → PRD update). Follow it; don't freestyle features.
+- `design/development-flow.md` — the feature cycle (grilling → feature issue
+  → build → ship → PRD update). Follow it; don't freestyle features.
 - `design/design-system.md` — Oxygen UI conventions and which skills to use.
 - `design/api-guidelines.md` — data fetching, error handling, user feedback,
   and the mock layer. Three rules are non-negotiable; the rest is judgment
@@ -38,12 +44,14 @@ React SPA console for AEP. Vite + TypeScript + Oxygen UI, talking to the
 ## Feature docs (issue-driven — ADR-0001)
 
 - **A feature is a GitHub issue** (labels `console` + `feature`): body = the
-  feature doc, grilling decisions land as a comment. Requires `gh` auth.
+  feature doc, including the **Decisions** section from the grilling that
+  preceded it. The issue is created *after* the interview, never before it.
+  Requires `gh` auth.
 - **`design/decisions/` ADRs are the current truth** — read them FIRST for
   context, then `gh issue list --repo wso2/labs-agentic-engineer --label
   console --label feature` (closed issues are frozen history, never edited;
   issues live upstream, not in forks).
-- Durable decisions graduate from issue-comments to ADRs (rule in
-  `design/development-flow.md` step 4).
+- Durable decisions graduate from the issue's Decisions section to ADRs (rule
+  in `design/development-flow.md` step 4).
 
 Commands are the uniform verbs from the root `Makefile` (`make build`, etc.).

--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -3,15 +3,15 @@
 > **What this is:** the stable product picture of the console — who it's for,
 > how it's organized, and what it does. Purpose, loop, personas, IA, and
 > non-goals describe the **target product** (baseline set 2026-07-02, before
-> any feature shipped); the **feature inventory** is what's actually shipped,
-> and **In flight** lists features currently being built.
+> any feature shipped); the **feature inventory** is what's actually shipped.
 >
-> **Update rules:** a feature entering build adds one line to *In flight*
-> (flow step 6); shipping a feature moves that line into the feature
-> inventory and amends any affected sections (flow step 8) — both are
-> required steps, not courtesies. Keep entries to one line/paragraph + a
-> link; detail lives in the feature's GitHub issue (see
-> `design/development-flow.md`, ADR-0001).
+> **Update rules:** the feature's own PR adds its inventory entry and amends
+> any section the feature changes — part of the PR, not a follow-up, since
+> merging the PR is what ships it (flow step 6). Keep entries to one
+> line/paragraph + a link; detail lives in the feature's GitHub issue (see
+> `design/development-flow.md`, ADR-0001). Work **in progress** isn't
+> tracked here — the open issues are: `gh issue list --repo
+> wso2/labs-agentic-engineer --label console --label feature`.
 
 ## Purpose
 
@@ -77,11 +77,12 @@ Approved at section level; per-section detail is defined feature-by-feature.
     (placeholder until its feature lands).
 - **Admin** — agent customization (instructions, skills). Architect/SRE only.
 
-## In flight
+## Feature inventory
 
-Features currently being built. One line each; **must be emptied on ship**
-(the line moves to the inventory below). If a line sits here for weeks,
-that's a stalled feature — investigate, don't ignore.
+One entry per **shipped** feature — a feature is shipped when its PR merges,
+which is also what closes its issue. Newest first; links go to the feature's
+GitHub issue plus any ADRs it produced. Features still being built aren't
+here: they're the open `console` + `feature` issues.
 
 - Deployments page — one-story rail + environment panel: Development /
   Validation / Production as one numbered rail (Builds-spine vocabulary,
@@ -224,10 +225,10 @@ that's a stalled feature — investigate, don't ignore.
   [#107](https://github.com/wso2/labs-agentic-engineer/issues/107) (BE
   handshake: [#108](https://github.com/wso2/labs-agentic-engineer/issues/108))
 
-## Feature inventory
+### Earlier features, with ship dates
 
-One row per **shipped** feature. Newest first. Links go to the feature's
-GitHub issue plus any ADRs it produced.
+Recorded in table form before the inventory settled on the entry format
+above. Same meaning: one row per shipped feature.
 
 | Feature | Shipped | Summary | Links |
 |---|---|---|---|

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -20,28 +20,19 @@ to `API_PROXY_TARGET`, default `http://localhost:9090`).
 ## How development works
 
 Console features are built in **Claude Code sessions** following a fixed,
-issue-driven cycle — grilling interview → feature issue (durable decisions
-become ADRs) → contract → mocks → UI → ship
-(spec: [`design/development-flow.md`](design/development-flow.md)). Don't
+issue-driven cycle: grilled first, built on mocks, integrated with the
+backend on one feature branch, then tested locally and merged. Don't
 freestyle a feature — start every one with the `/console-feature` skill,
-passing it the idea in plain words:
+which drives that cycle and pauses at each stage. Pass it an idea, or the
+number of an issue that already exists:
 
 ```
 /console-feature I want the project list to show each project's environments
-```
-
-It reads the PRD and ADRs, runs the grilling interview on the idea (the
-`/grill-me` session), then drafts the feature issue from the template with
-the decisions in the body, creates it with `gh` (labels `console` +
-`feature`, upstream repo) once you approve the draft, and asks at each
-following stage whether to continue: graduate ADRs, open the BE handshake
-issue if the contract changes, mark the PRD in-flight, build (contract →
-`make gen` → mocks → UI in mock mode), and ship. Stop at any checkpoint and
-pick the feature back up later with the issue number:
-
-```
 /console-feature 42
 ```
+
+The cycle itself — every stage, rule, and the feature-issue template — is
+specified in [`design/development-flow.md`](design/development-flow.md).
 
 ## Docs map
 
@@ -49,7 +40,7 @@ Start at the top, go down as needed:
 
 | Doc | What it answers |
 |---|---|
-| [`PRD.md`](PRD.md) | What the console does today; what's in flight |
+| [`PRD.md`](PRD.md) | What the console does today (shipped features only) |
 | [`design/development-flow.md`](design/development-flow.md) | How a feature goes from idea to shipped |
 | [`design/design-system.md`](design/design-system.md) | How things should look; which skills to use |
 | [`design/api-guidelines.md`](design/api-guidelines.md) | How to call the BFF; the mock layer; error handling |

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -26,7 +26,7 @@ freestyle a feature — start every one with the `/console-feature` skill,
 which drives that cycle and pauses at each stage. Pass it an idea, or the
 number of an issue that already exists:
 
-```
+```bash
 /console-feature I want the project list to show each project's environments
 /console-feature 42
 ```

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -20,22 +20,24 @@ to `API_PROXY_TARGET`, default `http://localhost:9090`).
 ## How development works
 
 Console features are built in **Claude Code sessions** following a fixed,
-issue-driven cycle — feature issue → grilling interview → decisions comment
-(durable ones become ADRs) → contract → mocks → UI → ship
+issue-driven cycle — grilling interview → feature issue (durable decisions
+become ADRs) → contract → mocks → UI → ship
 (spec: [`design/development-flow.md`](design/development-flow.md)). Don't
-freestyle a feature — run the cycle with the `/console-feature` skill:
+freestyle a feature — start every one with the `/console-feature` skill,
+passing it the idea in plain words:
 
 ```
 /console-feature I want the project list to show each project's environments
 ```
 
-It reads the PRD and ADRs, drafts the feature issue from the template,
-creates it with `gh` (labels `console` + `feature`, upstream repo), prints
-it, and then asks at each stage whether to continue: grill it (the
-`/grill-me` interview), post the decisions comment, graduate ADRs, open the
-BE handshake issue if the contract changes, mark the PRD in-flight, build
-(contract → `make gen` → mocks → UI in mock mode), and ship. Stop at any
-checkpoint and pick the feature back up later with the issue number:
+It reads the PRD and ADRs, runs the grilling interview on the idea (the
+`/grill-me` session), then drafts the feature issue from the template with
+the decisions in the body, creates it with `gh` (labels `console` +
+`feature`, upstream repo) once you approve the draft, and asks at each
+following stage whether to continue: graduate ADRs, open the BE handshake
+issue if the contract changes, mark the PRD in-flight, build (contract →
+`make gen` → mocks → UI in mock mode), and ship. Stop at any checkpoint and
+pick the feature back up later with the issue number:
 
 ```
 /console-feature 42

--- a/apps/console/design/api-guidelines.md
+++ b/apps/console/design/api-guidelines.md
@@ -79,5 +79,6 @@ The console is fully developable without a backend.
 - **Mode switch:** `VITE_API_MODE=mock` enables MSW in dev. Mock code is
   dev-only — excluded from production builds (dynamic import guarded by the
   flag; verify with a bundle check).
-- **Testing:** Playwright/component tests run against mocks. A small smoke
-  suite runs against the real BFF before ship (`development-flow.md` step 7).
+- **Testing:** Playwright/component tests run against mocks. Running the
+  feature against the real BFF on the local setup *is* the ship validation,
+  and it happens before the merge (`development-flow.md` step 7).

--- a/apps/console/design/decisions/ADR-0001-issue-driven-feature-flow.md
+++ b/apps/console/design/decisions/ADR-0001-issue-driven-feature-flow.md
@@ -13,25 +13,32 @@
 - **A feature is a GitHub issue** (labels `console` + `feature`): the body is
   the feature doc; while the issue is open it is edited in place to match the
   current shape of the feature.
-- **The issue is born grilled.** The grilling interview runs on the raw idea
-  *before* any issue exists, and the issue is created from its outcome — the
-  body carries a **Decisions** section (decided / why / rejected) instead of
-  the outcome arriving later as a comment. An issue therefore always
-  represents a settled feature shape, never a placeholder to grill into.
+- **Nothing is built ungrilled**, and the grilling outcome is written down
+  wherever the feature entered from:
+  - **From an idea** — the interview runs *before* any issue exists and the
+    issue is created from its outcome, its body carrying a **Decisions**
+    section (decided / why / rejected). The issue is *born grilled*.
+  - **From an issue someone opened by hand** — the interview runs on that
+    issue and the outcome is posted as a **decisions comment**. The comment
+    is the record: the body isn't rewritten to claim decisions its author
+    didn't make, and the comment isn't edited afterwards (a reversal is a
+    new comment). Nobody opens an issue merely to have somewhere to grill.
 - **`/console-feature` is the entry point** for frontend feature work: pass
-  it the idea, it grills, opens the issue, and drives the build.
+  it an idea or an existing issue number; it grills, records the outcome,
+  and drives the build.
 - **Closed issues are frozen history** — never edited when superseded.
 - **ADRs in `design/decisions/` are the current truth.** A decision graduates
-  from the issue's Decisions section to an ADR when it (i) sets a convention
-  other features must
+  from the issue (its Decisions section or its decisions comment) to an ADR
+  when it (i) sets a convention other features must
   follow, (ii) changes the PRD, or (iii) rejects an approach someone would
   plausibly re-propose. Feature-local choices stay in the issue and may
   fossilize. A superseding ADR marks its predecessor `Superseded by ADR-NNNN`.
 - **Lookup order for sessions:** ADRs first, then
   `gh issue list --label console` — console work requires `gh` auth.
 - `design/features/` was deleted; its still-live content was distilled into
-  ADR-0002…0004. The BE-handshake pattern (separate BE issue, both PRs
-  reference it) is unchanged.
+  ADR-0002…0004. The BE-handshake pattern (a separate BE issue carrying the
+  request) is unchanged — though where the two halves meet moved from `main`
+  to the feature branch in ADR-0018.
 
 ## Consequences
 
@@ -39,3 +46,8 @@
   workflow tooling is (boards, labels, PR links).
 - Sessions without `gh` access can't read feature history — accepted; ADRs
   carry everything that must survive.
+- Issues filed by people who never ran the skill stay first-class: they come
+  in the same door and get grilled before any build. The flip side is that
+  "an issue exists" never means "the shape is settled" — a filled Decisions
+  section or a decisions comment does, and that check is what the skill runs
+  before it will build anything.

--- a/apps/console/design/decisions/ADR-0001-issue-driven-feature-flow.md
+++ b/apps/console/design/decisions/ADR-0001-issue-driven-feature-flow.md
@@ -12,11 +12,18 @@
 
 - **A feature is a GitHub issue** (labels `console` + `feature`): the body is
   the feature doc; while the issue is open it is edited in place to match the
-  current shape of the feature; grilling outcomes are posted as a **decisions
-  comment**.
+  current shape of the feature.
+- **The issue is born grilled.** The grilling interview runs on the raw idea
+  *before* any issue exists, and the issue is created from its outcome — the
+  body carries a **Decisions** section (decided / why / rejected) instead of
+  the outcome arriving later as a comment. An issue therefore always
+  represents a settled feature shape, never a placeholder to grill into.
+- **`/console-feature` is the entry point** for frontend feature work: pass
+  it the idea, it grills, opens the issue, and drives the build.
 - **Closed issues are frozen history** — never edited when superseded.
 - **ADRs in `design/decisions/` are the current truth.** A decision graduates
-  from issue-comment to ADR when it (i) sets a convention other features must
+  from the issue's Decisions section to an ADR when it (i) sets a convention
+  other features must
   follow, (ii) changes the PRD, or (iii) rejects an approach someone would
   plausibly re-propose. Feature-local choices stay in the issue and may
   fossilize. A superseding ADR marks its predecessor `Superseded by ADR-NNNN`.

--- a/apps/console/design/decisions/ADR-0017-merge-is-the-ship.md
+++ b/apps/console/design/decisions/ADR-0017-merge-is-the-ship.md
@@ -1,0 +1,48 @@
+# ADR-0017: The merge is the ship
+
+- **Status:** Accepted
+- **Date:** 2026-08-17
+- **Context:** the flow left its last stage half-specified. Validation was
+  "defined per-feature by the developer for now", and Ship was a sequence
+  that ran *after* the merge — validate, move the PRD line, close the issue.
+  In practice it never ran. The PRD's *In flight* section had accumulated
+  ~20 entries whose PRs had merged long before (the Deployments page landed
+  its line in PR #395 itself, commit `fd8fdee9`, and it was still sitting
+  there), while the inventory table it was supposed to drain into stopped at
+  six rows on 2026-07-28. A step that is always skipped isn't a step — the
+  bookkeeping has to happen where work already happens.
+
+## Decision
+
+- **Validation is a local run against the real API.** Bring up the local
+  setup and run the console against `aep-api` rather than MSW: mocks proved
+  the UI, and validation is what proves the contract. Walk the feature as
+  the issue's experience walkthrough describes it; the developer's
+  confirmation is the gate.
+- **Merging the PR ships the feature and closes the issue** (`Closes #<n>`
+  in the PR body). Validation therefore happens while the PR is still open,
+  and **nothing follows the merge** — the state after it is the shipped
+  state.
+- **The PRD update rides in the feature PR**: the inventory entry plus
+  amendments to any section the feature changes. The record merges with the
+  code that earns it.
+- **The PRD's *In flight* section is deleted.** Open `console` + `feature`
+  issues are the in-flight tracker; the PRD records shipped features only.
+
+## Consequences
+
+- A feature can no longer be shipped-but-unrecorded, the failure this ADR
+  was written from: the entry is a reviewable part of the diff, and there is
+  no post-merge step to forget.
+- "What's being built right now" needs `gh` — the same cost ADR-0001 already
+  accepted, and consistent with its principle that workflow state lives
+  where workflow tooling is.
+- The BE handshake must be **implemented** before merge, not merely agreed:
+  validation runs against a real API. This tightens the old "agreement
+  before ship" — mock-mode FE work still proceeds on an unagreed contract.
+  ADR-0018 gives that requirement a location: the backend lands on the
+  feature branch, so the merge to `main` carries both halves at once.
+- The stranded *In flight* entries were folded into the inventory as-is, and
+  the six dated table rows kept below them under their own sub-heading. No
+  ship dates were invented for the folded entries; the two formats can
+  converge the next time someone touches them.

--- a/apps/console/design/decisions/ADR-0018-feature-branch-integrates-frontend-and-backend.md
+++ b/apps/console/design/decisions/ADR-0018-feature-branch-integrates-frontend-and-backend.md
@@ -1,0 +1,52 @@
+# ADR-0018: The feature branch integrates frontend and backend
+
+- **Status:** Accepted
+- **Date:** 2026-08-17
+- **Context:** the flow had the frontend and the backend sending **separate
+  PRs to `main`**, both referencing a handshake issue that had to exist
+  *before* the frontend was built. Two problems. The handshake was written
+  before anyone knew what the API should be, so it was a sketch — while the
+  mock build is what actually discovers the contract, by making real UI code
+  and typed mocks live against it. And with both halves merging
+  independently, `main` could hold a frontend calling an endpoint that
+  didn't exist yet, so the first place the two met was `main` itself.
+  This repo is a monorepo — `apps/console` and `services/aep-api` are one
+  tree — so nothing forced them apart.
+
+## Decision
+
+- **The feature branch is the integration point.** The frontend is built on
+  mocks and pushed there; the backend's PR then targets **that branch**, not
+  `main`. Only the branch merges to `main`, so a feature never reaches
+  `main` in halves.
+- **The handshake issue is created from a mock-validated frontend**, not
+  before the build. Its body is the contract diff already on the branch —
+  a proposal that has been proven to work against real UI code — plus the
+  rationale, the feature issue link, and **the feature branch name**.
+- **Two validation gates, proving different things.** Mock mode proves the
+  frontend and produces the contract proposal (flow step 5); the local setup
+  proves the two halves agree (flow step 7). Neither substitutes for the
+  other.
+- **The feature PR closes both issues.** Its body carries `Closes` for the
+  feature issue *and* the handshake issue, because GitHub fires closing
+  keywords only when a PR merges into the default branch — the backend's PR
+  into the feature branch cannot close its own issue.
+
+## Consequences
+
+- The contract request improves: the backend is handed a diff that a working
+  frontend already exercises, instead of a sketch written before anyone had
+  built anything.
+- The backend can no longer merge independently of the feature that asked
+  for it, and vice versa. That is the point, and the cost is a longer-lived
+  feature branch that has to be kept current with `main`.
+- Mock-mode frontend work still proceeds against an unagreed contract, which
+  is what ADR-0001's handshake pattern was protecting; only the meeting
+  point moved from `main` to the branch. ADR-0017's "implemented before
+  merge" now has a concrete location: on the branch.
+- A feature with no contract change skips the handshake entirely and goes
+  straight from mock validation to the local-setup validation.
+- The old promise that a handshake issue exists *before* build is withdrawn.
+  Anyone wanting early backend notice should say so on the feature issue —
+  the handshake issue itself now means "here is the proven diff, please
+  implement it".

--- a/apps/console/design/decisions/ADR-0018-feature-branch-integrates-frontend-and-backend.md
+++ b/apps/console/design/decisions/ADR-0018-feature-branch-integrates-frontend-and-backend.md
@@ -27,10 +27,10 @@
   frontend and produces the contract proposal (flow step 5); the local setup
   proves the two halves agree (flow step 7). Neither substitutes for the
   other.
-- **The feature PR closes both issues.** Its body carries `Closes` for the
-  feature issue *and* the handshake issue, because GitHub fires closing
-  keywords only when a PR merges into the default branch — the backend's PR
-  into the feature branch cannot close its own issue.
+- **The feature PR closes every issue the feature opened** — the feature
+  issue always, and the handshake issue whenever there was one. GitHub fires
+  closing keywords only when a PR merges into the default branch, so the
+  backend's PR into the feature branch cannot close its own issue.
 
 ## Consequences
 

--- a/apps/console/design/design-system.md
+++ b/apps/console/design/design-system.md
@@ -29,8 +29,11 @@ Never pull raw MUI or another component library alongside Oxygen UI.
   a component.
 - **`dataviz` skill** — read it **before** writing any chart, dashboard, stat
   tile, or visualization code. Non-optional for anything chart-shaped.
-- **`grill-me` skill** — for refining feature experience docs (see
-  `development-flow.md`).
+- **`console-feature` skill** — the entry point for a frontend feature: it
+  grills the idea, opens the feature issue from the outcome, and drives the
+  build (see `development-flow.md`). It runs the **`grill-me`** interview for
+  you; reach for `grill-me` directly only to re-grill an existing feature's
+  shape.
 
 ## Conventions
 

--- a/apps/console/design/design-system.md
+++ b/apps/console/design/design-system.md
@@ -29,11 +29,12 @@ Never pull raw MUI or another component library alongside Oxygen UI.
   a component.
 - **`dataviz` skill** — read it **before** writing any chart, dashboard, stat
   tile, or visualization code. Non-optional for anything chart-shaped.
-- **`console-feature` skill** — the entry point for a frontend feature: it
-  grills the idea, opens the feature issue from the outcome, and drives the
-  build (see `development-flow.md`). It runs the **`grill-me`** interview for
-  you; reach for `grill-me` directly only to re-grill an existing feature's
-  shape.
+- **`console-feature` skill** — the entry point for a frontend feature, from
+  either an idea or an existing issue number: it grills, records the outcome
+  (new issue body, or a comment on the issue), and drives the build (see
+  `development-flow.md`). It runs the **`grill-me`** interview for you; reach
+  for `grill-me` directly only to re-grill a feature's shape outside the
+  cycle.
 
 ## Conventions
 

--- a/apps/console/design/development-flow.md
+++ b/apps/console/design/development-flow.md
@@ -15,7 +15,7 @@ Issues live in the **upstream** repo — pass
 `--repo wso2/labs-agentic-engineer` to every `gh issue` command (working
 clones may have a fork as `origin`).
 
-```
+```text
        ┌─ an idea ───▶ /console-feature <idea>   ──▶ grill ──▶ feature issue,
        │                                                       Decisions in the body
 PRD.md ┤ (context)                                                 │
@@ -41,7 +41,7 @@ PRD.md ┤ (context)                                                 │
                                              the local setup (real API)
                                                            │
                                                            ▼
-              merge branch ──▶ main: feature shipped, both issues closed
+              merge branch ──▶ main: feature shipped, its issues closed
 ```
 
 ## Steps
@@ -132,11 +132,12 @@ PRD.md ┤ (context)                                                 │
 
    **Merging the feature branch to `main` ships the feature**, so the merge
    comes last and nothing follows it: the PRD entry is already in the PR.
-   Put `Closes #<feature-issue>` **and** `Closes #<handshake-issue>` in that
-   PR's body — closing keywords only fire when a PR merges into the default
-   branch, so the backend's own PR into the feature branch can't close its
-   issue. A **merged PR is frozen**: anything discovered afterwards is a new
-   issue referencing the original.
+   Put `Closes #<feature-issue>` in that PR's body — plus
+   `Closes #<handshake-issue>` whenever the feature raised one, because
+   closing keywords fire only when a PR merges into the default branch, so
+   the backend's own PR into the feature branch can't close its issue. A
+   **merged PR is frozen**: anything discovered afterward is a new issue
+   referencing the original.
 
 ## Rules
 

--- a/apps/console/design/development-flow.md
+++ b/apps/console/design/development-flow.md
@@ -1,19 +1,27 @@
 # Console development flow
 
-Issue-driven (ADR-0001): a feature lives in a **GitHub issue** from idea to
-ship. The repo keeps only what must outlive the feature — the PRD, the
-guides, and concise ADRs. Console work requires `gh` auth. The
-`/console-feature` skill drives this flow end-to-end (with a checkpoint at
-each stage); this doc remains the spec it follows.
+Issue-driven (ADR-0001): a feature lives in a **GitHub issue** from the
+moment it's been grilled until it ships. The repo keeps only what must
+outlive the feature — the PRD, the guides, and concise ADRs. Console work
+requires `gh` auth.
+
+**Start every frontend feature with the `/console-feature` skill** — pass it
+the idea in plain words. It runs the grilling interview, opens the feature
+issue from the outcome, and then drives the build with a checkpoint at each
+stage. This doc remains the spec it follows.
 
 Issues live in the **upstream** repo — pass
 `--repo wso2/labs-agentic-engineer` to every `gh issue` command (working
 clones may have a fork as `origin`).
 
 ```
-PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ decisions comment
-                      (labels:                             │
-                       console,feature)     durable? ──▶ ADR in design/decisions/
+PRD.md ──(context)──▶ /console-feature <idea> ──▶ grilling interview
+                                                           │
+                                    (decided shape) ──▶ feature issue
+                                                        (labels:
+                                                         console,feature)
+                                                           │
+                                        durable? ──▶ ADR in design/decisions/
                                                            │
         needs BE change? ──▶ separate BE issue (handshake) │
                                                            ▼
@@ -31,22 +39,30 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
 
 ## Steps
 
-1. **Open a feature issue.** `gh issue create` with labels `console` +
-   `feature`; the body is the feature doc (template below). Read `PRD.md`
-   first — the feature must fit the product picture or explicitly change it.
+1. **Grill the idea.** Before any issue exists, run `/grill-me` on the raw
+   idea (the `/console-feature` skill does this for you). Read `PRD.md` and
+   the ADRs first — the feature must fit the product picture or explicitly
+   change it. Every open question is decided by the developer in the
+   interview, never answered on their behalf.
 
-2. **Grill it.** Run `/grill-me` on the issue. While the issue is **open**,
-   edit the body in place so it always reflects the current shape of the
-   feature.
+2. **Open the feature issue.** `gh issue create` with labels `console` +
+   `feature`; the body is the feature doc (template below), filled from the
+   grilling outcome — including the **Decisions** section: what was decided,
+   why, what was rejected. The issue is born grilled: it exists only once
+   the shape of the feature is settled.
 
-3. **Record decisions.** Post the grilling outcome as a **comment** on the
-   issue: what was decided, why, what was rejected.
+3. **Keep it current.** While the issue is **open**, edit the body in place
+   so it always reflects the current shape of the feature, Decisions
+   included. The issue tracks the **end state**, not the history of getting
+   there — superseded rationale is overwritten, and anything that must
+   survive that becomes an ADR (step 4).
 
 4. **Graduate durable decisions to ADRs** (`design/decisions/ADR-NNNN-*.md`).
    A decision earns an ADR when it **(i)** sets a convention other features
    must follow, **(ii)** changes the PRD, or **(iii)** rejects an approach
    someone would plausibly re-propose. Feature-local choices stay in the
-   issue. A superseding ADR marks the old one `Superseded by ADR-NNNN`.
+   issue's Decisions section. A superseding ADR marks the old one
+   `Superseded by ADR-NNNN`.
 
 5. **BE handshake.** New/changed `aep-api` behavior gets its own GitHub
    issue whose body is the request (proposed spec diff, rationale, link to
@@ -62,8 +78,8 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
    the spec is the **source of truth** for the API (see #76); editing it
    *is* the contract change — → `pnpm --filter @aep/console gen` (console-
    scoped; root `make gen` regenerates every Go module and is never needed
-   for console work) → typed MSW mocks (cover the scenarios from the
-   decisions comment) → UI in mock mode (`VITE_API_MODE=mock`). Follow
+   for console work) → typed MSW mocks (cover the scenarios from the issue's
+   Decisions section) → UI in mock mode (`VITE_API_MODE=mock`). Follow
    `design-system.md` and `api-guidelines.md`.
 
    **The PR is where the build lives from here.** Open it upstream, attach
@@ -83,6 +99,9 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
 
 ## Rules
 
+- **`/console-feature` is the entry point** for frontend feature work — an
+  idea goes through the skill (grill → issue → build), not straight into
+  code.
 - **Closed issues and merged PRs are frozen history** — never edited or
   pushed to when later work supersedes them; post-merge requests become a
   new issue referencing the original. **ADRs are the current truth**;
@@ -90,10 +109,13 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
 - Lookup order for any session needing context: **ADRs first**, then
   `gh issue list --repo wso2/labs-agentic-engineer --label console --label
   feature` (and `--state closed` for history).
-- No UI feature work without a feature issue. Bug fixes and polish are
-  exempt.
+- No UI feature work without a grilled feature issue. Bug fixes and polish
+  are exempt.
 
 ## Feature issue body template
+
+Filled from the grilling outcome — the issue is created after the interview,
+not before it.
 
 ```markdown
 ## Problem
@@ -103,11 +125,15 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
 <!-- Which PRD personas this serves. -->
 
 ## Experience walkthrough
-<!-- The user's path, step by step. This is what gets grilled. -->
+<!-- The user's path, step by step. The grilled, decided version. -->
 
 ## Scope
 **In:**
 **Out (explicitly):**
+
+## Decisions
+<!-- The grilling outcome: what was decided, why, what was rejected.
+     Durable ones graduate to ADRs (flow step 4). -->
 
 ## Contract changes
 <!-- aep-api endpoints needed (OpenAPI sketch), or "None". Becomes the BE
@@ -117,5 +143,6 @@ PRD.md ──(context)──▶ feature issue ──▶ /grill-me ──▶ deci
 <!-- Empty / loading / error / permission states. -->
 
 ## Open questions
-<!-- Worked through in the grilling. -->
+<!-- Anything the grilling deliberately left open, with why. Empty is the
+     normal case — open questions are what the interview closes. -->
 ```

--- a/apps/console/design/development-flow.md
+++ b/apps/console/design/development-flow.md
@@ -1,121 +1,177 @@
 # Console development flow
 
-Issue-driven (ADR-0001): a feature lives in a **GitHub issue** from the
-moment it's been grilled until it ships. The repo keeps only what must
-outlive the feature — the PRD, the guides, and concise ADRs. Console work
-requires `gh` auth.
+Issue-driven (ADR-0001): a feature lives in a **GitHub issue** until it
+ships, and no issue enters the build without having been grilled. The repo
+keeps only what must outlive the feature — the PRD, the guides, and concise
+ADRs. Console work requires `gh` auth.
 
 **Start every frontend feature with the `/console-feature` skill** — pass it
-the idea in plain words. It runs the grilling interview, opens the feature
-issue from the outcome, and then drives the build with a checkpoint at each
-stage. This doc remains the spec it follows.
+the idea in plain words, or the number of an issue that already exists. It
+runs the grilling interview, gets the outcome written down, and then drives
+the build with a checkpoint at each stage. This doc remains the spec it
+follows.
 
 Issues live in the **upstream** repo — pass
 `--repo wso2/labs-agentic-engineer` to every `gh issue` command (working
 clones may have a fork as `origin`).
 
 ```
-PRD.md ──(context)──▶ /console-feature <idea> ──▶ grilling interview
-                                                           │
-                                    (decided shape) ──▶ feature issue
-                                                        (labels:
-                                                         console,feature)
+       ┌─ an idea ───▶ /console-feature <idea>   ──▶ grill ──▶ feature issue,
+       │                                                       Decisions in the body
+PRD.md ┤ (context)                                                 │
+       │                                                           │
+       └─ an issue ──▶ /console-feature <issue#> ──▶ grill ──▶ decisions comment
+          opened by hand                                        on that issue
+                       (either way: one issue, labels console + feature)
                                                            │
                                         durable? ──▶ ADR in design/decisions/
                                                            │
-        needs BE change? ──▶ separate BE issue (handshake) │
                                                            ▼
-                                          PRD "In flight" line (issue link)
-                                                           │
-   contract diff ──▶ console gen ──▶ mocks ──▶ UI build ──▶ PR
+   contract diff ──▶ console gen ──▶ mocks ──▶ UI ──▶ feature branch + PR
+                                                      (+ PRD entry)
                                                            │
                             feedback loop: review ⇄ push (on the PR)
                                                            │
-                                                        merge (PR frozen)
+                                              gate: validate in mock mode
+                                                           │
+      changed the contract? ──▶ BE handshake issue ──▶ backend PR lands on
+                                (diff + branch name)      the feature branch
+                                                           │
+                                       gate: validate the whole feature on
+                                             the local setup (real API)
                                                            │
                                                            ▼
-        ship: validate ──▶ PRD inventory row ──▶ close the issue
+              merge branch ──▶ main: feature shipped, both issues closed
 ```
 
 ## Steps
 
-1. **Grill the idea.** Before any issue exists, run `/grill-me` on the raw
-   idea (the `/console-feature` skill does this for you). Read `PRD.md` and
-   the ADRs first — the feature must fit the product picture or explicitly
-   change it. Every open question is decided by the developer in the
-   interview, never answered on their behalf.
+1. **Grill first — whichever end you start from.** Read `PRD.md` and the ADRs
+   first: the feature must fit the product picture or explicitly change it.
+   Then run `/grill-me` (the `/console-feature` skill does this for you).
+   Every open question is decided by the developer in the interview, never
+   answered on their behalf. There are two entry points, and they differ only
+   in *where the outcome is written down*:
 
-2. **Open the feature issue.** `gh issue create` with labels `console` +
-   `feature`; the body is the feature doc (template below), filled from the
-   grilling outcome — including the **Decisions** section: what was decided,
-   why, what was rejected. The issue is born grilled: it exists only once
-   the shape of the feature is settled.
+   - **From an idea** — nothing exists yet. Grill the raw idea, then create
+     the issue from the outcome (step 2). The issue is **born grilled**.
+   - **From an existing issue** — someone opened it by hand. Grill the issue
+     as written, then post the outcome as a **decisions comment** on it:
+     what was decided, why, what was rejected. The comment is the record —
+     don't retro-fit it into a body someone else wrote. Never open an issue
+     just to "have somewhere to grill"; that's the idea entry point.
+
+2. **Open the feature issue** (idea entry point). `gh issue create` with
+   labels `console` + `feature`; the body is the feature doc (template
+   below), filled from the grilling outcome — including the **Decisions**
+   section. The issue exists only once the shape of the feature is settled.
 
 3. **Keep it current.** While the issue is **open**, edit the body in place
    so it always reflects the current shape of the feature, Decisions
-   included. The issue tracks the **end state**, not the history of getting
-   there — superseded rationale is overwritten, and anything that must
-   survive that becomes an ADR (step 4).
+   included. The issue body tracks the **end state**, not the history of
+   getting there — superseded rationale is overwritten, and anything that
+   must survive that becomes an ADR (step 4). Comments are the opposite:
+   a decisions comment is a dated record and stays as posted; a later
+   reversal is a **new** comment, not an edit of the old one.
 
 4. **Graduate durable decisions to ADRs** (`design/decisions/ADR-NNNN-*.md`).
    A decision earns an ADR when it **(i)** sets a convention other features
    must follow, **(ii)** changes the PRD, or **(iii)** rejects an approach
-   someone would plausibly re-propose. Feature-local choices stay in the
-   issue's Decisions section. A superseding ADR marks the old one
-   `Superseded by ADR-NNNN`.
+   someone would plausibly re-propose. Feature-local choices stay with the
+   issue — its Decisions section or its decisions comment. A superseding ADR
+   marks the old one `Superseded by ADR-NNNN`.
 
-5. **BE handshake.** New/changed `aep-api` behavior gets its own GitHub
-   issue whose body is the request (proposed spec diff, rationale, link to
-   the feature issue). The handshake issue must **exist before build**;
-   explicit BE agreement is required **before ship**, not before build —
-   mock-mode FE work can't break anyone, and the FE PR makes the contract
-   discussion concrete. FE and BE send separate PRs referencing it.
+5. **Build the frontend on mocks.** Contract diff in
+   `packages/contracts/api/v1/openapi.yaml` — the spec is the **source of
+   truth** for the API (see #76); editing it *is* the contract change — →
+   `pnpm --filter @aep/console gen` (console-scoped; root `make gen`
+   regenerates every Go module and is never needed for console work) → typed
+   MSW mocks (cover the scenarios from the grilling decisions) → UI in mock
+   mode (`VITE_API_MODE=mock`). Follow `design-system.md` and
+   `api-guidelines.md`.
 
-6. **Mark it in flight.** One line + issue link in the PRD's **In flight**
-   section.
-
-7. **Build.** Contract diff in `packages/contracts/api/v1/openapi.yaml` —
-   the spec is the **source of truth** for the API (see #76); editing it
-   *is* the contract change — → `pnpm --filter @aep/console gen` (console-
-   scoped; root `make gen` regenerates every Go module and is never needed
-   for console work) → typed MSW mocks (cover the scenarios from the issue's
-   Decisions section) → UI in mock mode (`VITE_API_MODE=mock`). Follow
-   `design-system.md` and `api-guidelines.md`.
-
-   **The PR is where the build lives from here.** Open it upstream, attach
-   the feature's screenshots to it (drag-and-drop by a human — screenshots
+   Push it to the **feature branch** and open the PR against `main`. That
+   branch is where the whole feature is assembled — frontend now, backend
+   next — and it is the only thing that ever merges to `main`. Attach the
+   feature's screenshots to the PR (drag-and-drop by a human — screenshots
    are never pushed to git branches), and post a comment on the feature
-   issue linking the PR: from that point all feedback belongs on the PR,
-   not the issue. Review comments loop back into this step (implement →
-   verify → push). A **merged PR is frozen** — anything requested after
-   merge becomes a new issue referencing the original.
+   issue linking the PR: from that point all feedback belongs on the PR, not
+   the issue. Review comments loop back into this step (implement → verify →
+   push).
 
-8. **Ship.** Entry condition: the BE handshake issue is agreed and
-   implemented. **Validate the feature** (the validation procedure is
-   defined per-feature by the developer for now — a fixed procedure will be
-   specified here later). Then move the PRD In-flight line into the feature
-   inventory (linking the issue + any ADRs), amend affected PRD sections,
-   **close the issue**. A feature PR without the PRD update is incomplete.
+   The PR also carries the **PRD update**: the feature's entry in the
+   feature inventory, linking the issue and any ADRs, plus amendments to any
+   PRD section the feature changes. A feature PR without the PRD update is
+   incomplete.
+
+   **Gate: validate the feature in mock mode** and get the developer's
+   confirmation. A mock-validated frontend is what makes the next step
+   concrete — until it exists there is nothing solid to ask the backend for.
+
+6. **BE handshake.** Only if the feature changes the contract. New or
+   changed `aep-api` behavior gets its own GitHub issue whose body is the
+   request: **the contract diff already on the feature branch** (exercised
+   by real UI code and typed mocks, so it is a proposal that has been
+   proven to work, not a sketch), the rationale, a link to the feature
+   issue, and **the feature branch name**.
+
+   **The backend lands on the feature branch, not on `main`** — its PR
+   targets the branch, so frontend and backend meet before either reaches
+   `main` and neither can ship half a feature. Contract deltas discovered
+   while implementing go back into the same branch and the same handshake
+   issue.
+
+7. **Ship — test it in the local setup, then merge.** Entry condition: the
+   backend changes are on the feature branch (or the feature needed none).
+   Bring up the local setup with the branch built into it
+   (`docs/developer-guide/setup.md`) and test the feature against the real
+   `aep-api` — **not** mock mode: mocks proved the frontend, and this is
+   what proves the two halves agree. Walk it the way the issue's experience
+   walkthrough describes it, and get the developer's confirmation that it
+   holds.
+
+   **Merging the feature branch to `main` ships the feature**, so the merge
+   comes last and nothing follows it: the PRD entry is already in the PR.
+   Put `Closes #<feature-issue>` **and** `Closes #<handshake-issue>` in that
+   PR's body — closing keywords only fire when a PR merges into the default
+   branch, so the backend's own PR into the feature branch can't close its
+   issue. A **merged PR is frozen**: anything discovered afterwards is a new
+   issue referencing the original.
 
 ## Rules
 
-- **`/console-feature` is the entry point** for frontend feature work — an
-  idea goes through the skill (grill → issue → build), not straight into
-  code.
+- **`/console-feature` is the entry point** for frontend feature work — pass
+  it an idea or an existing issue number; either way the grilling happens
+  before any code.
+- **The feature branch is the integration point.** Frontend and backend both
+  land there and are validated together; only the branch merges to `main`.
+  A feature never reaches `main` in halves.
+- **The merge is the ship.** Validation happens on the local setup while the
+  PR is still open; merging closes the issues via `Closes #<n>` and freezes
+  the PR. Nothing about a feature is left to do after its merge.
+- **Two validation gates, and they prove different things.** Mock mode
+  proves the frontend and produces the contract proposal; the local setup
+  proves frontend and backend agree. Neither substitutes for the other.
 - **Closed issues and merged PRs are frozen history** — never edited or
   pushed to when later work supersedes them; post-merge requests become a
   new issue referencing the original. **ADRs are the current truth**;
   supersede explicitly.
+- **The open issue is the in-flight tracker** — `gh issue list --repo
+  wso2/labs-agentic-engineer --label console --label feature` is what's
+  being built right now. The PRD records shipped features only.
 - Lookup order for any session needing context: **ADRs first**, then
   `gh issue list --repo wso2/labs-agentic-engineer --label console --label
   feature` (and `--state closed` for history).
-- No UI feature work without a grilled feature issue. Bug fixes and polish
-  are exempt.
+- No UI feature work without a **grilled** feature issue — born grilled, or
+  grilled after the fact with a decisions comment. Bug fixes and polish are
+  exempt.
 
 ## Feature issue body template
 
-Filled from the grilling outcome — the issue is created after the interview,
-not before it.
+The shape every feature issue converges on. When the issue is created after
+the interview, it's filled from the grilling outcome. An issue opened by hand
+should still follow it — its **Decisions** section stays empty and the
+grilling outcome arrives as a decisions comment instead (step 1).
 
 ```markdown
 ## Problem
@@ -132,12 +188,13 @@ not before it.
 **Out (explicitly):**
 
 ## Decisions
-<!-- The grilling outcome: what was decided, why, what was rejected.
+<!-- The grilling outcome: what was decided, why, what was rejected. Empty
+     for an issue opened by hand — its outcome is a decisions comment.
      Durable ones graduate to ADRs (flow step 4). -->
 
 ## Contract changes
 <!-- aep-api endpoints needed (OpenAPI sketch), or "None". Becomes the BE
-     handshake issue (flow step 5). -->
+     handshake issue (flow step 6). -->
 
 ## States to design
 <!-- Empty / loading / error / permission states. -->


### PR DESCRIPTION
## Problem

The console feature cycle had four things wrong with it, three of which only became visible once the first was fixed.

1. **The issue came before the grilling** — so an issue was a placeholder to grill into, existing while the feature's shape was still unsettled.
2. **Only one entry point.** The cycle assumed you started from an idea. An issue someone filed by hand had nowhere to go.
3. **Ship never ran.** Ship was a post-merge sequence — validate, move the PRD line, close the issue — and in practice nobody did it. The PRD's *In flight* section had accumulated 24 entries whose PRs merged long ago (the Deployments page landed its own line in #395, commit `fd8fdee9`, and was still sitting there), while the inventory table it was meant to drain into stopped at six rows on 2026-07-28.
4. **The frontend and backend met on `main`.** Both sent separate PRs there, referencing a handshake issue written *before* the frontend existed — so the request was a sketch, and `main` could hold a frontend calling an endpoint that didn't exist yet.

## Change

```
       ┌─ an idea ───▶ /console-feature <idea>   ──▶ grill ──▶ feature issue,
       │                                                       Decisions in the body
PRD.md ┤ (context)                                                 │
       └─ an issue ──▶ /console-feature <issue#> ──▶ grill ──▶ decisions comment
          opened by hand                                        on that issue
                                                           │
                                        durable? ──▶ ADR in design/decisions/
                                                           ▼
   contract diff ──▶ console gen ──▶ mocks ──▶ UI ──▶ feature branch + PR
                                                      (+ PRD entry)
                                                           │
                                              gate: validate in mock mode
                                                           │
      changed the contract? ──▶ BE handshake issue ──▶ backend PR lands on
                                (diff + branch name)      the feature branch
                                                           │
                                       gate: validate the whole feature on
                                             the local setup (real API)
                                                           ▼
              merge branch ──▶ main: feature shipped, its issues closed
```

**Grill first, from either end.** From an idea, the interview runs first and the issue is created from its outcome with **Decisions** in the body — born grilled. From an issue someone filed by hand, the interview runs on the issue and the outcome is posted as a **decisions comment**: the comment is the record, so the body keeps its author's words and isn't rewritten to claim decisions they didn't make. Either way nothing is built ungrilled.

**The merge is the ship** (ADR-0017). Validation happens on the local setup while the PR is open, and merging closes the issue via `Closes #<n>`. The PRD entry rides in the feature PR, so the record merges with the code that earns it and there is no post-merge step to forget. The PRD's *In flight* section is dropped — the open `console` + `feature` issues are the tracker.

**The feature branch integrates frontend and backend** (ADR-0018). The frontend is built on mocks and pushed there; the backend's PR then targets **that branch**, not `main`. Only the branch merges to `main`, so a feature never reaches `main` in halves. The handshake issue is created *from* a mock-validated frontend, carrying a contract diff that real UI code and typed mocks already exercise.

**Two validation gates, proving different things.** Mock mode proves the frontend and produces the contract proposal; the local setup proves the two halves agree. Neither substitutes for the other.

## Deduplication

The cycle was narrated in three places — the spec, the skill, and the console README — and every change in this PR had to be applied to all three. `development-flow.md` is now the single spec:

| File | Before | After |
|---|---|---|
| `design/development-flow.md` | 205 | 206 — the spec, unchanged in role |
| `.agents/skills/console-feature/SKILL.md` | 154 | 129 — routing, pause classes, completion criteria, commands |
| `apps/console/README.md` | 71 | 53 — intro + link |
| `apps/console/AGENTS.md` | 60 | 53 — pointers, no cycle summary |

The skill dropped the ~35 lines that restated spec steps 5–7 (the contract → gen → mocks → UI chain, PR conventions, handshake body, ship mechanics). Its stage walk now opens with *"Each stage runs the spec's step of the same number — read what to do there."*

**`console-feature` is now model-invoked.** `AGENTS.md` instructed the agent to use it, but `disable-model-invocation: true` kept it out of the agent's reach — only a human typing `/console-feature` could fire it. That made the cycle's central guardrail ("no UI feature work without a grilled issue") depend on remembering a slash command, which is the exact failure the flow exists to prevent.

## Decisions recorded during review

- **In-place body edits overwrite superseded rationale**, since Decisions lives in the body rather than an immutable comment. Accepted: the issue body tracks the end state, not the history; anything that must outlive it graduates to an ADR. Comments are the opposite — a decisions comment stands as posted, and a reversal is a new comment.
- **The feature PR closes every issue the feature opened** — the feature issue always, the handshake issue only when one was raised. GitHub fires closing keywords only when a PR merges into the default branch, so the backend's PR into the feature branch cannot close its own issue. Without this, every handshake issue would silently stay open.
- **The handshake no longer exists before the build.** Withdrawn deliberately — the old rationale already argued that the FE PR is what makes the contract concrete; this follows it through.
- **Longer-lived feature branches** are the cost of integrating on the branch. No rebase/merge policy is specified yet; flagged rather than invented.

## Files

| File | What changed |
|---|---|
| `design/development-flow.md` | Steps restructured to 7 (grill → issue → keep current → ADRs → frontend on mocks → BE handshake → ship). Diagram redrawn with both entry points and both gates. Rules added: the branch is the integration point, the merge is the ship, two gates, the open issue is the in-flight tracker. Template gains `## Decisions`. |
| `design/decisions/ADR-0017-merge-is-the-ship.md` | **New.** Local validation, merge-closes-issue, PRD entry in the PR, *In flight* dropped. |
| `design/decisions/ADR-0018-feature-branch-integrates-frontend-and-backend.md` | **New.** Branch as integration point, handshake from a mock-validated frontend, closing keywords on the feature PR, two gates. |
| `design/decisions/ADR-0001-issue-driven-feature-flow.md` | Amended: born grilled *and* grilled-in-place; the handshake's meeting point moved to the branch. |
| `.agents/skills/console-feature/SKILL.md` | Model-invoked. Idea/issue mode routing, pause classes renamed **re-ask / auto-proceed / halt** (each named for its behavior on silence), deduped stage walk. |
| `apps/console/PRD.md` | *In flight* folded into the feature inventory; update rules rewritten. |
| `apps/console/AGENTS.md`, `README.md`, `design/design-system.md`, `design/api-guidelines.md` | Cycle narrations replaced with pointers; the smoke-test line now points at the local-setup validation. |

## Proof of execution

Docs and skill markdown only — no source, config, or generated code touched, so there is no build or test surface.

Verified no PRD content was lost when *In flight* was folded in:

```
$ echo "bullets before: $(git show HEAD~1:apps/console/PRD.md | sed -n '/^## In flight/,/^## Feature inventory/p' | grep -c '^- ')"
bullets before: 24
$ echo "bullets after:  $(sed -n '/^## Feature inventory/,/^### Earlier/p' apps/console/PRD.md | grep -c '^- ')"
bullets after:  24
```

Verified no stale references to the retired model remain:

```
$ grep -rn "separate PRs\|both PRs\|In flight" --include=*.md apps/console .agents
apps/console/design/decisions/ADR-0017-merge-is-the-ship.md:8:  In practice it never ran. The PRD's *In flight* section had accumulated
apps/console/design/decisions/ADR-0017-merge-is-the-ship.md:29:- **The PRD's *In flight* section is deleted.** Open `console` + `feature`
apps/console/design/decisions/ADR-0017-merge-is-the-ship.md:45:- The stranded *In flight* entries were folded into the inventory as-is, and
```

The only surviving mentions are in ADR-0017, which records what was replaced and why — no live doc still describes the old model.

The real proof is the next feature run through the skill, which will exercise grill → issue → mocks → handshake → local validation → merge end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
