### PR TITLE
fix(console): show Open app on overview when a web-application is deployed

### DIFF
--- a/apps/console/src/features/projects/components/ComponentsList.test.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { components } from "../../../generated/aep-api";
+
+let mockUrl: string | undefined = "https://storefront.dev.example.com/";
+
+vi.mock("../api/queries", () => ({
+  useComponentEndpointUrl: () => ({ data: mockUrl }),
+}));
+
+vi.mock("./ComponentOpenApiDialog", () => ({
+  ComponentOpenApiDialog: () => null,
+}));
+
+import { ComponentsList } from "./ComponentsList";
+
+type Component = components["schemas"]["Component"];
+
+const webapp: Component = {
+  name: "storefront",
+  displayName: "Storefront",
+  description: "SPA",
+  type: "web-application",
+  status: "active",
+};
+
+describe("ComponentsList — Open app", () => {
+  it("links a deployed web-application to its public URL", () => {
+    mockUrl = "https://storefront.dev.example.com/";
+    render(<ComponentsList projectName="shop" items={[webapp]} />);
+    const link = screen.getByRole("link", { name: "Open Storefront" });
+    expect(link).toHaveAttribute("href", "https://storefront.dev.example.com/");
+  });
+
+  it("omits Open when the web-application has no public URL yet", () => {
+    mockUrl = undefined;
+    render(<ComponentsList projectName="shop" items={[webapp]} />);
+    expect(screen.queryByRole("link", { name: "Open Storefront" })).toBeNull();
+  });
+});

--- a/apps/console/src/features/projects/components/ComponentsList.test.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.test.tsx
@@ -19,7 +19,7 @@
 // @vitest-environment jsdom
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../../../generated/aep-api";
 
 let mockUrl: string | undefined = "https://storefront.dev.example.com/";
@@ -44,9 +44,20 @@ const webapp: Component = {
   status: "active",
 };
 
