### PR TITLE
Mint web-application HTTPRoute hostnames from aep-api

### DIFF
--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -512,6 +512,15 @@ func (c *componentClient) CreateComponent(ctx context.Context, orgName, projectN
 		}
 	}
 
+	// Cloud PAS web-application still emits a hostname-less catch-all HTTPRoute.
+	// Overlay httproute-external before the Component exists so the first
+	// release renders a dedicated hostname (issue 538).
+	if req != nil && isWebApplicationEntrypoint(req.Type) {
+		if err := c.ensureWebApplicationHTTPRouteHostnames(ctx, orgName); err != nil {
+			return nil, fmt.Errorf("create component: ensure web-application HTTPRoute hostnames: %w", err)
+		}
+	}
+
 	resp, err := c.oc.CreateComponentWithResponse(ctx, orgName, buildCreateComponentBody(projectName, req))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create component: %w", err)

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -512,10 +512,10 @@ func (c *componentClient) CreateComponent(ctx context.Context, orgName, projectN
 		}
 	}
 
-	// Cloud PAS web-application still emits a hostname-less catch-all HTTPRoute.
-	// Overlay httproute-external before the Component exists so the first
-	// release renders a dedicated hostname (issue 538).
-	if req != nil && isWebApplicationEntrypoint(req.Type) {
+	// Org web-application types from PAS still emit a hostname-less catch-all
+	// HTTPRoute. Replace it before the Component exists so the first release
+	// renders a dedicated hostname.
+	if req != nil && req.Type == webApplicationComponentTypeRef {
 		if err := c.ensureWebApplicationHTTPRouteHostnames(ctx, orgName); err != nil {
 			return nil, fmt.Errorf("create component: ensure web-application HTTPRoute hostnames: %w", err)
 		}

--- a/services/aep-api/internal/clients/openchoreo/web_application_httproute.go
+++ b/services/aep-api/internal/clients/openchoreo/web_application_httproute.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	ocgen "github.com/wso2/aep/aep-api/internal/clients/openchoreo/gen"
+)
+
+// WebApplicationComponentTypeName is the namespaced ComponentType PAS
+// bootstraps into each org. AEP components reference it as
+// deployment/web-application; the CR's metadata.name is unprefixed.
+const WebApplicationComponentTypeName = "web-application"
+
+const webApplicationComponentTypeRef = "deployment/web-application"
+
+// Same CEL as deployments/helm-charts/platform/templates/openchoreo-org-types/
+// componenttype-web-application.yaml and setup-aep.sh. Dedicated hostname +
+// path / so OpenChoreo fills ReleaseBinding status.endpoints[].externalURLs.
+const webApplicationHTTPRouteForEach = `${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "REST", "GraphQL", "Websocket"]) ? [name] : []).flatten()}`
+
+const webApplicationHTTPRouteHostnames = `${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}`
+
+func isWebApplicationEntrypoint(componentType string) bool {
+	return componentType == webApplicationComponentTypeRef || componentType == WebApplicationComponentTypeName
+}
+
+func resourceID(r any) string {
+	m, ok := r.(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := m["id"].(string)
+	return id
+}
+
+func resourceHasHostnames(r any) bool {
+	m, ok := r.(map[string]any)
+	if !ok {
+		return false
+	}
+	tmpl, _ := m["template"].(map[string]any)
+	spec, _ := tmpl["spec"].(map[string]any)
+	switch h := spec["hostnames"].(type) {
+	case string:
+		return h != ""
+	case []any:
+		return len(h) > 0
+	default:
+		return false
+	}
+}
+
+func webApplicationExternalHTTPRoute() map[string]any {
+	return map[string]any{
+		"id":      "httproute-external",
+		"forEach": webApplicationHTTPRouteForEach,
+		"var":     "endpoint",
+		"template": map[string]any{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata": map[string]any{
+				"name":      `${oc_generate_name(metadata.componentName, endpoint)}`,
+				"namespace": `${metadata.namespace}`,
+				"labels":    `${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint, "openchoreo.dev/endpoint-visibility": "external"})}`,
+			},
+			"spec": map[string]any{
+				"parentRefs": []any{
+					map[string]any{
+						"name":      `${gateway.ingress.external.name}`,
+						"namespace": `${gateway.ingress.external.namespace}`,
+					},
+				},
+				"hostnames": webApplicationHTTPRouteHostnames,
+				"rules": []any{
+					map[string]any{
+						"matches": []any{
+							map[string]any{
+								"path": map[string]any{
+									"type":  "PathPrefix",
+									"value": "/",
+								},
+							},
+						},
+						"backendRefs": []any{
+							map[string]any{
+								"name": `${metadata.componentName}`,
+								"port": `${workload.endpoints[endpoint].port}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// patchWebApplicationHTTPRouteResources replaces a hostname-less HTTPRoute
+// template with httproute-external. Returns a new slice; in is not mutated.
+func patchWebApplicationHTTPRouteResources(in []any) ([]any, bool) {
+	hosted := false
+	for _, r := range in {
+		if resourceID(r) == "httproute-external" && resourceHasHostnames(r) {
+			hosted = true
+			break
+		}
+	}
+
+	out := make([]any, 0, len(in))
+	changed := false
+	replaced := false
+	for _, r := range in {
+		id := resourceID(r)
+		switch {
+		case hosted && id == "httproute":
+			changed = true
+			continue
+		case !hosted && (id == "httproute" || id == "httproute-external"):
+			out = append(out, webApplicationExternalHTTPRoute())
+			replaced = true
+			changed = true
+		default:
+			out = append(out, r)
+		}
+	}
+	if hosted || replaced {
+		return out, changed
+	}
+	inserted := false
+	withInsert := make([]any, 0, len(out)+1)
+	for _, r := range out {
+		withInsert = append(withInsert, r)
+		if resourceID(r) == "service" {
+			withInsert = append(withInsert, webApplicationExternalHTTPRoute())
+			inserted = true
+		}
+	}
+	if !inserted {
+		withInsert = append(withInsert, webApplicationExternalHTTPRoute())
+	}
+	return withInsert, true
+}
+
+func patchWebApplicationComponentTypeDoc(doc map[string]any) (bool, error) {
+	if doc == nil {
+		return false, fmt.Errorf("web-application componenttype: empty document")
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	if spec == nil {
+		return false, nil
+	}
+	raw, ok := spec["resources"]
+	if !ok {
+		return false, nil
+	}
+	resources, ok := raw.([]any)
+	if !ok {
+		return false, fmt.Errorf("web-application componenttype: spec.resources is %T, want array", raw)
+	}
+	patched, changed := patchWebApplicationHTTPRouteResources(resources)
+	if !changed {
+		return false, nil
+	}
+	spec["resources"] = patched
+	return true, nil
+}
+
+// ensureWebApplicationHTTPRouteHostnames overlays httproute-external onto the
+// org's namespaced web-application ComponentType when it still emits a
+// catch-all HTTPRoute. 404 is a no-op: local cluster types already mint
+// hostnames and there is nothing namespaced to patch.
+func (c *componentClient) ensureWebApplicationHTTPRouteHostnames(ctx context.Context, orgName string) error {
+	return retryStaleWrite(ctx, "componenttype/"+WebApplicationComponentTypeName+" httproute", func(ctx context.Context) error {
+		getResp, err := c.oc.GetComponentTypeWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(WebApplicationComponentTypeName))
+		if err != nil {
+			return fmt.Errorf("get web-application componenttype: %w", err)
+		}
+		if getResp.StatusCode() == http.StatusNotFound {
+			return nil
+		}
+		if getResp.StatusCode() != http.StatusOK {
+			return fmt.Errorf("get web-application componenttype: %w", handleErrorResponse(getResp.StatusCode(), ErrorResponses{
+				JSON401: getResp.JSON401,
+				JSON403: getResp.JSON403,
+				JSON404: getResp.JSON404,
+				JSON500: getResp.JSON500,
+			}))
+		}
+
+		var doc map[string]any
+		if err := json.Unmarshal(getResp.Body, &doc); err != nil {
+			return fmt.Errorf("decode web-application componenttype: %w", err)
+		}
+		changed, err := patchWebApplicationComponentTypeDoc(doc)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			return nil
+		}
+		raw, err := json.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("marshal web-application componenttype: %w", err)
+		}
+		updResp, err := c.oc.UpdateComponentTypeWithBodyWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(WebApplicationComponentTypeName), "application/json", bytes.NewReader(raw))
+		if err != nil {
+			return fmt.Errorf("update web-application componenttype: %w", err)
+		}
+		if updResp.StatusCode() != http.StatusOK && updResp.StatusCode() != http.StatusCreated {
+			return fmt.Errorf("update web-application componenttype: %w", handleErrorResponse(updResp.StatusCode(), ErrorResponses{
+				JSON400: updResp.JSON400,
+				JSON401: updResp.JSON401,
+				JSON403: updResp.JSON403,
+				JSON404: updResp.JSON404,
+				JSON409: updResp.JSON409,
+				JSON500: updResp.JSON500,
+			}))
+		}
+		return nil
+	})
+}

--- a/services/aep-api/internal/clients/openchoreo/web_application_httproute.go
+++ b/services/aep-api/internal/clients/openchoreo/web_application_httproute.go
@@ -26,50 +26,25 @@ import (
 	ocgen "github.com/wso2/aep/aep-api/internal/clients/openchoreo/gen"
 )
 
-// WebApplicationComponentTypeName is the namespaced ComponentType PAS
-// bootstraps into each org. AEP components reference it as
-// deployment/web-application; the CR's metadata.name is unprefixed.
-const WebApplicationComponentTypeName = "web-application"
-
+const webApplicationComponentTypeName = "web-application"
 const webApplicationComponentTypeRef = "deployment/web-application"
 
-// Same CEL as deployments/helm-charts/platform/templates/openchoreo-org-types/
-// componenttype-web-application.yaml and setup-aep.sh. Dedicated hostname +
-// path / so OpenChoreo fills ReleaseBinding status.endpoints[].externalURLs.
+// Same CEL as the local org web-application type (helm + setup-aep.sh): a
+// dedicated hostname and path / so OpenChoreo fills
+// ReleaseBinding status.endpoints[].externalURLs.
 const webApplicationHTTPRouteForEach = `${workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "REST", "GraphQL", "Websocket"]) ? [name] : []).flatten()}`
 
 const webApplicationHTTPRouteHostnames = `${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
               .map(h, oc_dns_label(endpoint, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}`
 
-func isWebApplicationEntrypoint(componentType string) bool {
-	return componentType == webApplicationComponentTypeRef || componentType == WebApplicationComponentTypeName
-}
-
-func resourceID(r any) string {
+func componentTypeResourceID(r any) string {
 	m, ok := r.(map[string]any)
 	if !ok {
 		return ""
 	}
 	id, _ := m["id"].(string)
 	return id
-}
-
-func resourceHasHostnames(r any) bool {
-	m, ok := r.(map[string]any)
-	if !ok {
-		return false
-	}
-	tmpl, _ := m["template"].(map[string]any)
-	spec, _ := tmpl["spec"].(map[string]any)
-	switch h := spec["hostnames"].(type) {
-	case string:
-		return h != ""
-	case []any:
-		return len(h) > 0
-	default:
-		return false
-	}
 }
 
 func webApplicationExternalHTTPRoute() map[string]any {
@@ -116,50 +91,21 @@ func webApplicationExternalHTTPRoute() map[string]any {
 	}
 }
 
-// patchWebApplicationHTTPRouteResources replaces a hostname-less HTTPRoute
-// template with httproute-external. Returns a new slice; in is not mutated.
+// patchWebApplicationHTTPRouteResources replaces id:httproute (the PAS
+// catch-all) with httproute-external. Everything else, including an already
+// hosted httproute-external, is left alone.
 func patchWebApplicationHTTPRouteResources(in []any) ([]any, bool) {
-	hosted := false
-	for _, r := range in {
-		if resourceID(r) == "httproute-external" && resourceHasHostnames(r) {
-			hosted = true
-			break
-		}
-	}
-
 	out := make([]any, 0, len(in))
 	changed := false
-	replaced := false
 	for _, r := range in {
-		id := resourceID(r)
-		switch {
-		case hosted && id == "httproute":
+		if componentTypeResourceID(r) == "httproute" {
+			out = append(out, webApplicationExternalHTTPRoute())
 			changed = true
 			continue
-		case !hosted && (id == "httproute" || id == "httproute-external"):
-			out = append(out, webApplicationExternalHTTPRoute())
-			replaced = true
-			changed = true
-		default:
-			out = append(out, r)
 		}
+		out = append(out, r)
 	}
-	if hosted || replaced {
-		return out, changed
-	}
-	inserted := false
-	withInsert := make([]any, 0, len(out)+1)
-	for _, r := range out {
-		withInsert = append(withInsert, r)
-		if resourceID(r) == "service" {
-			withInsert = append(withInsert, webApplicationExternalHTTPRoute())
-			inserted = true
-		}
-	}
-	if !inserted {
-		withInsert = append(withInsert, webApplicationExternalHTTPRoute())
-	}
-	return withInsert, true
+	return out, changed
 }
 
 func patchWebApplicationComponentTypeDoc(doc map[string]any) (bool, error) {
@@ -186,13 +132,12 @@ func patchWebApplicationComponentTypeDoc(doc map[string]any) (bool, error) {
 	return true, nil
 }
 
-// ensureWebApplicationHTTPRouteHostnames overlays httproute-external onto the
-// org's namespaced web-application ComponentType when it still emits a
-// catch-all HTTPRoute. 404 is a no-op: local cluster types already mint
-// hostnames and there is nothing namespaced to patch.
+// ensureWebApplicationHTTPRouteHostnames replaces a catch-all httproute on
+// the org namespaced web-application ComponentType. 404 is a no-op: local
+// installs often have only the already-hosted cluster type.
 func (c *componentClient) ensureWebApplicationHTTPRouteHostnames(ctx context.Context, orgName string) error {
-	return retryStaleWrite(ctx, "componenttype/"+WebApplicationComponentTypeName+" httproute", func(ctx context.Context) error {
-		getResp, err := c.oc.GetComponentTypeWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(WebApplicationComponentTypeName))
+	return retryStaleWrite(ctx, "componenttype/"+webApplicationComponentTypeName+" httproute", func(ctx context.Context) error {
+		getResp, err := c.oc.GetComponentTypeWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(webApplicationComponentTypeName))
 		if err != nil {
 			return fmt.Errorf("get web-application componenttype: %w", err)
 		}
@@ -223,7 +168,7 @@ func (c *componentClient) ensureWebApplicationHTTPRouteHostnames(ctx context.Con
 		if err != nil {
 			return fmt.Errorf("marshal web-application componenttype: %w", err)
 		}
-		updResp, err := c.oc.UpdateComponentTypeWithBodyWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(WebApplicationComponentTypeName), "application/json", bytes.NewReader(raw))
+		updResp, err := c.oc.UpdateComponentTypeWithBodyWithResponse(ctx, orgName, ocgen.ComponentTypeNameParam(webApplicationComponentTypeName), "application/json", bytes.NewReader(raw))
 		if err != nil {
 			return fmt.Errorf("update web-application componenttype: %w", err)
 		}

--- a/services/aep-api/internal/clients/openchoreo/web_application_httproute_test.go
+++ b/services/aep-api/internal/clients/openchoreo/web_application_httproute_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPatchWebApplicationHTTPRouteResources_ReplacesCatchAll(t *testing.T) {
+	t.Parallel()
+	in := []any{
+		map[string]any{"id": "service", "template": map[string]any{"kind": "Service"}},
+		map[string]any{
+			"id":          "httproute",
+			"includeWhen": "${size(workload.endpoints) > 0}",
+			"template": map[string]any{
+				"kind": "HTTPRoute",
+				"spec": map[string]any{
+					"parentRefs": []any{
+						map[string]any{"name": "gateway-default", "namespace": "openchoreo-data-plane"},
+					},
+					"rules": []any{
+						map[string]any{
+							"backendRefs": []any{
+								map[string]any{"name": "${metadata.componentName}", "port": "${workload.toServicePorts()[0].port}"},
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]any{"id": "env-config"},
+	}
+
+	out, changed := patchWebApplicationHTTPRouteResources(in)
+	if !changed {
+		t.Fatal("expected the catch-all httproute to be replaced")
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 (service, httproute-external, env-config)", len(out))
+	}
+	if resourceID(out[0]) != "service" || resourceID(out[2]) != "env-config" {
+		t.Fatalf("surrounding resources moved: ids=%v", resourceIDs(out))
+	}
+	ext, ok := out[1].(map[string]any)
+	if !ok {
+		t.Fatalf("httproute-external is %T, want map", out[1])
+	}
+	if ext["id"] != "httproute-external" {
+		t.Errorf("id = %v, want httproute-external", ext["id"])
+	}
+	if ext["includeWhen"] != nil {
+		t.Errorf("includeWhen = %v, want omitted (visibility forEach replaces it)", ext["includeWhen"])
+	}
+	tmpl, _ := ext["template"].(map[string]any)
+	spec, _ := tmpl["spec"].(map[string]any)
+	hostnames, _ := spec["hostnames"].(string)
+	if hostnames == "" || !strings.Contains(hostnames, "oc_dns_label") || !strings.Contains(hostnames, "gateway.ingress.external") {
+		t.Errorf("hostnames = %q, want oc_dns_label on gateway.ingress.external", hostnames)
+	}
+	if _, ok := spec["parentRefs"]; !ok {
+		t.Error("parentRefs missing")
+	}
+}
+
+func TestPatchWebApplicationHTTPRouteResources_IdempotentWhenHostnamesExist(t *testing.T) {
+	t.Parallel()
+	in := []any{
+		map[string]any{
+			"id": "httproute-external",
+			"template": map[string]any{
+				"spec": map[string]any{
+					"hostnames": "already-minted.example.com",
+				},
+			},
+		},
+	}
+	out, changed := patchWebApplicationHTTPRouteResources(in)
+	if changed {
+		t.Fatal("already-hosted httproute-external must not be rewritten")
+	}
+	if len(out) != 1 {
+		t.Fatalf("len(out) = %d, want 1", len(out))
+	}
+}
+
+func TestPatchWebApplicationHTTPRouteResources_RewritesExternalWithoutHostnames(t *testing.T) {
+	t.Parallel()
+	in := []any{
+		map[string]any{
+			"id":       "httproute-external",
+			"template": map[string]any{"spec": map[string]any{"rules": []any{}}},
+		},
+	}
+	out, changed := patchWebApplicationHTTPRouteResources(in)
+	if !changed {
+		t.Fatal("expected hostname-less httproute-external to be rewritten")
+	}
+	hostnames := resourceHostnames(out[0])
+	if hostnames == "" {
+		t.Fatal("rewritten route has no hostnames")
+	}
+}
+
+func TestPatchComponentTypeDoc_PreservesResourceVersion(t *testing.T) {
+	t.Parallel()
+	doc := map[string]any{
+		"apiVersion": "openchoreo.dev/v1alpha1",
+		"kind":       "ComponentType",
+		"metadata": map[string]any{
+			"name":            "web-application",
+			"resourceVersion": "4242",
+			"uid":             "abc",
+		},
+		"spec": map[string]any{
+			"resources": []any{
+				map[string]any{"id": "httproute", "template": map[string]any{"kind": "HTTPRoute"}},
+			},
+		},
+	}
+	changed, err := patchWebApplicationComponentTypeDoc(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected patch")
+	}
+	meta, _ := doc["metadata"].(map[string]any)
+	if meta["resourceVersion"] != "4242" || meta["uid"] != "abc" {
+		t.Errorf("metadata clobbered: %v", meta)
+	}
+}
+
+func resourceIDs(resources []any) []string {
+	ids := make([]string, len(resources))
+	for i, r := range resources {
+		ids[i] = resourceID(r)
+	}
+	return ids
+}
+
+func resourceHostnames(r any) string {
+	m, _ := r.(map[string]any)
+	tmpl, _ := m["template"].(map[string]any)
+	spec, _ := tmpl["spec"].(map[string]any)
+	h, _ := spec["hostnames"].(string)
+	return h
+}
+
+func TestEnsureWebApplicationHTTPRouteHostnames_NoopOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL}).(*componentClient)
+	if err := c.ensureWebApplicationHTTPRouteHostnames(context.Background(), "wc-abc"); err != nil {
+		t.Fatalf("404 must be a no-op, got %v", err)
+	}
+}
+
+func TestEnsureWebApplicationHTTPRouteHostnames_PutsHostnamesAndKeepsResourceVersion(t *testing.T) {
+	var putBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/componenttypes/web-application"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"apiVersion": "openchoreo.dev/v1alpha1",
+				"kind":       "ComponentType",
+				"metadata": map[string]any{
+					"name":            "web-application",
+					"resourceVersion": "7",
+				},
+				"spec": map[string]any{
+					"resources": []any{
+						map[string]any{"id": "httproute", "template": map[string]any{"kind": "HTTPRoute"}},
+					},
+				},
+			})
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/componenttypes/web-application"):
+			decodeJSONBody(t, r, &putBody)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(putBody)
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL}).(*componentClient)
+	if err := c.ensureWebApplicationHTTPRouteHostnames(context.Background(), "wc-abc"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	meta, _ := putBody["metadata"].(map[string]any)
+	if meta["resourceVersion"] != "7" {
+		t.Errorf("PUT dropped resourceVersion: %v", meta)
+	}
+	spec, _ := putBody["spec"].(map[string]any)
+	resources, _ := spec["resources"].([]any)
+	if len(resources) != 1 || resourceID(resources[0]) != "httproute-external" {
+		t.Errorf("PUT resources = %v", resources)
+	}
+	if resourceHostnames(resources[0]) == "" {
+		t.Fatal("PUT route has no hostnames")
+	}
+}
+
+func TestCreateComponent_WebApplicationEnsuresHTTPRouteHostnames(t *testing.T) {
+	var gotTypeGet, gotComponentPost atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/componenttypes/web-application"):
+			gotTypeGet.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{"name": "web-application"},
+				"spec": map[string]any{
+					"resources": []any{
+						map[string]any{
+							"id": "httproute-external",
+							"template": map[string]any{
+								"spec": map[string]any{"hostnames": "already.example.com"},
+							},
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/components"):
+			gotComponentPost.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]any{"name": "widgets-storefront"},
+				"spec": map[string]any{
+					"componentType": map[string]any{"name": "deployment/web-application"},
+					"owner":         map[string]any{"projectName": "widgets"},
+				},
+			})
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	if _, err := c.CreateComponent(context.Background(), "wc-abc", "widgets", &CreateComponentRequest{
+		Name: "storefront",
+		Type: "deployment/web-application",
+	}); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+	if !gotTypeGet.Load() {
+		t.Fatal("web-application create must GET the org ComponentType before POSTing the Component")
+	}
+	if !gotComponentPost.Load() {
+		t.Fatal("Component POST never happened")
+	}
+}
+
+func TestCreateComponent_ServiceDoesNotTouchWebApplicationType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/componenttypes/") {
+			t.Errorf("service create must not touch ComponentTypes, got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{"name": "widgets-api"},
+			"spec": map[string]any{
+				"componentType": map[string]any{"name": "deployment/service"},
+				"owner":         map[string]any{"projectName": "widgets"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	if _, err := c.CreateComponent(context.Background(), "wc-abc", "widgets", &CreateComponentRequest{
+		Name: "api",
+		Type: "deployment/service",
+	}); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/web_application_httproute_test.go
+++ b/services/aep-api/internal/clients/openchoreo/web_application_httproute_test.go
@@ -59,7 +59,7 @@ func TestPatchWebApplicationHTTPRouteResources_ReplacesCatchAll(t *testing.T) {
 	if len(out) != 3 {
 		t.Fatalf("len(out) = %d, want 3 (service, httproute-external, env-config)", len(out))
 	}
-	if resourceID(out[0]) != "service" || resourceID(out[2]) != "env-config" {
+	if componentTypeResourceID(out[0]) != "service" || componentTypeResourceID(out[2]) != "env-config" {
 		t.Fatalf("surrounding resources moved: ids=%v", resourceIDs(out))
 	}
 	ext, ok := out[1].(map[string]any)
@@ -104,24 +104,6 @@ func TestPatchWebApplicationHTTPRouteResources_IdempotentWhenHostnamesExist(t *t
 	}
 }
 
-func TestPatchWebApplicationHTTPRouteResources_RewritesExternalWithoutHostnames(t *testing.T) {
-	t.Parallel()
-	in := []any{
-		map[string]any{
-			"id":       "httproute-external",
-			"template": map[string]any{"spec": map[string]any{"rules": []any{}}},
-		},
-	}
-	out, changed := patchWebApplicationHTTPRouteResources(in)
-	if !changed {
-		t.Fatal("expected hostname-less httproute-external to be rewritten")
-	}
-	hostnames := resourceHostnames(out[0])
-	if hostnames == "" {
-		t.Fatal("rewritten route has no hostnames")
-	}
-}
-
 func TestPatchComponentTypeDoc_PreservesResourceVersion(t *testing.T) {
 	t.Parallel()
 	doc := map[string]any{
@@ -154,7 +136,7 @@ func TestPatchComponentTypeDoc_PreservesResourceVersion(t *testing.T) {
 func resourceIDs(resources []any) []string {
 	ids := make([]string, len(resources))
 	for i, r := range resources {
-		ids[i] = resourceID(r)
+		ids[i] = componentTypeResourceID(r)
 	}
 	return ids
 }
@@ -225,7 +207,7 @@ func TestEnsureWebApplicationHTTPRouteHostnames_PutsHostnamesAndKeepsResourceVer
 	}
 	spec, _ := putBody["spec"].(map[string]any)
 	resources, _ := spec["resources"].([]any)
-	if len(resources) != 1 || resourceID(resources[0]) != "httproute-external" {
+	if len(resources) != 1 || componentTypeResourceID(resources[0]) != "httproute-external" {
 		t.Errorf("PUT resources = %v", resources)
 	}
 	if resourceHostnames(resources[0]) == "" {


### PR DESCRIPTION
## Summary

- Fixes [wso2/labs-agentic-engineer#538](https://github.com/wso2/labs-agentic-engineer/issues/538) in this repo (wso2cloud [#910](https://github.com/wso2-enterprise/wso2cloud/pull/910) was closed).
- On `CreateComponent` for a web-application, aep-api GETs the org namespaced `web-application` ComponentType and, if it still has a hostname-less catch-all `httproute`, overlays `httproute-external` with `oc_dns_label` + path `/` — the same CEL as helm / `setup-aep.sh`.
- Local types already mint hostnames (404 on the namespaced GET is a no-op). Service components are untouched. The PUT round-trips the raw CR so `resourceVersion` survives.
- Does **not** invent a URL in aep-api from Service DNS. Deployments **Open** still needs the HTTPS reader ([#541](https://github.com/wso2/labs-agentic-engineer/pull/541)) on HTTPS-only gateways.

## Test plan

- [x] `go test ./internal/clients/openchoreo/ -count=1` (includes catch-all rewrite, idempotent hosted route, 404 no-op, PUT keeps `resourceVersion`, web-application create GETs the type, service create does not).
- [ ] After aep-api rolls out: create a new `web-application` with `visibility: external`; DP HTTPRoute has a dedicated hostname, not a catch-all `/`.
- [ ] ReleaseBinding `status.endpoints[].externalURLs` is populated.
- [ ] list-deployments `endpointUrl` + Deployments **Open** (with #541 on cloud HTTPS).