### PR TITLE
Readable wireframe canvas: single column, screen-focused viewport, edit-following camera

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -100,6 +100,14 @@ here: they're the open `console` + `feature` issues.
   route. `@aep/excalidraw-dsl`'s `tryDslToPrototype` compiles per-screen
   scenes client-side (no BE handshake, no contract change; ADR-0008) —
   [#348](https://github.com/wso2/labs-agentic-engineer/issues/348)
+- Spec view — readable wireframe canvas: screens compile into a single column
+  instead of a two-across grid, and the canvas opens focused on the first
+  screen at a legible size with the top of the second peeking below; while an
+  agent edits, the viewport pans to the screen being changed instead of
+  refitting the whole board, and stays put when nothing identifiable changed.
+  `@aep/excalidraw-dsl` stamps each element with its screen so the viewer can
+  group per screen; no contract change —
+  [#552](https://github.com/wso2/labs-agentic-engineer/issues/552)
 - Project create — reference document upload on the "What do you want to
   build?" view: `.md`/`.txt`/`.pdf`/`.png`/`.jpg`/`.jpeg` (≤10 files, ≤5 MB
   each) attached in a chat-style composer and uploaded post-create over

--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -26,10 +26,11 @@ import type { CollabSpec } from "../collab/useCollabSpec";
 
 // The heavy lazy canvas is irrelevant here — record what scene/model it receives.
 vi.mock("@aep/ui-excalidraw-view", () => ({
-  ExcalidrawView: ({ scene }: { scene: string }) => (
+  ExcalidrawView: ({ scene, focusScreens }: { scene: string; focusScreens?: readonly string[] }) => (
     <div
       data-testid="excalidraw"
       data-elements={String(JSON.parse(scene).elements?.length ?? 0)}
+      data-focus={(focusScreens ?? []).join(",")}
     />
   ),
   PrototypeView: (p: { model: { screens: unknown[] }; trailingSlot?: unknown }) => (
@@ -94,6 +95,39 @@ describe("WireframePanel streaming", () => {
     });
     const grown = Number(screen.getByTestId("excalidraw").dataset.elements);
     expect(grown).toBeGreaterThan(first);
+  });
+
+  it("returns to the first screen when a GENERATION turn ends", () => {
+    // A fresh wireframe is drawn top to bottom; the camera follows each new
+    // screen and would be left on the last one. Completing a generation should
+    // read like opening the wireframe: start at the first screen.
+    mockDerived.mockReturnValue({ scene: null, isPending: false, isError: true });
+    const doc = new Y.Doc();
+    const ytext = doc.getText(DSL_PATH);
+    const { rerender } = renderPanel(makeCollab(ytext, true));
+    act(() => {
+      ytext.insert(0, 'screen First "a"\n  heading "A"\nscreen Second "b"\n  heading "B"\n');
+    });
+    // Agent leaves the room: the turn is over.
+    rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, false)} />);
+    expect(screen.getByTestId("excalidraw").dataset.focus).toBe("First");
+  });
+
+  it("does NOT return to the first screen when an EDIT turn ends", () => {
+    // The reader was somewhere; follow-the-edit already put the camera where
+    // the change is. Snapping back to the first screen would undo that.
+    mockDerived.mockReturnValue({ scene: null, isPending: false, isError: true });
+    const doc = new Y.Doc();
+    const ytext = doc.getText(DSL_PATH);
+    // Screens exist BEFORE the agent arrives — this is an edit, not a generation.
+    ytext.insert(0, 'screen First "a"\n  heading "A"\nscreen Second "b"\n  heading "B"\n');
+    const { rerender } = renderPanel(makeCollab(ytext, false));
+    rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, true)} />);
+    act(() => {
+      ytext.insert(ytext.length, '  button "Go"\n');
+    });
+    rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, false)} />);
+    expect(screen.getByTestId("excalidraw").dataset.focus).not.toBe("First");
   });
 
   it("holds the last good scene when an intermediate compile fails", () => {

--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -127,7 +127,9 @@ describe("WireframePanel streaming", () => {
       ytext.insert(ytext.length, '  button "Go"\n');
     });
     rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, false)} />);
-    expect(screen.getByTestId("excalidraw").dataset.focus).not.toBe("First");
+    // Exactly the edited screen — "not First" would also pass on an empty
+    // focus, which would mean the camera moved nowhere at all.
+    expect(screen.getByTestId("excalidraw").dataset.focus).toBe("Second");
   });
 
   it("holds the last good scene when an intermediate compile fails", () => {

--- a/apps/console/src/features/spec/components/WireframePanel.test.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.test.tsx
@@ -288,6 +288,36 @@ describe("WireframePanel prototype toggle", () => {
     });
   });
 
