### PR TITLE
Per-persona user flows for the wireframe prototype

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -99,6 +99,14 @@ that's a stalled feature — investigate, don't ignore.
   route. `@aep/excalidraw-dsl`'s `tryDslToPrototype` compiles per-screen
   scenes client-side (no BE handshake, no contract change; ADR-0008) —
   [#348](https://github.com/wso2/labs-agentic-engineer/issues/348)
+- Spec view — prototype user flows: `wireframes.dsl` declares named
+  `flow "<name>"` blocks (optional `role`/`description` lines) listing each
+  persona's screens in walkthrough order; the prototype toolbar leads with a
+  **User flow** picker that scopes the screen picker to the chosen flow, the
+  canvas marks each screen's membership (`Approval queue · Screen 2`,
+  `Common · Screen 1`), and `?flow=<Name>` joins `?screen=` on the full-screen
+  route. Same client-side derivation, no contract change —
+  [#491](https://github.com/wso2/labs-agentic-engineer/issues/491)
 - Agent chat — structured question cards: `ask_question` (single) +
   `ask_questions` (batch form) tool-calls rendered as native Oxygen UI cards
   in the activity stream (answer returns as the next turn's plain text);

--- a/apps/console/src/features/spec/components/PrototypePage.test.tsx
+++ b/apps/console/src/features/spec/components/PrototypePage.test.tsx
@@ -37,11 +37,17 @@ let prototypeMountCount = 0;
 
 // The heavy lazy canvas is irrelevant here — record what model/initialScreen it receives.
 vi.mock("@aep/ui-excalidraw-view", () => ({
-  PrototypeView: (p: { model: { screens: unknown[] }; initialScreen?: string }) => {
+  PrototypeView: (p: { model: { screens: unknown[] }; initialScreen?: string; initialFlow?: string }) => {
     useEffect(() => {
       prototypeMountCount += 1;
     }, []);
-    return <div data-testid="prototype" data-initial={p.initialScreen ?? ""} />;
+    return (
+      <div
+        data-testid="prototype"
+        data-initial={p.initialScreen ?? ""}
+        data-flow={p.initialFlow ?? ""}
+      />
+    );
   },
 }));
 
@@ -74,7 +80,13 @@ describe("PrototypePage", () => {
     mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: MODEL, isPending: false, isError: false });
     render(
-      <PrototypePage projectName="p" component="shop" screen="Login" onScreenChange={vi.fn()} />,
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        screen="Login"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
     );
     expect(screen.getByTestId("prototype")).toHaveAttribute("data-initial", "Login");
   });
@@ -82,35 +94,70 @@ describe("PrototypePage", () => {
   it("explains when the component has no wireframes", () => {
     mockFiles.mockReturnValue({ data: [], isPending: false, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: null, isPending: false, isError: false });
-    render(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
     expect(screen.getByText(/no wireframes/i)).toBeInTheDocument();
   });
 
   it("shows a spinner while the spec files are loading", () => {
     mockFiles.mockReturnValue({ data: undefined, isPending: true, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: null, isPending: false, isError: false });
-    render(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
     expect(screen.getByLabelText(/loading/i)).toBeInTheDocument();
   });
 
   it("shows an error alert when the spec files fail to load", () => {
     mockFiles.mockReturnValue({ data: undefined, isPending: false, isError: true });
     mockDerivedPrototype.mockReturnValue({ model: null, isPending: false, isError: false });
-    render(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("shows a spinner while the prototype model is deriving", () => {
     mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: null, isPending: true, isError: false });
-    render(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
     expect(screen.getByLabelText(/loading/i)).toBeInTheDocument();
   });
 
   it("explains when the wireframe could not be rendered as a prototype", () => {
     mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: null, isPending: false, isError: false });
-    render(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
     expect(screen.getByText(/could not be rendered/i)).toBeInTheDocument();
   });
 
@@ -118,7 +165,12 @@ describe("PrototypePage", () => {
     mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
     mockDerivedPrototype.mockReturnValue({ model: MODEL, isPending: false, isError: false });
     const { rerender } = render(
-      <PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />,
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
     );
     expect(prototypeMountCount).toBe(1);
 
@@ -133,8 +185,44 @@ describe("PrototypePage", () => {
       isPending: false,
       isError: false,
     });
-    rerender(<PrototypePage projectName="p" component="shop" onScreenChange={vi.fn()} />);
+    rerender(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
 
     expect(prototypeMountCount).toBe(2);
+  });
+
+  it("passes the deep-linked flow through to the prototype", () => {
+    mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
+    mockDerivedPrototype.mockReturnValue({ model: MODEL, isPending: false, isError: false });
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        flow="Admin path"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("prototype")).toHaveAttribute("data-flow", "Admin path");
+  });
+
+  it("omits the flow when the link carries none, letting the viewer pick the first", () => {
+    mockFiles.mockReturnValue({ data: FILES, isPending: false, isError: false });
+    mockDerivedPrototype.mockReturnValue({ model: MODEL, isPending: false, isError: false });
+    render(
+      <PrototypePage
+        projectName="p"
+        component="shop"
+        onScreenChange={vi.fn()}
+        onFlowChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("prototype")).toHaveAttribute("data-flow", "");
   });
 });

--- a/apps/console/src/features/spec/components/PrototypePage.test.tsx
+++ b/apps/console/src/features/spec/components/PrototypePage.test.tsx
@@ -60,6 +60,7 @@ const FILES = [
 ];
 const MODEL = {
   screens: [{ name: "Login", width: 1280, height: 800, sceneJson: "{}", hotspots: [] }],
+  flows: [{ name: "Admin path", screens: ["Login"] }],
 };
 
 beforeEach(() => {
@@ -128,7 +129,7 @@ describe("PrototypePage", () => {
       isError: false,
     });
     mockDerivedPrototype.mockReturnValue({
-      model: { screens: [...MODEL.screens] },
+      model: { screens: [...MODEL.screens], flows: [...MODEL.flows] },
       isPending: false,
       isError: false,
     });

--- a/apps/console/src/features/spec/components/PrototypePage.tsx
+++ b/apps/console/src/features/spec/components/PrototypePage.tsx
@@ -46,19 +46,25 @@ function Centered({ children }: { children: React.ReactNode }) {
  * (#348). Mirrors WireframePanel's inline "Prototype" mode, but as the
  * whole page: resolve the component's `.dsl` via `buildDesignSection` (the
  * same tree WireframePanel/SpecView use for the sidebar), derive the model,
- * and hand off to `PrototypeView` with the deep-linked `screen` — the route
- * wrapper syncs `onScreenChange` back into `?screen=` via replace-navigation.
+ * and hand off to `PrototypeView` with the deep-linked `screen` and `flow` —
+ * the route wrapper syncs `onScreenChange`/`onFlowChange` back into
+ * `?screen=`/`?flow=` via replace-navigation, so a shared link restores both
+ * the screen and the persona.
  */
 export function PrototypePage({
   projectName,
   component,
   screen,
+  flow,
   onScreenChange,
+  onFlowChange,
 }: {
   projectName: string;
   component: string;
   screen?: string;
+  flow?: string;
   onScreenChange: (screen: string) => void;
+  onFlowChange: (flow: string) => void;
 }) {
   const filesQuery = useSpecFiles(projectName);
   const node = useMemo(() => {
@@ -109,7 +115,9 @@ export function PrototypePage({
         model={model}
         fillHeight
         onScreenChange={onScreenChange}
+        onFlowChange={onFlowChange}
         {...(screen ? { initialScreen: screen } : {})}
+        {...(flow ? { initialFlow: flow } : {})}
       />
     );
   }

--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -190,7 +190,10 @@ describe("WireframePanel streaming", () => {
 
 describe("WireframePanel prototype toggle", () => {
   const SCENE = JSON.stringify({ elements: [{ type: "rectangle" }] });
-  const MODEL = { screens: [{ name: "Login", width: 1280, height: 800, sceneJson: SCENE, hotspots: [] }] };
+  const MODEL = {
+    screens: [{ name: "Login", width: 1280, height: 800, sceneJson: SCENE, hotspots: [] }],
+    flows: [],
+  };
 
   it("shows the toggle only when settled, and swaps to PrototypeView", () => {
     mockDerived.mockReturnValue({ scene: SCENE, isPending: false, isError: false });

--- a/apps/console/src/mocks/fixtures/project.ts
+++ b/apps/console/src/mocks/fixtures/project.ts
@@ -974,6 +974,22 @@ screen Orders "Shopper tracks past orders and their status"
     row "#10432 | Jul 8, 2026 | 3 | $302.00 | Shipped"
     row "#10391 | Jun 27, 2026 | 1 | $89.00 | Delivered"
     row "#10355 | Jun 15, 2026 | 2 | $168.00 | Delivered"
+
+// Two journeys over the same three screens, so mock mode exercises every
+// flow case the prototype has to render: a screen in one flow (Cart, Orders),
+// a screen both flows reach (Catalog → "Common" on the canvas), and a flow
+// picker with more than one entry.
+flow "Browse & buy"
+  role "Shopper"
+  description "A shopper finds products and checks out"
+  Catalog
+  Cart
+
+flow "Order tracking"
+  role "Shopper"
+  description "A signed-in shopper checks where a placed order is"
+  Catalog
+  Orders
 `;
 
 const catalogApiDesignJson = `{

--- a/apps/console/src/routes/-projects.$projectName_.prototype.$component.test.tsx
+++ b/apps/console/src/routes/-projects.$projectName_.prototype.$component.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `PrototypeRoute` calls `Route.useParams()` / `Route.useSearch()` /
+// `Route.useNavigate()`, all of which TanStack Router attaches to the
+// object `createFileRoute(path)(options)` returns. Mocking `createFileRoute`
+// to return the options verbatim (plus stubbed hooks) lets us exercise the
+// real `validateSearch` and the real `PrototypeRoute` component without a
+// full router.
+const mockUseParams = vi.fn();
+const mockUseSearch = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    useParams: () => mockUseParams(),
+    useSearch: () => mockUseSearch(),
+    useNavigate: () => mockNavigate,
+  }),
+}));
+
+// The heavy page is irrelevant here — record the callbacks PrototypeRoute
+// wires up so the tests can invoke them directly.
+let captured: {
+  onScreenChange?: (screen: string) => void;
+  onFlowChange?: (flow: string) => void;
+} = {};
+
+vi.mock("../features/spec/components/PrototypePage", () => ({
+  PrototypePage: (props: {
+    onScreenChange: (screen: string) => void;
+    onFlowChange: (flow: string) => void;
+  }) => {
+    captured = props;
+    return <div data-testid="prototype-page" />;
+  },
+}));
+
+import { Route as RouteUnderTest } from "./projects.$projectName_.prototype.$component";
+
+// `createFileRoute` is mocked above to hand back its options object as-is
+// (plus stubbed hooks), so at runtime `Route` also carries `component` and
+// `validateSearch` — properties the real generated `Route` type doesn't
+// expose. Cast through this narrower shape to access them from the tests.
+const Route = RouteUnderTest as unknown as {
+  validateSearch: (search: Record<string, unknown>) => { screen?: string; flow?: string };
+  component: React.ComponentType;
+};
+const PrototypeRoute = Route.component;
+
+beforeEach(() => {
+  mockUseParams.mockReset();
+  mockUseSearch.mockReset();
+  mockNavigate.mockReset();
+  captured = {};
+});
+
+describe("prototype route", () => {
+  describe("validateSearch", () => {
+    it("keeps both screen and flow when present", () => {
+      expect(Route.validateSearch({ screen: "Login", flow: "Admin path" })).toEqual({
+        screen: "Login",
+        flow: "Admin path",
+      });
+    });
+
+    it("drops non-string and empty values", () => {
+      expect(Route.validateSearch({ screen: "", flow: 42 })).toEqual({});
+      expect(Route.validateSearch({})).toEqual({});
+    });
+  });
+
+  describe("PrototypeRoute", () => {
+    beforeEach(() => {
+      mockUseParams.mockReturnValue({ projectName: "p", component: "shop" });
+    });
+
+    it("preserves flow when onScreenChange navigates (fails if the object form of search regresses)", () => {
+      mockUseSearch.mockReturnValue({ screen: "Login", flow: "Admin path" });
+      render(<PrototypeRoute />);
+
+      captured.onScreenChange!("Orders");
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      const call = mockNavigate.mock.calls[0]![0] as { replace: boolean; search: (prev: unknown) => unknown };
+      expect(call.replace).toBe(true);
+      expect(typeof call.search).toBe("function");
+      expect(call.search({ flow: "Admin path", screen: "Login" })).toEqual({
+        flow: "Admin path",
+        screen: "Orders",
+      });
+    });
+
+    it("preserves screen when onFlowChange navigates", () => {
+      mockUseSearch.mockReturnValue({ screen: "Login", flow: "Admin path" });
+      render(<PrototypeRoute />);
+
+      captured.onFlowChange!("Customer path");
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      const call = mockNavigate.mock.calls[0]![0] as { replace: boolean; search: (prev: unknown) => unknown };
+      expect(call.replace).toBe(true);
+      expect(typeof call.search).toBe("function");
+      expect(call.search({ flow: "Admin path", screen: "Login" })).toEqual({
+        flow: "Customer path",
+        screen: "Login",
+      });
+    });
+  });
+});

--- a/apps/console/src/routes/projects.$projectName_.prototype.$component.tsx
+++ b/apps/console/src/routes/projects.$projectName_.prototype.$component.tsx
@@ -25,33 +25,44 @@ import { PrototypePage } from "../features/spec/components/PrototypePage";
 // header (#348).
 //
 // `?screen=<Name>` deep-links to a specific screen of the component's
-// prototype (e.g. a link shared mid-review). `PrototypeView` drives screen
-// navigation internally and calls back on every change via `onScreenChange`;
-// this route syncs that back into the URL with a REPLACE navigation (not
-// push), so clicking through screens doesn't pile up history entries — the
-// browser back button leaves the prototype rather than stepping screen by
-// screen.
+// prototype (e.g. a link shared mid-review), and `?flow=<Name>` deep-links
+// the persona/flow alongside it. `PrototypeView` drives screen and flow
+// navigation internally and calls back on every change via `onScreenChange`
+// / `onFlowChange`; this route syncs both back into the URL with a REPLACE
+// navigation (not push), so clicking through screens doesn't pile up history
+// entries — the browser back button leaves the prototype rather than
+// stepping screen by screen. Both params are merged onto the previous search
+// on every sync so changing one never drops the other.
 export const Route = createFileRoute(
   "/projects/$projectName_/prototype/$component",
 )({
-  validateSearch: (search: Record<string, unknown>): { screen?: string } => ({
+  validateSearch: (search: Record<string, unknown>): { screen?: string; flow?: string } => ({
     ...(typeof search.screen === "string" && search.screen
       ? { screen: search.screen }
       : {}),
+    ...(typeof search.flow === "string" && search.flow ? { flow: search.flow } : {}),
   }),
   component: PrototypeRoute,
 });
 
 function PrototypeRoute() {
   const { projectName, component } = Route.useParams();
-  const { screen } = Route.useSearch();
+  const { screen, flow } = Route.useSearch();
   const navigate = Route.useNavigate();
   return (
     <PrototypePage
       projectName={projectName}
       component={component}
-      onScreenChange={(s) => void navigate({ search: { screen: s }, replace: true })}
+      // Both params are preserved on every sync: a shared link restores the
+      // persona AND the screen, and changing one must not drop the other.
+      onScreenChange={(s) =>
+        void navigate({ search: (prev) => ({ ...prev, screen: s }), replace: true })
+      }
+      onFlowChange={(f) =>
+        void navigate({ search: (prev) => ({ ...prev, flow: f }), replace: true })
+      }
       {...(screen ? { screen } : {})}
+      {...(flow ? { flow } : {})}
     />
   );
 }

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -106,9 +106,22 @@ interface WireframeFlow {
   to: string;
 }
 
+/**
+ * A named `flow "…"` block: one persona's walkthrough, REFERENCING screen
+ * names rather than defining screens — so a screen shared by two personas
+ * (Login, a sign-out landing) is listed by each flow and still compiled once.
+ * `screens` holds canonical names, entry point first.
+ */
+interface WireframeNamedFlow {
+  name: string;
+  screens: string[];
+}
+
 interface WireframeAst {
   screens: WireframeScreen[];
+  /** Legacy unnamed `flow` block edges — parsed, never rendered. */
   flows: WireframeFlow[];
+  namedFlows: WireframeNamedFlow[];
 }
 
 // ---------- Domain Model DSL ----------
@@ -296,7 +309,7 @@ export function tryDslToPrototype(
     const screens: PrototypeScreen[] = ast.screens.map((screen) => {
       const chromeHotspots: PrototypeHotspot[] = [];
       const elements = renderWireframes(
-        { screens: [screen], flows: [] },
+        { screens: [screen], flows: [], namedFlows: [] },
         { prototype: { validTargets, chromeHotspots } },
       );
       const scene: ExcalidrawScene = {
@@ -502,12 +515,17 @@ function buildWireframes(
   dsl: string,
   errors: string[] | null,
 ): { ast: WireframeAst; legacy: boolean } {
-  const ast: WireframeAst = { screens: [], flows: [] };
+  const ast: WireframeAst = { screens: [], flows: [], namedFlows: [] };
   let screen: FlowScreen | null = null;
   let stack: Ctx[] = [];
   let inFlow = false;
   let legacy = false;
   const err = (no: number, msg: string) => errors?.push(`line ${no}: ${msg}`);
+  // The named `flow "…"` block currently open (null inside a legacy unnamed
+  // block). Screen references are collected with their line numbers and
+  // resolved AFTER the parse — a flow may list a screen declared further down.
+  let currentFlow: WireframeNamedFlow | null = null;
+  const flowRefs: Array<{ flow: WireframeNamedFlow; raw: string; line: number }> = [];
 
   const lines = dsl.split(/\r?\n/);
   for (let no = 1; no <= lines.length; no++) {
@@ -533,11 +551,23 @@ function buildWireframes(
         ast.screens.push(screen);
         stack = [{ level: 0, kind: 'root', nodes: screen.tree }];
         inFlow = false;
+        currentFlow = null;
         continue;
       }
-      if (/^flow\b/i.test(trimmed)) {
+      const flowHead = /^flow(?:\s+"((?:[^"\\]|\\.)*)")?\s*$/i.exec(trimmed);
+      if (flowHead) {
         screen = null;
         inFlow = true;
+        currentFlow = null;
+        if (flowHead[1] !== undefined) {
+          const name = unescapeQuoted(flowHead[1]);
+          if (ast.namedFlows.some((f) => f.name === name)) {
+            err(no, `duplicate flow ${JSON.stringify(name)} — declare each flow once`);
+          } else {
+            currentFlow = { name, screens: [] };
+            ast.namedFlows.push(currentFlow);
+          }
+        }
         continue;
       }
       screen = null;
@@ -547,8 +577,19 @@ function buildWireframes(
     }
 
     if (inFlow) {
-      const flowMatch = /^([\w-]+)\s*->\s*([\w-]+)$/.exec(trimmed);
-      if (flowMatch) ast.flows.push({ from: flowMatch[1]!, to: flowMatch[2]! });
+      const edge = /^([\w-]+)\s*->\s*([\w-]+)$/.exec(trimmed);
+      if (edge) {
+        ast.flows.push({ from: edge[1]!, to: edge[2]! });
+        continue;
+      }
+      if (currentFlow) {
+        const ref = /^([\w-]+)$/.exec(trimmed);
+        if (ref) {
+          flowRefs.push({ flow: currentFlow, raw: ref[1]!, line: no });
+          continue;
+        }
+        err(no, `unknown flow line ${JSON.stringify(trimmed.slice(0, 40))} — expected a screen name`);
+      }
       continue;
     }
     if (!screen) continue;
@@ -657,6 +698,22 @@ function buildWireframes(
   }
 
   for (const s of ast.screens) layoutScreen(s as FlowScreen);
+
+  // Resolved here, not inline, because a flow may list a screen declared
+  // further down the file. An unknown name is always an authoring bug, so it
+  // is reported with its line; a repeat within one flow is the author drawing
+  // a return trip (sign out → Login) that the `-> Target` arrows already
+  // carry, so the first position wins and the duplicate is dropped.
+  const canonicalByLower = new Map(ast.screens.map((s) => [s.name.toLowerCase(), s.name]));
+  for (const ref of flowRefs) {
+    const canonical = canonicalByLower.get(ref.raw.toLowerCase());
+    if (!canonical) {
+      err(ref.line, `flow references unknown screen ${JSON.stringify(ref.raw)}`);
+      continue;
+    }
+    if (!ref.flow.screens.includes(canonical)) ref.flow.screens.push(canonical);
+  }
+
   return { ast, legacy };
 }
 

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -552,6 +552,8 @@ function buildWireframes(
   // resolved AFTER the parse — a flow may list a screen declared further down.
   let currentFlow: WireframeNamedFlow | null = null;
   const flowRefs: Array<{ flow: WireframeNamedFlow; raw: string; line: number }> = [];
+  // Header line per named flow, so an empty flow can be rejected at ITS line.
+  const namedFlowLines: Array<{ flow: WireframeNamedFlow; line: number }> = [];
 
   const lines = dsl.split(/\r?\n/);
   for (let no = 1; no <= lines.length; no++) {
@@ -592,6 +594,7 @@ function buildWireframes(
           } else {
             currentFlow = { name, screens: [] };
             ast.namedFlows.push(currentFlow);
+            namedFlowLines.push({ flow: currentFlow, line: no });
           }
         }
         continue;
@@ -752,6 +755,15 @@ function buildWireframes(
       continue;
     }
     if (!ref.flow.screens.includes(canonical)) ref.flow.screens.push(canonical);
+  }
+  // A flow with no screen references cannot start anywhere — the picker would
+  // offer a journey with no entry. Always an authoring bug (a role/description
+  // shell, or legacy `A -> B` edge lines that a named flow does not read), so
+  // it is rejected at the flow's own header line.
+  for (const { flow: f, line } of namedFlowLines) {
+    if (f.screens.length === 0) {
+      err(line, `flow ${JSON.stringify(f.name)} lists no screens — list at least one screen reference`);
+    }
   }
 
   return { ast, legacy };

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -114,6 +114,10 @@ interface WireframeFlow {
  */
 interface WireframeNamedFlow {
   name: string;
+  /** Optional `role "…"` keyword line: the persona who walks this flow. */
+  role?: string;
+  /** Optional `description "…"` keyword line, mirroring a screen's subtitle. */
+  description?: string;
   screens: string[];
 }
 
@@ -299,6 +303,10 @@ export interface PrototypeScreen {
  */
 export interface PrototypeFlow {
   name: string;
+  /** The persona who walks this flow, from the `role "…"` keyword line. */
+  role?: string;
+  /** What the journey is, from the `description "…"` keyword line. */
+  description?: string;
   screens: string[];
 }
 
@@ -363,6 +371,8 @@ export function tryDslToPrototype(
     });
     const flows: PrototypeFlow[] = ast.namedFlows.map((f) => ({
       name: f.name,
+      ...(f.role !== undefined ? { role: f.role } : {}),
+      ...(f.description !== undefined ? { description: f.description } : {}),
       screens: [...f.screens],
     }));
     return { ok: true, model: { screens, flows } };
@@ -599,6 +609,20 @@ function buildWireframes(
         continue;
       }
       if (currentFlow) {
+        // Keyword metadata (`role "…"`, `description "…"`) is grammar-distinct
+        // from a screen reference: a reference is a BARE name, so a screen
+        // literally named `role` still resolves — only keyword + quoted string
+        // reads as metadata.
+        const kw = /^(role|description)\s+"((?:[^"\\]|\\.)*)"$/i.exec(trimmed);
+        if (kw) {
+          const key = kw[1]!.toLowerCase() as 'role' | 'description';
+          if (currentFlow[key] !== undefined) {
+            err(no, `duplicate ${key} for flow ${JSON.stringify(currentFlow.name)} — declare it once`);
+          } else {
+            currentFlow[key] = unescapeQuoted(kw[2]!);
+          }
+          continue;
+        }
         const ref = /^([\w-]+)$/.exec(trimmed);
         if (ref) {
           flowRefs.push({ flow: currentFlow, raw: ref[1]!, line: no });

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -1160,6 +1160,17 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
   const screenNameByLower = new Map<string, string>();
   ast.screens.forEach((s) => screenNameByLower.set(s.name.toLowerCase(), s.name));
 
+  // Flow membership, shown on the canvas so the grid answers "whose screen is
+  // this?" without entering the prototype. A screen listed by several flows
+  // reads "Common" rather than a list — the names are the personas' walkthrough
+  // labels, and stacking them makes the marker unreadable at grid zoom.
+  const flowLabelByLower = new Map<string, string>();
+  for (const s of ast.screens) {
+    const owning = ast.namedFlows.filter((f) => f.screens.includes(s.name));
+    if (owning.length === 1) flowLabelByLower.set(s.name.toLowerCase(), owning[0]!.name);
+    else if (owning.length > 1) flowLabelByLower.set(s.name.toLowerCase(), 'Common');
+  }
+
   // Variable-size screens flow left-to-right, COLUMNS per row; each row is as
   // tall as its tallest screen.
   let curX = 0;
@@ -1197,15 +1208,21 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
           'left',
         ),
       );
+      // Right-aligned, so widening the box for the flow label moves nothing:
+      // the text still ends at the screen's right edge and the title block
+      // keeps its height.
+      const flowLabel = flowLabelByLower.get(screen.name.toLowerCase());
+      const marker = flowLabel ? `${flowLabel} · Screen ${number}` : `Screen ${number}`;
+      const markerW = 300;
       out.push(
         withColor(
           makeText(
             stableId(`screen-num:${screen.name}:${idx}`),
-            sx + screen.width - 120,
+            sx + screen.width - (markerW + 12),
             sy,
-            108,
+            markerW,
             18,
-            `Screen ${number}`,
+            marker,
             14,
             'right',
           ),

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -292,8 +292,20 @@ export interface PrototypeScreen {
   hotspots: PrototypeHotspot[];
 }
 
+/**
+ * One persona's walkthrough. `screens` are canonical `PrototypeScreen` names,
+ * entry point first — membership lives on the flow, not the screen, so one
+ * screen can belong to several flows without being compiled twice.
+ */
+export interface PrototypeFlow {
+  name: string;
+  screens: string[];
+}
+
 export interface PrototypeModel {
   screens: PrototypeScreen[];
+  /** Empty when the DSL declares no `flow "…"` blocks. */
+  flows: PrototypeFlow[];
 }
 
 export function tryDslToPrototype(
@@ -349,7 +361,11 @@ export function tryDslToPrototype(
       if (screen.description) out.description = screen.description;
       return out;
     });
-    return { ok: true, model: { screens } };
+    const flows: PrototypeFlow[] = ast.namedFlows.map((f) => ({
+      name: f.name,
+      screens: [...f.screens],
+    }));
+    return { ok: true, model: { screens, flows } };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -107,3 +107,52 @@ flow
     [],
   );
 });
+
+test("the model publishes each declared flow, in declaration order, entry screen first", () => {
+  const m = model(TWO_FLOWS);
+  assert.deepEqual(
+    m.flows.map((f) => f.name),
+    ["Admin path", "Customer path"],
+  );
+  assert.deepEqual(m.flows[0]!.screens, ["Login", "AdminQueue", "AuditDetail"]);
+  assert.deepEqual(m.flows[1]!.screens, ["Login", "Orders"]);
+});
+
+test("a shared screen is compiled once and referenced by both flows", () => {
+  const m = model(TWO_FLOWS);
+  assert.equal(m.screens.filter((s) => s.name === "Login").length, 1);
+  assert.ok(m.flows.every((f) => f.screens.includes("Login")));
+});
+
+test("a DSL with no named flows compiles to an empty flow list", () => {
+  const m = model(`screen Login "Sign in"
+screen Dashboard "Home"
+
+flow
+  Login -> Dashboard
+`);
+  assert.deepEqual(m.flows, []);
+});
+
+test("flow screen references resolve case-insensitively to the canonical name", () => {
+  const m = model(`screen Login "Sign in"
+screen AdminQueue "Queue"
+
+flow "Admin path"
+  login
+  ADMINQUEUE
+`);
+  assert.deepEqual(m.flows[0]!.screens, ["Login", "AdminQueue"]);
+});
+
+test("a screen listed twice in one flow keeps its first position", () => {
+  const m = model(`screen Login "Sign in"
+screen AdminQueue "Queue"
+
+flow "Admin path"
+  Login
+  AdminQueue
+  Login
+`);
+  assert.deepEqual(m.flows[0]!.screens, ["Login", "AdminQueue"]);
+});

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -18,7 +18,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { tryDslToPrototype, validateWireframeSyntax } from "../src/index.js";
+import { dslToExcalidraw, tryDslToPrototype, validateWireframeSyntax } from "../src/index.js";
 
 const TWO_FLOWS = `screen Login "Sign in"
   button "Sign in" primary -> AdminQueue
@@ -155,4 +155,51 @@ flow "Admin path"
   Login
 `);
   assert.deepEqual(m.flows[0]!.screens, ["Login", "AdminQueue"]);
+});
+
+function canvasTexts(dsl: string): string[] {
+  const scene = JSON.parse(dslToExcalidraw("wireframes", dsl)) as {
+    elements: Array<{ type: string; text?: string }>;
+  };
+  return scene.elements.filter((e) => e.type === "text").map((e) => e.text ?? "");
+}
+
+test("a screen in exactly one flow is labelled with that flow's name", () => {
+  const texts = canvasTexts(TWO_FLOWS);
+  assert.ok(texts.includes("Admin path · Screen 2"), texts.join(" | "));
+  assert.ok(texts.includes("Customer path · Screen 4"), texts.join(" | "));
+});
+
+test("a screen in two or more flows is labelled Common", () => {
+  const texts = canvasTexts(TWO_FLOWS);
+  assert.ok(texts.includes("Common · Screen 1"), texts.join(" | "));
+});
+
+test("a screen in no flow keeps the bare screen-number marker", () => {
+  const texts = canvasTexts(`screen Login "Sign in"
+screen Stranded "Nobody lists me"
+
+flow "Admin path"
+  Login
+`);
+  assert.ok(texts.includes("Screen 2"), texts.join(" | "));
+  assert.ok(!texts.some((t) => t.endsWith("· Screen 2")), "unassigned screen must carry no flow label");
+});
+
+test("a DSL with no named flows carries no flow label anywhere on the canvas", () => {
+  const texts = canvasTexts(`screen Login "Sign in"
+  button "Sign in" primary -> Dashboard
+screen Dashboard "Home"
+  navbar "App | Home"
+`);
+  assert.ok(texts.includes("Screen 1"), texts.join(" | "));
+  assert.ok(texts.includes("Screen 2"), texts.join(" | "));
+  // Target the flow-label marker format specifically ("... · Screen N" at the
+  // end of a string), not any middle dot on the canvas: the `-> Dashboard`
+  // arrow above legitimately draws its own "→ Screen 2 · Dashboard" nav
+  // marker, which carries a middle dot of its own and must not trip this.
+  assert.ok(
+    !texts.some((t) => /· Screen \d+$/.test(t)),
+    "no screen may gain a flow label",
+  );
 });

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -203,3 +203,103 @@ screen Dashboard "Home"
     "no screen may gain a flow label",
   );
 });
+
+test("role and description keyword lines attach to the flow", () => {
+  const m = model(`screen MyRisks "Owner: my risks"
+screen NewRisk "Owner: log a risk"
+
+flow "Log a risk"
+  role "Risk owner"
+  description "An owner records a new risk and tracks it"
+  MyRisks
+  NewRisk
+`);
+  assert.equal(m.flows[0]!.role, "Risk owner");
+  assert.equal(m.flows[0]!.description, "An owner records a new risk and tracks it");
+  assert.deepEqual(m.flows[0]!.screens, ["MyRisks", "NewRisk"]);
+});
+
+test("role and description are optional and independent", () => {
+  const m = model(`screen A "a"
+screen B "b"
+
+flow "First"
+  role "Admin"
+  A
+
+flow "Second"
+  description "No role declared"
+  B
+
+flow "Third"
+  A
+  B
+`);
+  assert.equal(m.flows[0]!.role, "Admin");
+  assert.equal(m.flows[0]!.description, undefined);
+  assert.equal(m.flows[1]!.role, undefined);
+  assert.equal(m.flows[1]!.description, "No role declared");
+  assert.equal(m.flows[2]!.role, undefined);
+  assert.equal(m.flows[2]!.description, undefined);
+});
+
+test("keyword lines may appear after screen references", () => {
+  const m = model(`screen A "a"
+
+flow "First"
+  A
+  role "Admin"
+`);
+  assert.equal(m.flows[0]!.role, "Admin");
+  assert.deepEqual(m.flows[0]!.screens, ["A"]);
+});
+
+test("a duplicate role line is rejected with its line number", () => {
+  const errs = validateWireframeSyntax(`screen A "a"
+
+flow "First"
+  role "Admin"
+  role "Owner"
+  A
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 5: /);
+  assert.match(errs[0]!, /duplicate role/);
+});
+
+test("a duplicate description line is rejected with its line number", () => {
+  const errs = validateWireframeSyntax(`screen A "a"
+
+flow "First"
+  description "one"
+  description "two"
+  A
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 5: /);
+  assert.match(errs[0]!, /duplicate description/);
+});
+
+test("a mistyped keyword falls through to the unknown-flow-line error", () => {
+  const errs = validateWireframeSyntax(`screen A "a"
+
+flow "First"
+  descripton "typo"
+  A
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 4: /);
+  assert.match(errs[0]!, /unknown flow line/);
+});
+
+test("a screen literally named role still resolves as a bare reference", () => {
+  const m = model(`screen role "An unfortunate name"
+screen A "a"
+
+flow "First"
+  role
+  A
+`);
+  assert.deepEqual(m.flows[0]!.screens, ["role", "A"]);
+  assert.equal(m.flows[0]!.role, undefined);
+});

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -303,3 +303,35 @@ flow "First"
   assert.deepEqual(m.flows[0]!.screens, ["role", "A"]);
   assert.equal(m.flows[0]!.role, undefined);
 });
+
+test("a named flow listing no screens is rejected with the header's line number", () => {
+  const errs = validateWireframeSyntax(`screen A "a"
+
+flow "Ghost"
+  role "Nobody"
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 3: /);
+  assert.match(errs[0]!, /lists no screens/);
+});
+
+test("a named flow holding only legacy edge lines is rejected as empty", () => {
+  const errs = validateWireframeSyntax(`screen A "a"
+screen B "b"
+
+flow "Edges only"
+  A -> B
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 4: /);
+  assert.match(errs[0]!, /lists no screens/);
+});
+
+test("the tolerant compile keeps an empty flow rather than failing the model", () => {
+  const m = model(`screen A "a"
+
+flow "Ghost"
+  role "Nobody"
+`);
+  assert.deepEqual(m.flows[0]!.screens, []);
+});

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tryDslToPrototype, validateWireframeSyntax } from "../src/index.js";
+
+const TWO_FLOWS = `screen Login "Sign in"
+  button "Sign in" primary -> AdminQueue
+screen AdminQueue "Admin: approval queue"
+  button "Open" -> AuditDetail
+screen AuditDetail "Admin: audit detail"
+screen Orders "Customer: my orders"
+
+flow "Admin path"
+  Login
+  AdminQueue
+  AuditDetail
+
+flow "Customer path"
+  Login
+  Orders
+`;
+
+function model(dsl: string) {
+  const res = tryDslToPrototype(dsl);
+  assert.ok(res.ok, `expected ok, got ${!res.ok ? res.error : ""}`);
+  return res.model;
+}
+
+test("a valid DSL with named flows passes the write gate", () => {
+  assert.deepEqual(validateWireframeSyntax(TWO_FLOWS), []);
+});
+
+test("a flow naming a screen that does not exist is rejected with its line number", () => {
+  const errs = validateWireframeSyntax(`screen Login "Sign in"
+
+flow "Admin path"
+  Login
+  Typo
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 5: /);
+  assert.match(errs[0]!, /unknown screen "Typo"/);
+});
+
+test("a flow may reference a screen declared later in the file", () => {
+  assert.deepEqual(
+    validateWireframeSyntax(`flow "Admin path"
+  Login
+screen Login "Sign in"
+`),
+    [],
+  );
+});
+
+test("declaring the same flow name twice is rejected", () => {
+  const errs = validateWireframeSyntax(`screen Login "Sign in"
+screen Orders "Orders"
+
+flow "Admin path"
+  Login
+
+flow "Admin path"
+  Orders
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 7: /);
+  assert.match(errs[0]!, /duplicate flow "Admin path"/);
+});
+
+test("a screen in no flow is not an error", () => {
+  assert.deepEqual(
+    validateWireframeSyntax(`screen Login "Sign in"
+screen Stranded "Nobody lists me"
+
+flow "Admin path"
+  Login
+`),
+    [],
+  );
+});
+
+test("the legacy unnamed flow block still parses and still reports nothing", () => {
+  assert.deepEqual(
+    validateWireframeSyntax(`screen Login "Sign in"
+screen Dashboard "Home"
+
+flow
+  Login -> Dashboard
+`),
+    [],
+  );
+});

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -25,6 +25,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
 import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
@@ -265,9 +266,14 @@ export function PrototypeView({
           </Select>
         </FormControl>
         {screen.description && (
-          <Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
-            {screen.description}
-          </Typography>
+          // Two pickers now sit left of it, so a long description truncates;
+          // the tooltip carries the full text. Harmlessly redundant when the
+          // description fits.
+          <Tooltip title={screen.description}>
+            <Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
+              {screen.description}
+            </Typography>
+          </Tooltip>
         )}
         {trailingSlot && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
       </Box>

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -17,8 +17,8 @@
  */
 
 import { useMemo, useReducer, useRef, useState, useEffect, Suspense, type ReactNode } from "react";
-import { Box, CircularProgress, IconButton, MenuItem, Select, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
+import { Box, Chip, CircularProgress, IconButton, MenuItem, Select, Typography } from "@wso2/oxygen-ui";
+import { ArrowLeft, UserRound } from "@wso2/oxygen-ui-icons-react";
 import type { PrototypeModel } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport } from "./scene.js";
@@ -191,18 +191,34 @@ export function PrototypeView({
             value={flow ?? ""}
             onChange={(e) => onFlowSelected(String(e.target.value))}
             aria-label="Flow"
+            // Menu items carry two lines (name + role · journey); the CLOSED
+            // control shows only the name, so it stays one row tall.
+            renderValue={(v) => String(v)}
           >
-            {model.flows.map((f) => (
-              <MenuItem key={f.name} value={f.name}>
-                {f.name}
-              </MenuItem>
-            ))}
+            {model.flows.map((f) => {
+              const detail = [f.role, f.description].filter(Boolean).join(" · ");
+              return (
+                <MenuItem key={f.name} value={f.name}>
+                  <Box sx={{ py: 0.25 }}>
+                    <Typography variant="body2">{f.name}</Typography>
+                    {detail && (
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        {detail}
+                      </Typography>
+                    )}
+                  </Box>
+                </MenuItem>
+              );
+            })}
           </Select>
-          {/* Who walks this flow and what the journey is — the flow-level
-              counterpart of the screen row's description text. */}
-          {(selectedFlow?.role || selectedFlow?.description) && (
+          {/* The persona reads as a labelled chip, not stray prose; the
+              journey description follows muted, mirroring the screen row. */}
+          {selectedFlow?.role && (
+            <Chip size="small" variant="outlined" icon={<UserRound size={14} />} label={selectedFlow.role} />
+          )}
+          {selectedFlow?.description && (
             <Typography variant="body2" color="text.secondary" noWrap>
-              {[selectedFlow.role, selectedFlow.description].filter(Boolean).join(" · ")}
+              {selectedFlow.description}
             </Typography>
           )}
           {trailingSlot && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -17,8 +17,17 @@
  */
 
 import { useMemo, useReducer, useRef, useState, useEffect, Suspense, type ReactNode } from "react";
-import { Box, Chip, CircularProgress, IconButton, MenuItem, Select, Typography } from "@wso2/oxygen-ui";
-import { ArrowLeft, UserRound } from "@wso2/oxygen-ui-icons-react";
+import {
+  Box,
+  CircularProgress,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { ArrowLeft } from "@wso2/oxygen-ui-icons-react";
 import type { PrototypeModel } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport } from "./scene.js";
@@ -27,6 +36,17 @@ import { resolveFlow, flowEntryScreen, pickerScreens } from "./flowState.js";
 import { hotspotToViewport, type ViewportRect } from "./hotspotOverlay.js";
 
 const FLASH_MS = 900;
+
+// A Select menu defaults to opening OVER its control, aligned on the selected
+// option — which in a toolbar drops the list on top of the row it belongs to
+// and over the panel beside it. Anchor it under the control instead, and cap
+// the width so a long "role · journey" line wraps rather than stretching the
+// menu across the page.
+const MENU_PROPS = {
+  anchorOrigin: { vertical: "bottom", horizontal: "left" },
+  transformOrigin: { vertical: "top", horizontal: "left" },
+  slotProps: { paper: { sx: { maxWidth: 460, mt: 0.5 } } },
+} as const;
 
 // Hotspot highlight: the wireframes' flow-accent blue, NOT the brand orange —
 // primary CTAs are drawn filled orange, so an orange ring on top of one is
@@ -182,89 +202,112 @@ export function PrototypeView({
           A wireframe with no declared flows has no outer level, so it keeps
           the original single row. */}
       {hasFlows && (
-        <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1, borderBottom: 1, borderColor: "divider" }}>
-          <Typography variant="caption" color="text.secondary">
-            User flow
-          </Typography>
-          <Select
-            size="small"
-            value={flow ?? ""}
-            onChange={(e) => onFlowSelected(String(e.target.value))}
-            aria-label="Flow"
-            // Menu items carry two lines (name + role · journey); the CLOSED
-            // control shows only the name, so it stays one row tall.
-            renderValue={(v) => String(v)}
-          >
-            {model.flows.map((f) => {
-              const detail = [f.role, f.description].filter(Boolean).join(" · ");
-              return (
-                <MenuItem key={f.name} value={f.name}>
-                  <Box sx={{ py: 0.25 }}>
-                    <Typography variant="body2">{f.name}</Typography>
-                    {detail && (
-                      <Typography variant="caption" color="text.secondary" display="block">
-                        {detail}
-                      </Typography>
-                    )}
-                  </Box>
-                </MenuItem>
-              );
-            })}
-          </Select>
-          {/* The persona reads as a labelled chip, not stray prose; the
-              journey description follows muted, mirroring the screen row. */}
-          {selectedFlow?.role && (
-            <Chip size="small" variant="outlined" icon={<UserRound size={14} />} label={selectedFlow.role} />
-          )}
+        <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1.5, borderBottom: 1, borderColor: "divider" }}>
+          <FormControl size="small" sx={{ minWidth: 220 }}>
+            <InputLabel id="aep-flow-label">User flow</InputLabel>
+            <Select
+              labelId="aep-flow-label"
+              label="User flow"
+              value={flow ?? ""}
+              onChange={(e) => onFlowSelected(String(e.target.value))}
+              // Menu items carry two lines (name + role · journey); the CLOSED
+              // control shows only the name, so the control stays one row tall.
+              renderValue={(v) => String(v)}
+              MenuProps={MENU_PROPS}
+            >
+              {model.flows.map((f) => {
+                const detail = [f.role, f.description].filter(Boolean).join(" · ");
+                return (
+                  <MenuItem key={f.name} value={f.name}>
+                    <Box sx={{ py: 0.25 }}>
+                      <Typography variant="body2">{f.name}</Typography>
+                      {detail && (
+                        <Typography variant="caption" color="text.secondary" display="block" sx={{ whiteSpace: "normal" }}>
+                          {detail}
+                        </Typography>
+                      )}
+                    </Box>
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+          {/* Description only. The role is spelled out per option in the open
+              menu, which is where personas are actually compared — repeating it
+              on the closed row only costs width. */}
           {selectedFlow?.description && (
-            <Typography variant="body2" color="text.secondary" noWrap>
+            <Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
               {selectedFlow.description}
             </Typography>
           )}
-          {trailingSlot && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}
+          {trailingSlot && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
         </Box>
       )}
       <Box
         sx={{
-          // Indented and recessed when it sits under a flow row: the screens
-          // belong to the flow above, and reading them as a nested tier is the
-          // whole point. Without a flow row this IS the toolbar, so it keeps
-          // the plain surface and flush padding.
-          pl: hasFlows ? 3 : 1.5,
+          // Recessed and slightly indented when it sits under a flow row: the
+          // screens belong to the flow above. The nesting is carried mostly by
+          // the surface tint and the smaller controls — a deep indent just
+          // strands the back button in whitespace. Without a flow row this IS
+          // the toolbar, so it keeps the plain surface and flush padding.
+          pl: hasFlows ? 2 : 1.5,
           pr: 1.5,
-          py: hasFlows ? 0.75 : 1,
+          // A notched label rides ON the control's top edge, so the row needs
+          // headroom above the field or the label collides with the row above.
+          pt: hasFlows ? 1.25 : 1,
+          pb: hasFlows ? 0.75 : 1,
           bgcolor: hasFlows ? "action.hover" : undefined,
           display: "flex",
-          alignItems: "center",
+          // Bottom-aligned once the field carries a notched label: the label
+          // makes the field group taller, so centring would leave the back
+          // button floating against the box rather than level with it.
+          alignItems: hasFlows ? "flex-end" : "center",
           gap: 1,
           borderBottom: 1,
           borderColor: "divider",
         }}
       >
-        <IconButton size="small" aria-label="Back" disabled={nav.stack.length === 0} onClick={() => dispatch({ type: "back" })}>
+        <IconButton
+          size="small"
+          aria-label="Back"
+          disabled={nav.stack.length === 0}
+          onClick={() => dispatch({ type: "back" })}
+          sx={{ mb: hasFlows ? 0.25 : 0 }}
+        >
           <ArrowLeft size={16} />
         </IconButton>
-        <Typography variant="caption" color="text.secondary">
-          Screen
-        </Typography>
-        <Select
+        {/* Deliberately smaller than the flow control above: the inner tier
+            should read as subordinate, and shrinking it is what buys that
+            without a deep indent. */}
+        <FormControl
           size="small"
-          value={nav.current}
-          onChange={(e) => dispatch({ type: "navigate", to: String(e.target.value) })}
-          aria-label="Screen"
+          sx={{
+            minWidth: 180,
+            "& .MuiInputBase-input": { py: 0.75, fontSize: 13 },
+            "& .MuiInputLabel-root": { fontSize: 13 },
+          }}
         >
-          {pickerScreens(model, flow, nav.current).map((name) => (
-            <MenuItem key={name} value={name}>
-              {name}
-            </MenuItem>
-          ))}
-        </Select>
+          <InputLabel id="aep-screen-label">Screen</InputLabel>
+          <Select
+            labelId="aep-screen-label"
+            label="Screen"
+            value={nav.current}
+            onChange={(e) => dispatch({ type: "navigate", to: String(e.target.value) })}
+            MenuProps={MENU_PROPS}
+          >
+            {pickerScreens(model, flow, nav.current).map((name) => (
+              <MenuItem key={name} value={name}>
+                {name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         {screen.description && (
-          <Typography variant="body2" color="text.secondary" noWrap>
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ minWidth: 0, mb: hasFlows ? 0.9 : 0 }}>
             {screen.description}
           </Typography>
         )}
-        {trailingSlot && !hasFlows && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}
+        {trailingSlot && !hasFlows && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
       </Box>
       <Box sx={{ position: "relative", flex: 1, minHeight: 0 }} onClick={onDeadAreaClick}>
         <Box sx={{ position: "absolute", inset: 0 }}>

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -150,6 +150,9 @@ export function PrototypeView({
     }, FLASH_MS);
   };
 
+  const hasFlows = model.flows.length > 0;
+  const selectedFlow = flow === null ? undefined : model.flows.find((f) => f.name === flow);
+
   const onFlowSelected = (next: string) => {
     setFlow(next);
     onFlowChange?.(next);
@@ -173,10 +176,16 @@ export function PrototypeView({
         "& .App-menu_top__left": { display: "none !important" },
       }}
     >
-      {/* Toolbar: back · screen picker · description · trailing slot (e.g.
-          the console's view switch, pushed to the right edge) — one row. */}
-      <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1, borderBottom: 1, borderColor: "divider" }}>
-        {model.flows.length > 0 && (
+      {/* Toolbar, two tiers: the flow is the outer context and screen
+          navigation happens INSIDE it, so the screen row is indented and sits
+          on a recessed surface rather than beside the flow picker as a peer.
+          A wireframe with no declared flows has no outer level, so it keeps
+          the original single row. */}
+      {hasFlows && (
+        <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1, borderBottom: 1, borderColor: "divider" }}>
+          <Typography variant="caption" color="text.secondary">
+            User flow
+          </Typography>
           <Select
             size="small"
             value={flow ?? ""}
@@ -189,10 +198,39 @@ export function PrototypeView({
               </MenuItem>
             ))}
           </Select>
-        )}
+          {/* Who walks this flow and what the journey is — the flow-level
+              counterpart of the screen row's description text. */}
+          {(selectedFlow?.role || selectedFlow?.description) && (
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {[selectedFlow.role, selectedFlow.description].filter(Boolean).join(" · ")}
+            </Typography>
+          )}
+          {trailingSlot && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}
+        </Box>
+      )}
+      <Box
+        sx={{
+          // Indented and recessed when it sits under a flow row: the screens
+          // belong to the flow above, and reading them as a nested tier is the
+          // whole point. Without a flow row this IS the toolbar, so it keeps
+          // the plain surface and flush padding.
+          pl: hasFlows ? 3 : 1.5,
+          pr: 1.5,
+          py: hasFlows ? 0.75 : 1,
+          bgcolor: hasFlows ? "action.hover" : undefined,
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <IconButton size="small" aria-label="Back" disabled={nav.stack.length === 0} onClick={() => dispatch({ type: "back" })}>
           <ArrowLeft size={16} />
         </IconButton>
+        <Typography variant="caption" color="text.secondary">
+          Screen
+        </Typography>
         <Select
           size="small"
           value={nav.current}
@@ -210,7 +248,7 @@ export function PrototypeView({
             {screen.description}
           </Typography>
         )}
-        {trailingSlot && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}
+        {trailingSlot && !hasFlows && <Box sx={{ ml: "auto" }}>{trailingSlot}</Box>}
       </Box>
       <Box sx={{ position: "relative", flex: 1, minHeight: 0 }} onClick={onDeadAreaClick}>
         <Box sx={{ position: "absolute", inset: 0 }}>

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -23,6 +23,7 @@ import type { PrototypeModel } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport } from "./scene.js";
 import { prototypeNavReducer } from "./prototypeState.js";
+import { resolveFlow, flowEntryScreen, pickerScreens } from "./flowState.js";
 import { hotspotToViewport, type ViewportRect } from "./hotspotOverlay.js";
 
 const FLASH_MS = 900;
@@ -42,8 +43,12 @@ export interface PrototypeViewProps {
   model: PrototypeModel;
   /** Start screen (deep link). Unknown/absent → first screen. */
   initialScreen?: string;
+  /** Start flow (deep link). Unknown/absent → first declared flow. */
+  initialFlow?: string;
   /** Fires on every screen change — the full-screen route syncs the URL. */
   onScreenChange?: (screen: string) => void;
+  /** Fires on every flow change — the full-screen route syncs the URL. */
+  onFlowChange?: (flow: string) => void;
   /** Fill the parent's height (else fixed 600px), like ExcalidrawView. */
   fillHeight?: boolean;
   /** Right-aligned toolbar slot (e.g. the console's Canvas | Prototype switch,
@@ -55,10 +60,27 @@ export interface PrototypeViewProps {
 // Expects to be remounted (e.g. via a `key`) when `model` changes: `initialData`
 // is captured once at mount, and the screen-swap effect only reacts to
 // navigation, not to a new `model` identity.
-export function PrototypeView({ model, initialScreen, onScreenChange, fillHeight, trailingSlot }: PrototypeViewProps) {
+export function PrototypeView({
+  model,
+  initialScreen,
+  initialFlow,
+  onScreenChange,
+  onFlowChange,
+  fillHeight,
+  trailingSlot,
+}: PrototypeViewProps) {
   const byName = useMemo(() => new Map(model.screens.map((s) => [s.name, s])), [model]);
   const first = model.screens[0]!.name;
-  const start = initialScreen && byName.has(initialScreen) ? initialScreen : first;
+  // Flow selection is view state, not navigation state: it survives clicking
+  // across flows (the flow is a starting lens, not a cage), so it lives beside
+  // the nav reducer rather than inside it.
+  const [flow, setFlow] = useState<string | null>(() => resolveFlow(model, initialFlow));
+  // A deep-linked screen wins over the flow's entry screen — a shared link
+  // points at a screen, and honouring the flow instead would silently move the
+  // reader somewhere else.
+  const start = initialScreen && byName.has(initialScreen)
+    ? initialScreen
+    : (flowEntryScreen(model, flow) ?? first);
   const [nav, dispatch] = useReducer(prototypeNavReducer, { current: start, stack: [] });
   const apiRef = useRef<any>(null);
   const [flash, setFlash] = useState(false);
@@ -128,6 +150,13 @@ export function PrototypeView({ model, initialScreen, onScreenChange, fillHeight
     }, FLASH_MS);
   };
 
+  const onFlowSelected = (next: string) => {
+    setFlow(next);
+    onFlowChange?.(next);
+    const entry = flowEntryScreen(model, next);
+    if (entry) dispatch({ type: "reset", to: entry });
+  };
+
   return (
     <Box
       sx={{
@@ -147,6 +176,20 @@ export function PrototypeView({ model, initialScreen, onScreenChange, fillHeight
       {/* Toolbar: back · screen picker · description · trailing slot (e.g.
           the console's view switch, pushed to the right edge) — one row. */}
       <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1, borderBottom: 1, borderColor: "divider" }}>
+        {model.flows.length > 0 && (
+          <Select
+            size="small"
+            value={flow ?? ""}
+            onChange={(e) => onFlowSelected(String(e.target.value))}
+            aria-label="Flow"
+          >
+            {model.flows.map((f) => (
+              <MenuItem key={f.name} value={f.name}>
+                {f.name}
+              </MenuItem>
+            ))}
+          </Select>
+        )}
         <IconButton size="small" aria-label="Back" disabled={nav.stack.length === 0} onClick={() => dispatch({ type: "back" })}>
           <ArrowLeft size={16} />
         </IconButton>
@@ -156,9 +199,9 @@ export function PrototypeView({ model, initialScreen, onScreenChange, fillHeight
           onChange={(e) => dispatch({ type: "navigate", to: String(e.target.value) })}
           aria-label="Screen"
         >
-          {model.screens.map((s) => (
-            <MenuItem key={s.name} value={s.name}>
-              {s.name}
+          {pickerScreens(model, flow, nav.current).map((name) => (
+            <MenuItem key={name} value={name}>
+              {name}
             </MenuItem>
           ))}
         </Select>

--- a/packages/ui/excalidraw-view/src/PrototypeView.tsx
+++ b/packages/ui/excalidraw-view/src/PrototypeView.tsx
@@ -171,7 +171,6 @@ export function PrototypeView({
   };
 
   const hasFlows = model.flows.length > 0;
-  const selectedFlow = flow === null ? undefined : model.flows.find((f) => f.name === flow);
 
   const onFlowSelected = (next: string) => {
     setFlow(next);
@@ -196,14 +195,30 @@ export function PrototypeView({
         "& .App-menu_top__left": { display: "none !important" },
       }}
     >
-      {/* Toolbar, two tiers: the flow is the outer context and screen
-          navigation happens INSIDE it, so the screen row is indented and sits
-          on a recessed surface rather than beside the flow picker as a peer.
-          A wireframe with no declared flows has no outer level, so it keeps
-          the original single row. */}
-      {hasFlows && (
-        <Box sx={{ px: 1.5, py: 1, display: "flex", alignItems: "center", gap: 1.5, borderBottom: 1, borderColor: "divider" }}>
-          <FormControl size="small" sx={{ minWidth: 220 }}>
+      {/* Toolbar, ONE row: back · User flow · Screen · screen description.
+          The flow's own description is deliberately absent here — each option
+          in the open flow menu carries it, and repeating it in the row cost
+          the width that forced a second tier. No flows → the flow control
+          simply isn't rendered and the same row serves as before. */}
+      <Box
+        sx={{
+          px: 1.5,
+          // A notched label rides ON a control's top edge, so the row needs a
+          // little more headroom above than below.
+          pt: 1.25,
+          pb: 0.75,
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <IconButton size="small" aria-label="Back" disabled={nav.stack.length === 0} onClick={() => dispatch({ type: "back" })}>
+          <ArrowLeft size={16} />
+        </IconButton>
+        {hasFlows && (
+          <FormControl size="small" sx={{ minWidth: 200 }}>
             <InputLabel id="aep-flow-label">User flow</InputLabel>
             <Select
               labelId="aep-flow-label"
@@ -232,61 +247,8 @@ export function PrototypeView({
               })}
             </Select>
           </FormControl>
-          {/* Description only. The role is spelled out per option in the open
-              menu, which is where personas are actually compared — repeating it
-              on the closed row only costs width. */}
-          {selectedFlow?.description && (
-            <Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
-              {selectedFlow.description}
-            </Typography>
-          )}
-          {trailingSlot && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
-        </Box>
-      )}
-      <Box
-        sx={{
-          // Recessed and slightly indented when it sits under a flow row: the
-          // screens belong to the flow above. The nesting is carried mostly by
-          // the surface tint and the smaller controls — a deep indent just
-          // strands the back button in whitespace. Without a flow row this IS
-          // the toolbar, so it keeps the plain surface and flush padding.
-          pl: hasFlows ? 2 : 1.5,
-          pr: 1.5,
-          // A notched label rides ON the control's top edge, so the row needs
-          // headroom above the field or the label collides with the row above.
-          pt: hasFlows ? 1.25 : 1,
-          pb: hasFlows ? 0.75 : 1,
-          bgcolor: hasFlows ? "action.hover" : undefined,
-          display: "flex",
-          // Bottom-aligned once the field carries a notched label: the label
-          // makes the field group taller, so centring would leave the back
-          // button floating against the box rather than level with it.
-          alignItems: hasFlows ? "flex-end" : "center",
-          gap: 1,
-          borderBottom: 1,
-          borderColor: "divider",
-        }}
-      >
-        <IconButton
-          size="small"
-          aria-label="Back"
-          disabled={nav.stack.length === 0}
-          onClick={() => dispatch({ type: "back" })}
-          sx={{ mb: hasFlows ? 0.25 : 0 }}
-        >
-          <ArrowLeft size={16} />
-        </IconButton>
-        {/* Deliberately smaller than the flow control above: the inner tier
-            should read as subordinate, and shrinking it is what buys that
-            without a deep indent. */}
-        <FormControl
-          size="small"
-          sx={{
-            minWidth: 180,
-            "& .MuiInputBase-input": { py: 0.75, fontSize: 13 },
-            "& .MuiInputLabel-root": { fontSize: 13 },
-          }}
-        >
+        )}
+        <FormControl size="small" sx={{ minWidth: 180 }}>
           <InputLabel id="aep-screen-label">Screen</InputLabel>
           <Select
             labelId="aep-screen-label"
@@ -303,11 +265,11 @@ export function PrototypeView({
           </Select>
         </FormControl>
         {screen.description && (
-          <Typography variant="caption" color="text.secondary" noWrap sx={{ minWidth: 0, mb: hasFlows ? 0.9 : 0 }}>
+          <Typography variant="body2" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
             {screen.description}
           </Typography>
         )}
-        {trailingSlot && !hasFlows && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
+        {trailingSlot && <Box sx={{ ml: "auto", flexShrink: 0 }}>{trailingSlot}</Box>}
       </Box>
       <Box sx={{ position: "relative", flex: 1, minHeight: 0 }} onClick={onDeadAreaClick}>
         <Box sx={{ position: "absolute", inset: 0 }}>

--- a/packages/ui/excalidraw-view/src/flowState.ts
+++ b/packages/ui/excalidraw-view/src/flowState.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { PrototypeModel } from "@aep/excalidraw-dsl";
+
+/**
+ * Which flow the viewer should show. A model with no declared flows resolves
+ * to `null`, which is what hides the flow picker and returns the viewer to its
+ * pre-flows behaviour: one flat list of every screen.
+ */
+export function resolveFlow(model: PrototypeModel, requested?: string): string | null {
+  if (model.flows.length === 0) return null;
+  if (requested && model.flows.some((f) => f.name === requested)) return requested;
+  return model.flows[0]!.name;
+}
+
+/** The screen a flow starts on: its first listed screen. */
+export function flowEntryScreen(model: PrototypeModel, flow: string | null): string | null {
+  const found = flow === null ? undefined : model.flows.find((f) => f.name === flow);
+  return found?.screens[0] ?? model.screens[0]?.name ?? null;
+}
+
+/**
+ * Options for the screen picker: the selected flow's screens in walkthrough
+ * order, so the control reads as the flow's steps.
+ *
+ * `current` is appended when it sits outside the flow. That happens on a
+ * cross-flow click — chrome and shared screens (Login, a sign-out landing) are
+ * reachable from more than one persona — and a Select must never hold a value
+ * its options do not contain.
+ */
+export function pickerScreens(
+  model: PrototypeModel,
+  flow: string | null,
+  current: string,
+): string[] {
+  const found = flow === null ? undefined : model.flows.find((f) => f.name === flow);
+  if (!found) return model.screens.map((s) => s.name);
+  return found.screens.includes(current) ? [...found.screens] : [...found.screens, current];
+}

--- a/packages/ui/excalidraw-view/src/prototypeState.ts
+++ b/packages/ui/excalidraw-view/src/prototypeState.ts
@@ -17,7 +17,13 @@
  */
 
 export interface PrototypeNavState { current: string; stack: string[] }
-export type PrototypeNavEvent = { type: 'navigate'; to: string } | { type: 'back' };
+export type PrototypeNavEvent =
+  | { type: 'navigate'; to: string }
+  | { type: 'back' }
+  /** Switching flows: land on the new flow's entry screen with no history —
+   *  a persona switch starts a fresh walkthrough, it does not continue the
+   *  previous persona's. */
+  | { type: 'reset'; to: string };
 
 /** Figma-style prototype navigation: every navigate (click OR picker jump)
  *  pushes history; back pops it. Same-screen navigates and empty-stack backs
@@ -30,6 +36,7 @@ export function prototypeNavReducer(
     if (event.to === state.current) return state;
     return { current: event.to, stack: [...state.stack, state.current] };
   }
+  if (event.type === 'reset') return { current: event.to, stack: [] };
   if (state.stack.length === 0) return state;
   return { current: state.stack.at(-1)!, stack: state.stack.slice(0, -1) };
 }

--- a/packages/ui/excalidraw-view/test/flowState.test.ts
+++ b/packages/ui/excalidraw-view/test/flowState.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { PrototypeModel } from "@aep/excalidraw-dsl";
+import { resolveFlow, flowEntryScreen, pickerScreens } from "../src/flowState.js";
+
+function screen(name: string) {
+  return { name, width: 1280, height: 800, sceneJson: "{}", hotspots: [] };
+}
+
+const MODEL: PrototypeModel = {
+  screens: ["Login", "AdminQueue", "AuditDetail", "Orders"].map(screen),
+  flows: [
+    { name: "Admin path", screens: ["Login", "AdminQueue", "AuditDetail"] },
+    { name: "Customer path", screens: ["Login", "Orders"] },
+  ],
+};
+
+const NO_FLOWS: PrototypeModel = { screens: [screen("Login"), screen("Orders")], flows: [] };
+
+test("an absent request resolves to the first declared flow", () => {
+  assert.equal(resolveFlow(MODEL, undefined), "Admin path");
+});
+
+test("a known request resolves to itself", () => {
+  assert.equal(resolveFlow(MODEL, "Customer path"), "Customer path");
+});
+
+test("an unknown request falls back to the first declared flow", () => {
+  assert.equal(resolveFlow(MODEL, "Ghost path"), "Admin path");
+});
+
+test("a model with no flows resolves to null — the picker is hidden", () => {
+  assert.equal(resolveFlow(NO_FLOWS, "Admin path"), null);
+});
+
+test("the entry screen is the flow's first listed screen", () => {
+  assert.equal(flowEntryScreen(MODEL, "Customer path"), "Login");
+  assert.equal(flowEntryScreen(MODEL, "Admin path"), "Login");
+});
+
+test("with no flow selected the entry screen is the model's first screen", () => {
+  assert.equal(flowEntryScreen(NO_FLOWS, null), "Login");
+});
+
+test("the picker lists the selected flow's screens in flow order", () => {
+  assert.deepEqual(pickerScreens(MODEL, "Admin path", "AdminQueue"), [
+    "Login",
+    "AdminQueue",
+    "AuditDetail",
+  ]);
+});
+
+test("a screen reached across flows is appended so the picker never holds a value it lacks", () => {
+  assert.deepEqual(pickerScreens(MODEL, "Admin path", "Orders"), [
+    "Login",
+    "AdminQueue",
+    "AuditDetail",
+    "Orders",
+  ]);
+});
+
+test("with no flow selected the picker lists every screen", () => {
+  assert.deepEqual(pickerScreens(NO_FLOWS, null, "Login"), ["Login", "Orders"]);
+});

--- a/packages/ui/excalidraw-view/test/prototypeState.test.ts
+++ b/packages/ui/excalidraw-view/test/prototypeState.test.ts
@@ -39,3 +39,13 @@ test("back on an empty stack is a no-op", () => {
   const before = { current: "Login", stack: [] };
   assert.equal(prototypeNavReducer(before, { type: "back" }), before);
 });
+
+test("reset jumps to a screen and clears the back stack — a flow switch starts a fresh walkthrough", () => {
+  const s = prototypeNavReducer({ current: "Detail", stack: ["Login", "List"] }, { type: "reset", to: "AdminQueue" });
+  assert.deepEqual(s, { current: "AdminQueue", stack: [] });
+});
+
+test("reset to the screen already shown still clears the stack", () => {
+  const s = prototypeNavReducer({ current: "Login", stack: ["Home"] }, { type: "reset", to: "Login" });
+  assert.deepEqual(s, { current: "Login", stack: [] });
+});

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -325,14 +325,15 @@ stops communicating.
 
 ## Worked example — risk register webapp wireframes
 
-A complete `wireframes.dsl` for a three-screen desktop flow. This example has a
-single role (no diverging permissions), so its chrome is uniform — every
-screen repeats the same `navbar` + `sidebar`; that's a property of this app,
-not the rule to imitate (see "Scope the chrome to the role" above for what
-changes once an app has more than one). Note the rest of the rhythm: blocks
-stack in reading order; `row` groups things side by side; the primary action is
-the one `primary` button per screen; status is carried by `badge`s, not prose.
-No coordinates anywhere — the compiler computes every position.
+A complete `wireframes.dsl` for a three-screen desktop flow. Its manager and
+owner roles happen to reach the same three destinations — dashboard, new-risk
+form, detail view — so their sidebars coincide and the chrome is uniform;
+that's a consequence of overlapping destinations, not evidence of a single
+role (see "Scope the chrome to the role" above — a role that cannot reach a
+destination must not list it). Note the rest of the rhythm: blocks stack in
+reading order; `row` groups things side by side; the primary action is the one
+`primary` button per screen; status is carried by `badge`s, not prose. No
+coordinates anywhere — the compiler computes every position.
 
 ```
 // Risk register — three screens, desktop

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -170,7 +170,7 @@ automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
 Line-oriented, nested by 2-space indentation. **No coordinates anywhere** —
 position comes from structure:
 
-```
+```text
 screen <Name> ["what this view is for"]   // one per view; description renders as a subtitle
   navbar "App | Nav1 -> Screen | Nav2"    // top bar; first item is the brand; bell+avatar automatic
   sidebar "Item1 -> Screen | Item2"       // left rail; same items on every screen a role sees
@@ -233,18 +233,19 @@ screen should be reachable by clicking — or be a landing screen whose
 description says which role it serves. Not every control needs an arrow; what
 matters is that no view is stranded.
 
-### Flows — one per role
+### Flows — one per role or journey
 
 The screens say what exists; a **flow** says who walks which ones, in what
 order. The prototype's top-level control is the flow picker, so a wireframe set
 without flows offers the reviewer no way to ask for the admin's journey.
 
-Declare one `flow` block per role or journey named in `design.md`, listing that
+Declare one `flow` block per role or journey named in `design.md` (or in
+`specs/requirements/` when the design doc is absent), listing that
 role's screens in walkthrough order, **entry screen first**. Name the flow for
 its **task** ("Approval queue", "Log a risk"), and carry the persona on a
 `role` line — not in the name:
 
-```
+```text
 flow "Approval queue"
   role "Admin"
   description "An admin reviews queued items and audits the outcome"
@@ -348,7 +349,7 @@ stack in reading order; `row` groups things side by side; the primary action
 is the one `primary` button per screen; status is carried by `badge`s, not
 prose. No coordinates anywhere — the compiler computes every position.
 
-```
+```text
 // Risk register — two roles, five screens, desktop
 
 screen RiskQueue "Manager monitors open risk across registers and acts on what's overdue"

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -240,15 +240,21 @@ order. The prototype's top-level control is the flow picker, so a wireframe set
 without flows offers the reviewer no way to ask for the admin's journey.
 
 Declare one `flow` block per role or journey named in `design.md`, listing that
-role's screens in walkthrough order, **entry screen first**:
+role's screens in walkthrough order, **entry screen first**. Name the flow for
+its **task** ("Approval queue", "Log a risk"), and carry the persona on a
+`role` line — not in the name:
 
 ```
-flow "Admin path"
+flow "Approval queue"
+  role "Admin"
+  description "An admin reviews queued items and audits the outcome"
   Login
   AdminQueue
   AuditDetail
 
-flow "Customer path"
+flow "My orders"
+  role "Customer"
+  description "A signed-in customer checks a placed order"
   Login          // a reference, not a copy — one screen, two memberships
   Orders
 ```
@@ -258,6 +264,11 @@ flow "Customer path"
 - The name is quoted and must be unique — declaring one flow twice rejects the
   write.
 - A name that matches no `screen` rejects the write with its line number.
+- `role "…"` names the persona who walks the flow; `description "…"` says what
+  the journey is, like a screen's description says what the view is. Both are
+  keyword lines inside the block, at most one of each (a duplicate rejects the
+  write). Give every role-serving flow its `role`; a genuinely role-less
+  journey (a public checkout) may omit it.
 - A screen in no flow is allowed, but ask yourself who reaches it.
 
 Syntax is validated at write time: an unknown keyword, a misplaced
@@ -456,24 +467,29 @@ screen RiskDetail "The owner tracks remediation for the risks they own"
       text "2h ago — A. Chen closed CVE-2026-1"
       text "1d ago — M. Diaz started cert rotation"
 
-flow "Manager path"
+flow "Approval queue"
+  role "Manager"
+  description "A manager triages queued risks and reviews each in detail"
   RiskQueue
   QueueRiskDetail
 
-flow "Owner path"
+flow "Log a risk"
+  role "Risk owner"
+  description "An owner records a new risk and tracks its remediation"
   MyRisks
   NewRisk
   RiskDetail
 ```
 
-The two `flow` blocks close the file: each lists only its own role's screens,
-entry screen first, and each screen is reachable by clicking from somewhere in
-its own flow — `RiskQueue`'s "Review next" CTA and its table both lead to
-`QueueRiskDetail`; `MyRisks`'s
-button leads to `NewRisk` and its table leads to `RiskDetail`. They are what
-the prototype's flow picker offers the reviewer — "Manager path" walks
-queue-then-escalate, "Owner path" walks log-then-remediate — and neither flow
-references a screen the other role can't reach.
+The two `flow` blocks close the file: each names its task, carries its `role`
+and a one-line `description`, and lists only its own role's screens, entry
+screen first. Each screen is reachable by clicking from somewhere in its own
+flow — `RiskQueue`'s "Review next" CTA and its table both lead to
+`QueueRiskDetail`; `MyRisks`'s button leads to `NewRisk` and its table leads to
+`RiskDetail`. They are what the prototype's flow picker offers the reviewer —
+the Manager's "Approval queue" walks queue-then-escalate, the Risk owner's
+"Log a risk" walks log-then-remediate — and neither flow references a screen
+the other role can't reach.
 
 Checklist before finishing a wireframe file:
 

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -351,7 +351,10 @@ screen RiskQueue "Manager monitors open risk across registers and acts on what's
     card "Open risks | 24 | across 6 registers"
     card "Overdue actions | 6 | need follow-up"
     card "High severity | 3 | review this week"
-  heading "Needs review"
+  row
+    heading "Needs review"
+    right
+    button "Review next" primary -> QueueRiskDetail
   tabs "All | Overdue | High severity"
   table "Risk | Owner | Severity | Status | Updated" -> QueueRiskDetail
     row "Unpatched edge servers | Platform team | High | Open | 2h ago"
@@ -397,17 +400,29 @@ screen QueueRiskDetail "Manager reviews progress and escalates risks that stall"
     badge "High" danger
     badge "Open" info
   text "Owner: Platform team — Updated 2h ago"
-  heading "Remediation"
-  progress "60%" info
-  text "6 of 10 actions complete"
-  table "Action | Assignee | Due | Status"
-    row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
-    row "Rotate edge certs | M. Diaz | Mon | In progress"
-    row "Close inbound 8443 | Platform | Tue | To do"
-  row
+  split 60/40
+    left
+      heading "Remediation"
+      progress "60%" info
+      text "6 of 10 actions complete"
+      table "Action | Assignee | Due | Status"
+        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+        row "Rotate edge certs | M. Diaz | Mon | In progress"
+        row "Close inbound 8443 | Platform | Tue | To do"
+      row
+        right
+        button "Reassign owner"
+        button "Escalate" primary
     right
-    button "Reassign owner"
-    button "Escalate" primary
+      card "Review notes"
+        text "You · 3d: second week overdue — needs a date."
+        text "R. Osei · 1d: agreed, escalate if Monday slips."
+        row
+          textarea "Add a review note…"
+          button "Post note"
+      heading "Review history"
+      text "1d ago — You flagged this risk for review"
+      text "6d ago — R. Osei reassigned it to Platform team"
 
 screen RiskDetail "The owner tracks remediation for the risks they own"
   navbar "RiskHub"
@@ -436,7 +451,7 @@ screen RiskDetail "The owner tracks remediation for the risks they own"
         text "M. Diaz · 1d: Monday, after the freeze."
         row
           textarea "Add a comment…"
-          button "Post" primary
+          button "Post"
       heading "Activity"
       text "2h ago — A. Chen closed CVE-2026-1"
       text "1d ago — M. Diaz started cert rotation"
@@ -453,7 +468,8 @@ flow "Owner path"
 
 The two `flow` blocks close the file: each lists only its own role's screens,
 entry screen first, and each screen is reachable by clicking from somewhere in
-its own flow — `RiskQueue`'s table leads to `QueueRiskDetail`; `MyRisks`'s
+its own flow — `RiskQueue`'s "Review next" CTA and its table both lead to
+`QueueRiskDetail`; `MyRisks`'s
 button leads to `NewRisk` and its table leads to `RiskDetail`. They are what
 the prototype's flow picker offers the reviewer — "Manager path" walks
 queue-then-escalate, "Owner path" walks log-then-remediate — and neither flow

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -325,41 +325,54 @@ stops communicating.
 
 ## Worked example — risk register webapp wireframes
 
-A complete `wireframes.dsl` for a three-screen desktop flow. Its manager and
-owner roles happen to reach the same three destinations — dashboard, new-risk
-form, detail view — so their sidebars coincide and the chrome is uniform;
-that's a consequence of overlapping destinations, not evidence of a single
-role (see "Scope the chrome to the role" above — a role that cannot reach a
-destination must not list it). Note the rest of the rhythm: blocks stack in
-reading order; `row` groups things side by side; the primary action is the one
-`primary` button per screen; status is carried by `badge`s, not prose. No
-coordinates anywhere — the compiler computes every position.
+A complete `wireframes.dsl` for a two-role desktop flow. The manager and the
+owner each get their own dashboard and detail screen — a shared `RiskDetail`
+would need two different sidebars, and a screen can only carry one, so each
+role's landing view and remediation view are split in two. `navbar` stays
+brand-only and identical everywhere; each `sidebar` lists only that role's
+destinations, and the items both roles have (Overview, All Registers, Audits,
+Settings) keep the same label and the same order — only the role-specific
+entry (Review Queue vs. My Risks) differs. Note the rest of the rhythm: blocks
+stack in reading order; `row` groups things side by side; the primary action
+is the one `primary` button per screen; status is carried by `badge`s, not
+prose. No coordinates anywhere — the compiler computes every position.
 
 ```
-// Risk register — three screens, desktop
+// Risk register — two roles, five screens, desktop
 
-screen RiskDashboard "Managers monitor open risk and act on what's overdue"
+screen RiskQueue "Manager monitors open risk across registers and acts on what's overdue"
   navbar "RiskHub"
-  sidebar "Overview | My Risks | All Registers | Audits | Settings"
+  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
   row
-    heading "Risk Overview"
+    heading "Risk Queue"
     right
-    button "New risk" primary -> NewRisk
+    select "Register: All"
   row
     card "Open risks | 24 | across 6 registers"
     card "Overdue actions | 6 | need follow-up"
     card "High severity | 3 | review this week"
-  heading "Recent activity"
-  tabs "All | Mine | Watching"
-  table "Risk | Owner | Severity | Status | Updated" -> RiskDetail
+  heading "Needs review"
+  tabs "All | Overdue | High severity"
+  table "Risk | Owner | Severity | Status | Updated" -> QueueRiskDetail
     row "Unpatched edge servers | Platform team | High | Open | 2h ago"
     row "Stale access keys | Security | Medium | In review | 1d ago"
     row "Vendor SOC2 lapse | Compliance | High | Overdue | 3d ago"
 
+screen MyRisks "Owner tracks the risks they own and logs new ones"
+  navbar "RiskHub"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  row
+    heading "My Risks"
+    right
+    button "New risk" primary -> NewRisk
+  table "Risk | Severity | Status | Updated" -> RiskDetail
+    row "Unpatched edge servers | High | Open | 2h ago"
+    row "Rotate edge certs | Medium | In progress | 1d ago"
+
 screen NewRisk "An owner logs a new risk into a register"
   navbar "RiskHub"
-  sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / New risk"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  breadcrumb "My Risks / New risk"
   heading "New Risk"
   input "Title — e.g. Unpatched edge servers"
   textarea "What is the risk and why does it matter?"
@@ -373,12 +386,33 @@ screen NewRisk "An owner logs a new risk into a register"
   row
     right
     button "Cancel"
-    button "Create risk" primary -> RiskDashboard
+    button "Create risk" primary -> MyRisks
 
-screen RiskDetail "The owner tracks remediation for one risk"
+screen QueueRiskDetail "Manager reviews progress and escalates risks that stall"
   navbar "RiskHub"
-  sidebar "Overview | My Risks | All Registers | Audits | Settings"
-  breadcrumb "Risks / Unpatched edge servers"
+  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
+  breadcrumb "Risk Queue / Unpatched edge servers"
+  row
+    heading "Unpatched edge servers"
+    badge "High" danger
+    badge "Open" info
+  text "Owner: Platform team — Updated 2h ago"
+  heading "Remediation"
+  progress "60%" info
+  text "6 of 10 actions complete"
+  table "Action | Assignee | Due | Status"
+    row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+    row "Rotate edge certs | M. Diaz | Mon | In progress"
+    row "Close inbound 8443 | Platform | Tue | To do"
+  row
+    right
+    button "Reassign owner"
+    button "Escalate" primary
+
+screen RiskDetail "The owner tracks remediation for the risks they own"
+  navbar "RiskHub"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  breadcrumb "My Risks / Unpatched edge servers"
   row
     heading "Unpatched edge servers"
     badge "High" danger
@@ -408,20 +442,22 @@ screen RiskDetail "The owner tracks remediation for one risk"
       text "1d ago — M. Diaz started cert rotation"
 
 flow "Manager path"
-  RiskDashboard
-  RiskDetail
+  RiskQueue
+  QueueRiskDetail
 
 flow "Owner path"
-  RiskDashboard
+  MyRisks
   NewRisk
   RiskDetail
 ```
 
-The two `flow` blocks close the file: they reference the same three screens
-declared above rather than duplicating them, and they are what the prototype's
-flow picker offers the reviewer — "Manager path" walks monitor-then-act,
-"Owner path" walks log-then-remediate, and both start at `RiskDashboard`
-because that's where each role lands first.
+The two `flow` blocks close the file: each lists only its own role's screens,
+entry screen first, and each screen is reachable by clicking from somewhere in
+its own flow — `RiskQueue`'s table leads to `QueueRiskDetail`; `MyRisks`'s
+button leads to `NewRisk` and its table leads to `RiskDetail`. They are what
+the prototype's flow picker offers the reviewer — "Manager path" walks
+queue-then-escalate, "Owner path" walks log-then-remediate — and neither flow
+references a screen the other role can't reach.
 
 Checklist before finishing a wireframe file:
 

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -105,11 +105,13 @@ Rules of thumb:
 
 - Name the screen for its role and put the role in the description:
   `screen ReviewQueue "Manager reviews and approves pending requests"`.
-- **A role screen is the SAME app — keep the identical `navbar` and `sidebar`
-  every other screen uses**, with the same items in the same order. The role
-  changes what's *inside* the screen — which buttons, columns, rows — not the
-  shell. Never give a scoped role its own smaller sidebar; that reads as a
-  different app.
+- **Scope the chrome to the role.** An admin screen's `sidebar` lists the
+  admin's destinations; a customer screen's lists the customer's. Real
+  permissioned apps do not show people links they cannot use, and a prototype
+  that does sends the reviewer down another persona's path.
+- **Keep the overlap identical.** Items both roles have use the same label,
+  the same order, and the same `navbar` brand, so the screens still read as one
+  product rather than two. Only the role-specific entries differ.
 - Reflect the real difference in **actions and data** — a role that can't
   approve/assign/delete simply doesn't have that button or column. Don't reskin
   one layout and call it two. The role difference should be legible from the
@@ -171,7 +173,7 @@ position comes from structure:
 ```
 screen <Name> ["what this view is for"]   // one per view; description renders as a subtitle
   navbar "App | Nav1 -> Screen | Nav2"    // top bar; first item is the brand; bell+avatar automatic
-  sidebar "Item1 -> Screen | Item2"       // left rail; same items on every screen of the app
+  sidebar "Item1 -> Screen | Item2"       // left rail; same items on every screen of a role's flow
   <kind> "<label>" [WxH] [variant] [-> Screen]   // a block: stacks below the previous one
   row                            // children go side by side (equal shares, 16px gaps)
     <kind> "<label>" …
@@ -231,6 +233,33 @@ screen should be reachable by clicking — or be a landing screen whose
 description says which role it serves. Not every control needs an arrow; what
 matters is that no view is stranded.
 
+### Flows — one per role
+
+The screens say what exists; a **flow** says who walks which ones, in what
+order. The prototype's top-level control is the flow picker, so a wireframe set
+without flows offers the reviewer no way to ask for the admin's journey.
+
+Declare one `flow` block per role or journey named in `design.md`, listing that
+role's screens in walkthrough order, **entry screen first**:
+
+```
+flow "Admin path"
+  Login
+  AdminQueue
+  AuditDetail
+
+flow "Customer path"
+  Login          // a reference, not a copy — one screen, two memberships
+  Orders
+```
+
+- A flow **references** screens by name; screens stay declared once. List a
+  shared screen (sign-in, a sign-out landing) in every flow that reaches it.
+- The name is quoted and must be unique — declaring one flow twice rejects the
+  write.
+- A name that matches no `screen` rejects the write with its line number.
+- A screen in no flow is allowed, but ask yourself who reaches it.
+
 Syntax is validated at write time: an unknown keyword, a misplaced
 `left`/`right`/table-`row`, or old-style x,y coordinates rejects the write with
 line numbers (`INVALID_DSL`) — fix every listed line and re-emit the file.
@@ -286,8 +315,11 @@ stops communicating.
   dashboard app) uses the `sidebar` for section links and a brand-only
   `navbar` (`navbar "Acme"`). A simple public flow (storefront, checkout) uses
   a link-carrying `navbar` and **no sidebar**. Never both on one screen.
-- Repeat the SAME `navbar` (and `sidebar`) verbatim on every screen of one app
-  — consistent chrome is what makes screens read as one product.
+- Repeat the SAME `navbar` on every screen of one app. Repeat the SAME
+  `sidebar` too, EXCEPT where a role's screens scope it to that role's
+  destinations — the items both roles share still keep the same label and
+  order, so the screens read as one product even when the rail isn't
+  word-for-word identical.
 - Comments start with `//`. Every screen should be reachable from some
   control's `-> Screen`.
 
@@ -370,7 +402,22 @@ screen RiskDetail "The owner tracks remediation for one risk"
       heading "Activity"
       text "2h ago — A. Chen closed CVE-2026-1"
       text "1d ago — M. Diaz started cert rotation"
+
+flow "Manager path"
+  RiskDashboard
+  RiskDetail
+
+flow "Owner path"
+  RiskDashboard
+  NewRisk
+  RiskDetail
 ```
+
+The two `flow` blocks close the file: they reference the same three screens
+declared above rather than duplicating them, and they are what the prototype's
+flow picker offers the reviewer — "Manager path" walks monitor-then-act,
+"Owner path" walks log-then-remediate, and both start at `RiskDashboard`
+because that's where each role lands first.
 
 Checklist before finishing a wireframe file:
 
@@ -378,7 +425,11 @@ Checklist before finishing a wireframe file:
   duplicate takes on the same screen. Where a role changes the view, there's a
   screen per role, named and described for it.
 - Every screen has a one-line description saying what it's for.
-- Chrome (`navbar`, `sidebar`) is identical across screens of the same app.
+- `navbar` is identical across every screen of the app; `sidebar` is scoped
+  to each role's destinations, with shared items kept at the same label and
+  order across roles.
+- Each role or journey named in `design.md` has its own `flow "<name>"` block,
+  entry screen first, referencing existing screens by name.
 - Labels are content-bearing ("Open risks | 24 | across 6 registers",
   "Platform team", "Overdue"), never placeholders like "text" or "label".
 - The right primitive does each job — `badge` for status, `tabs` for section

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -173,7 +173,7 @@ position comes from structure:
 ```
 screen <Name> ["what this view is for"]   // one per view; description renders as a subtitle
   navbar "App | Nav1 -> Screen | Nav2"    // top bar; first item is the brand; bell+avatar automatic
-  sidebar "Item1 -> Screen | Item2"       // left rail; same items on every screen of a role's flow
+  sidebar "Item1 -> Screen | Item2"       // left rail; same items on every screen a role sees
   <kind> "<label>" [WxH] [variant] [-> Screen]   // a block: stacks below the previous one
   row                            // children go side by side (equal shares, 16px gaps)
     <kind> "<label>" …
@@ -325,8 +325,11 @@ stops communicating.
 
 ## Worked example — risk register webapp wireframes
 
-A complete `wireframes.dsl` for a three-screen desktop flow. Note the rhythm:
-every screen repeats the same `navbar` + `sidebar` (consistent chrome); blocks
+A complete `wireframes.dsl` for a three-screen desktop flow. This example has a
+single role (no diverging permissions), so its chrome is uniform — every
+screen repeats the same `navbar` + `sidebar`; that's a property of this app,
+not the rule to imitate (see "Scope the chrome to the role" above for what
+changes once an app has more than one). Note the rest of the rhythm: blocks
 stack in reading order; `row` groups things side by side; the primary action is
 the one `primary` button per screen; status is carried by `badge`s, not prose.
 No coordinates anywhere — the compiler computes every position.


### PR DESCRIPTION
Closes #491.

Wireframes already give each role its own screens, but the prototype offered one flat screen list — a stakeholder couldn't ask "show me the manager's journey". This adds named flows to the wireframes DSL and makes them the prototype's top-level navigation: `wireframes.dsl` declares `flow "<name>"` blocks (with optional `role` and `description` lines) listing each persona's screens in walkthrough order, and the prototype toolbar leads with a User flow picker that scopes the screen picker to the chosen flow. Everything stays client-side derived from the `.dsl` (ADR-0008): no contract change, no BE handshake.

- `@aep/excalidraw-dsl`: parse named flow blocks (screen references, entry first; shared screens listed by every flow that reaches them), with write-gate errors for unknown screens, duplicate flow names, and duplicate role/description lines. Published as `PrototypeModel.flows`; the grid canvas marks each screen's membership (`Review claims · Screen 2`, `Common · Screen 1`) with layout untouched. Legacy bare `flow` blocks keep parsing and stay inert.
- `@aep/ui-excalidraw-view`: single-row toolbar — back · User flow · Screen · description (tooltip when truncated). Flow options carry `role · journey` on a second line; switching flows lands on the flow's entry screen and clears back-history. Cross-flow clicks navigate normally (the flow is a lens, not a cage); the current screen joins the picker when outside the flow. No flows declared → the picker vanishes and behaviour is identical to before.
- `@aep/console`: the full-screen route gains `?flow=` beside `?screen=`, each preserved when the other changes, so a shared link restores persona and screen; a route-level test pins the param-preserving navigation.
- `skills/wireframes`: chrome is now scoped per role (shared items keep identical label and order); one flow block per role/journey is required, named for the task with the persona on its `role` line. The worked example reworked to five role-split screens demonstrating the rule, validated through the real compiler.

## Proof of real execution

Tested against a real project (ExpenseHub, three roles) in the locally deployed platform — the flows below were authored by the design agent following the updated skill:

1. Prototype toolbar with the User flow picker on the manager's queue screen
2. Open flow menu showing each persona's role · journey per option

<img width="1660" height="873" alt="Screenshot 2026-08-17 at 21 52 52" src="https://github.com/user-attachments/assets/3bff8bdb-c63c-4362-afae-826a7f002f78" />
<img width="1660" height="873" alt="Screenshot 2026-08-17 at 21 52 58" src="https://github.com/user-attachments/assets/d21fdd90-a193-48a4-a676-f2ab27f21f89" />


## Testing

23 new compiler tests, 11 pure viewer-state tests, route tests including a revert-proven param-preservation test; full suites green on latest upstream/main (91 dsl · 17 viewer · 828 console), `make typecheck` / `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
