### PR TITLE
fix(scripts): project-rebuild deploys the build it just made

### DIFF
--- a/scripts/project-rebuild.sh
+++ b/scripts/project-rebuild.sh
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Rebuild one component of a platform-created project from what is on its
-# default branch — the local-dev trigger for
-# POST /projects/{project}/components/{component}/builds.
+# Rebuild AND deploy one component of a platform-created project from what is on
+# its default branch.
 #
 # The loop it was written for: clone the repo the platform created for a project,
 # change code by hand, push to the default branch, run this. The push alone does
@@ -36,17 +35,40 @@
 # this clones the head of the repo's default branch at the moment the build pod
 # runs. Push first, then run this.
 #
-# There is no deploy call to make afterwards, and none exists: components are
-# created AutoDeploy=true, so OpenChoreo drives Workload → ComponentRelease →
-# ReleaseBinding off a green build. The last section only watches that happen.
+# --- Why this script deploys, and what it deliberately does not deploy --------
 #
-# Requires jq — the build log is a JSON array, which sed cannot walk honestly.
+# Components carry `autoDeploy: false` (ADR-0017): a green build posts a Workload
+# and NOTHING promotes it. The platform's own deploy is a stage of the milestone
+# run, so an off-run hand-edit has no deploy behind it — this script performs one.
+#
+# It performs the SAME TWO WRITES the run supervisor's deploy stage performs
+# (projects.DeploymentService.deployOne): cut a ComponentRelease from the Workload
+# the build just posted, then point the component's existing ReleaseBinding at it.
+# The endpoint URL does not move — every name in the serving path (binding,
+# RenderedRelease, dataplane namespace, Service, gateway hostname) is keyed on
+# project/component/environment, never on the release.
+#
+# What it does NOT do, and this is the one way it differs from a real run: the
+# deploy stage rewrites the WHOLE binding from the CURRENT design in one call —
+# release pin, trait environment configs (jwtAuth) and workload overrides (env
+# vars, env-config.js) together, via DesiredDeploymentFor. This writes only the
+# pin, which is why the wiring already on the binding survives untouched. So a
+# hand-edit to CODE deploys exactly as the platform would; a change to the DESIGN
+# (api-security, env vars, a dependency's URL) does not reach the cluster through
+# here. Run a real cycle for that.
+#
+# It also deploys ONE component, so it skips the wave ordering a run derives from
+# the design's hard wiring edges (ADR-0019). In this loop the component's
+# dependencies are already up, which is what makes that safe.
+#
+# Requires jq — the build log and the ReleaseBinding are JSON, which sed cannot
+# walk honestly.
 set -euo pipefail
 
 usage() {
     echo "Usage: $(basename "$0") <project> <component>" >&2
     echo "  Builds <component> from the head of the project repo's default branch," >&2
-    echo "  tails the build log, then reports the deploy AutoDeploy performs." >&2
+    echo "  tails the build log, then cuts a release and re-pins the binding to it." >&2
 }
 
 PROJECT="${1:-}"
@@ -60,8 +82,25 @@ BFF_URL="${BFF_URL:-http://localhost:9090}"
 THUNDER_URL="${THUNDER_URL:-http://thunder.openchoreo.localhost:8080}"
 SEEDER_CLIENT_ID="${SEEDER_CLIENT_ID:-aep-local-dev-seeder}"
 SEEDER_CLIENT_SECRET="${SEEDER_CLIENT_SECRET:-aep-local-dev-seeder-secret}"
