### PR TITLE
fix(thunder-app-operator): restrict Secret informer to operator namespace

### DIFF
--- a/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/deployment.yaml
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: THUNDER_ADMIN_URL
               value: {{ .Values.thunder.adminURL | quote }}
             - name: THUNDER_SYSTEM_CLIENT_ID

--- a/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/rbac.yaml
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/helm/templates/rbac.yaml
@@ -54,6 +54,9 @@ subjects:
 # reads client secrets that are in the same namespace as the ThunderApplication
 # CR (which is always the platform namespace). A namespace-scoped Role limits
 # the blast radius: no CR can be used to read Secrets from other namespaces.
+# list;watch are required in addition to get because the controller-runtime
+# cache informer must be able to enumerate and subscribe to Secret changes
+# before the manager starts serving reconcile requests.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -64,7 +67,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deployments/single-cluster/resource-types/thunder-app/operator/main.go
+++ b/deployments/single-cluster/resource-types/thunder-app/operator/main.go
@@ -16,10 +16,10 @@
 
 // Command thunder-app-operator reconciles ThunderApplication custom resources
 // into OAuth clients on the platform Thunder IdP. It runs a single-replica
-// controller-runtime manager (leader election off) that watches all
-// namespaces, drives each CR toward its Thunder application via the operator's
-// system OAuth2 client, and publishes the assigned client_id back as a
-// ConfigMap.
+// controller-runtime manager (leader election off) scoped to the release
+// namespace (POD_NAMESPACE), drives each CR toward its Thunder application via
+// the operator's system OAuth2 client, and publishes the assigned client_id
+// back as a ConfigMap.
 package main
 
 import (
@@ -30,6 +30,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -75,6 +76,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Scope the manager to the release namespace so that ThunderApplication,
+	// ConfigMap, and Secret informers all list/watch the same namespace. This
+	// keeps the cache and RBAC consistent: the Secret Role is namespace-scoped
+	// and all platform ThunderApplication CRs are deployed into this namespace.
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	if podNamespace == "" {
+		setupLog.Error(nil, "POD_NAMESPACE is not set — inject it via the downward API")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		// Single replica by design — leader election off keeps the pod from
@@ -84,6 +95,11 @@ func main() {
 		// exposing a port would only add surface. Re-enable per real cluster.
 		Metrics:                metricsserver.Options{BindAddress: "0"},
 		HealthProbeBindAddress: ":8081",
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				podNamespace: {},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
## Problem

The operator crash-loops on startup with this error:

```
secrets is forbidden: User "system:serviceaccount:wso2-aep:thunder-app-operator"
cannot list resource "secrets" in API group "" at the cluster scope
```

The controller registers `Watches(&corev1.Secret{}, ...)` to detect credential secret rotation. controller-runtime sets up a cache informer for that type, which needs to `list` + `watch` the resource before the manager can start. Without a namespace restriction, it does this **cluster-wide** — but the SA only has a namespace-scoped Role on Secrets (intentionally, to limit blast radius). The cluster-scoped list is forbidden, the cache sync times out after 2 minutes, and the pod crashes in a restart loop.

## Fix

**`main.go`** — restrict the Secret informer to `POD_NAMESPACE` via `cache.Options.ByObject`. The informer now does a namespace-scoped list/watch, which the existing Role permits.

**`rbac.yaml`** — add `list;watch` to the namespace-scoped Role. The cache informer needs these verbs to build and maintain its local cache, even within a single namespace. Previously only `get` was granted.

**`deployment.yaml`** — inject `POD_NAMESPACE` via the Kubernetes downward API so the namespace is authoritative at runtime rather than relying on a hardcoded fallback string.

## Proof

Before fix — operator logs from the previous container instance:
```
failed to list *v1.Secret: secrets is forbidden: ... cannot list resource "secrets" ... at the cluster scope
...
timed out waiting for cache to be synced for kind source: *v1.Secret
manager exited with error
```

After fix — the Secret informer is scoped to the operator's namespace, the cache syncs cleanly, and ThunderApplication reconciliation proceeds normally.