+  it("an agent turn switches a prototype reader to canvas, and leaves them there afterwards", () => {
+    // The canvas is the editing view: it is the only place every kind of change
+    // — content, a new screen, a reshaped flow — is visible, and it follows the
+    // edit. So a turn starting while the reader is in the prototype takes them
+    // to canvas. And it STAYS there when the turn ends: returning to the
+    // prototype by itself is what bounced readers back to screen 1 mid-review.
+    mockDerived.mockReturnValue({ scene: null, isPending: true, isError: false });
+    mockDerivedPrototype.mockReturnValue({ model: null, isPending: true, isError: false });
+    const doc = new Y.Doc();
+    const ytext = doc.getText(DSL_PATH);
+    ytext.insert(0, 'screen Catalog "Seeded"\n  heading "Browse"\n');
+    const { rerender } = renderPanel(makeCollab(ytext, false));
+
+    fireEvent.click(screen.getByRole("button", { name: /prototype/i }));
+    expect(screen.getByTestId("prototype")).toBeInTheDocument();
+
+    // Agent arrives: a turn begins.
+    rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, true)} />);
+    expect(screen.queryByTestId("prototype")).not.toBeInTheDocument();
+    expect(screen.getByTestId("excalidraw")).toBeInTheDocument();
+
+    // Agent leaves: the turn is over. Still canvas — no silent return.
+    rerender(<WireframePanel projectName="p" dslPath={DSL_PATH} files={[]} collab={makeCollab(ytext, false)} />);
+    expect(screen.queryByTestId("prototype")).not.toBeInTheDocument();
+    expect(screen.getByTestId("excalidraw")).toBeInTheDocument();
+    // …and the reader can go back by choice.
+    fireEvent.click(screen.getByRole("button", { name: /prototype/i }));
+    expect(screen.getByTestId("prototype")).toBeInTheDocument();
+  });
+
   it("hides the toggle while the agent is drawing", () => {
     mockDerived.mockReturnValue({ scene: null, isPending: false, isError: true });
     const doc = new Y.Doc();

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -28,7 +28,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { ExcalidrawView, PrototypeView } from "@aep/ui-excalidraw-view";
 import { useDerivedPrototype, useDerivedWireframe } from "../api/useDerivedDesign";
-import { deriveWireframeScene } from "../derive/deriveWireframe";
+import { deriveLiveWireframe, focusTargets, type LiveCompile } from "../derive/deriveWireframe";
 import { derivePrototypeModel } from "../derive/derivePrototype";
 import type { SpecFileEntry } from "../api/mapping";
 import type { CollabSpec } from "../collab/useCollabSpec";
@@ -65,13 +65,26 @@ export function WireframePanel({
   // from: SpecView renders this panel unkeyed, so the ref survives a move to
   // another component, and untagged it would let component A's last good render
   // stand in for component B's uncompilable source.
-  const lastGoodLive = useRef<{ path: string; scene: string } | null>(null);
-  const liveScene = useMemo(() => {
+  //
+  // The held compile is also the PREVIOUS compile the next one is measured
+  // against: `deriveLiveWireframe` reports which screens changed since it, and
+  // that report is what steers the canvas to the agent's edit (#552). A
+  // failed mid-stream compile leaves the held one in place AND reports no
+  // change, so a half-written frame never moves the viewport.
+  const lastGoodLive = useRef<{ path: string; result: LiveCompile } | null>(null);
+  const live = useMemo(() => {
     if (typeof liveSource !== "string" || liveSource.trim().length === 0) return null;
-    const compiled = deriveWireframeScene(dslPath, liveSource);
-    if (compiled) lastGoodLive.current = { path: dslPath, scene: compiled };
-    return lastGoodLive.current?.path === dslPath ? lastGoodLive.current.scene : null;
+    const previous = lastGoodLive.current?.path === dslPath ? lastGoodLive.current.result : null;
+    const compiled = deriveLiveWireframe(dslPath, liveSource, previous);
+    if (compiled) {
+      lastGoodLive.current = { path: dslPath, result: compiled };
+      return { scene: compiled.json, focusScreens: focusTargets(compiled, previous) };
+    }
+    return lastGoodLive.current?.path === dslPath
+      ? { scene: lastGoodLive.current.result.json, focusScreens: [] as string[] }
+      : null;
   }, [dslPath, liveSource]);
+  const liveScene = live?.scene ?? null;
 
   // Two independent facts, deliberately NOT one flag:
   //   hasLiveContent — the doc has something renderable, so the doc is the
@@ -241,7 +254,7 @@ export function WireframePanel({
           </Typography>
         )
       ) : hasLiveContent ? (
-        <ExcalidrawView scene={liveScene!} fillHeight />
+        <ExcalidrawView scene={liveScene!} focusScreens={live!.focusScreens} fillHeight />
       ) : (
         <ExcalidrawView key={sha} scene={scene!} fillHeight />
       )}

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -78,11 +78,14 @@ export function WireframePanel({
     const compiled = deriveLiveWireframe(dslPath, liveSource, previous);
     if (compiled) {
       lastGoodLive.current = { path: dslPath, result: compiled };
-      return { scene: compiled.json, focusScreens: focusTargets(compiled, previous) };
+      return {
+        scene: compiled.json,
+        focusScreens: focusTargets(compiled, previous),
+        screenOrder: compiled.screenOrder,
+      };
     }
-    return lastGoodLive.current?.path === dslPath
-      ? { scene: lastGoodLive.current.result.json, focusScreens: [] as string[] }
-      : null;
+    const held = lastGoodLive.current?.path === dslPath ? lastGoodLive.current.result : null;
+    return held ? { scene: held.json, focusScreens: [] as string[], screenOrder: held.screenOrder } : null;
   }, [dslPath, liveSource]);
   const liveScene = live?.scene ?? null;
 
@@ -95,6 +98,30 @@ export function WireframePanel({
   // used to keep the view switch permanently hidden (#348).
   const hasLiveContent = liveScene != null;
   const agentBusy = collab.peers.some((p) => p.kind === "agent");
+
+  // A turn that begins with NO renderable screens is a generation; one that
+  // begins with screens is an edit. Decided at the moment the agent arrives,
+  // because by the time it leaves the doc is full either way.
+  const turnStartedEmpty = useRef<boolean | null>(null);
+  // Starts false, not `agentBusy`: a panel that MOUNTS mid-turn must still
+  // see that turn as having started, or a generation opened mid-draw would
+  // never return to its first screen.
+  const wasBusy = useRef(false);
+  if (agentBusy && !wasBusy.current) turnStartedEmpty.current = !hasLiveContent;
+  // Generation draws top to bottom and the camera follows each new screen, so
+  // it ends on the LAST one — an accident of arrival order. Completing a
+  // generation should read like opening the wireframe: return to the first
+  // screen. An edit turn does NOT: follow-the-edit already put the camera
+  // where the change is, and snapping back would undo that.
+  const generationJustEnded = wasBusy.current && !agentBusy && turnStartedEmpty.current === true;
+  wasBusy.current = agentBusy;
+  const focusScreens = useMemo(() => {
+    if (generationJustEnded && live) {
+      const first = live.screenOrder[0];
+      return first ? [first] : [];
+    }
+    return live?.focusScreens ?? [];
+  }, [generationJustEnded, live]);
 
   // Committed fetch: the collab-less base path only (mirrors `usesCollab`
   // disabling the content query for markdown) — passing "" disables it. An
@@ -254,7 +281,7 @@ export function WireframePanel({
           </Typography>
         )
       ) : hasLiveContent ? (
-        <ExcalidrawView scene={liveScene!} focusScreens={live!.focusScreens} fillHeight />
+        <ExcalidrawView scene={liveScene!} focusScreens={focusScreens} fillHeight />
       ) : (
         <ExcalidrawView key={sha} scene={scene!} fillHeight />
       )}

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -114,7 +114,17 @@ export function WireframePanel({
   // screen. An edit turn does NOT: follow-the-edit already put the camera
   // where the change is, and snapping back would undo that.
   const generationJustEnded = wasBusy.current && !agentBusy && turnStartedEmpty.current === true;
+  // A turn beginning while the reader is in the prototype takes them to the
+  // canvas — the editing view, and the only one where every kind of change
+  // (content, a new screen, a reshaped flow) is visible and followed. It is a
+  // real mode change, not a render guard: when the turn ends the reader STAYS
+  // on canvas and returns to the prototype by choice. Returning for them is
+  // what used to bounce a mid-review reader back to screen 1.
+  const turnJustStarted = agentBusy && !wasBusy.current;
   wasBusy.current = agentBusy;
+  useEffect(() => {
+    if (turnJustStarted) setMode("canvas");
+  }, [turnJustStarted]);
   const focusScreens = useMemo(() => {
     if (generationJustEnded && live) {
       const first = live.screenOrder[0];

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -246,7 +246,12 @@ export function WireframePanel({
   // (fillHeight) sets `flex: 1` on its own root inside the flex column.
   return (
     <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-      {agentBusy && hasLiveContent && (
+      {(showOwnHeader || (agentBusy && hasLiveContent)) && (
+        // ONE header row for both states, at a constant height. The drawing
+        // chip (~24px) and the view switch (~32px) used to live in separate
+        // rows with only their content setting the height, so entering and
+        // leaving a turn resized the header by ~8px and the whole canvas
+        // jumped with it. minHeight pins the row; only the content swaps.
         // The chip means "actively being generated", not "rendered from the
         // live doc" — the doc is ALWAYS the source while collab is up (rooms
         // are seeded), so it MUST key on the peer, not on the live text.
@@ -254,28 +259,19 @@ export function WireframePanel({
           sx={{
             px: 1.5,
             py: 1,
+            minHeight: 48,
             display: "flex",
             alignItems: "center",
+            justifyContent: agentBusy ? "flex-start" : "flex-end",
             borderBottom: 1,
             borderColor: "divider",
           }}
         >
-          <Chip size="small" color="primary" variant="outlined" label="Drawing…" />
-        </Box>
-      )}
-      {showOwnHeader && (
-        <Box
-          sx={{
-            px: 1.5,
-            py: 1,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-end",
-            borderBottom: 1,
-            borderColor: "divider",
-          }}
-        >
-          {viewSwitch}
+          {agentBusy && hasLiveContent ? (
+            <Chip size="small" color="primary" variant="outlined" label="Drawing…" />
+          ) : (
+            viewSwitch
+          )}
         </Box>
       )}
       {mode === "prototype" && showToggle ? (

--- a/apps/console/src/features/spec/components/WireframePanel.tsx
+++ b/apps/console/src/features/spec/components/WireframePanel.tsx
@@ -215,7 +215,13 @@ export function WireframePanel({
           border: 0,
           borderRadius: 999,
           px: 1.5,
-          minHeight: 28,
+          py: 0,
+          // Exact, not a floor: the small ToggleButton's own padding makes its
+          // natural height ~37px, which pushed the settled header to ~57px
+          // while the Drawing-chip header pinned at 48px — an ~8px canvas jump
+          // at every turn boundary. 28px + the pill's 4px + row padding = 48px
+          // in BOTH states.
+          height: 28,
           textTransform: "none",
           fontSize: "0.8125rem",
           color: "text.secondary",

--- a/apps/console/src/features/spec/derive/deriveWireframe.test.ts
+++ b/apps/console/src/features/spec/derive/deriveWireframe.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { deriveWireframeScene } from "./deriveWireframe";
+import { deriveLiveWireframe, deriveWireframeScene, focusTargets } from "./deriveWireframe";
 
 const dsl = `screen Home
   heading "Welcome"
@@ -69,5 +69,72 @@ screen Cart "Review and check out"
     const texts = scene.elements.filter((e: { type: string }) => e.type === "text");
     expect(texts.some((t: { text?: string }) => t.text === "Catalog")).toBe(true);
     expect(texts.some((t: { text?: string }) => t.text === "Cart")).toBe(true);
+  });
+});
+
+describe("deriveLiveWireframe", () => {
+  const path = "design/components/web/wireframes.dsl";
+  const two = `screen Home\n  heading "Welcome"\nscreen Cart\n  button "Pay"\n`;
+
+  it("compiles and reports no changed screens when there is nothing to compare against", () => {
+    const r = deriveLiveWireframe(path, two, null);
+    expect(r).not.toBeNull();
+    expect(r!.changedScreens).toEqual([]);
+    expect(JSON.parse(r!.json).elements.length).toBeGreaterThan(0);
+  });
+
+  it("reports only the screen the edit touched, given the previous compile", () => {
+    const first = deriveLiveWireframe(path, two, null);
+    const second = deriveLiveWireframe(path, two.replace('button "Pay"', 'button "Pay" primary'), first);
+    expect(second!.changedScreens).toEqual(["Cart"]);
+  });
+
+  it("returns null for an uncompilable source, leaving the caller's held compile in place", () => {
+    const first = deriveLiveWireframe(path, two, null);
+    expect(deriveLiveWireframe(path, "garbage {{{", first)).toBeNull();
+    expect(deriveLiveWireframe(path, "", first)).toBeNull();
+  });
+
+  it("treats a domain-model DSL as a plain compile with no screens to report", () => {
+    const r = deriveLiveWireframe("design/erd.dsl", `entity User\n  id: uuid\n`, null);
+    expect(r).not.toBeNull();
+    expect(r!.changedScreens).toEqual([]);
+  });
+});
+
+describe("focusTargets", () => {
+  const path = "design/components/web/wireframes.dsl";
+  const three = `screen One\n  heading "A"\nscreen Two\n  button "Go"\nscreen Three\n  heading "C"\n`;
+  const filler = Array.from({ length: 20 }, (_, i) => `  text "line ${i}"`).join("\n");
+
+  it("follows a surgical edit live: one screen changed out of three is a target", () => {
+    const base = deriveLiveWireframe(path, three, null)!;
+    const edited = deriveLiveWireframe(path, three.replace('heading "A"', `heading "A"\n${filler}`), base)!;
+    expect(focusTargets(edited, base)).toEqual(["One"]);
+  });
+
+  it("holds still mid-rewrite: a flush missing most screens is not a target", () => {
+    // An agent rewriting the file emits a flush where Two and Three are not
+    // yet written back. The compiler honestly reports all three as changed;
+    // panning there would fit the whole board.
+    const base = deriveLiveWireframe(path, three, null)!;
+    const midRewrite = deriveLiveWireframe(path, `screen One\n  heading "A"\n${filler}\n`, base)!;
+    expect(midRewrite.changedScreens).toEqual(["One", "Two", "Three"]);
+    expect(focusTargets(midRewrite, base)).toEqual([]);
+  });
+
+  it("measures breadth against the larger compile, so a shrunken flush cannot look narrow", () => {
+    // Mid-rewrite the new compile holds ONE screen; measured against itself,
+    // 'One changed of one' would wrongly count as a narrow edit.
+    const base = deriveLiveWireframe(path, three, null)!;
+    const shrunken = deriveLiveWireframe(path, `screen One\n  heading "A"\n${filler}\n`, base)!;
+    expect(Object.keys(shrunken.fingerprints)).toEqual(["One"]);
+    expect(focusTargets(shrunken, base)).toEqual([]);
+  });
+
+  it("reports nothing when nothing changed", () => {
+    const base = deriveLiveWireframe(path, three, null)!;
+    const same = deriveLiveWireframe(path, three, base)!;
+    expect(focusTargets(same, base)).toEqual([]);
   });
 });

--- a/apps/console/src/features/spec/derive/deriveWireframe.ts
+++ b/apps/console/src/features/spec/derive/deriveWireframe.ts
@@ -16,7 +16,12 @@
  * under the License.
  */
 
-import { tryDslToExcalidraw, type DslKind } from "@aep/excalidraw-dsl";
+import {
+  compileWireframes,
+  tryDslToExcalidraw,
+  type DslKind,
+  type WireframeCompile,
+} from "@aep/excalidraw-dsl";
 
 /** `erd`/`domain` filenames are domain-model DSL; everything else is wireframes. */
 export function kindFor(path: string): DslKind {
@@ -32,4 +37,54 @@ export function kindFor(path: string): DslKind {
 export function deriveWireframeScene(path: string, dsl: string): string | null {
   const res = tryDslToExcalidraw(kindFor(path), dsl);
   return res.ok ? res.json : null;
+}
+
+/**
+ * The live-edit variant: compile AND learn which screens this compile changed
+ * versus `previous`, so the canvas can follow the agent's edit instead of
+ * guessing. `previous` is this function's own prior result for the SAME file
+ * (null on first compile or after switching files); the caller holds it — the
+ * compiler remembers nothing. Domain-model DSLs have no screens and take the
+ * plain path. Returns null when the source does not compile, exactly like
+ * `deriveWireframeScene`.
+ */
+export type LiveCompile = Extract<WireframeCompile, { ok: true }>;
+
+/**
+ * Which of a compile's changed screens the canvas should actually move to.
+ *
+ * A surgical edit changes one or two screens: follow it, live, from the first
+ * flush. But an agent that REWRITES the file makes the in-between flushes
+ * genuinely incomplete — screens are absent until written back — so the
+ * compiler honestly reports most of them as changed. Panning to that union is
+ * the whole board, zoomed out to nothing. A change touching more than half the
+ * screens is therefore a rewrite in flight, not an edit to follow: hold still
+ * and let the canvas keep drawing until the report narrows. Deciding this from
+ * the compiler's report rather than from a timer means a clean edit is never
+ * delayed and a rewrite never yanks the viewport.
+ */
+export function focusTargets(compile: LiveCompile, previous: LiveCompile | null): string[] {
+  const changed = compile.changedScreens;
+  if (changed.length === 0) return [];
+  // Measured against the LARGER of the two compiles: mid-rewrite the new one
+  // has lost screens, and counting only what survived would make a three-of-
+  // three change look like three-of-one.
+  const total = Math.max(
+    Object.keys(compile.fingerprints).length,
+    previous ? Object.keys(previous.fingerprints).length : 0,
+  );
+  return changed.length * 2 > total ? [] : changed;
+}
+
+export function deriveLiveWireframe(
+  path: string,
+  dsl: string,
+  previous: LiveCompile | null,
+): LiveCompile | null {
+  if (kindFor(path) !== "wireframes") {
+    const res = tryDslToExcalidraw("domain-model", dsl);
+    return res.ok ? { ok: true, json: res.json, changedScreens: [], fingerprints: {} } : null;
+  }
+  const res = compileWireframes(dsl, previous);
+  return res.ok ? res : null;
 }

--- a/apps/console/src/features/spec/derive/deriveWireframe.ts
+++ b/apps/console/src/features/spec/derive/deriveWireframe.ts
@@ -83,7 +83,9 @@ export function deriveLiveWireframe(
 ): LiveCompile | null {
   if (kindFor(path) !== "wireframes") {
     const res = tryDslToExcalidraw("domain-model", dsl);
-    return res.ok ? { ok: true, json: res.json, changedScreens: [], fingerprints: {} } : null;
+    return res.ok
+      ? { ok: true, json: res.json, changedScreens: [], fingerprints: {}, screenOrder: [] }
+      : null;
   }
   const res = compileWireframes(dsl, previous);
   return res.ok ? res : null;

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -255,6 +255,102 @@ export function dslToExcalidraw(kind: DslKind, dsl: string): string {
   return JSON.stringify(scene, null, 2);
 }
 
+// ---------- Wireframe compile that reports what changed ----------
+
+/**
+ * A wireframe compile plus the compiler's own account of which screens
+ * changed since `previous`. Hold the result and pass it back on the next
+ * compile; the compiler remembers nothing between calls.
+ */
+export type WireframeCompile =
+  | {
+      ok: true;
+      json: string;
+      /**
+       * Screens whose rendered content differs from `previous`, in canvas
+       * order (topmost first). Empty when nothing changed or when there was
+       * no `previous` to compare against. A screen that merely moved because
+       * one above it grew is NOT listed — comparison is relative to each
+       * screen's own origin.
+       */
+      changedScreens: string[];
+      /** Per-screen fingerprints, carried so the NEXT compile can compare. */
+      fingerprints: Record<string, string>;
+    }
+  | { ok: false; error: string };
+
+/**
+ * A screen's rendered content as one comparable string, positions taken
+ * relative to the screen's own top-left. Screens stack in one column, so a
+ * taller screen above shifts everything below it; comparing absolute
+ * coordinates would call every shifted screen "changed". Element ids are
+ * already screen-relative, and everything else is compared verbatim.
+ */
+function screenFingerprint(elements: readonly ExcalidrawElement[]): string {
+  let ox = Number.POSITIVE_INFINITY;
+  let oy = Number.POSITIVE_INFINITY;
+  for (const e of elements) {
+    if (e.x < ox) ox = e.x;
+    if (e.y < oy) oy = e.y;
+  }
+  return elements
+    .map((e) => JSON.stringify({ ...e, x: e.x - ox, y: e.y - oy }))
+    .sort()
+    .join('\n');
+}
+
+/**
+ * Compile a wireframes DSL and report which screens changed versus the
+ * previous compile. This is what lets a viewer follow an edit without
+ * guessing: the compiler KNOWS the screen structure, so it — not a diff over
+ * a flat scene — says what moved. `previous` is the prior result from this
+ * function (or null on first compile / a different file); the caller keeps
+ * it, the compiler stays pure.
+ *
+ * A source that does not compile returns `ok: false` exactly like
+ * `tryDslToExcalidraw`, and reports no change — so a half-written stream
+ * frame never produces a focus signal.
+ */
+export function compileWireframes(dsl: string, previous: WireframeCompile | null): WireframeCompile {
+  const base = tryDslToExcalidraw('wireframes', dsl);
+  if (!base.ok) return base;
+  const elements = (JSON.parse(base.json) as ExcalidrawScene).elements;
+
+  // Bucket by the screen tag every element carries, remembering each screen's
+  // topmost y so the report can be ordered the way the canvas is.
+  const byScreen = new Map<string, ExcalidrawElement[]>();
+  const topOf = new Map<string, number>();
+  for (const e of elements) {
+    const name = e.customData?.screen;
+    if (!name) continue;
+    const bucket = byScreen.get(name);
+    if (bucket) bucket.push(e);
+    else byScreen.set(name, [e]);
+    const t = topOf.get(name);
+    if (t === undefined || e.y < t) topOf.set(name, e.y);
+  }
+
+  const fingerprints: Record<string, string> = {};
+  for (const [name, els] of byScreen) fingerprints[name] = screenFingerprint(els);
+
+  const prior = previous?.ok ? previous.fingerprints : null;
+  const changedScreens: string[] = [];
+  if (prior) {
+    for (const name of Object.keys(fingerprints)) {
+      if (prior[name] !== fingerprints[name]) changedScreens.push(name);
+    }
+    // A removed screen has nothing left to show, but the gap it left is worth
+    // reporting; it is ordered by where it used to sit — which only the
+    // previous compile knows, so we rank it by its old neighbours' top.
+    for (const name of Object.keys(prior)) {
+      if (!(name in fingerprints)) changedScreens.push(name);
+    }
+    changedScreens.sort((a, b) => (topOf.get(a) ?? Number.POSITIVE_INFINITY) - (topOf.get(b) ?? Number.POSITIVE_INFINITY));
+  }
+
+  return { ok: true, json: base.json, changedScreens, fingerprints };
+}
+
 export function tryDslToExcalidraw(
   kind: DslKind,
   dsl: string,

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -1316,7 +1316,13 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
       // treatment table cells get — so nothing renders outside the screen.
       const clipText = (label: string, fontSize: number): string =>
         truncateLabel(label, fitChars(sx + screen.width - 16 - ex, fontSize));
-      const eid = stableId(`el:${screen.name}:${el.kind}:${el.label}:${ex}:${ey}`);
+      // Identity is SCREEN-relative (el.x/el.y), never the canvas position
+      // (ex/ey). Screens stack in one column, so growing one screen shifts
+      // every screen below it; keying identity on canvas coordinates gave
+      // every one of those elements a new id, which made a viewer diff read
+      // an untouched screen as wholly replaced. The screen name still keeps
+      // ids unique across screens.
+      const eid = stableId(`el:${screen.name}:${el.kind}:${el.label}:${el.x}:${el.y}`);
       // A `-> ScreenName` on this element draws a navigation marker right
       // beside it, so the reader sees exactly which control goes where.
       if (!opts?.prototype && el.navTo) {

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -342,12 +342,25 @@ export function compileWireframes(dsl: string, previous: WireframeCompile | null
       if (prior[name] !== fingerprints[name]) changedScreens.push(name);
     }
     // A removed screen has nothing left to show, but the gap it left is worth
-    // reporting; it is ordered by where it used to sit — which only the
-    // previous compile knows, so we rank it by its old neighbours' top.
+    // reporting; it is ordered by where it USED to sit, which only the previous
+    // compile knows.
     for (const name of Object.keys(prior)) {
       if (!(name in fingerprints)) changedScreens.push(name);
     }
-    changedScreens.sort((a, b) => (topOf.get(a) ?? Number.POSITIVE_INFINITY) - (topOf.get(b) ?? Number.POSITIVE_INFINITY));
+    // Rank on the previous canvas — the one the reader was actually looking at
+    // — placing each screen by its old index and falling back to the new
+    // ordering for screens that did not exist before. Ranking a removed screen
+    // by the CURRENT canvas is impossible (it has no position there), and
+    // defaulting it to last claimed the screen below it changed first.
+    const priorRank = new Map(
+      (previous?.ok ? previous.screenOrder : []).map((name, i) => [name, i] as const),
+    );
+    const currentRank = new Map(
+      [...topOf.entries()].sort((a, b) => a[1] - b[1]).map(([name], i) => [name, i] as const),
+    );
+    const rankOf = (name: string): number =>
+      priorRank.get(name) ?? (currentRank.get(name) ?? 0) + priorRank.size;
+    changedScreens.sort((a, b) => rankOf(a) - rankOf(b));
   }
 
   const screenOrder = [...topOf.entries()].sort((a, b) => a[1] - b[1]).map(([name]) => name);
@@ -677,6 +690,14 @@ function buildWireframes(
           tree: [],
         };
         if (screenMatch[2]) screen.description = unescapeQuoted(screenMatch[2]);
+        // Screen names are identity: element ids are screen-relative, the
+        // per-screen fingerprints that drive the viewer's focus are keyed by
+        // name, and `-> Target` resolves by name (case-insensitively). Two
+        // screens sharing one name merge into a single fingerprint and emit
+        // colliding element ids, so it is always an authoring bug.
+        if (ast.screens.some((s) => s.name.toLowerCase() === screen!.name.toLowerCase())) {
+          err(no, `duplicate screen ${JSON.stringify(screen.name)} — declare each screen once`);
+        }
         ast.screens.push(screen);
         stack = [{ level: 0, kind: 'root', nodes: screen.tree }];
         inFlow = false;

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -1428,14 +1428,39 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
         const num = screenNumber.get(el.navTo.toLowerCase());
         if (num !== undefined) {
           const label = `→ Screen ${num} · ${el.navTo}`;
+          const markerW = Math.max(120, label.length * 8);
+          const markerH = 16;
+          // Beside the control when there is room; below it when there is not.
+          // "Room" means the marker would neither cross the screen's right edge
+          // nor land on a sibling laid out to the right on the same row — the
+          // common case being two buttons side by side, where a marker drawn
+          // across the neighbour made BOTH unreadable.
+          const besideX = ex + el.width + 10;
+          const besideY = ey + Math.max(0, (el.height - markerH) / 2);
+          const screenRight = sx + screen.width - 16;
+          const crossesEdge = besideX + markerW > screenRight;
+          const hitsSibling = screen.elements.some((other) => {
+            if (other === el) return false;
+            const ox = sx + other.x;
+            const oy = frameY + other.y;
+            return (
+              ox < besideX + markerW &&
+              ox + other.width > besideX &&
+              oy < besideY + markerH &&
+              oy + other.height > besideY
+            );
+          });
+          const below = crossesEdge || hitsSibling;
+          const mx = below ? Math.min(ex, screenRight - markerW) : besideX;
+          const my = below ? ey + el.height + 4 : besideY;
           out.push(
             withColor(
               makeText(
-                stableId(`nav:${screen.name}:${el.label}:${el.navTo}:${ex}:${ey}`),
-                ex + el.width + 10,
-                ey + Math.max(0, (el.height - 16) / 2),
-                Math.max(120, label.length * 8),
-                16,
+                stableId(`nav:${screen.name}:${el.label}:${el.navTo}:${el.x}:${el.y}`),
+                mx,
+                my,
+                markerW,
+                markerH,
                 label,
                 13,
                 'left',

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -235,7 +235,7 @@ interface ArrowElement extends ExcalidrawElementBase {
   endIsSpecial?: null;
 }
 
-type ExcalidrawElement = RectElement | TextElement | ArrowElement;
+export type ExcalidrawElement = RectElement | TextElement | ArrowElement;
 
 // ---------- Public API ----------
 

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -189,6 +189,8 @@ interface ExcalidrawElementBase {
   updated: number;
   link: null;
   locked: boolean;
+  /** Which `screen` emitted this element; set on every element of the grid scene. */
+  customData?: { screen: string };
 }
 
 interface RectElement extends ExcalidrawElementBase {
@@ -1068,7 +1070,11 @@ const DEFAULT_SCREEN_W = 1280; // desktop webapp frame (override: `screen Name W
 const DEFAULT_SCREEN_H = 800;
 const SCREEN_GAP_X = 120;
 const SCREEN_GAP_Y = 120;
-const COLUMNS = 2;
+// Screens stack in one column: side-by-side rows shrank every screen to an
+// illegible size once the viewer fitted the whole board, and a single column
+// is what lets the viewer land on the FIRST screen with the next one's top
+// edge peeking below as the cue that there is more.
+const COLUMNS = 1;
 const TITLE_H = 32; // screen-name row drawn ABOVE the outline
 const DESC_H = 22; // extra headroom for a screen description subtitle
 const NAVBAR_H = 56;
@@ -1213,6 +1219,7 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
   let curY = 0;
   let rowMaxH = 0;
   ast.screens.forEach((screen, idx) => {
+    const firstEl = out.length;
     const number = idx + 1;
     if (idx > 0 && idx % COLUMNS === 0) {
       curX = 0;
@@ -1755,6 +1762,13 @@ function renderWireframes(ast: WireframeAst, opts?: WireframeRenderOpts): Excali
           break;
         }
       }
+    }
+    // Every element a screen emitted — frame, title block, chrome, body — is
+    // tagged with the screen it belongs to. Excalidraw preserves `customData`
+    // and never renders it; it is what lets a viewer group elements per screen
+    // (focus the first, follow the changed one) without geometry guesswork.
+    for (let i = firstEl; i < out.length; i++) {
+      out[i] = { ...out[i]!, customData: { screen: screen.name } };
     }
   });
 

--- a/packages/excalidraw-dsl/src/index.ts
+++ b/packages/excalidraw-dsl/src/index.ts
@@ -276,6 +276,8 @@ export type WireframeCompile =
       changedScreens: string[];
       /** Per-screen fingerprints, carried so the NEXT compile can compare. */
       fingerprints: Record<string, string>;
+      /** Screen names in canvas order (topmost first); `[0]` is where a reader starts. */
+      screenOrder: string[];
     }
   | { ok: false; error: string };
 
@@ -348,7 +350,8 @@ export function compileWireframes(dsl: string, previous: WireframeCompile | null
     changedScreens.sort((a, b) => (topOf.get(a) ?? Number.POSITIVE_INFINITY) - (topOf.get(b) ?? Number.POSITIVE_INFINITY));
   }
 
-  return { ok: true, json: base.json, changedScreens, fingerprints };
+  const screenOrder = [...topOf.entries()].sort((a, b) => a[1] - b[1]).map(([name]) => name);
+  return { ok: true, json: base.json, changedScreens, fingerprints, screenOrder };
 }
 
 export function tryDslToExcalidraw(

--- a/packages/excalidraw-dsl/test/dsl.test.ts
+++ b/packages/excalidraw-dsl/test/dsl.test.ts
@@ -333,3 +333,60 @@ test("a short text line is left untouched (no ellipsis)", () => {
   const t = els.find((e) => e.type === "text" && /Owner/.test(e.text ?? ""))!;
   assert.equal(t.text, "Owner: Platform team");
 });
+
+// ---------- navigation markers must never overprint ----------
+
+/** Axis-aligned overlap between two boxes, with a small tolerance. */
+function overlaps(a: El, b: El): boolean {
+  return (
+    a.x < b.x + b.width - 1 &&
+    a.x + a.width > b.x + 1 &&
+    a.y < b.y + b.height - 1 &&
+    a.y + a.height > b.y + 1
+  );
+}
+
+test("a navigation marker never overprints a neighbouring control in the same row", () => {
+  // Two buttons side by side, the LEFT one navigating. Its marker must not be
+  // drawn across the right one — that made both unreadable.
+  const els = compile(`screen Confirm
+  row
+    right
+    button "Go back" -> Chat
+    button "Confirm booking" primary -> Booked
+screen Chat
+  heading "c"
+screen Booked
+  heading "b"`);
+  const marker = els.find((e) => e.type === "text" && /Screen 2 · Chat/.test(e.text ?? ""))!;
+  assert.ok(marker, "marker missing");
+  const confirmBtn = els.find((e) => e.type === "rectangle" && e.backgroundColor === "#fa7b3f")!;
+  assert.ok(confirmBtn, "primary button missing");
+  assert.ok(!overlaps(marker, confirmBtn), "marker drawn over the neighbouring button");
+});
+
+test("a navigation marker never runs past the screen's right edge", () => {
+  const els = compile(`screen Confirm
+  row
+    right
+    button "Confirm booking" primary -> Booked
+screen Booked
+  heading "b"`);
+  const marker = els.find((e) => e.type === "text" && /Screen 2 · Booked/.test(e.text ?? ""))!;
+  assert.ok(marker, "marker missing");
+  assert.ok(marker.x + marker.width <= 1280 + 1, `marker ends at ${marker.x + marker.width}, past 1280`);
+});
+
+test("a navigation marker with room to its right still sits beside its control", () => {
+  const els = compile(`screen Catalog
+  button "View product" -> ProductDetail
+screen ProductDetail
+  heading "Details"`);
+  const btn = els.find((e) => e.type === "rectangle" && e.width < 400 && e.height < 60)!;
+  const marker = els.find((e) => e.type === "text" && /Screen 2 · ProductDetail/.test(e.text ?? ""))!;
+  assert.ok(marker.x >= btn.x + btn.width, "marker should be to the right when there is room");
+  assert.ok(
+    Math.abs(marker.y + marker.height / 2 - (btn.y + btn.height / 2)) < 12,
+    "vertically centred on the control",
+  );
+});

--- a/packages/excalidraw-dsl/test/flows.test.ts
+++ b/packages/excalidraw-dsl/test/flows.test.ts
@@ -43,6 +43,31 @@ function model(dsl: string) {
   return res.model;
 }
 
+test("a duplicate screen name is rejected with the second declaration's line number", () => {
+  // Two screens with one name merge into one fingerprint and one screenOrder
+  // entry, and their screen-relative element ids collide — Excalidraw scenes
+  // must not carry duplicate ids. Always an authoring bug; reject like a
+  // duplicate flow name.
+  const errs = validateWireframeSyntax(`screen One
+  heading "A"
+screen One
+  heading "B"
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 3: /);
+  assert.match(errs[0]!, /duplicate screen "One"/);
+});
+
+test("duplicate screen detection is case-insensitive, matching screen-name resolution", () => {
+  const errs = validateWireframeSyntax(`screen Login
+  heading "A"
+screen LOGIN
+  heading "B"
+`);
+  assert.equal(errs.length, 1);
+  assert.match(errs[0]!, /^line 3: /);
+});
+
 test("a valid DSL with named flows passes the write gate", () => {
   assert.deepEqual(validateWireframeSyntax(TWO_FLOWS), []);
 });

--- a/packages/excalidraw-dsl/test/layout.test.ts
+++ b/packages/excalidraw-dsl/test/layout.test.ts
@@ -302,3 +302,38 @@ test("row-in-card passes the syntax gate and the layout oracle", () => {
   assert.deepEqual(validateWireframeSyntax(dsl), []);
   assert.deepEqual(validateWireframeLayout(dsl), []);
 });
+
+
+test("screens stack vertically: every screen frame shares x=0 and each starts below the previous", () => {
+  const els = compile(`screen One
+  heading "First"
+screen Two
+  heading "Second"
+screen Three
+  heading "Third"
+`);
+  const frames = els
+    .filter((e) => e.type === "rectangle" && e.width === 1280)
+    .sort((a, b) => a.y - b.y);
+  assert.equal(frames.length, 3);
+  assert.ok(frames.every((f) => f.x === 0), "all frames at x=0");
+  assert.ok(frames[1]!.y >= frames[0]!.y + frames[0]!.height, "second below first");
+  assert.ok(frames[2]!.y >= frames[1]!.y + frames[1]!.height, "third below second");
+});
+
+test("every element carries customData.screen naming the screen it belongs to", () => {
+  const els = compile(`screen Login "Sign in"
+  button "Go" primary
+screen Home "Landing"
+  heading "Welcome"
+`);
+  const byScreen = new Map<string, number>();
+  for (const e of els) {
+    const s = (e as { customData?: { screen?: string } }).customData?.screen;
+    assert.ok(s, `element ${e.id} lacks customData.screen`);
+    byScreen.set(s!, (byScreen.get(s!) ?? 0) + 1);
+  }
+  assert.ok((byScreen.get("Login") ?? 0) > 0);
+  assert.ok((byScreen.get("Home") ?? 0) > 0);
+  assert.equal(byScreen.size, 2);
+});

--- a/packages/excalidraw-dsl/test/layout.test.ts
+++ b/packages/excalidraw-dsl/test/layout.test.ts
@@ -321,6 +321,24 @@ screen Three
   assert.ok(frames[2]!.y >= frames[1]!.y + frames[1]!.height, "third below second");
 });
 
+test("a screen's element ids survive an earlier screen growing taller", () => {
+  // Screens stack in one column, so growing an earlier screen moves every
+  // later one down the canvas. Identity is screen-relative precisely so that
+  // move does not re-id untouched elements — a viewer diffing two scenes
+  // would otherwise read every screen below the edit as wholly replaced.
+  const filler = Array.from({ length: 20 }, (_, i) => `  text "line ${i}"`).join("\n");
+  const idsOfTwo = (dsl: string) =>
+    compile(dsl)
+      .filter((e) => (e as { customData?: { screen?: string } }).customData?.screen === "Two")
+      .map((e) => e.id)
+      .sort();
+
+  const before = idsOfTwo(`screen One\n  heading "A"\nscreen Two\n  heading "B"\n`);
+  const after = idsOfTwo(`screen One\n  heading "A"\n${filler}\nscreen Two\n  heading "B"\n`);
+  assert.ok(before.length > 0);
+  assert.deepEqual(after, before, "screen Two's ids must not change when screen One grows");
+});
+
 test("every element carries customData.screen naming the screen it belongs to", () => {
   const els = compile(`screen Login "Sign in"
   button "Go" primary

--- a/packages/excalidraw-dsl/test/layout.test.ts
+++ b/packages/excalidraw-dsl/test/layout.test.ts
@@ -25,6 +25,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  compileWireframes,
   dslToExcalidraw,
   validateWireframeLayout,
   validateWireframeSyntax,
@@ -354,4 +355,75 @@ screen Home "Landing"
   assert.ok((byScreen.get("Login") ?? 0) > 0);
   assert.ok((byScreen.get("Home") ?? 0) > 0);
   assert.equal(byScreen.size, 2);
+});
+
+
+// ---------- compileWireframes: the compiler reports which screens changed ----------
+
+const SHOP = `screen One
+  heading "A"
+screen Two
+  button "Go"
+screen Three
+  heading "C"
+`;
+
+test("compileWireframes with no previous result reports no changed screens", () => {
+  const r = compileWireframes(SHOP, null);
+  assert.ok(r.ok);
+  assert.deepEqual(r.changedScreens, []);
+  assert.ok(JSON.parse(r.json).elements.length > 0);
+});
+
+test("compileWireframes reports only the screen whose content changed", () => {
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const second = compileWireframes(SHOP.replace('button "Go"', 'button "Go" primary'), first);
+  assert.ok(second.ok);
+  assert.deepEqual(second.changedScreens, ["Two"]);
+});
+
+test("compileWireframes does not report screens that merely moved down", () => {
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const filler = Array.from({ length: 20 }, (_, i) => `  text "line ${i}"`).join("\n");
+  const grown = SHOP.replace('  heading "A"', `  heading "A"\n${filler}`);
+  const second = compileWireframes(grown, first);
+  assert.ok(second.ok);
+  assert.deepEqual(second.changedScreens, ["One"], "Two and Three shifted but did not change");
+});
+
+test("compileWireframes reports an added screen and a removed screen", () => {
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const added = compileWireframes(SHOP + 'screen Four\n  heading "D"\n', first);
+  assert.ok(added.ok);
+  assert.deepEqual(added.changedScreens, ["Four"]);
+  const removed = compileWireframes(SHOP.replace('screen Three\n  heading "C"\n', ""), first);
+  assert.ok(removed.ok);
+  assert.deepEqual(removed.changedScreens, ["Three"]);
+});
+
+test("compileWireframes reports nothing when the source is unchanged", () => {
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const again = compileWireframes(SHOP, first);
+  assert.ok(again.ok);
+  assert.deepEqual(again.changedScreens, []);
+});
+
+test("compileWireframes reports changed screens in canvas order", () => {
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const both = compileWireframes(
+    SHOP.replace('heading "C"', 'heading "C2"').replace('heading "A"', 'heading "A2"'),
+    first,
+  );
+  assert.ok(both.ok);
+  assert.deepEqual(both.changedScreens, ["One", "Three"]);
+});
+
+test("compileWireframes fails like tryDslToExcalidraw on an empty source", () => {
+  const r = compileWireframes("", null);
+  assert.equal(r.ok, false);
 });

--- a/packages/excalidraw-dsl/test/layout.test.ts
+++ b/packages/excalidraw-dsl/test/layout.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../src/index.js";
 
 type El = {
+  id: string;
   type: string;
   x: number;
   y: number;
@@ -402,6 +403,21 @@ test("compileWireframes reports an added screen and a removed screen", () => {
   const removed = compileWireframes(SHOP.replace('screen Three\n  heading "C"\n', ""), first);
   assert.ok(removed.ok);
   assert.deepEqual(removed.changedScreens, ["Three"]);
+});
+
+test("compileWireframes ranks a removed screen by where it USED to sit", () => {
+  // Remove Two and edit Three in one step. Two is gone from the new compile, so
+  // its position is only knowable from the previous one — without that it sorts
+  // last and the report claims Three changed before Two, contradicting the
+  // canvas the reader was looking at.
+  const first = compileWireframes(SHOP, null);
+  assert.ok(first.ok);
+  const next = compileWireframes(
+    SHOP.replace('screen Two\n  button "Go"\n', "").replace('heading "C"', 'heading "C2"'),
+    first,
+  );
+  assert.ok(next.ok);
+  assert.deepEqual(next.changedScreens, ["Two", "Three"]);
 });
 
 test("compileWireframes reports nothing when the source is unchanged", () => {

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -24,18 +24,20 @@ import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
 import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport, focusElements } from "./scene.js";
-import { elementsOfScreens, openingFocusElements, focusTargetScreens } from "./screenFocus.js";
-
-// How long the scene must stop changing before the viewport commits to a
-// focus. Long enough to sit out an agent's flush cadence, short enough that a
-// finished edit does not feel ignored.
-const SETTLE_MS = 600;
+import { elementsOfScreens, openingFocusElements } from "./screenFocus.js";
 
 export interface ExcalidrawViewProps {
   /** Serialised Excalidraw scene JSON. */
   scene: string;
   /** Fill the parent's height (else fixed 600px). */
   fillHeight?: boolean;
+  /**
+   * Screens the viewport should move to once this `scene` is applied — the
+   * compiler's own report of what the last edit touched (`compileWireframes`
+   * → `changedScreens`). Empty or absent means "leave the viewport where the
+   * reader put it": the view never guesses what changed.
+   */
+  focusScreens?: readonly string[];
 }
 
 // On open, land on the FIRST screen at a readable size, with the top of the
@@ -50,7 +52,7 @@ function focusInitial(api: ExcalidrawImperativeAPI, elements: ExcalidrawElement[
   else fitContentToViewport(api, elements);
 }
 
-function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
+function ExcalidrawViewImpl({ scene, fillHeight, focusScreens }: ExcalidrawViewProps) {
   // Committed scenes remount via `key` upstream (uncontrolled + simple). A
   // STREAMED scene instead keeps one mounted canvas and pushes each new
   // compile through `updateScene` — remounting this (lazy, canvas-heavy)
@@ -60,11 +62,11 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
   const initialData = useMemo(() => parseScene(scene), [scene]);
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const mountedScene = useRef(scene);
-  // The last SETTLED scene — the baseline a finished edit is diffed against.
-  // Deliberately not updated per flush: comparing against the previous flush
-  // would measure the churn, not the edit.
-  const settledElements = useRef<ExcalidrawElement[] | null>(initialData?.elements ?? null);
-  const focusTimer = useRef<number | null>(null);
+  // Read inside the scene effect without being a dependency of it: a focus
+  // rides the scene it was reported for, and a later prop change alone must
+  // not re-pan a canvas the reader has since moved.
+  const focusRef = useRef(focusScreens);
+  focusRef.current = focusScreens;
 
   useEffect(() => {
     if (scene === mountedScene.current) return; // initial mount already has it
@@ -74,33 +76,15 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
     if (!api || !next?.elements) return; // unparseable → keep the last frame
     try {
       api.updateScene({ elements: next.elements });
+      // Follow the agent's work: the compiler says which screens this scene
+      // changed, so pan there. Nothing reported → the viewport stays exactly
+      // where the reader put it — never a refit of the whole board.
+      const target = focusRef.current ?? [];
+      if (target.length > 0) focusElements(api, elementsOfScreens(next.elements, target), true);
     } catch {
-      return; // api torn down
+      /* api torn down */
     }
-    const elements = next.elements;
-    // Draw every flush, but decide where to LOOK only once the writing pauses.
-    // A wireframe arrives in many flushes while an agent edits, and the
-    // in-between states are half-written — chasing each one would pan on every
-    // keystroke and, worse, mid-write frames read as "everything changed".
-    // Comparing against the last SETTLED scene is what makes the target the
-    // edit itself rather than the churn.
-    if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
-    focusTimer.current = window.setTimeout(() => {
-      focusTimer.current = null;
-      const live = apiRef.current;
-      if (!live) return;
-      const target = focusTargetScreens(settledElements.current, elements);
-      if (target.length > 0) focusElements(live, elementsOfScreens(elements, target), true);
-      settledElements.current = elements;
-    }, SETTLE_MS);
   }, [scene]);
-
-  useEffect(
-    () => () => {
-      if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
-    },
-    [],
-  );
 
   return (
     <Box

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -16,13 +16,12 @@
  * under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// The Excalidraw API and its scene elements are untyped here on purpose: the
-// library is lazy-loaded (see lazyExcalidraw.ts), so its types are not in the
-// build graph. Same convention as scene.ts / screenFocus.ts / PrototypeView.tsx.
-
 import { Suspense, useEffect, useMemo, useRef } from "react";
 import { Box, CircularProgress } from "@wso2/oxygen-ui";
+// Type-only: erased at compile time, so the lazy runtime import in
+// lazyExcalidraw.ts is unaffected and the bundle still splits.
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport, focusElements } from "./scene.js";
 import { elementsOfScreens, openingFocusElements, changedScreenNames } from "./screenFocus.js";
@@ -39,7 +38,7 @@ export interface ExcalidrawViewProps {
 // the fitted box, not left to the panel's aspect ratio. A scene with no
 // screen tags (older compiles, non-wireframe scenes) falls back to fitting
 // everything.
-function focusInitial(api: any, elements: any[] | undefined) {
+function focusInitial(api: ExcalidrawImperativeAPI, elements: ExcalidrawElement[] | undefined) {
   if (!elements?.length) return;
   const target = openingFocusElements(elements);
   if (target.length) focusElements(api, target, false);
@@ -54,11 +53,11 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
   // compiler emits stable element ids/seeds, so successive scenes diff
   // cleanly: existing elements keep their identity, new ones appear.
   const initialData = useMemo(() => parseScene(scene), [scene]);
-  const apiRef = useRef<any>(null);
+  const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const mountedScene = useRef(scene);
   // The elements currently on the canvas, kept so a streamed update can be
   // diffed against them and the viewport moved to what actually changed.
-  const shownElements = useRef<any[] | null>(initialData?.elements ?? null);
+  const shownElements = useRef<ExcalidrawElement[] | null>(initialData?.elements ?? null);
 
   useEffect(() => {
     if (scene === mountedScene.current) return; // initial mount already has it
@@ -100,9 +99,12 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
     >
       <Box sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
         <ExcalidrawComponent
+          // parseScene returns a loose shape (scene.ts); aligning it with
+          // Excalidraw's ExcalidrawInitialDataState is its own change.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           initialData={initialData as any}
           viewModeEnabled
-          excalidrawAPI={(api: any) => {
+          excalidrawAPI={(api: ExcalidrawImperativeAPI) => {
             apiRef.current = api;
             focusInitial(api, initialData?.elements);
           }}

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -16,6 +16,11 @@
  * under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The Excalidraw API and its scene elements are untyped here on purpose: the
+// library is lazy-loaded (see lazyExcalidraw.ts), so its types are not in the
+// build graph. Same convention as scene.ts / screenFocus.ts / PrototypeView.tsx.
+
 import { Suspense, useEffect, useMemo, useRef } from "react";
 import { Box, CircularProgress } from "@wso2/oxygen-ui";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -24,7 +24,12 @@ import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
 import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport, focusElements } from "./scene.js";
-import { elementsOfScreens, openingFocusElements, changedScreenNames } from "./screenFocus.js";
+import { elementsOfScreens, openingFocusElements, focusTargetScreens } from "./screenFocus.js";
+
+// How long the scene must stop changing before the viewport commits to a
+// focus. Long enough to sit out an agent's flush cadence, short enough that a
+// finished edit does not feel ignored.
+const SETTLE_MS = 600;
 
 export interface ExcalidrawViewProps {
   /** Serialised Excalidraw scene JSON. */
@@ -55,9 +60,11 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
   const initialData = useMemo(() => parseScene(scene), [scene]);
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const mountedScene = useRef(scene);
-  // The elements currently on the canvas, kept so a streamed update can be
-  // diffed against them and the viewport moved to what actually changed.
-  const shownElements = useRef<ExcalidrawElement[] | null>(initialData?.elements ?? null);
+  // The last SETTLED scene — the baseline a finished edit is diffed against.
+  // Deliberately not updated per flush: comparing against the previous flush
+  // would measure the churn, not the edit.
+  const settledElements = useRef<ExcalidrawElement[] | null>(initialData?.elements ?? null);
+  const focusTimer = useRef<number | null>(null);
 
   useEffect(() => {
     if (scene === mountedScene.current) return; // initial mount already has it
@@ -67,17 +74,33 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
     if (!api || !next?.elements) return; // unparseable → keep the last frame
     try {
       api.updateScene({ elements: next.elements });
-      // Follow the agent's work: pan to whichever screen(s) this update
-      // touched. When nothing is detectable, leave the viewport where the
-      // reader put it — never refit the whole board, which is what shrank
-      // every screen to an illegible size on each keystroke.
-      const changed = changedScreenNames(shownElements.current, next.elements);
-      if (changed.length > 0) focusElements(api, elementsOfScreens(next.elements, changed), true);
-      shownElements.current = next.elements;
     } catch {
-      /* api torn down */
+      return; // api torn down
     }
+    const elements = next.elements;
+    // Draw every flush, but decide where to LOOK only once the writing pauses.
+    // A wireframe arrives in many flushes while an agent edits, and the
+    // in-between states are half-written — chasing each one would pan on every
+    // keystroke and, worse, mid-write frames read as "everything changed".
+    // Comparing against the last SETTLED scene is what makes the target the
+    // edit itself rather than the churn.
+    if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
+    focusTimer.current = window.setTimeout(() => {
+      focusTimer.current = null;
+      const live = apiRef.current;
+      if (!live) return;
+      const target = focusTargetScreens(settledElements.current, elements);
+      if (target.length > 0) focusElements(live, elementsOfScreens(elements, target), true);
+      settledElements.current = elements;
+    }, SETTLE_MS);
   }, [scene]);
+
+  useEffect(
+    () => () => {
+      if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
+    },
+    [],
+  );
 
   return (
     <Box

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -19,13 +19,26 @@
 import { Suspense, useEffect, useMemo, useRef } from "react";
 import { Box, CircularProgress } from "@wso2/oxygen-ui";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
-import { parseScene, fitContentToViewport } from "./scene.js";
+import { parseScene, fitContentToViewport, focusElements } from "./scene.js";
+import { elementsOfScreens, openingFocusElements, changedScreenNames } from "./screenFocus.js";
 
 export interface ExcalidrawViewProps {
   /** Serialised Excalidraw scene JSON. */
   scene: string;
   /** Fill the parent's height (else fixed 600px). */
   fillHeight?: boolean;
+}
+
+// On open, land on the FIRST screen at a readable size, with the top of the
+// second peeking below as the cue that there is more — the peek is part of
+// the fitted box, not left to the panel's aspect ratio. A scene with no
+// screen tags (older compiles, non-wireframe scenes) falls back to fitting
+// everything.
+function focusInitial(api: any, elements: any[] | undefined) {
+  if (!elements?.length) return;
+  const target = openingFocusElements(elements);
+  if (target.length) focusElements(api, target, false);
+  else fitContentToViewport(api, elements);
 }
 
 function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
@@ -38,6 +51,9 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
   const initialData = useMemo(() => parseScene(scene), [scene]);
   const apiRef = useRef<any>(null);
   const mountedScene = useRef(scene);
+  // The elements currently on the canvas, kept so a streamed update can be
+  // diffed against them and the viewport moved to what actually changed.
+  const shownElements = useRef<any[] | null>(initialData?.elements ?? null);
 
   useEffect(() => {
     if (scene === mountedScene.current) return; // initial mount already has it
@@ -47,7 +63,13 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
     if (!api || !next?.elements) return; // unparseable → keep the last frame
     try {
       api.updateScene({ elements: next.elements });
-      fitContentToViewport(api, next.elements);
+      // Follow the agent's work: pan to whichever screen(s) this update
+      // touched. When nothing is detectable, leave the viewport where the
+      // reader put it — never refit the whole board, which is what shrank
+      // every screen to an illegible size on each keystroke.
+      const changed = changedScreenNames(shownElements.current, next.elements);
+      if (changed.length > 0) focusElements(api, elementsOfScreens(next.elements, changed), true);
+      shownElements.current = next.elements;
     } catch {
       /* api torn down */
     }
@@ -77,7 +99,7 @@ function ExcalidrawViewImpl({ scene, fillHeight }: ExcalidrawViewProps) {
           viewModeEnabled
           excalidrawAPI={(api: any) => {
             apiRef.current = api;
-            if (initialData?.elements?.length) fitContentToViewport(api, initialData.elements);
+            focusInitial(api, initialData?.elements);
           }}
         />
       </Box>

--- a/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
+++ b/packages/ui/excalidraw-view/src/ExcalidrawView.tsx
@@ -24,7 +24,12 @@ import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
 import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
 import { ExcalidrawComponent } from "./lazyExcalidraw.js";
 import { parseScene, fitContentToViewport, focusElements } from "./scene.js";
-import { elementsOfScreens, openingFocusElements } from "./screenFocus.js";
+import {
+  elementsOfScreens,
+  openingFocusElements,
+  screenAtViewportCenter,
+  screensToFollow,
+} from "./screenFocus.js";
 
 export interface ExcalidrawViewProps {
   /** Serialised Excalidraw scene JSON. */
@@ -67,6 +72,10 @@ function ExcalidrawViewImpl({ scene, fillHeight, focusScreens }: ExcalidrawViewP
   // not re-pan a canvas the reader has since moved.
   const focusRef = useRef(focusScreens);
   focusRef.current = focusScreens;
+  // What the previous scene changed — one flush of memory, enough to tell a
+  // sweep (a different single screen each flush) from an edit being written.
+  const previouslyChanged = useRef<readonly string[] | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (scene === mountedScene.current) return; // initial mount already has it
@@ -77,10 +86,21 @@ function ExcalidrawViewImpl({ scene, fillHeight, focusScreens }: ExcalidrawViewP
     try {
       api.updateScene({ elements: next.elements });
       // Follow the agent's work: the compiler says which screens this scene
-      // changed, so pan there. Nothing reported → the viewport stays exactly
-      // where the reader put it — never a refit of the whole board.
-      const target = focusRef.current ?? [];
+      // changed. Nothing reported → the viewport stays exactly where the
+      // reader put it — never a refit of the whole board. And even a reported
+      // change does not always move the camera: not if the reader is already
+      // on that screen, and not once the flushes reveal a sweep across screens.
+      const changed = focusRef.current ?? [];
+      const host = hostRef.current;
+      const looking = host
+        ? screenAtViewportCenter(next.elements, api.getAppState(), host.clientWidth, host.clientHeight)
+        : null;
+      const target = screensToFollow(changed, looking, previouslyChanged.current);
       if (target.length > 0) focusElements(api, elementsOfScreens(next.elements, target), true);
+      // A frame that changed nothing is a natural boundary: clearing the
+      // memory there means a sweep's aftermath cannot make the NEXT unrelated
+      // single-screen edit look like a continuation of it.
+      previouslyChanged.current = changed.length > 0 ? changed : null;
     } catch {
       /* api torn down */
     }
@@ -104,7 +124,7 @@ function ExcalidrawViewImpl({ scene, fillHeight, focusScreens }: ExcalidrawViewP
         "& .App-menu_top__left": { display: "none !important" },
       }}
     >
-      <Box sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
+      <Box ref={hostRef} sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
         <ExcalidrawComponent
           // parseScene returns a loose shape (scene.ts); aligning it with
           // Excalidraw's ExcalidrawInitialDataState is its own change.

--- a/packages/ui/excalidraw-view/src/scene.ts
+++ b/packages/ui/excalidraw-view/src/scene.ts
@@ -17,6 +17,11 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// Type-only imports: erased at compile time, so the lazy runtime load of
+// @excalidraw/excalidraw (lazyExcalidraw.ts) is unaffected.
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
+
 export type Scene = { elements?: any; appState?: any; files?: any };
 
 // appState.collaborators is a Map at runtime; a JSON round-trip turns it into a
@@ -56,12 +61,27 @@ export function fitContentToViewport(api: any, elements: any) {
  * Bring a subset of the scene into view — one screen, or the screens an edit
  * touched. A slightly tighter zoom factor than the whole-board fit, so a single
  * screen fills the viewport with a small margin rather than floating in space.
+ *
+ * Typed against Excalidraw's own imperative API (type-only import — erased at
+ * compile time, so the runtime lazy-load is unaffected). The elements are our
+ * compiler's — runtime-compatible with what `scrollToContent` reads (it only
+ * takes bounds), but declared independently, so the library call needs an
+ * explicit unknown-bridge. The cast localises that single seam instead of
+ * untyping the whole signature.
  */
-export function focusElements(api: any, elements: any[], animate: boolean) {
+export function focusElements(
+  api: ExcalidrawImperativeAPI,
+  elements: readonly ExcalidrawElement[],
+  animate: boolean,
+): void {
   if (!elements.length) return;
   requestAnimationFrame(() => {
     try {
-      api.scrollToContent(elements, { fitToContent: true, viewportZoomFactor: 0.85, animate });
+      api.scrollToContent(elements as unknown as Parameters<ExcalidrawImperativeAPI["scrollToContent"]>[0], {
+        fitToContent: true,
+        viewportZoomFactor: 0.85,
+        animate,
+      });
     } catch {
       /* api torn down */
     }

--- a/packages/ui/excalidraw-view/src/scene.ts
+++ b/packages/ui/excalidraw-view/src/scene.ts
@@ -51,3 +51,19 @@ export function fitContentToViewport(api: any, elements: any) {
     }
   });
 }
+
+/**
+ * Bring a subset of the scene into view — one screen, or the screens an edit
+ * touched. A slightly tighter zoom factor than the whole-board fit, so a single
+ * screen fills the viewport with a small margin rather than floating in space.
+ */
+export function focusElements(api: any, elements: any[], animate: boolean) {
+  if (!elements.length) return;
+  requestAnimationFrame(() => {
+    try {
+      api.scrollToContent(elements, { fitToContent: true, viewportZoomFactor: 0.85, animate });
+    } catch {
+      /* api torn down */
+    }
+  });
+}

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -27,6 +27,16 @@
  * (follow the agent's work).
  */
 
+/**
+ * Whether two versions of the same element render identically. Compiler
+ * output is plain JSON built field-by-field in a fixed order, so serialising
+ * is a stable way to catch every rendered difference — geometry, colours,
+ * text — without enumerating fields that would drift as the compiler grows.
+ */
+function sameContent(a: any, b: any): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 function screenOf(el: any): string | null {
   const s = el?.customData?.screen;
   return typeof s === "string" && s.length > 0 ? s : null;
@@ -63,8 +73,12 @@ export function firstScreenName(elements: any[]): string | null {
  * nothing changed or there is no previous scene to compare against; the
  * caller treats "empty" as "leave the viewport alone".
  *
- * Diffing by id + `version` matches how the compiler emits scenes: ids are
- * stable across recompiles and Excalidraw bumps `version` on any mutation.
+ * Matched ids are compared by CONTENT, not by `version`: the compiler stamps
+ * `version: 1` on every element and builds ids from kind + label + position,
+ * so a restyle (a button gaining `primary`, say) keeps both the id and the
+ * version while the rendered colours change — comparing versions would report
+ * no change and strand the reader on another screen. Both sides are
+ * deterministic compiler output, so a structural comparison is stable.
  */
 export function changedScreenNames(prev: any[] | null, next: any[]): string[] {
   if (!prev) return [];
@@ -84,7 +98,7 @@ export function changedScreenNames(prev: any[] | null, next: any[]): string[] {
 
   for (const el of next) {
     const before = prevById.get(el.id);
-    if (!before || before.version !== el.version) mark(el);
+    if (!before || !sameContent(before, el)) mark(el);
   }
   for (const el of prev) {
     if (!nextById.has(el.id)) mark(el);

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -118,3 +118,85 @@ export function openingFocusElements<T extends FocusableElement>(elements: reado
   const marker = { ...anchor, id: "__peek-marker", y: bandBottom, height: 0, width: 0 };
   return [...firstEls, ...band, marker];
 }
+
+/** The slice of Excalidraw's appState the viewport maths needs. */
+export interface ViewportState {
+  scrollX: number;
+  scrollY: number;
+  zoom: { value: number };
+}
+
+/**
+ * Which screen the reader is looking at: the one whose frame contains the
+ * centre of the viewport, or — when the centre falls in the gap between
+ * frames — the nearest one. Inverts Excalidraw's `viewport = (scene + scroll)
+ * × zoom` to recover the scene point under the viewport's middle. Null when
+ * the scene carries no screen tags.
+ */
+export function screenAtViewportCenter(
+  elements: readonly (FocusableElement & { x?: number; width?: number })[],
+  view: ViewportState,
+  viewportWidth: number,
+  viewportHeight: number,
+): string | null {
+  const z = view.zoom.value || 1;
+  const cx = viewportWidth / 2 / z - view.scrollX;
+  const cy = viewportHeight / 2 / z - view.scrollY;
+
+  // Each screen's frame as the union of its elements.
+  const frames = new Map<string, { top: number; bottom: number }>();
+  for (const el of elements) {
+    const s = screenOf(el);
+    if (s === null || typeof el.y !== "number") continue;
+    const top = el.y;
+    const bottom = el.y + (el.height ?? 0);
+    const f = frames.get(s);
+    if (!f) frames.set(s, { top, bottom });
+    else {
+      if (top < f.top) f.top = top;
+      if (bottom > f.bottom) f.bottom = bottom;
+    }
+  }
+  if (frames.size === 0) return null;
+
+  let best: { name: string; distance: number } | null = null;
+  for (const [name, f] of frames) {
+    // Zero when the centre is inside the frame; otherwise the vertical gap.
+    const distance = cy < f.top ? f.top - cy : cy > f.bottom ? cy - f.bottom : 0;
+    if (best === null || distance < best.distance) best = { name, distance };
+  }
+  void cx; // screens stack in one column; horizontal position never disambiguates
+  return best?.name ?? null;
+}
+
+/**
+ * Given what the compiler says changed, which screens should the camera
+ * actually move to — if any.
+ *
+ * - The reader's own screen is among the changed → hold still. The edit is
+ *   under their nose; moving would only twitch the camera.
+ * - A sweep is in progress → hold still. A sweep (the same change applied to
+ *   every screen) lands one flush per screen, and at the first flush it is
+ *   indistinguishable from a single edit — so the camera goes there. But a
+ *   SECOND consecutive flush changing a DIFFERENT single screen is the sweep's
+ *   signature; from then on the camera holds, rather than touring every
+ *   screen and stranding the reader on the last one. The caller passes what
+ *   the previous flush changed; a repeat of the SAME screen is one edit still
+ *   being written and is followed.
+ * - Otherwise → the changed screens.
+ */
+export function screensToFollow(
+  changed: readonly string[],
+  currentScreen: string | null,
+  previouslyChanged: readonly string[] | null,
+): string[] {
+  if (changed.length === 0) return [];
+  if (currentScreen !== null && changed.includes(currentScreen)) return [];
+  const isSweep =
+    previouslyChanged !== null &&
+    previouslyChanged.length === 1 &&
+    changed.length === 1 &&
+    previouslyChanged[0] !== changed[0];
+  if (isSweep) return [];
+  return [...changed];
+}

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -17,7 +17,7 @@
  */
 
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
 
 /**
  * Per-screen grouping over a compiled grid scene. The DSL compiler stamps
@@ -28,22 +28,34 @@
  */
 
 /**
+ * The part of a compiled element this module reads. Every function here is
+ * generic over it, so callers keep their own element type end-to-end (the
+ * viewer passes `ExcalidrawElement`s straight through to `scrollToContent`)
+ * while tests can pass a minimal stand-in.
+ */
+export type FocusableElement = Pick<ExcalidrawElement, "id" | "y" | "customData"> &
+  Partial<Pick<ExcalidrawElement, "height">>;
+
+/**
  * Whether two versions of the same element render identically. Compiler
  * output is plain JSON built field-by-field in a fixed order, so serialising
  * is a stable way to catch every rendered difference — geometry, colours,
  * text — without enumerating fields that would drift as the compiler grows.
  */
-function sameContent(a: any, b: any): boolean {
+function sameContent(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-function screenOf(el: any): string | null {
+function screenOf(el: FocusableElement): string | null {
   const s = el?.customData?.screen;
   return typeof s === "string" && s.length > 0 ? s : null;
 }
 
 /** The elements belonging to any of `names`, in scene order. */
-export function elementsOfScreens(elements: any[], names: readonly string[]): any[] {
+export function elementsOfScreens<T extends FocusableElement>(
+  elements: readonly T[],
+  names: readonly string[],
+): T[] {
   if (names.length === 0) return [];
   const want = new Set(names);
   return elements.filter((el) => {
@@ -56,7 +68,7 @@ export function elementsOfScreens(elements: any[], names: readonly string[]): an
  * The screen highest on the canvas — screens stack in one column, so this is
  * the first one the author declared. Null when nothing is tagged.
  */
-export function firstScreenName(elements: any[]): string | null {
+export function firstScreenName(elements: readonly FocusableElement[]): string | null {
   let best: { name: string; y: number } | null = null;
   for (const el of elements) {
     const s = screenOf(el);
@@ -80,15 +92,18 @@ export function firstScreenName(elements: any[]): string | null {
  * no change and strand the reader on another screen. Both sides are
  * deterministic compiler output, so a structural comparison is stable.
  */
-export function changedScreenNames(prev: any[] | null, next: any[]): string[] {
+export function changedScreenNames(
+  prev: readonly FocusableElement[] | null,
+  next: readonly FocusableElement[],
+): string[] {
   if (!prev) return [];
-  const prevById = new Map<string, any>();
+  const prevById = new Map<string, FocusableElement>();
   for (const el of prev) prevById.set(el.id, el);
-  const nextById = new Map<string, any>();
+  const nextById = new Map<string, FocusableElement>();
   for (const el of next) nextById.set(el.id, el);
 
   const changed = new Map<string, number>(); // name → topmost y, for ordering
-  const mark = (el: any) => {
+  const mark = (el: FocusableElement) => {
     const s = screenOf(el);
     if (s === null) return;
     const y = typeof el.y === "number" ? el.y : Number.POSITIVE_INFINITY;
@@ -116,7 +131,7 @@ export function changedScreenNames(prev: any[] | null, next: any[]): string[] {
  * the target box on purpose. Falls back to the first screen when there is no
  * second, and to nothing when the scene carries no screen tags.
  */
-export function openingFocusElements(elements: any[]): any[] {
+export function openingFocusElements<T extends FocusableElement>(elements: readonly T[]): T[] {
   const first = firstScreenName(elements);
   if (!first) return [];
   const firstEls = elementsOfScreens(elements, [first]);

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Per-screen grouping over a compiled grid scene. The DSL compiler stamps
+ * every element with `customData.screen`, which is what makes these questions
+ * answerable without geometry guesswork: which elements are the first
+ * screen's (focus it on open), and which screens did the last edit touch
+ * (follow the agent's work).
+ */
+
+function screenOf(el: any): string | null {
+  const s = el?.customData?.screen;
+  return typeof s === "string" && s.length > 0 ? s : null;
+}
+
+/** The elements belonging to any of `names`, in scene order. */
+export function elementsOfScreens(elements: any[], names: readonly string[]): any[] {
+  if (names.length === 0) return [];
+  const want = new Set(names);
+  return elements.filter((el) => {
+    const s = screenOf(el);
+    return s !== null && want.has(s);
+  });
+}
+
+/**
+ * The screen highest on the canvas — screens stack in one column, so this is
+ * the first one the author declared. Null when nothing is tagged.
+ */
+export function firstScreenName(elements: any[]): string | null {
+  let best: { name: string; y: number } | null = null;
+  for (const el of elements) {
+    const s = screenOf(el);
+    if (s === null) continue;
+    const y = typeof el.y === "number" ? el.y : Number.POSITIVE_INFINITY;
+    if (best === null || y < best.y) best = { name: s, y };
+  }
+  return best?.name ?? null;
+}
+
+/**
+ * Screens whose element set differs between two scenes — an element added,
+ * removed, or re-versioned — in canvas order (topmost first). Empty when
+ * nothing changed or there is no previous scene to compare against; the
+ * caller treats "empty" as "leave the viewport alone".
+ *
+ * Diffing by id + `version` matches how the compiler emits scenes: ids are
+ * stable across recompiles and Excalidraw bumps `version` on any mutation.
+ */
+export function changedScreenNames(prev: any[] | null, next: any[]): string[] {
+  if (!prev) return [];
+  const prevById = new Map<string, any>();
+  for (const el of prev) prevById.set(el.id, el);
+  const nextById = new Map<string, any>();
+  for (const el of next) nextById.set(el.id, el);
+
+  const changed = new Map<string, number>(); // name → topmost y, for ordering
+  const mark = (el: any) => {
+    const s = screenOf(el);
+    if (s === null) return;
+    const y = typeof el.y === "number" ? el.y : Number.POSITIVE_INFINITY;
+    const cur = changed.get(s);
+    if (cur === undefined || y < cur) changed.set(s, y);
+  };
+
+  for (const el of next) {
+    const before = prevById.get(el.id);
+    if (!before || before.version !== el.version) mark(el);
+  }
+  for (const el of prev) {
+    if (!nextById.has(el.id)) mark(el);
+  }
+
+  return [...changed.entries()].sort((a, b) => a[1] - b[1]).map(([name]) => name);
+}
+
+/**
+ * What to bring into view when a wireframe opens: the whole first screen,
+ * plus the top slice of the second so its title (and a sliver of frame) shows
+ * beneath as the cue that there is more below. Fitting the first screen ALONE
+ * only shows that cue by accident — a wide panel fits the screen at a zoom
+ * whose height ends exactly at its bottom edge — so the peek band is part of
+ * the target box on purpose. Falls back to the first screen when there is no
+ * second, and to nothing when the scene carries no screen tags.
+ */
+export function openingFocusElements(elements: any[]): any[] {
+  const first = firstScreenName(elements);
+  if (!first) return [];
+  const firstEls = elementsOfScreens(elements, [first]);
+
+  // The second screen is the tagged screen whose topmost element is the
+  // lowest one still ABOVE nothing else — i.e. the next in canvas order.
+  const firstBottom = Math.max(...firstEls.map((e) => (e.y ?? 0) + (e.height ?? 0)));
+  let second: { name: string; top: number } | null = null;
+  for (const el of elements) {
+    const s = screenOf(el);
+    if (s === null || s === first) continue;
+    const y = typeof el.y === "number" ? el.y : Number.POSITIVE_INFINITY;
+    if (second === null || y < second.top) second = { name: s, top: y };
+  }
+  if (!second) return firstEls;
+
+  // Peek band: from the second screen's top down to a fixed depth — enough
+  // for its title block and the first ~10% of its frame.
+  const PEEK = firstBottom - (firstEls.length ? Math.min(...firstEls.map((e) => e.y ?? 0)) : 0);
+  const peekDepth = Math.max(80, PEEK * 0.12);
+  // Only elements that END inside the band count: the second screen's frame
+  // rectangle STARTS in the band but is a full screen tall, and letting it in
+  // would fit both screens — the very thing this function exists to avoid.
+  const bandBottom = second.top + peekDepth;
+  const band = elementsOfScreens(elements, [second.name]).filter(
+    (e) => typeof e.y === "number" && e.y + (e.height ?? 0) <= bandBottom,
+  );
+  // A zero-size marker at the band's bottom edge pins the fitted box to that
+  // depth regardless of which second-screen elements happen to end inside it,
+  // so a sliver of the second frame is always in view. It is only ever handed
+  // to scrollToContent for its bounds — never added to the scene.
+  const anchor = firstEls[0]!;
+  const marker = { ...anchor, id: "__peek-marker", y: bandBottom, height: 0, width: 0 };
+  return [...firstEls, ...band, marker];
+}

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -23,8 +23,12 @@ import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
  * Per-screen grouping over a compiled grid scene. The DSL compiler stamps
  * every element with `customData.screen`, which is what makes these questions
  * answerable without geometry guesswork: which elements are the first
- * screen's (focus it on open), and which screens did the last edit touch
- * (follow the agent's work).
+ * screen's (focus it on open), and which elements belong to the screens the
+ * compiler reported as changed (follow the agent's work).
+ *
+ * Deciding WHICH screens changed is not done here. The compiler knows the
+ * screen structure and reports it (`compileWireframes` → `changedScreens`);
+ * this module only maps names to elements and frames them.
  */
 
 /**
@@ -34,46 +38,7 @@ import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
  * while tests can pass a minimal stand-in.
  */
 export type FocusableElement = Pick<ExcalidrawElement, "id" | "y" | "customData"> &
-  Partial<Pick<ExcalidrawElement, "x" | "height">>;
-
-/**
- * A screen's contents as one comparable string, with element positions taken
- * RELATIVE to the screen's own top-left corner.
- *
- * The relativity is the whole point. Screens stack in a single column, so
- * growing one screen pushes every screen below it down the canvas: their
- * absolute coordinates all change while their content is untouched. Comparing
- * absolute positions would report every one of them as edited, making the
- * focus target the whole board and zooming the canvas out to nothing.
- *
- * Everything else is compared verbatim — compiler output is plain JSON built
- * field-by-field in a fixed order, so serialising catches every rendered
- * difference (colours, text, size) without enumerating fields that would
- * drift as the compiler grows.
- */
-function screenFingerprint(elements: readonly FocusableElement[]): string {
-  const originX = Math.min(...elements.map((e) => e.x ?? 0));
-  const originY = Math.min(...elements.map((e) => e.y ?? 0));
-  return elements
-    .map((e) => JSON.stringify({ ...e, x: (e.x ?? 0) - originX, y: (e.y ?? 0) - originY }))
-    .sort()
-    .join("\n");
-}
-
-/** Tagged elements bucketed by their screen, in scene order. */
-function groupByScreen(
-  elements: readonly FocusableElement[],
-): Map<string, FocusableElement[]> {
-  const byScreen = new Map<string, FocusableElement[]>();
-  for (const el of elements) {
-    const s = screenOf(el);
-    if (s === null) continue;
-    const bucket = byScreen.get(s);
-    if (bucket) bucket.push(el);
-    else byScreen.set(s, [el]);
-  }
-  return byScreen;
-}
+  Partial<Pick<ExcalidrawElement, "height">>;
 
 function screenOf(el: FocusableElement): string | null {
   const s = el?.customData?.screen;
@@ -106,65 +71,6 @@ export function firstScreenName(elements: readonly FocusableElement[]): string |
     if (best === null || y < best.y) best = { name: s, y };
   }
   return best?.name ?? null;
-}
-
-/**
- * Screens whose element set differs between two scenes — an element added,
- * removed, or re-versioned — in canvas order (topmost first). Empty when
- * nothing changed or there is no previous scene to compare against; the
- * caller treats "empty" as "leave the viewport alone".
- *
- * Matched ids are compared by CONTENT, not by `version`: the compiler stamps
- * `version: 1` on every element and builds ids from kind + label + position,
- * so a restyle (a button gaining `primary`, say) keeps both the id and the
- * version while the rendered colours change — comparing versions would report
- * no change and strand the reader on another screen. Both sides are
- * deterministic compiler output, so a structural comparison is stable.
- */
-export function changedScreenNames(
-  prev: readonly FocusableElement[] | null,
-  next: readonly FocusableElement[],
-): string[] {
-  if (!prev) return [];
-  const before = groupByScreen(prev);
-  const after = groupByScreen(next);
-
-  const changed: Array<{ name: string; top: number }> = [];
-  for (const [name, els] of after) {
-    const wasThere = before.get(name);
-    if (!wasThere || screenFingerprint(wasThere) !== screenFingerprint(els)) {
-      changed.push({ name, top: Math.min(...els.map((e) => e.y ?? 0)) });
-    }
-  }
-  // A screen that disappeared has nothing left to focus, but the gap it left
-  // is worth showing, so it is ordered by where it used to sit.
-  for (const [name, els] of before) {
-    if (!after.has(name)) changed.push({ name, top: Math.min(...els.map((e) => e.y ?? 0)) });
-  }
-
-  return changed.sort((a, b) => a.top - b.top).map((c) => c.name);
-}
-
-/**
- * Which screens the viewport should actually chase after an update — the
- * changed screens, unless the change is too broad to be a target.
- *
- * A wireframe is rewritten in flushes while an agent works, and mid-write the
- * document is transiently incomplete: screens disappear and come back, so
- * across those frames nearly every screen reads as edited. Focusing that union
- * means fitting the whole board — the zoomed-out, unreadable state this whole
- * feature exists to prevent. So a change touching MOST of the wireframe is
- * treated as a rewrite rather than an edit, and the viewport holds still until
- * the document settles into something narrower.
- */
-export function focusTargetScreens(
-  prev: readonly FocusableElement[] | null,
-  next: readonly FocusableElement[],
-): string[] {
-  const changed = changedScreenNames(prev, next);
-  if (changed.length === 0) return [];
-  const total = Math.max(groupByScreen(next).size, groupByScreen(prev ?? []).size);
-  return changed.length * 2 > total ? [] : changed;
 }
 
 /**

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -34,16 +34,45 @@ import type { ExcalidrawElement } from "@aep/excalidraw-dsl";
  * while tests can pass a minimal stand-in.
  */
 export type FocusableElement = Pick<ExcalidrawElement, "id" | "y" | "customData"> &
-  Partial<Pick<ExcalidrawElement, "height">>;
+  Partial<Pick<ExcalidrawElement, "x" | "height">>;
 
 /**
- * Whether two versions of the same element render identically. Compiler
- * output is plain JSON built field-by-field in a fixed order, so serialising
- * is a stable way to catch every rendered difference — geometry, colours,
- * text — without enumerating fields that would drift as the compiler grows.
+ * A screen's contents as one comparable string, with element positions taken
+ * RELATIVE to the screen's own top-left corner.
+ *
+ * The relativity is the whole point. Screens stack in a single column, so
+ * growing one screen pushes every screen below it down the canvas: their
+ * absolute coordinates all change while their content is untouched. Comparing
+ * absolute positions would report every one of them as edited, making the
+ * focus target the whole board and zooming the canvas out to nothing.
+ *
+ * Everything else is compared verbatim — compiler output is plain JSON built
+ * field-by-field in a fixed order, so serialising catches every rendered
+ * difference (colours, text, size) without enumerating fields that would
+ * drift as the compiler grows.
  */
-function sameContent(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+function screenFingerprint(elements: readonly FocusableElement[]): string {
+  const originX = Math.min(...elements.map((e) => e.x ?? 0));
+  const originY = Math.min(...elements.map((e) => e.y ?? 0));
+  return elements
+    .map((e) => JSON.stringify({ ...e, x: (e.x ?? 0) - originX, y: (e.y ?? 0) - originY }))
+    .sort()
+    .join("\n");
+}
+
+/** Tagged elements bucketed by their screen, in scene order. */
+function groupByScreen(
+  elements: readonly FocusableElement[],
+): Map<string, FocusableElement[]> {
+  const byScreen = new Map<string, FocusableElement[]>();
+  for (const el of elements) {
+    const s = screenOf(el);
+    if (s === null) continue;
+    const bucket = byScreen.get(s);
+    if (bucket) bucket.push(el);
+    else byScreen.set(s, [el]);
+  }
+  return byScreen;
 }
 
 function screenOf(el: FocusableElement): string | null {
@@ -97,29 +126,23 @@ export function changedScreenNames(
   next: readonly FocusableElement[],
 ): string[] {
   if (!prev) return [];
-  const prevById = new Map<string, FocusableElement>();
-  for (const el of prev) prevById.set(el.id, el);
-  const nextById = new Map<string, FocusableElement>();
-  for (const el of next) nextById.set(el.id, el);
+  const before = groupByScreen(prev);
+  const after = groupByScreen(next);
 
-  const changed = new Map<string, number>(); // name → topmost y, for ordering
-  const mark = (el: FocusableElement) => {
-    const s = screenOf(el);
-    if (s === null) return;
-    const y = typeof el.y === "number" ? el.y : Number.POSITIVE_INFINITY;
-    const cur = changed.get(s);
-    if (cur === undefined || y < cur) changed.set(s, y);
-  };
-
-  for (const el of next) {
-    const before = prevById.get(el.id);
-    if (!before || !sameContent(before, el)) mark(el);
+  const changed: Array<{ name: string; top: number }> = [];
+  for (const [name, els] of after) {
+    const wasThere = before.get(name);
+    if (!wasThere || screenFingerprint(wasThere) !== screenFingerprint(els)) {
+      changed.push({ name, top: Math.min(...els.map((e) => e.y ?? 0)) });
+    }
   }
-  for (const el of prev) {
-    if (!nextById.has(el.id)) mark(el);
+  // A screen that disappeared has nothing left to focus, but the gap it left
+  // is worth showing, so it is ordered by where it used to sit.
+  for (const [name, els] of before) {
+    if (!after.has(name)) changed.push({ name, top: Math.min(...els.map((e) => e.y ?? 0)) });
   }
 
-  return [...changed.entries()].sort((a, b) => a[1] - b[1]).map(([name]) => name);
+  return changed.sort((a, b) => a.top - b.top).map((c) => c.name);
 }
 
 /**

--- a/packages/ui/excalidraw-view/src/screenFocus.ts
+++ b/packages/ui/excalidraw-view/src/screenFocus.ts
@@ -146,6 +146,28 @@ export function changedScreenNames(
 }
 
 /**
+ * Which screens the viewport should actually chase after an update — the
+ * changed screens, unless the change is too broad to be a target.
+ *
+ * A wireframe is rewritten in flushes while an agent works, and mid-write the
+ * document is transiently incomplete: screens disappear and come back, so
+ * across those frames nearly every screen reads as edited. Focusing that union
+ * means fitting the whole board — the zoomed-out, unreadable state this whole
+ * feature exists to prevent. So a change touching MOST of the wireframe is
+ * treated as a rewrite rather than an edit, and the viewport holds still until
+ * the document settles into something narrower.
+ */
+export function focusTargetScreens(
+  prev: readonly FocusableElement[] | null,
+  next: readonly FocusableElement[],
+): string[] {
+  const changed = changedScreenNames(prev, next);
+  if (changed.length === 0) return [];
+  const total = Math.max(groupByScreen(next).size, groupByScreen(prev ?? []).size);
+  return changed.length * 2 > total ? [] : changed;
+}
+
+/**
  * What to bring into view when a wireframe opens: the whole first screen,
  * plus the top slice of the second so its title (and a sliver of frame) shows
  * beneath as the cue that there is more below. Fitting the first screen ALONE

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -88,6 +88,17 @@ test("a brand-new screen is changed", () => {
   assert.deepEqual(changedScreenNames(SCENE, next), ["Settings"]);
 });
 
+test("a restyled element is changed even when its id and version are identical", () => {
+  // The compiler stamps `version: 1` on every element and builds ids from
+  // kind + label + position, so a variant-only edit (button → primary) keeps
+  // BOTH stable while the rendered colours change. Comparing version alone
+  // would report no change and strand the reader on another screen.
+  const next = SCENE.map((e) =>
+    e.id === "l1" ? { ...e, backgroundColor: "#fa7b3f" } : e,
+  ) as El[];
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
+});
+
 test("identical scenes report no change", () => {
   assert.deepEqual(changedScreenNames(SCENE, SCENE.map((e) => ({ ...e }))), []);
 });

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { elementsOfScreens, firstScreenName, changedScreenNames, openingFocusElements } from "../src/screenFocus.js";
+
+type El = { id: string; y: number; version: number; customData?: { screen: string } };
+const el = (id: string, screen: string, y: number, version = 1): El => ({
+  id,
+  y,
+  version,
+  customData: { screen },
+});
+
+const SCENE: El[] = [
+  el("h1", "Home", 0),
+  el("h2", "Home", 40),
+  el("l1", "Login", 900),
+  el("l2", "Login", 940),
+  el("d1", "Detail", 1800),
+];
+
+test("elementsOfScreens returns only the named screens' elements", () => {
+  assert.deepEqual(
+    elementsOfScreens(SCENE, ["Login"]).map((e) => e.id),
+    ["l1", "l2"],
+  );
+  assert.deepEqual(
+    elementsOfScreens(SCENE, ["Home", "Detail"]).map((e) => e.id),
+    ["h1", "h2", "d1"],
+  );
+});
+
+test("elementsOfScreens ignores elements with no screen tag", () => {
+  const scene = [...SCENE, { id: "x", y: 5, version: 1 } as El];
+  assert.deepEqual(elementsOfScreens(scene, ["Home"]).map((e) => e.id), ["h1", "h2"]);
+});
+
+test("firstScreenName is the screen whose topmost element is highest on the canvas", () => {
+  assert.equal(firstScreenName(SCENE), "Home");
+  assert.equal(firstScreenName([...SCENE].reverse()), "Home");
+});
+
+test("firstScreenName is null for an empty or untagged scene", () => {
+  assert.equal(firstScreenName([]), null);
+  assert.equal(firstScreenName([{ id: "x", y: 0, version: 1 } as El]), null);
+});
+
+test("an edited element names its screen as changed", () => {
+  const next = SCENE.map((e) => (e.id === "l2" ? { ...e, version: 2 } : e));
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
+});
+
+test("edits across several screens name them all, in canvas order", () => {
+  const next = SCENE.map((e) => (e.id === "d1" || e.id === "h1" ? { ...e, version: 2 } : e));
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Home", "Detail"]);
+});
+
+test("a screen that gained an element is changed", () => {
+  const next = [...SCENE, el("l3", "Login", 980)];
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
+});
+
+test("a screen that lost an element is changed", () => {
+  const next = SCENE.filter((e) => e.id !== "d1");
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Detail"]);
+});
+
+test("a brand-new screen is changed", () => {
+  const next = [...SCENE, el("s1", "Settings", 2700)];
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Settings"]);
+});
+
+test("identical scenes report no change", () => {
+  assert.deepEqual(changedScreenNames(SCENE, SCENE.map((e) => ({ ...e }))), []);
+});
+
+test("with no previous scene nothing is reported as changed", () => {
+  assert.deepEqual(changedScreenNames(null, SCENE), []);
+});
+
+test("the opening focus is the first screen plus a peek band of the second", () => {
+  const scene = [
+    { id: "a1", y: 0, height: 32, version: 1, customData: { screen: "Home" } },
+    { id: "a2", y: 32, height: 800, version: 1, customData: { screen: "Home" } },
+    // second screen: title at 952, frame 984..1784, a body element deep inside
+    { id: "b1", y: 952, height: 32, version: 1, customData: { screen: "Login" } },
+    { id: "b2", y: 984, height: 800, version: 1, customData: { screen: "Login" } },
+    { id: "b3", y: 1500, height: 40, version: 1, customData: { screen: "Login" } },
+    { id: "c1", y: 1904, height: 32, version: 1, customData: { screen: "Detail" } },
+  ];
+  const ids = openingFocusElements(scene).map((e) => e.id);
+  assert.ok(ids.includes("a1") && ids.includes("a2"), "whole first screen");
+  assert.ok(ids.includes("b1"), "second screen's title is in the peek band");
+  assert.ok(!ids.includes("b2"), "second screen's full-height frame is NOT — it would fit both screens");
+  assert.ok(!ids.includes("b3"), "deep body of the second screen is not");
+  assert.ok(!ids.includes("c1"), "third screen is not");
+  const marker = openingFocusElements(scene).find((e) => e.id === "__peek-marker")!;
+  assert.ok(marker, "a bounds marker pins the peek depth");
+  assert.ok(marker.y > 952 && marker.y < 1500, "marker sits inside the second screen's top band");
+});
+
+test("the opening focus falls back to the first screen alone when there is no second", () => {
+  const scene = [
+    { id: "a1", y: 0, height: 32, version: 1, customData: { screen: "Home" } },
+    { id: "a2", y: 32, height: 800, version: 1, customData: { screen: "Home" } },
+  ];
+  assert.deepEqual(openingFocusElements(scene).map((e) => e.id), ["a1", "a2"]);
+});
+
+test("the opening focus is empty for an untagged scene", () => {
+  assert.deepEqual(openingFocusElements([{ id: "x", y: 0, height: 10, version: 1 }]), []);
+});

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -19,7 +19,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { elementsOfScreens, firstScreenName, changedScreenNames, openingFocusElements } from "../src/screenFocus.js";
+import {
+  elementsOfScreens,
+  firstScreenName,
+  changedScreenNames,
+  openingFocusElements,
+  focusTargetScreens,
+} from "../src/screenFocus.js";
 
 type El = { id: string; y: number; version: number; customData?: { screen: string } };
 const el = (id: string, screen: string, y: number, version = 1): El => ({
@@ -114,6 +120,21 @@ test("a screen that only shifted down is NOT changed", () => {
     el("d1", "Detail", 1800 + 270),
   ];
   assert.deepEqual(changedScreenNames(SCENE, next), ["Home"]);
+});
+
+test("a change spanning most of the wireframe is not a focus target", () => {
+  // Mid-stream the document is transiently incomplete — screens disappear and
+  // come back as the agent rewrites the file — so across those frames every
+  // screen looks edited. Focusing their union is the whole board, i.e. the
+  // zoomed-out-to-nothing state this feature exists to prevent. A change that
+  // broad is a rewrite, not an edit: leave the viewport alone.
+  const wiped: El[] = [el("h1", "Home", 0)]; // Login and Detail momentarily gone
+  assert.deepEqual(focusTargetScreens(SCENE, wiped), []);
+});
+
+test("an edit touching a minority of screens is still a focus target", () => {
+  const next = SCENE.map((e) => (e.id === "l2" ? { ...e, backgroundColor: "#fa7b3f" } : e)) as El[];
+  assert.deepEqual(focusTargetScreens(SCENE, next), ["Login"]);
 });
 
 test("identical scenes report no change", () => {

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -19,7 +19,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { elementsOfScreens, firstScreenName, openingFocusElements } from "../src/screenFocus.js";
+import {
+  elementsOfScreens,
+  firstScreenName,
+  openingFocusElements,
+  screenAtViewportCenter,
+  screensToFollow,
+} from "../src/screenFocus.js";
 
 type El = { id: string; y: number; version: number; customData?: { screen: string } };
 const el = (id: string, screen: string, y: number, version = 1): El => ({
@@ -94,4 +100,79 @@ test("the opening focus falls back to the first screen alone when there is no se
 
 test("the opening focus is empty for an untagged scene", () => {
   assert.deepEqual(openingFocusElements([{ id: "x", y: 0, height: 10, version: 1 }]), []);
+});
+
+// ---------- which screen is the reader looking at, and should the camera move ----------
+
+// Three screens stacked: Home 0..800, Login 1000..1800, Detail 2000..2800.
+const STACK = [
+  { id: "h", x: 0, y: 0, width: 1280, height: 800, version: 1, customData: { screen: "Home" } },
+  { id: "l", x: 0, y: 1000, width: 1280, height: 800, version: 1, customData: { screen: "Login" } },
+  { id: "d", x: 0, y: 2000, width: 1280, height: 800, version: 1, customData: { screen: "Detail" } },
+];
+
+test("screenAtViewportCenter names the screen under the middle of the viewport", () => {
+  // zoom 1, no scroll, 1280x800 viewport → centre at scene (640, 400) → Home
+  assert.equal(
+    screenAtViewportCenter(STACK, { scrollX: 0, scrollY: 0, zoom: { value: 1 } }, 1280, 800),
+    "Home",
+  );
+  // scrolled so that scene y=1400 is the centre → Login
+  assert.equal(
+    screenAtViewportCenter(STACK, { scrollX: 0, scrollY: -1000, zoom: { value: 1 } }, 1280, 800),
+    "Login",
+  );
+});
+
+test("screenAtViewportCenter accounts for zoom", () => {
+  // zoom 0.5: viewport 1280x800 spans 2560x1600 scene units; centre is scene (1280, 800)
+  // with scroll 0 — between Home's bottom (800) and Login's top (1000) → nearest is Home.
+  assert.equal(
+    screenAtViewportCenter(STACK, { scrollX: 0, scrollY: 0, zoom: { value: 0.5 } }, 1280, 800),
+    "Home",
+  );
+});
+
+test("screenAtViewportCenter falls back to the nearest screen when the centre is in a gap", () => {
+  // centre at y=1950: gap between Login (ends 1800) and Detail (starts 2000); Detail is nearer
+  assert.equal(
+    screenAtViewportCenter(STACK, { scrollX: 0, scrollY: -1550, zoom: { value: 1 } }, 1280, 800),
+    "Detail",
+  );
+});
+
+test("screenAtViewportCenter is null for an untagged scene", () => {
+  assert.equal(screenAtViewportCenter([], { scrollX: 0, scrollY: 0, zoom: { value: 1 } }, 1280, 800), null);
+});
+
+test("screensToFollow holds still when the reader's screen is among the changed", () => {
+  // The edit is under the reader's nose — moving would only twitch the camera.
+  assert.deepEqual(screensToFollow(["Login"], "Login", null), []);
+  assert.deepEqual(screensToFollow(["Home", "Login"], "Login", null), []);
+});
+
+test("screensToFollow moves to a single edit made entirely elsewhere", () => {
+  assert.deepEqual(screensToFollow(["Home"], "Login", null), ["Home"]);
+  assert.deepEqual(screensToFollow(["Home", "Detail"], "Login", null), ["Home", "Detail"]);
+});
+
+test("screensToFollow recognises a sweep and stops touring", () => {
+  // A sweep edit (the same header on every screen) lands one flush per
+  // screen: Home, then Login, then Detail. At the FIRST flush it is
+  // indistinguishable from a single edit to Home, so the camera goes there.
+  // But the SECOND flush changing a DIFFERENT single screen is the sweep's
+  // signature — from then on the camera holds, rather than touring every
+  // screen and stranding the reader on the last one.
+  assert.deepEqual(screensToFollow(["Home"], "Detail", null), ["Home"]); // flush 1: looks like an edit
+  assert.deepEqual(screensToFollow(["Login"], "Detail", ["Home"]), []); // flush 2: a sweep — hold
+  assert.deepEqual(screensToFollow(["Detail"], "Detail", ["Login"]), []); // flush 3: on it anyway
+});
+
+test("screensToFollow does not mistake a repeated edit to one screen for a sweep", () => {
+  // Several flushes all changing Home is one edit being written — keep following it.
+  assert.deepEqual(screensToFollow(["Home"], "Detail", ["Home"]), ["Home"]);
+});
+
+test("screensToFollow follows everything when the reader's screen is unknown", () => {
+  assert.deepEqual(screensToFollow(["Home"], null, null), ["Home"]);
 });

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -99,6 +99,23 @@ test("a restyled element is changed even when its id and version are identical",
   assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
 });
 
+test("a screen that only shifted down is NOT changed", () => {
+  // Screens stack in one column, so growing an earlier screen pushes every
+  // later one down. Those screens are untouched — reporting them would make
+  // the focus target the whole board and zoom the canvas out to nothing,
+  // which is the failure this guards.
+  const next: El[] = [
+    el("h1", "Home", 0),
+    el("h2", "Home", 40),
+    el("h3", "Home", 80), // Home grew by one element…
+    // …so Login and Detail shift down by 270, unchanged in themselves.
+    el("l1", "Login", 900 + 270),
+    el("l2", "Login", 940 + 270),
+    el("d1", "Detail", 1800 + 270),
+  ];
+  assert.deepEqual(changedScreenNames(SCENE, next), ["Home"]);
+});
+
 test("identical scenes report no change", () => {
   assert.deepEqual(changedScreenNames(SCENE, SCENE.map((e) => ({ ...e }))), []);
 });

--- a/packages/ui/excalidraw-view/test/screenFocus.test.ts
+++ b/packages/ui/excalidraw-view/test/screenFocus.test.ts
@@ -19,13 +19,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import {
-  elementsOfScreens,
-  firstScreenName,
-  changedScreenNames,
-  openingFocusElements,
-  focusTargetScreens,
-} from "../src/screenFocus.js";
+import { elementsOfScreens, firstScreenName, openingFocusElements } from "../src/screenFocus.js";
 
 type El = { id: string; y: number; version: number; customData?: { screen: string } };
 const el = (id: string, screen: string, y: number, version = 1): El => ({
@@ -67,82 +61,6 @@ test("firstScreenName is the screen whose topmost element is highest on the canv
 test("firstScreenName is null for an empty or untagged scene", () => {
   assert.equal(firstScreenName([]), null);
   assert.equal(firstScreenName([{ id: "x", y: 0, version: 1 } as El]), null);
-});
-
-test("an edited element names its screen as changed", () => {
-  const next = SCENE.map((e) => (e.id === "l2" ? { ...e, version: 2 } : e));
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
-});
-
-test("edits across several screens name them all, in canvas order", () => {
-  const next = SCENE.map((e) => (e.id === "d1" || e.id === "h1" ? { ...e, version: 2 } : e));
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Home", "Detail"]);
-});
-
-test("a screen that gained an element is changed", () => {
-  const next = [...SCENE, el("l3", "Login", 980)];
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
-});
-
-test("a screen that lost an element is changed", () => {
-  const next = SCENE.filter((e) => e.id !== "d1");
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Detail"]);
-});
-
-test("a brand-new screen is changed", () => {
-  const next = [...SCENE, el("s1", "Settings", 2700)];
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Settings"]);
-});
-
-test("a restyled element is changed even when its id and version are identical", () => {
-  // The compiler stamps `version: 1` on every element and builds ids from
-  // kind + label + position, so a variant-only edit (button → primary) keeps
-  // BOTH stable while the rendered colours change. Comparing version alone
-  // would report no change and strand the reader on another screen.
-  const next = SCENE.map((e) =>
-    e.id === "l1" ? { ...e, backgroundColor: "#fa7b3f" } : e,
-  ) as El[];
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Login"]);
-});
-
-test("a screen that only shifted down is NOT changed", () => {
-  // Screens stack in one column, so growing an earlier screen pushes every
-  // later one down. Those screens are untouched — reporting them would make
-  // the focus target the whole board and zoom the canvas out to nothing,
-  // which is the failure this guards.
-  const next: El[] = [
-    el("h1", "Home", 0),
-    el("h2", "Home", 40),
-    el("h3", "Home", 80), // Home grew by one element…
-    // …so Login and Detail shift down by 270, unchanged in themselves.
-    el("l1", "Login", 900 + 270),
-    el("l2", "Login", 940 + 270),
-    el("d1", "Detail", 1800 + 270),
-  ];
-  assert.deepEqual(changedScreenNames(SCENE, next), ["Home"]);
-});
-
-test("a change spanning most of the wireframe is not a focus target", () => {
-  // Mid-stream the document is transiently incomplete — screens disappear and
-  // come back as the agent rewrites the file — so across those frames every
-  // screen looks edited. Focusing their union is the whole board, i.e. the
-  // zoomed-out-to-nothing state this feature exists to prevent. A change that
-  // broad is a rewrite, not an edit: leave the viewport alone.
-  const wiped: El[] = [el("h1", "Home", 0)]; // Login and Detail momentarily gone
-  assert.deepEqual(focusTargetScreens(SCENE, wiped), []);
-});
-
-test("an edit touching a minority of screens is still a focus target", () => {
-  const next = SCENE.map((e) => (e.id === "l2" ? { ...e, backgroundColor: "#fa7b3f" } : e)) as El[];
-  assert.deepEqual(focusTargetScreens(SCENE, next), ["Login"]);
-});
-
-test("identical scenes report no change", () => {
-  assert.deepEqual(changedScreenNames(SCENE, SCENE.map((e) => ({ ...e }))), []);
-});
-
-test("with no previous scene nothing is reported as changed", () => {
-  assert.deepEqual(changedScreenNames(null, SCENE), []);
 });
 
 test("the opening focus is the first screen plus a peek band of the second", () => {


### PR DESCRIPTION
Closes #552.

Generated wireframes compiled into a two-column grid and the viewer fitted the whole board on open, so every screen rendered too small to read — the first thing anyone did was zoom in. The same fit ran again on every scene update, so while an agent edited a wireframe the canvas kept snapping back to the whole board and the reader lost their place mid-turn.

This PR makes the canvas readable and makes the viewport follow the *editing experience* end to end. The scope grew during review-in-use: each behaviour below was driven by testing the previous one against the live agent.

## What the reader experiences

- **Open a wireframe** → screens stack in a single column; the canvas opens on the **first screen at a legible size**, with the top of the second peeking below as the scroll cue. The peek is part of the fitted box, not left to the panel's aspect ratio.
- **Ask for an edit** → the camera pans to the edited screen on the first flush and follows it live, wherever the reader was. If the reader is already on the edited screen, the camera doesn't twitch.
- **Sweep edit** (same change applied to every screen, one flush each) → at most one initial hop, then the camera holds instead of touring every screen and stranding the reader on the last one.
- **Agent rewrites the whole file** → the half-written flushes never move the viewport; the canvas keeps drawing and the camera stays put.
- **Generation finishes** → the canvas returns to the **first screen** (a generation ends on the last screen only as an accident of drawing order). An *edit* turn does not do this — follow-the-edit already placed the camera.
- **Reader is in Prototype when a turn starts** → they're taken to **Canvas** (the editing view — the only place content changes, new screens, and reshaped flows are all visible) and **stay** there when the turn ends. Previously the prototype unmounted by accident and snapped back to screen 1 mid-review.

## How: the compiler reports what changed

The first implementation diffed two flat scenes in the viewer to guess what the agent edited. Every defect this PR fixes along the way (see commits) traced to that guessing: restyles invisible to a `version` compare, element ids that shifted with the canvas, mid-stream frames reading as "everything changed", a settle timer to paper over it. The end state removes the guessing:

- `@aep/excalidraw-dsl` gains `compileWireframes(dsl, previous)` → `{ json, changedScreens, screenOrder, fingerprints }`. Screens are fingerprinted **relative to their own origin** (a screen that merely moved because one above it grew is not "changed"), and element identity is screen-relative for the same reason. The caller holds the previous result; the compiler stays pure. A source that doesn't compile reports nothing — a half-written stream frame never produces a focus signal.
- Every compiled element carries `customData: { screen }`, so the viewer can group per screen without geometry heuristics.
- `ExcalidrawView` takes `focusScreens` and frames them; `screenFocus.ts` holds the pure viewport logic (first-screen target with peek band, screen-under-viewport-centre, sweep detection). No diff code, no timers.
- `WireframePanel` wires it: `deriveLiveWireframe` + `focusTargets` (breadth rule: a change touching most screens is a rewrite in flight — hold still), generation-vs-edit detection at turn boundaries, and the prototype→canvas mode switch.

Scenes with no screen tags (older compiles, domain-model DSLs) fall back to fit-the-whole-board, so nothing else rendering through these components changes. No contract change; everything stays client-side derived per ADR-0008.

## Bundled: navigation-marker overprint fix

One deliberately **unrelated** fix rides along (kept in this PR by choice — flagged here so reviewers see it): the `→ Screen N · Name` navigation marker was placed unconditionally to the right of its control, which in a row of buttons printed it straight across the neighbouring button, making both unreadable; on a rightmost control it ran off the screen. The marker now goes beside its control when there is room, below it otherwise, clamped inside the frame (`2349f59d`).

## Testing

107 compiler tests (marker collision/edge/beside cases, changed-screen reporting incl. shifted-screens and add/remove, vertical stacking, per-element tags), 33 viewer tests (opening peek band, viewport-centre screen detection, sweep recognition), 864 console tests (generation-vs-edit turn ends, prototype→canvas-and-stays, focus breadth rule, live-compile derive incl. uncompilable frames). `make typecheck` and `make lint` clean.

Verified in the running console against the live agent: open/first-screen framing at both panel widths, follow-the-edit from elsewhere, a real sweep edit ("update the header on every screen") holding after one hop, a full-file rewrite holding throughout, generation returning to screen 1, prototype→canvas on edit, and side-by-side navigating buttons rendering both markers legibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
