### PR TITLE
fix(aep-api): prefer HTTPS external URLs for Deployments Open

### DIFF
--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -278,8 +278,9 @@ func workflowRunToModel(run ocgen.WorkflowRun) gen.WorkflowRun {
 	}
 }
 
-// deploymentFromReleaseBinding pulls the first HTTP external URL from the
-// binding's resolved endpoints via the typed `ExternalURLs.Http *EndpointURL`.
+// deploymentFromReleaseBinding pulls the first public URL from the binding's
+// resolved endpoints. Cloud gateways populate `externalURLs.https` only;
+// local/HTTP listeners populate `http`. Prefer https when both exist.
 func deploymentFromReleaseBinding(rb ocgen.ReleaseBinding) gen.Deployment {
 	var projectName, componentName, environment, releaseName string
 	if rb.Spec != nil {
@@ -292,8 +293,8 @@ func deploymentFromReleaseBinding(rb ocgen.ReleaseBinding) gen.Deployment {
 	var endpointURL string
 	if rb.Status != nil && rb.Status.Endpoints != nil {
 		for _, ep := range *rb.Status.Endpoints {
-			if ep.ExternalURLs != nil && ep.ExternalURLs.Http != nil {
-				endpointURL = formatEndpointURL(ep.ExternalURLs.Http)
+			if u := publicEndpointURL(ep.ExternalURLs); u != "" {
+				endpointURL = u
 				break
 			}
 		}
@@ -313,6 +314,21 @@ func deploymentFromReleaseBinding(rb ocgen.ReleaseBinding) gen.Deployment {
 		CreatedAt:     derefTimeRFC3339(rb.Metadata.CreationTimestamp),
 		Status:        status,
 	}
+}
+
+// publicEndpointURL prefers the HTTPS gateway URL when OpenChoreo resolved
+// one, else HTTP. Empty when the binding has no external URL at all.
+func publicEndpointURL(urls *ocgen.EndpointGatewayURLs) string {
+	if urls == nil {
+		return ""
+	}
+	if urls.Https != nil {
+		return formatEndpointURL(urls.Https)
+	}
+	if urls.Http != nil {
+		return formatEndpointURL(urls.Http)
+	}
+	return ""
 }
 
 // formatEndpointURL renders ocgen.EndpointURL as scheme://host:port/path. Path

--- a/services/aep-api/internal/clients/openchoreo/component_client_endpoint_url_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client_endpoint_url_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"testing"
+
+	ocgen "github.com/wso2/aep/aep-api/internal/clients/openchoreo/gen"
+)
+
+func TestDeploymentFromReleaseBinding_HTTPSOnlyPopulatesEndpointURL(t *testing.T) {
+	got := deploymentFromReleaseBinding(bindingWithExternal(httpsURL(
+		"development-wc-019feb11-3f4674c4.gateway.dp.dev.cloud.wso2.com",
+		"/hello-world-api-16-hello-api-http",
+		443,
+	), nil))
+	want := "https://development-wc-019feb11-3f4674c4.gateway.dp.dev.cloud.wso2.com:443/hello-world-api-16-hello-api-http"
+	if got.EndpointURL != want {
+		t.Fatalf("EndpointURL = %q, want %q", got.EndpointURL, want)
+	}
+}
+
+func TestDeploymentFromReleaseBinding_HTTPOnlyStillWorks(t *testing.T) {
+	got := deploymentFromReleaseBinding(bindingWithExternal(nil, httpURL(
+		"web.local",
+		"/",
+		80,
+	)))
+	want := "http://web.local:80/"
+	if got.EndpointURL != want {
+		t.Fatalf("EndpointURL = %q, want %q", got.EndpointURL, want)
+	}
+}
+
+func TestDeploymentFromReleaseBinding_PrefersHTTPSWhenBothPresent(t *testing.T) {
+	got := deploymentFromReleaseBinding(bindingWithExternal(
+		httpsURL("gw.example.com", "/app", 443),
+		httpURL("gw.example.com", "/app", 80),
+	))
+	want := "https://gw.example.com:443/app"
+	if got.EndpointURL != want {
+		t.Fatalf("EndpointURL = %q, want %q", got.EndpointURL, want)
+	}
+}
+
+func TestDeploymentFromReleaseBinding_NeitherSchemeOmitsEndpointURL(t *testing.T) {
+	got := deploymentFromReleaseBinding(bindingWithExternal(nil, nil))
+	if got.EndpointURL != "" {
+		t.Fatalf("EndpointURL = %q, want empty", got.EndpointURL)
+	}
+}
+
+func bindingWithExternal(https, http *ocgen.EndpointURL) ocgen.ReleaseBinding {
+	release := "hello-api-rel"
+	eps := []ocgen.EndpointURLStatus{{
+		Name: "http",
+		ExternalURLs: &ocgen.EndpointGatewayURLs{
+			Https: https,
+			Http:  http,
+		},
+	}}
+	return ocgen.ReleaseBinding{
+		Metadata: ocgen.ObjectMeta{Name: "hello-api-development"},
+		Spec: &ocgen.ReleaseBindingSpec{
+			Environment: "development",
+			ReleaseName: &release,
+			Owner: struct {
+				ComponentName string `json:"componentName"`
+				ProjectName   string `json:"projectName"`
+			}{ComponentName: "proj-hello-api", ProjectName: "proj"},
+		},
+		Status: &ocgen.ReleaseBindingStatus{Endpoints: &eps},
+	}
+}
+
+func httpsURL(host, path string, port int32) *ocgen.EndpointURL {
+	scheme := "https"
+	p := path
+	return &ocgen.EndpointURL{Host: host, Path: &p, Port: &port, Scheme: &scheme}
+}
+
+func httpURL(host, path string, port int32) *ocgen.EndpointURL {
+	scheme := "http"
+	p := path
+	return &ocgen.EndpointURL{Host: host, Path: &p, Port: &port, Scheme: &scheme}
+}


### PR DESCRIPTION
## Summary
- Cloud ReleaseBindings expose `externalURLs.https` only. aep-api copied `http`, so `endpointUrl` was empty and Deployments hid **Open**.
- Prefer `https` when present, else `http`; omit the field when neither exists. No new UI.

Fixes #537

## Test plan
- [ ] `go test ./internal/clients/openchoreo/` in `services/aep-api`
- [ ] On cloud-dev, list-deployments for a Ready **service** (HTTPS gateway only) returns `endpointUrl`
- [ ] Deployments row shows **Open** to that URL
- [ ] Local/HTTP playground still shows Open for HTTP-only bindings