### PR TITLE
fix(skills): architecture contradicted itself on `stories`, so no build passed

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -142,12 +142,11 @@ into `workload.yaml` and the managed-API gateway binds to. The port lives in
 - **Preserved verbatim** where the platform has already written them:
   `exposesAPI`, `componentAgentInstructions`, and any dependency
   `status`/`reason`.
-- **Recomputed and overwritten** on every save: a dependency's `wiring` object,
-  and the component's `stories` array — the platform restamps it from the
-  design.cell citations, so cite stories in the CELL, never here.
+- **Recomputed and overwritten** on every save: a dependency's `wiring` object.
   The platform derives its `ref` and its env-var names from the dependency's name
   and its resource type's declared outputs, so anything you write there is
-  discarded.
+  discarded. `stories` is NOT in this class — it is yours to author, per the
+  **stories** field above.
 
 ### dependencies — one entry per Interactions arrow
 


### PR DESCRIPTION
## Symptom

Every project fails the build gate after the design phase, deterministically:

```
UNCOVERED_STORY: story 1 is in the PRD but no component's design.json lists it in `stories`
UNCOVERED_STORY: story 2 …   (and so on, for every story)
```

## Cause: `architecture` contradicts itself

It states both:

- the **stories** enrichment field: *"the PRD story numbers this component serves, as an integer array … Claim every story the component actually serves."*
- the **Recomputed and overwritten** bullet: *"the component's `stories` array — the platform restamps it from the design.cell citations, so cite stories in the CELL, never here."*

The second is stale, and it's the one that wins, because it's framed as a platform fact — *"anything you write there is discarded"*. An agent that believes the field is overwritten has no reason to fill it, so `stories` stays empty and the gate refuses every tag.

## Three independent confirmations that the field is agent-authored

- `services/aep-api/internal/spec/design_json.go` — `// Stories is the agent-authored list of PRD stories this component serves`. Nothing recomputes it; the fold copies it straight through.
- `services/aep-api/internal/spec/build_gate.go` — `componentStoryClaims` reads stories **only** from `components/<id>/design.json`, and `CellFacts` has no story field at all. There is nothing in the cell for the platform to restamp *from*.
- `skills/cell-design/SKILL.md` already agrees: *"The cell carries structure only. Which PRD stories a component serves is recorded in that component's `design.json` `stories` list during enrichment … never in the diagram."*

The cell's `[stories:]` suffix was retired and no skill teaches it any more. This bullet is what survived it.

## Change

`stories` removed from the recomputed-and-overwritten class, with a pointer to the field that owns it. `wiring` stays — that one genuinely is restamped.

```diff
-- **Recomputed and overwritten** on every save: a dependency's `wiring` object,
--  and the component's `stories` array — the platform restamps it from the
--  design.cell citations, so cite stories in the CELL, never here.
++- **Recomputed and overwritten** on every save: a dependency's `wiring` object.
+   … `stories` is NOT in this class — it is yours to author, per the
+   **stories** field above.
```

One file, prose only, no code or contract change.

## Verification

Found while debugging a report of "spec validation failed after the design phase" on a local stack — the failure reproduced on every project. I have not yet driven a full design→build cycle against the corrected skill (that needs a coding-agent run); the case for the change rests on the three code/skill facts above, each of which is checkable without a run. Worth a reviewer confirming that reading before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