+
+# The deploy talks to OpenChoreo directly, because the BFF exposes no deploy
+# trigger — `POST /components/{c}/builds` has no sibling, and the only caller of
+# DeploymentService is the run supervisor's activity.
+#
+# It uses the BFF's OWN service identity rather than the seeder client above:
+# OpenChoreo authorises per resource, and the seeder token that reads components
+# is 403 on releasebindings. These are deployments/docker-compose.yml's local-dev
+# defaults for a plane on the loopback interface; both are overridable, and
+# neither is a credential any real environment shares.
+OC_API_URL="${OC_API_URL:-http://api.openchoreo.localhost:8080}"
+OC_CLIENT_ID="${OC_CLIENT_ID:-aep-api-client}"
+OC_CLIENT_SECRET="${OC_CLIENT_SECRET:-aep-api-client-secret}"
+
+# The environment a project's components serve in — openchoreo.DevEnvironmentName.
+ENVIRONMENT="${ENVIRONMENT:-development}"
+
 # Two separate budgets because they bound different things: a cold image build
-# is minutes, while AutoDeploy reacting to a posted Workload is seconds.
+# is minutes, while a binding re-pin rolling out is seconds.
 BUILD_TIMEOUT="${BUILD_TIMEOUT:-900}"
 DEPLOY_TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 POLL_INTERVAL="${POLL_INTERVAL:-3}"
@@ -81,7 +120,7 @@ for var in BUILD_TIMEOUT DEPLOY_TIMEOUT POLL_INTERVAL HEARTBEAT; do
 done
 
 if ! command -v jq > /dev/null 2>&1; then
-    echo "❌ jq is required (the build log is a JSON array)." >&2
+    echo "❌ jq is required (the build log and the ReleaseBinding are JSON)." >&2
     echo "   macOS: brew install jq" >&2
     exit 1
 fi
@@ -92,13 +131,16 @@ if ! curl -fsS --max-time 3 "$BFF_URL/healthz" > /dev/null 2>&1; then
     exit 1
 fi
 