+const service: Component = {
+  name: "catalog-api",
+  displayName: "Catalog API",
+  description: "API",
+  type: "service",
+  status: "active",
+};
+
 describe("ComponentsList — Open app", () => {
-  it("links a deployed web-application to its public URL", () => {
+  beforeEach(() => {
     mockUrl = "https://storefront.dev.example.com/";
+  });
+
+  it("links a deployed web-application to its public URL", () => {
     render(<ComponentsList projectName="shop" items={[webapp]} />);
     const link = screen.getByRole("link", { name: "Open Storefront" });
     expect(link).toHaveAttribute("href", "https://storefront.dev.example.com/");
@@ -56,5 +67,10 @@ describe("ComponentsList — Open app", () => {
     mockUrl = undefined;
     render(<ComponentsList projectName="shop" items={[webapp]} />);
     expect(screen.queryByRole("link", { name: "Open Storefront" })).toBeNull();
+  });
+
+  it("does not put Open on a service row", () => {
+    render(<ComponentsList projectName="shop" items={[service]} />);
+    expect(screen.queryByRole("link", { name: /Open / })).toBeNull();
   });
 });

--- a/apps/console/src/features/projects/components/ComponentsList.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.tsx
@@ -161,7 +161,6 @@ function WebAppOpenLink({
       rel="noreferrer"
       variant="body2"
       aria-label={`Open ${displayName}`}
-      onClick={(e) => e.stopPropagation()}
       sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, flexShrink: 0 }}
     >
       Open app <ExternalLink size={14} />

--- a/apps/console/src/features/projects/components/ComponentsList.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.tsx
@@ -22,13 +22,15 @@ import {
   Box,
   Card,
   CardContent,
+  Link as MuiLink,
   Stack,
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Boxes } from "@wso2/oxygen-ui-icons-react";
+import { Boxes, ExternalLink } from "@wso2/oxygen-ui-icons-react";
 import { EmptyState } from "../../../components/EmptyState";
 import type { components } from "../../../generated/aep-api";
+import { useComponentEndpointUrl } from "../api/queries";
 import { ComponentOpenApiDialog } from "./ComponentOpenApiDialog";
 
 type Component = components["schemas"]["Component"];
@@ -38,12 +40,8 @@ const isWebApp = (c: Component) => c.type === "web-application";
 
 // Component cards: one compact single-row card per component — avatar, name and
 // description. Services open their OpenAPI contract on click (JWT-guarded, so
-// via the authenticated dialog, not a raw link).
-//
-// Deliberately state-free. A component's build state used to be rolled up from
-// its tasks, but an issue no longer names a component — issue bodies are prose
-// the platform writes and never reads back — so the roll-up had no input left.
-// What is running lives on the deployments board, which reads the cluster.
+// via the authenticated dialog, not a raw link). Web-applications show Open
+// app when list-deployments has resolved a public URL.
 export function ComponentsList({
   projectName,
   items,
@@ -113,6 +111,13 @@ export function ComponentsList({
                       {c.description ?? "—"}
                     </Typography>
                   </Box>
+                  {isWebApp(c) && (
+                    <WebAppOpenLink
+                      projectName={projectName}
+                      displayName={c.displayName ?? c.name}
+                      componentName={c.name}
+                    />
+                  )}
                 </Stack>
               </CardContent>
             </Card>
@@ -132,5 +137,34 @@ export function ComponentsList({
         onClose={() => setContractComponent(null)}
       />
     </>
+  );
+}
+
+// Public URL for a web-application row (#196 / #538): the hook already exists
+// and Deployments reads the same list-deployments field. Overview never called
+// it, so a Ready SPA had no Open link here even when endpointUrl was set.
+function WebAppOpenLink({
+  projectName,
+  componentName,
+  displayName,
+}: {
+  projectName: string;
+  componentName: string;
+  displayName: string;
+}) {
+  const { data: url } = useComponentEndpointUrl(projectName, componentName);
+  if (!url) return null;
+  return (
+    <MuiLink
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      variant="body2"
+      aria-label={`Open ${displayName}`}
+      onClick={(e) => e.stopPropagation()}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, flexShrink: 0 }}
+    >
+      Open app <ExternalLink size={14} />
+    </MuiLink>
   );
 }

--- a/apps/console/src/features/projects/components/ProjectOverview.test.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { projectKeys } from "../api/keys";
+
+const invalidateQueries = vi.fn();
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries }),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children?: React.ReactNode }) => <a>{children}</a>,
+}));
+
+let mockDeployStatus = "none";
+
+vi.mock("../api/queries", () => ({
+  useProject: () => ({ data: { name: "shop", displayName: "Shop" } }),
+  useProjectStatus: () => ({
+    data: {
+      phase: "components",
+      repoStatus: "ready",
+      repoUrl: "",
+      hasSpec: true,
+      hasDesign: true,
+      hasTasks: true,
+      specStatus: "approved",
+      designStatus: "approved",
+      spec: { exists: true, version: "v1", dirty: false, design: true },
+      build: { version: "v1", status: "succeeded" },
+      deploy: {
+        version: "v1",
+        status: mockDeployStatus,
+        components: { total: 1, ready: 0 },
+        validation: "none",
+      },
+    },
+    refetch: vi.fn(),
+  }),
+  useProjectComponents: () => ({
+    data: { items: [] },
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("./ComponentsList", () => ({ ComponentsList: () => null }));
+vi.mock("./OverviewPipeline", () => ({ OverviewPipeline: () => null }));
+vi.mock("./RecentActivity", () => ({ RecentActivity: () => null }));
+
+import { ProjectOverview } from "./ProjectOverview";
+
+describe("ProjectOverview — deploy transition", () => {
+  beforeEach(() => {
+    invalidateQueries.mockClear();
+    mockDeployStatus = "none";
+  });
+
+  it("invalidates components (including deployment URLs) when deploy status changes", () => {
+    const { rerender } = render(<ProjectOverview projectName="shop" />);
+    mockDeployStatus = "deployed";
+    rerender(<ProjectOverview projectName="shop" />);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: projectKeys.components("shop"),
+    });
+  });
+});

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -29,11 +29,13 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Link as LinkIcon } from "@wso2/oxygen-ui-icons-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { PageHeader } from "../../../components/PageHeader";
 import { SectionTitle } from "../../../components/SectionTitle";
 import { StatusChip } from "../../../components/StatusChip";
 import { useProject, useProjectComponents, useProjectStatus } from "../api/queries";
+import { projectKeys } from "../api/keys";
 import { projectChip } from "../lib/projectChip";
 import { RecentActivity } from "./RecentActivity";
 import { ComponentsList } from "./ComponentsList";
@@ -59,24 +61,27 @@ function SectionError({
 // The overview renders from ONE polling read (#183): the status aggregate
 // powers the whole pipeline. The components list has no interval of its own —
 // it refetches when the poll shows a build/deploy transition (the only times
-// components change).
+// components change). Invalidate the components *prefix* so nested
+// list-deployments queries (Open app) refresh with the list, not only the list.
 export function ProjectOverview({ projectName }: { projectName: string }) {
   const project = useProject(projectName);
   const status = useProjectStatus(projectName);
   const componentsQuery = useProjectComponents(projectName);
+  const queryClient = useQueryClient();
 
   const buildState = status.data?.build.status;
   const deployState = status.data?.deploy.status;
   const prev = useRef<string | undefined>(undefined);
-  const refetchComponents = componentsQuery.refetch;
   useEffect(() => {
     if (buildState === undefined) return;
     const key = `${buildState}:${deployState}`;
     if (prev.current !== undefined && prev.current !== key) {
-      void refetchComponents();
+      void queryClient.invalidateQueries({
+        queryKey: projectKeys.components(projectName),
+      });
     }
     prev.current = key;
-  }, [buildState, deployState, refetchComponents]);
+  }, [buildState, deployState, projectName, queryClient]);
 
   const displayName = project.data?.displayName ?? project.data?.name ?? projectName;
   const initial = (displayName.trim()[0] ?? "P").toUpperCase();


### PR DESCRIPTION
## Summary
- Overview never called `useComponentEndpointUrl`, so a Ready SPA had no **Open app** link even when list-deployments had a URL. Deployments already rendered Open.
- On a build/deploy status change, invalidate the components query *prefix* so nested list-deployments queries refresh too — staying on Overview while a webapp becomes Ready now shows the link.
- Helm / `setup-aep.sh` in this repo already mint `httproute-external` hostnames via `oc_dns_label`. Cloud tenant bootstrap (wso2cloud) still omits hostnames; that copy is out of this PR.

Related to #538. Cloud Open for a web-application also needs #537 (HTTPS reader) and the wso2cloud ComponentType hostname.

## Test plan
- [ ] `pnpm test` for `ComponentsList.test.tsx` and `ProjectOverview.test.tsx` in `apps/console`
- [ ] Local: deploy a web-application, stay on Overview until Ready, confirm **Open app** appears and hits the dedicated hostname
- [ ] Service cards still open the OpenAPI dialog, not a public URL