### PR TITLE
fix(console): surface gate-refusal details when Build fails from the dependency drawer

### DIFF
--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -394,6 +394,55 @@ describe("SpecView onBuild routing (#164)", () => {
     expect(screen.getByTestId("dependency-drawer")).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it("drawer Continue with a gate refusal — closes the drawer and surfaces the gate checklist", async () => {
+    mockPreflightRefetch.mockResolvedValue({
+      data: { needsInput: true, items: PREFLIGHT_ITEMS },
+    });
+    const gateError = Object.assign(new Error("spec validation failed"), {
+      details: [
+        { message: "story 1 is in the PRD but no component's design.json lists it in `stories`" },
+        { field: "components/api/design.json", message: "component \"api\" is still the platform scaffold" },
+      ],
+    });
+    mockMutateAsync.mockRejectedValue(gateError);
+
+    render(<SpecView projectName="proj1" />);
+    clickBuild();
+    await waitFor(() =>
+      expect(screen.getByTestId("dependency-drawer")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText("Drawer Continue"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Build refused/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/story 1 is in the PRD/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("dependency-drawer")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("drawer Continue with a non-gate error — surfaces the plain error", async () => {
+    mockPreflightRefetch.mockResolvedValue({
+      data: { needsInput: true, items: PREFLIGHT_ITEMS },
+    });
+    mockMutateAsync.mockRejectedValue(new Error("network timeout"));
+
+    render(<SpecView projectName="proj1" />);
+    clickBuild();
+    await waitFor(() =>
+      expect(screen.getByTestId("dependency-drawer")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText("Drawer Continue"));
+
+    await waitFor(() =>
+      expect(screen.getByText("network timeout")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Build refused/i)).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });
 
 // --- #252 Task 9: dependency-status wiring ---------------------------------

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -554,6 +554,7 @@ export function SpecView({ projectName }: { projectName: string }) {
   // any inputs the BFF/devflow rejects come back as `failures` — surface the
   // reasons and leave the drawer open so the user can fix them and retry.
   const onContinueBuild = async (inputs: BuildInputItem[]) => {
+    setGateRefusal(null);
     setBuildError(null);
     setBuildPhase("building");
     try {
@@ -570,9 +571,13 @@ export function SpecView({ projectName }: { projectName: string }) {
         params: { projectName },
       });
     } catch (e) {
-      setBuildError(
-        e instanceof Error ? e.message : "Failed to start the build.",
-      );
+      const details = (e as Error & { details?: Array<{ field?: string; message: string }> }).details;
+      if (Array.isArray(details) && details.length > 0) {
+        setDependencyDrawerOpen(false);
+        setGateRefusal(details);
+      } else {
+        setBuildError(e instanceof Error ? e.message : "Failed to start the build.");
+      }
     } finally {
       setBuildPhase(null);
     }


### PR DESCRIPTION
## Summary

- When a build fails the spec validation gate and the user went through the dependency drawer (has external dependencies), `onContinueBuild` only showed the generic `"spec validation failed"` message with no per-file detail
- The `runBuild` path (no dependencies, Cut-version dialog) already extracted `e.details` and rendered the actionable gate checklist — this aligns the drawer path with the same behaviour
- The drawer is also closed before the checklist is shown so the overlay doesn't occlude it

## Changes

**`SpecView.tsx` — `onContinueBuild`:**
- Extract `e.details` in the catch block (same cast as `runBuild`)
- If details are present: close the drawer, call `setGateRefusal(details)` to render the per-file checklist
- If no details: fall back to `setBuildError(message)` as before
- Clear `gateRefusal` on entry (mirrors `runBuild`)

**`SpecView.test.tsx`:**
- New test: drawer Continue with a gate refusal — closes the drawer and surfaces the gate checklist
- New test: drawer Continue with a non-gate error — surfaces the plain error (regression guard)

## Root cause

`onContinueBuild` and `runBuild` both call the same build mutation but handled the error differently. The `runBuild` path checked for `e.details` and called `setGateRefusal`; `onContinueBuild` did not. Commit `10c8f535` added the gate checklist UI to `runBuild` but left the drawer path unpatched.

## Test plan

- [x] `SpecView.test.tsx` — all 23 tests pass, including the two new ones
- [ ] Manual: deploy with dependencies, click Build, fill in secrets, click Continue — should now show the "Build refused — the design isn't complete" checklist with per-file items instead of the generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)