-TOKEN=$(curl -sS -X POST "${THUNDER_URL%/}/oauth2/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "grant_type=client_credentials" \
-    -d "client_id=${SEEDER_CLIENT_ID}" \
-    -d "client_secret=${SEEDER_CLIENT_SECRET}" 2> /dev/null \
-    | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+mint_token() {
+    curl -sS -X POST "${THUNDER_URL%/}/oauth2/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=$1" \
+        -d "client_secret=$2" 2> /dev/null \
+        | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
 
+TOKEN=$(mint_token "$SEEDER_CLIENT_ID" "$SEEDER_CLIENT_SECRET")
 if [ -z "$TOKEN" ]; then
     echo "❌ Thunder did not return an access_token for '${SEEDER_CLIENT_ID}'."
     echo "   The client is registered by deployments/scripts/setup-local.sh / start.sh."
@@ -107,29 +149,91 @@ fi
 
 API="${BFF_URL}/api/v1/projects/${PROJECT}/components/${COMPONENT}"
 
-# --- Baseline the deploy rows ------------------------------------------------
+# --- Everything the deploy needs is resolved BEFORE the build ----------------
 #
-# Read BEFORE the build, because AutoDeploy ROLLS THE EXISTING ReleaseBinding
-# rather than creating a new one — so "a deploy happened" is only visible as a
-# change against what was there beforehand, never as a row appearing.
-deployments_json() {
-    curl -sS -H "Authorization: Bearer ${TOKEN}" "${API}/deployments" 2> /dev/null || true
+# A build is minutes and a pushed image; discovering only afterwards that the
+# deploy cannot run is the one failure this ordering exists to prevent.
+
+OC_TOKEN=$(mint_token "$OC_CLIENT_ID" "$OC_CLIENT_SECRET")
+if [ -z "$OC_TOKEN" ]; then
+    echo "❌ Thunder did not return an access_token for '${OC_CLIENT_ID}' (the deploy identity)."
+    echo "   Set OC_CLIENT_ID / OC_CLIENT_SECRET to this plane's aep-api client."
+    exit 1
+fi
+
+# OpenChoreo's `namespace` path segment is the ORG. The BFF derives it from the
+# token, so it is never on the wire; ask it which org this token is bound to.
+# ORG= overrides for a plane carrying more than one.
+ORG="${ORG:-}"
+if [ -z "$ORG" ]; then
+    ORG=$(curl -sS -H "Authorization: Bearer ${TOKEN}" "${BFF_URL}/api/v1/organizations" 2> /dev/null \
+        | jq -r '.items[0].name // empty')
+fi
+if [ -z "$ORG" ]; then
+    echo "❌ Could not resolve the org from ${BFF_URL}/api/v1/organizations."
+    echo "   Pass it explicitly:  ORG=<org> $(basename "$0") ${PROJECT} ${COMPONENT}"
+    exit 1
+fi
+
+# The two OpenChoreo names this script has to spell for itself. Both are rules
+# Go owns — ocname.ScopedComponentName and openchoreo.ReleaseBindingName — and a
+# bash script cannot import them, so this is a SECOND SPELLING that will drift if
+# either rule changes. It is spelled once, here, so there is one place to fix.
+SCOPED="${PROJECT}-${COMPONENT}"
+BINDING="${SCOPED}-${ENVIRONMENT}"
+
+# Body and status separately, so a refusal prints its reason instead of being
+# swallowed by a non-2xx exit.
+oc_call() {
+    local method="$1" path="$2" body="${3:-}"
+    if [ -n "$body" ]; then
+        curl -sS -X "$method" "${OC_API_URL%/}${path}" \
+            -H "Authorization: Bearer ${OC_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$body" -w '\n%{http_code}' 2>&1
+    else
+        curl -sS -X "$method" "${OC_API_URL%/}${path}" \
+            -H "Authorization: Bearer ${OC_TOKEN}" -w '\n%{http_code}' 2>&1
+    fi
 }
 
-# Sorted keys so the comparison is over content, not field order.
-deploy_fingerprint() {
-    printf '%s' "$1" | jq -rSc '[.items[]? | {environment, releaseName, status}]' 2> /dev/null || printf ''
-}
+BINDING_PATH="/api/v1/namespaces/${ORG}/releasebindings/${BINDING}"
 
-BEFORE_JSON="$(deployments_json)"
-BEFORE="$(deploy_fingerprint "$BEFORE_JSON")"
+# A component with no binding yet cannot be deployed from here, and must not be:
+# writing a pin-only binding would create one carrying no traits, no env vars and
+# no files, which is a half-written object OpenChoreo would render and serve.
+# DeploymentService.Converge refuses the same case for the same reason.
+PRE=$(oc_call GET "$BINDING_PATH")
+PRE_CODE="${PRE##*$'\n'}"
+if [ "$PRE_CODE" = "404" ]; then
+    echo "❌ No ReleaseBinding ${BINDING} in org ${ORG} — this component has never been deployed."
+    echo "   Only a milestone run writes the first binding (it carries the trait configs,"
+    echo "   env vars and files this script deliberately does not compose). Run a cycle first."
+    exit 1
+fi
+if [ "$PRE_CODE" != "200" ]; then
+    echo "❌ Could not read ReleaseBinding ${BINDING} (HTTP ${PRE_CODE})."
+    echo "   ${PRE%$'\n'*}"
+    exit 1
+fi
+
+# A component provisioned before ADR-0017 still carries autoDeploy: true, and
+# OpenChoreo's controller then promotes the build's Workload on its own — racing
+# the pin below over one field. A WARNING and not a refusal: the race is usually
+# won by whoever writes last and the wait loop names the loss explicitly, so the
+# rebuild is still worth running. EnsureComponent re-asserts false the next time
+# a real cycle touches this component.
+if [ "$(oc_call GET "/api/v1/namespaces/${ORG}/components/${SCOPED}" | jq -r '.spec.autoDeploy // false' 2> /dev/null)" = "true" ]; then
+    echo "⚠️  ${SCOPED} still carries autoDeploy: true — OpenChoreo will promote this build too,"
+    echo "    so its release and this script's may race. To settle it before building:"
+    echo "    kubectl patch components.openchoreo.dev -n ${ORG} ${SCOPED} --type=merge -p '{\"spec\":{\"autoDeploy\":false}}'"
+    echo
+fi
 
 # --- Trigger -----------------------------------------------------------------
 
 echo "🔨 Building ${PROJECT}/${COMPONENT} from the default branch head"
 
-# Body and status separately, so a refusal prints its reason instead of being
-# swallowed by a non-2xx exit.
 RESP=$(curl -sS -X POST "${API}/builds" \
     -H "Authorization: Bearer ${TOKEN}" \
     -w '\n%{http_code}' 2>&1)
@@ -196,7 +300,7 @@ else
     done
 fi
 
-# --- The verdict -------------------------------------------------------------
+# --- The build verdict -------------------------------------------------------
 #
 # The log ending is not the verdict; the run's terminal condition Reason is. It
 # is read off the builds listing, which the BFF caps at 20 runs with no ordering
@@ -262,47 +366,202 @@ if [ "$STATUS" != "WorkflowSucceeded" ]; then
 fi
 echo "✅ Build ${RUN} succeeded."
 
-# --- The deploy that follows -------------------------------------------------
+# --- Cut the release ---------------------------------------------------------
 #
-# Nothing is triggered here. What is worth waiting for is EVIDENCE the green
-# build reached the cluster, and the deploy rows changing is the only honest one
-# available: `status` is the ReleaseBinding's LATEST CONDITION REASON — a display
-# string whose array order OpenChoreo does not guarantee — so this waits for
-# movement and then prints what the rows say rather than declaring the app ready.
+# The release is named off THIS BUILD, not off a commit, and that is the whole
+# reason the loop works. `generate-release` treats a name that already exists as
+# success, so a release name that did not change per build would silently keep
+# the previous image serving — and a rebuild with no new push (a Dockerfile fix,
+# a retry) is exactly that case. The build run name ends in the unix-milli suffix
+# openchoreo.NewBuildRunName appends, so it is unique per build and stable across
+# a re-run of this script for the same build.
+#
+# The 18/18 caps mirror projects.ReleaseNameFor's widths, which keep the whole
+# name inside the k8s label budget a release name is bound by.
+cap18() { printf '%s' "$1" | cut -c1-18 | sed 's/-*$//'; }
+
+SUFFIX="${RUN##*-}"
+if ! [[ "$SUFFIX" =~ ^[0-9]+$ ]]; then
+    # The run name was not shaped as expected. Fall back to its own tail rather
+    # than to a fixed string, which would collide across builds.
+    SUFFIX="$(printf '%s' "$RUN" | tr -cd 'a-z0-9' | tail -c 13)"
+fi
+RELEASE="$(cap18 "$PROJECT")-$(cap18 "$COMPONENT")-${SUFFIX}"
+
 echo
-echo "⏳ Waiting for AutoDeploy to move the ReleaseBinding…"
-AFTER_JSON="$BEFORE_JSON"
-MOVED=0
+echo "🚀 Cutting release ${RELEASE} from the Workload the build posted"
+CUT=$(oc_call POST "/api/v1/namespaces/${ORG}/components/${SCOPED}/generate-release" \
+    "{\"releaseName\":\"${RELEASE}\"}")
+CUT_CODE="${CUT##*$'\n'}"
+case "$CUT_CODE" in
+    200 | 201) ;;
+    # Already there — this script ran for this build before. The release was cut
+    # from the same build's Workload, so it is the one we want.
+    409) echo "   (release already existed — re-running for the same build)" ;;
+    *)
+        echo "❌ Could not cut the release (HTTP ${CUT_CODE})."
+        echo "   ${CUT%$'\n'*}"
+        exit 1
+        ;;
+esac
+
+# --- Re-pin the binding ------------------------------------------------------
+#
+# Read-modify-write of spec.releaseName ALONE. Everything else on the binding —
+# trait environment configs, workload overrides, the fields OpenChoreo's own
+# controllers own — is carried through untouched, which is what makes a pin-only
+# write safe here where a blind PUT would not be.
+#
+# Retried on 5xx because OpenChoreo's controllers rewrite these bindings
+# continuously and report a lost write race as a generic 500 (the same reason the
+# Go client wraps this call in retryStaleWrite).
+echo "📌 Pinning ${BINDING} to ${RELEASE}"
+PINNED=0
+OBSERVED_BEFORE=0
+REPINNED=1
+for attempt in 1 2 3; do
+    # Re-derived per attempt, not carried over: a retry re-reads, and the answer
+    # this decides ("will a reconcile follow our write?") is a property of the
+    # state we just read, not of the state the failed attempt read.
+    REPINNED=1
+    CUR=$(oc_call GET "$BINDING_PATH")
+    CUR_CODE="${CUR##*$'\n'}"
+    CUR_JSON="${CUR%$'\n'*}"
+    if [ "$CUR_CODE" != "200" ]; then
+        echo "❌ Could not read ${BINDING} (HTTP ${CUR_CODE})."
+        echo "   ${CUR_JSON}"
+        exit 1
+    fi
+    # Read from the SAME response the write is built on, so what the wait below
+    # treats as "before" is the state this write actually replaced.
+    OBSERVED_BEFORE=$(printf '%s' "$CUR_JSON" | jq -r '
+        (.status.conditions // [] | map(select(.type == "Ready")) | first)
+        | .observedGeneration // 0')
+    if [ "$(printf '%s' "$CUR_JSON" | jq -r '.spec.releaseName // ""')" = "$RELEASE" ]; then
+        # Already pinned here — a re-run for the same build. The write changes
+        # nothing, so no reconcile follows and the wait must not expect one.
+        REPINNED=0
+    fi
+    BODY=$(printf '%s' "$CUR_JSON" | jq -c --arg r "$RELEASE" '.spec.releaseName = $r')
+    PUT=$(oc_call PUT "$BINDING_PATH" "$BODY")
+    PUT_CODE="${PUT##*$'\n'}"
+    PUT_JSON="${PUT%$'\n'*}"
+    if [ "$PUT_CODE" = "200" ] || [ "$PUT_CODE" = "201" ]; then
+        PINNED=1
+        break
+    fi
+    if [ "$PUT_CODE" -ge 500 ] 2> /dev/null; then
+        echo "   ↻ stale write (HTTP ${PUT_CODE}), re-reading… (attempt ${attempt}/3)"
+        sleep "$POLL_INTERVAL"
+        continue
+    fi
+    echo "❌ Could not pin ${BINDING} (HTTP ${PUT_CODE})."
+    echo "   ${PUT_JSON}"
+    exit 1
+done
+
+if [ "$PINNED" != "1" ]; then
+    echo "❌ Could not pin ${BINDING} after 3 attempts — OpenChoreo kept rewriting it."
+    exit 1
+fi
+
+# --- Wait for it to come up --------------------------------------------------
+#
+# The binding's Ready condition is the verdict, and observedGeneration is what
+# makes it honest: a binding that was already serving reports Ready=True from the
+# PREVIOUS generation the instant after the pin lands, so reading the condition
+# alone would declare a deploy that has not started yet a success. The condition
+# carries the generation the controller stamped it at, and `metadata.generation`
+# is NOT on the wire (openchoreo-api strips it), so the gate is that the stamp
+# has ADVANCED past what the pin replaced — not that it matches a known number.
+#
+# spec.releaseName is re-read every poll for a different reason: this script is
+# not guaranteed to be the only writer of the pin. A component still carrying
+# `autoDeploy: true` from before ADR-0017 has OpenChoreo's controller promoting
+# releases too, and silently waiting for OUR release to come up while the
+# controller serves ITS one is the failure worth naming out loud.
+#
+# Ready=False is the binding's INITIAL state while it renders and rolls out, so
+# only the short list of reasons that waiting cannot fix is treated as failure —
+# the same allow-list as projects.terminalDeployReason. Everything else is
+# pending, bounded by DEPLOY_TIMEOUT.
+echo
+echo "⏳ Waiting for ${BINDING} to come up on ${RELEASE}…"
+READY="false"
+LAST_REASON=""
+LAST_BEAT=$SECONDS
+WAIT_FROM=$SECONDS
 DEPLOY_DEADLINE=$((SECONDS + DEPLOY_TIMEOUT))
 while [ "$SECONDS" -lt "$DEPLOY_DEADLINE" ]; do
-    NOW_JSON="$(deployments_json)"
-    NOW_FP="$(deploy_fingerprint "$NOW_JSON")"
-    # An unparseable read is a transient error, not a change — keep the last good
-    # rows rather than reporting a deploy that did not happen.
-    if [ -n "$NOW_FP" ]; then
-        AFTER_JSON="$NOW_JSON"
-        if [ "$NOW_FP" != "$BEFORE" ]; then
-            MOVED=1
+    NOW=$(oc_call GET "$BINDING_PATH")
+    NOW_CODE="${NOW##*$'\n'}"
+    if [ "$NOW_CODE" = "200" ]; then
+        # `|` and not a tab: read collapses runs of whitespace separators, which
+        # would shift the fields whenever a reason is empty.
+        IFS='|' read -r R_RELEASE R_STATUS R_REASON R_OBSERVED <<< "$(
+            printf '%s' "${NOW%$'\n'*}" | jq -r '
+                (.status.conditions // [] | map(select(.type == "Ready")) | first) as $c
+                | [.spec.releaseName // "", $c.status // "", $c.reason // "",
+                   ($c.observedGeneration // 0 | tostring)] | join("|")')"
+        ELAPSED=$((SECONDS - WAIT_FROM))
+
+        if [ "$R_RELEASE" != "$RELEASE" ]; then
+            echo
+            echo "❌ ${BINDING} is pinned to ${R_RELEASE:-nothing}, not ${RELEASE} — something re-pinned it."
+            echo "   Most likely the component still carries autoDeploy: true, so OpenChoreo promotes"
+            echo "   releases of its own. Check:"
+            echo "   kubectl get components.openchoreo.dev -n ${ORG} ${SCOPED} -o jsonpath='{.spec.autoDeploy}'"
+            exit 1
+        fi
+        if [ "$REPINNED" = "1" ] && [ "${R_OBSERVED:-0}" -le "${OBSERVED_BEFORE:-0}" ] 2> /dev/null; then
+            R_REASON="not observed yet"
+        elif [ "$R_STATUS" = "True" ]; then
+            READY="true"
             break
+        else
+            case "$(printf '%s' "$R_REASON" | tr '[:upper:]' '[:lower:]')" in
+                renderingfailed | renderfailed | invalidrelease | releasenotfound)
+                    echo "   [$(mmss "$ELAPSED")] ${R_REASON}"
+                    echo
+                    echo "❌ ${BINDING} will not come up: ${R_REASON}."
+                    echo "   kubectl describe releasebinding -n ${ORG} ${BINDING}"
+                    exit 1
+                    ;;
+            esac
+        fi
+
+        if [ "$R_REASON" != "$LAST_REASON" ]; then
+            echo "   [$(mmss "$ELAPSED")] ${R_REASON:-pending}"
+            LAST_REASON="$R_REASON"
+            LAST_BEAT=$SECONDS
+        elif [ $((SECONDS - LAST_BEAT)) -ge "$HEARTBEAT" ]; then
+            echo "   [$(mmss "$ELAPSED")] still ${R_REASON:-pending}…"
+            LAST_BEAT=$SECONDS
         fi
     fi
     sleep "$POLL_INTERVAL"
 done
 
-if [ "$MOVED" = "1" ]; then
-    echo "✅ The deploy rows changed."
+echo
+if [ "$READY" = "true" ]; then
+    echo "✅ ${COMPONENT} is serving ${RELEASE}."
 else
-    echo "⏱  The deploy rows did not change within ${DEPLOY_TIMEOUT}s."
-    echo "   Either the binding was already at this release, or the rollout is still in flight."
+    echo "⏱  ${BINDING} did not report Ready within ${DEPLOY_TIMEOUT}s (last: ${LAST_REASON:-unknown})."
+    echo "   The rollout may still land. Watch it:"
+    echo "   kubectl describe releasebinding -n ${ORG} ${BINDING}"
 fi
 
 echo
 echo "   Deployments:"
-printf '%s' "$AFTER_JSON" | jq -r '
+curl -sS -H "Authorization: Bearer ${TOKEN}" "${API}/deployments" 2> /dev/null | jq -r '
     if ((.items // []) | length) == 0 then
         "     (no ReleaseBinding for this component yet)"
     else
         .items[]
-        | "     \(.environment // "?"): \(.status // "?")"
-          + (if (.endpointUrl // "") != "" then "  → " + .endpointUrl else "" end)
+        | "     \(.environment // "?"): \(.status // "?")  [\(.releaseName // "?")]"
+          + (if (.endpointUrl // "") != "" then "\n       → " + .endpointUrl else "" end)
     end'
+
+if [ "$READY" != "true" ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Problem

ADR-0017 flipped components to `autoDeploy: false` and moved the deploy into the run supervisor's cycle stage. `scripts/project-rebuild.sh` predates that and was never updated, so its last third became wrong:

- It builds the image, the build posts a Workload, and **nothing promotes it** — the only caller of `DeploymentService.Deploy` is `delivery/run/activities.go:443`, and the BFF exposes no deploy trigger (`/deployments` is GET-only).
- The "Waiting for AutoDeploy to move the ReleaseBinding…" block therefore always times out and prints *"the rollout is still in flight"*, which is false.
- Its header comment — *"There is no deploy call to make afterwards, and none exists"* — is now true for the wrong reason.

The hand-edit loop the script exists for (clone repo → edit → push → rebuild) stopped being end-to-end.

## What changed

The script now performs the same two writes the run supervisor's deploy stage performs (`projects.DeploymentService.deployOne`), against the OpenChoreo API:

1. **Cut the release** — `POST /api/v1/namespaces/{org}/components/{project}-{component}/generate-release`, named `{project:18}-{component:18}-{millis}` off the build run's unix-milli suffix.
2. **Re-pin** — read-modify-write of `spec.releaseName` **alone** on the existing binding, retried 3× on 5xx (OpenChoreo reports a lost write race as a generic 500, same reason the Go client wraps this in `retryStaleWrite`).
3. **Wait honestly** — poll the binding's Ready condition, gated on `observedGeneration` advancing past what the pin replaced.

Supporting changes:

- Pre-flight resolves the OC token, the org and the binding **before** spending a build, and refuses a component with no binding — a pin-only write would create one carrying no traits, env vars or files, the case `DeploymentService.Converge` refuses for the same reason.
- Uses the BFF's own service identity (`aep-api-client`) for OpenChoreo, not the seeder client: OpenChoreo authorises per resource and the seeder token is **403 on `releasebindings`**. Both credentials are `deployments/docker-compose.yml`'s local-dev defaults and are overridable (`OC_CLIENT_ID`/`OC_CLIENT_SECRET`).
- Exit code now reflects the deploy, not just the build.

### Why the release name is build-derived, not commit-derived

`EnsureRelease` treats 409 as success (`component_chain_client.go:103`). A commit-derived name would 409 onto the existing release whenever you rebuild without a new push (a Dockerfile fix, a retry) and **silently keep serving the old image**. The build run name carries a unix-milli suffix (`oc_names.go:59`), so it is unique per build and stable across a re-run of the script for the same build.

### What it deliberately does not do

The deploy stage rewrites the **whole** binding from the current design in one call — release pin, trait environment configs (jwtAuth) and workload overrides (env vars, `env-config.js`) — via `DesiredDeploymentFor`. This writes only the pin, which is exactly why the wiring already on the binding survives untouched. So a hand-edit to **code** deploys as the platform would; a change to the **design** does not reach the cluster through here. Documented in the script header.

It also deploys one component, skipping the wave ordering a run derives from the design's hard wiring edges (ADR-0019) — safe in this loop because the component's dependencies are already up.

## Verification

All against a live local plane. **Read-only — no release was cut and no binding was written.**

```
1. seeder token: ok
2. oc token: ok
3. org resolved: 'default'
4. names: scoped='p18-bare-minimum-hello-hello-webapp' binding='p18-bare-minimum-hello-hello-webapp-development'
5. binding pre-check: HTTP 200
6. missing-binding branch: HTTP 404
7. release name: 'p18-bare-minimum-h-hello-webapp-1755400000000' (len 45, budget 63)
9. rmw preserves siblings: {"releaseName":"...","kept":["environment","owner","releaseName","state","workloadOverrides"]}
```

`generate-release` authorises correctly — a fake component returns `404 {"code":"NOT_FOUND","error":"Component not found"}`, i.e. past auth, not rejected by it.

**The endpoint URL does not move on a re-pin.** Every name in the serving path is keyed on project/component/environment, never on the release. Empirically on `p18`: the RenderedRelease was created `2026-08-03T11:51:49Z` and the HTTPRoute is 14d old, while the binding pins a release created `2026-08-14T05:38:52Z` — re-pinned 11 days later, both objects updated in place with identity and timestamps intact.

### A bug caught and fixed during verification

The first version of the readiness gate compared the Ready condition's `observedGeneration` against `metadata.generation`. **openchoreo-api strips `generation` from metadata** (kubectl reports `4`; the API response has no such field), so the gate was inert and would have reported success instantly off the *previous* generation's `Ready=True` — precisely the lie it existed to prevent. It now requires the stamp to advance past what the pin replaced, with a no-op path when the pin changes nothing. Gate truth table, exercised under bash 3.2:

```
E. real re-pin, stale Ready=True from old gen : WAIT (not observed yet)   <- the bug
F. real re-pin, controller caught up          : READY
G. real re-pin, caught up but not ready       : POLL
H. no-op re-pin (same release, no bump)       : READY
I. no-op re-pin, not ready                    : POLL
```

Field parsing uses `|` rather than tabs because `read` collapses runs of whitespace separators, which shifted fields whenever a condition reason was empty. Verified with empty `status`+`reason` (obs still parses as `7`) and with a conditions-less binding (no crash, obs `0`).

`bash -n` clean. Local bash is 3.2.57, so no 4.x-only parameter expansions are used.

## Not yet verified

**The two write calls and the full build→deploy loop have not been run end-to-end.** That needs a real build (minutes, an image push) and a live re-pin on a test project. Everything above is read-only probing of the same paths, payload shapes and decision logic. Happy to run it against a scratch project and attach the output before merge.

`/code-review` has not been run on this yet either.

## Note for reviewers: existing components still carry `autoDeploy: true`

Every user component on my local cluster (`p12`, `p15`, `p16`, `p18`, `p24`, `p25`) still has `autoDeploy: true` — `EnsureComponent` only re-asserts `false` when a real cycle next touches them. Until then OpenChoreo promotes the build's Workload itself and races this script over one field. Two guards were added rather than mutating the flag:

- a pre-flight **warning** with the `kubectl patch` to settle it, before minutes are spent on a build;
- the wait loop re-reads `spec.releaseName` each poll and **fails loudly** with that diagnosis if the pin is taken from under it.

The script does not flip the flag itself — that is a platform invariant `EnsureComponent` owns, and a script that leaves it flipped would hand a later run two writers on one binding's pin.

Also worth flagging as pre-existing staleness this PR does not touch: `component_service.go:39-56` and `componentbuild/handler.go:86` still document the AutoDeploy-drives-deploy chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
