### PR TITLE
fix(validation): prove endpoint reachability in the runner, pin .localhost endpoints for curl

### DIFF
--- a/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
+++ b/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
@@ -1,6 +1,8 @@
 # ADR-0006 — The runner proves endpoint reachability, and pins the endpoints for curl
 
-**Status:** Accepted · shipped 2026-08-19
+**Status:** Accepted · not yet shipped — awaiting a runner image rebuild
+(`make build-runner FORCE=1`, which is what carries the `SKILL.md` edit into a
+run) and a live validation cycle. Record the shipped date once both are done.
 
 ## Context
 
@@ -109,3 +111,27 @@ used as given.
   affect the run's other HTTP traffic (the test-credentials callback, `gh`, git).
 - The `.curlrc` lives in the runner's home directory, outside the git work tree,
   so unlike `.aep/` there is no path by which it could be committed.
+
+## How the curl half is verified
+
+The unit tests own what this repo can assert: the `resolve = host:port:address`
+syntax, the `0600` mode, the path, and the `.localhost`-only filter. That curl
+*loads* `$CURL_HOME/.curlrc` and applies `resolve` is third-party behaviour, and
+CI has no Docker step and never builds `aep-runner:dev` — so it is checked by
+hand against the image, and re-checked whenever the writer changes:
+
+```sh
+# 1. The mechanism, in the runner image (curl 7.88.1):
+docker run --rm --entrypoint sh aep-runner:dev -c '
+  mkdir -p /tmp/h
+  printf "resolve = probe.openchoreoapis.localhost:80:10.99.99.99\n" > /tmp/h/.curlrc
+  CURL_HOME=/tmp/h curl -sv -m 2 -o /dev/null http://probe.openchoreoapis.localhost/ 2>&1 |
+    grep -iE "added|trying"'
+# expect: "Added …:80:10.99.99.99 to DNS cache" then "Trying 10.99.99.99:80"
+# (without the config: "Trying 127.0.0.1:80" — RFC 6761)
+
+# 2. End to end, from a pod, against a real deployed endpoint:
+#      without a .curlrc  → curl exits 7
+#      with one pinning the gateway ClusterIP → HTTP 200
+```
+

--- a/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
+++ b/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
@@ -1,8 +1,6 @@
 # ADR-0006 — The runner proves endpoint reachability, and pins the endpoints for curl
 
-**Status:** Accepted · not yet shipped — awaiting a runner image rebuild
-(`make build-runner FORCE=1`, which is what carries the `SKILL.md` edit into a
-run) and a live validation cycle. Record the shipped date once both are done.
+**Status:** Accepted
 
 ## Context
 

--- a/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
+++ b/runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md
@@ -1,0 +1,111 @@
+# ADR-0006 — The runner proves endpoint reachability, and pins the endpoints for curl
+
+**Status:** Accepted · shipped 2026-08-19
+
+## Context
+
+A validation run is dispatched at deployed-green and told where the system is by
+the platform: `fetchValidationContext` writes the deployed endpoint URLs to
+`/tmp/validation-context.json` before the agent starts. The `aep-validation`
+skill then told the agent to probe each URL with `curl -sf -o /dev/null <url>`
+before authoring anything, and to comment on the issue and exit failure if one
+did not answer.
+
+On a local plane those URLs are `*.openchoreoapis.localhost`, and that probe
+cannot work. **curl (≥7.77) and Chromium both implement RFC 6761:** they resolve
+`localhost` and every `*.localhost` name to loopback *themselves*, consulting
+neither DNS nor `/etc/hosts`. Inside the runner pod loopback is the pod, so both
+get connection refused however healthy the deployment is — curl exit **7**
+("failed to connect"), not exit 6 ("couldn't resolve"). Node is unaffected;
+`dns.lookup` returns the real address.
+
+Nothing was misconfigured. The CoreDNS rewrite installed by
+`deployments/scripts/utils.sh` maps `*.openchoreoapis.localhost` to the
+data-plane gateway Service and answers correctly — it simply never gets asked.
+
+The skill had already been taught this. A paragraph explaining RFC 6761 and
+giving a `--resolve` recipe was added on 2026-08-06, in a commit titled *"stop
+rediscovering the .localhost resolver trap each run"*, and a validation run
+preloads the whole `SKILL.md` into the system prompt before its first token
+(`alwaysOnSkills` → `requireWorkflowBodies`). It did not hold. The skill's
+headline instruction was still the plain `curl` command, with the correction in
+the bullet below it, so the p26-bare-minimum-hello run of 2026-08-18 ran the
+broken form as its first action, then spent ~30 seconds and five tool calls
+inspecting `/etc/hosts`, `/etc/nsswitch.conf`, `ss -tlnp` and `sudo tee` before
+reaching the guidance it already had.
+
+The cost is not the wasted tokens. The same skill made an unreachable endpoint a
+reportable failure, so a run that took exit 7 at face value would have posted a
+false failure against a healthy deployment. Whether validation passed depended on
+the agent choosing to investigate rather than believe its own probe.
+
+This is the second time this exact shape has failed. The endpoint *fetch* used to
+be a `curl` in the skill too, with prose telling the agent to stop if it 404'd;
+the agent did not stop, and ADR-era reasoning moved it into
+`validation_context.ts` as a fatal preflight. The probe is the same class of fact
+and failed the same way.
+
+## Decision
+
+**1. Reachability is a platform fact, proved in runner code.** `probeEndpoints`
+runs in `oneshot.ts` immediately after the context fetch and before
+`runClaudeQuery`. An endpoint that does not answer fails the run with
+`endpoint_unreachable` before `agent_started`, so it costs no agent tokens and is
+reported as a platform fault rather than a validation verdict.
+
+**2. Any HTTP answer counts as reachable; only a transport failure does not.**
+Status is deliberately not evidence. An endpoint behind the `api-configuration`
+trait legitimately answers 401, an API root legitimately answers 404, and a
+gateway holding no matching HTTPRoute also answers 404 — indistinguishably from
+the app's own. Treating a status as a verdict would manufacture failures against
+healthy deployments, which is the fault being removed. Redirects are not
+followed: a login redirect points at the IdP on the *control* plane, a different
+hop with its own resolution story, and chasing it would turn an endpoint that
+answered into a false negative.
+
+**3. The URL stays truthful; the environment is fixed instead.** The runner
+writes a `resolve = <host>:<port>:<address>` entry per `.localhost` endpoint into
+curl's own config file (`$CURL_HOME/.curlrc`, `endpoint_access.ts`), so a plain
+`curl <url>` works with the real hostname, through the real gateway, carrying the
+real Host header. The address comes from DNS per run — the CoreDNS rewrite is the
+discovery channel — never from configuration, because a baked-in IP passes once
+and then silently points at nothing after a cluster rebuild.
+
+Rewriting the URL in the validation context was the alternative, and is worse in
+two distinct ways. An IP in the URL sends `Host: <ip>`, matches no HTTPRoute, and
+turns every criterion into a 404 that is not the app's fault. A Service-DNS URL
+(`http://<svc>.<dp-namespace>.svc…`) resolves natively but goes *around* the
+gateway, dropping the `api-configuration` trait's end-user auth, CORS and path
+rewrites — indistinguishable on a static webapp, but on an auth-gated API it
+would let a criterion pass through a side door while the real user path is
+broken. Validation is black-box verification of the deployed system, so the
+system under test must not change to make a URL convenient.
+
+**4. Nothing enters the API contract.** This is a local-plane-only condition —
+cloud endpoints are real DNS names and RFC 6761 never fires — so
+`curlResolveEntries` returns nothing there, no config is written, and the cloud
+path is untouched. A permanent field on
+`packages/contracts/api/internal/v1/openapi.yaml` would have been a local dev
+workaround promoted into the production contract, and `services/aep-api` has no
+Kubernetes client with which to learn the gateway address anyway.
+
+**5. The skill stops instructing and stops explaining.** Both the probe step and
+the ~20 lines of RFC 6761 guidance are deleted from `SKILL.md`, not reworded.
+Rewording would have left a correct instruction beside a wrong one; deleting the
+probe removes the trap, and pinning the endpoints removes the need to explain it.
+The skill now states only that the endpoints are reachable as written and must be
+used as given.
+
+## Consequences
+
+- A validation agent never probes endpoints and never sees exit 7. Its own ad-hoc
+  `curl` calls during authoring and healing work unmodified.
+- Chromium is unchanged: `playwright.config.template.ts` still applies
+  `--host-resolver-rules`, resolving the gateway through `getent`, which works.
+  `.curlrc` is a curl mechanism and does not reach the browser.
+- A `.curlrc` write failure is fatal. Proceeding would start an agent holding a
+  URL it cannot dial and no explanation of why — the state this ADR removes.
+- `resolve` entries are scoped per `host:port`, so pinning endpoint hosts does not
+  affect the run's other HTTP traffic (the test-credentials callback, `gh`, git).
+- The `.curlrc` lives in the runner's home directory, outside the git work tree,
+  so unlike `.aep/` there is no path by which it could be committed.

--- a/runners/remote-worker/src/lib/endpoint_access.test.ts
+++ b/runners/remote-worker/src/lib/endpoint_access.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  CURL_CONFIG_FILE,
+  curlResolveEntries,
+  probeEndpoints,
+  writeCurlResolveConfig,
+} from "./endpoint_access.js";
+
+const GATEWAY = "10.43.246.32";
+
+/** A lookup stub that answers every name with one address. */
+function stubLookup(address = GATEWAY) {
+  const asked: string[] = [];
+  return {
+    asked,
+    fn: async (host: string) => {
+      asked.push(host);
+      return { address };
+    },
+  };
+}
+
+async function tmpDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-curlrc-test-"));
+}
+
+// The `.localhost` filter is the whole point: RFC 6761 is what makes those names
+// unreachable, and pinning anything else would freeze an address curl already
+// resolves correctly — and freeze it wrong the moment the cluster changed.
+test("curlResolveEntries pins only .localhost hosts", async () => {
+  const lookup = stubLookup();
+  const entries = await curlResolveEntries(
+    [
+      { component: "webapp", url: "http://app.openchoreoapis.localhost:19080/" },
+      { component: "api", url: "https://api.example.com/v1" },
+    ],
+    lookup.fn,
+  );
+  assert.deepEqual(entries, [{ host: "app.openchoreoapis.localhost", port: 19080, address: GATEWAY }]);
+  assert.deepEqual(lookup.asked, ["app.openchoreoapis.localhost"]);
+});
+
+// A cloud plane names no `.localhost` endpoint, so the whole mechanism has to be
+// a no-op there rather than something that merely happens to write nothing
+// useful.
+test("curlResolveEntries returns nothing when no endpoint is .localhost", async () => {
+  const entries = await curlResolveEntries(
+    [{ component: "api", url: "https://api.example.com/" }],
+    stubLookup().fn,
+  );
+  assert.deepEqual(entries, []);
+});
+
+// curl's `resolve` is keyed by host:port, so the port the URL implies has to be
+// the port written — an entry on the wrong port silently does nothing.
+test("curlResolveEntries defaults the port from the scheme", async () => {
+  const entries = await curlResolveEntries(
+    [
+      { component: "plain", url: "http://a.localhost/" },
+      { component: "tls", url: "https://b.localhost/" },
+    ],
+    stubLookup().fn,
+  );
+  assert.deepEqual(
+    entries.map((e) => [e.host, e.port]),
+    [
+      ["a.localhost", 80],
+      ["b.localhost", 443],
+    ],
+  );
+});
+
+test("curlResolveEntries emits one entry per host:port", async () => {
+  const lookup = stubLookup();
+  const entries = await curlResolveEntries(
+    [
+      { component: "webapp", url: "http://gw.localhost:19080/app" },
+      { component: "api", url: "http://gw.localhost:19080/api" },
+    ],
+    lookup.fn,
+  );
+  assert.equal(entries.length, 1);
+  assert.equal(lookup.asked.length, 1);
+});
+
+// Skipped, never thrown: probeEndpoints is what decides whether the run may
+// proceed, and it names the endpoint that actually failed rather than the lookup
+// in front of it.
+test("curlResolveEntries skips a name that will not resolve", async () => {
+  const lines: string[] = [];
+  const entries = await curlResolveEntries(
+    [
+      { component: "gone", url: "http://gone.localhost:19080/" },
+      { component: "ok", url: "http://ok.localhost:19080/" },
+    ],
+    async (host) => {
+      if (host === "gone.localhost") throw new Error("ENOTFOUND");
+      return { address: GATEWAY };
+    },
+    (l) => lines.push(l),
+  );
+  assert.deepEqual(entries.map((e) => e.host), ["ok.localhost"]);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /gone\.localhost/);
+});
+
+test("curlResolveEntries skips a malformed URL without throwing", async () => {
+  const lines: string[] = [];
+  const entries = await curlResolveEntries(
+    [{ component: "bad", url: "not-a-url" }],
+    stubLookup().fn,
+    (l) => lines.push(l),
+  );
+  assert.deepEqual(entries, []);
+  assert.equal(lines.length, 1);
+});
+
+test("writeCurlResolveConfig writes one resolve line per entry, 0600", async () => {
+  const dir = await tmpDir();
+  const written = await writeCurlResolveConfig(dir, [
+    { host: "a.localhost", port: 19080, address: GATEWAY },
+    { host: "b.localhost", port: 443, address: "10.0.0.9" },
+  ]);
+  assert.equal(written, path.join(dir, CURL_CONFIG_FILE));
+
+  const body = await fs.promises.readFile(written as string, "utf8");
+  assert.match(body, /^resolve = a\.localhost:19080:10\.43\.246\.32$/m);
+  assert.match(body, /^resolve = b\.localhost:443:10\.0\.0\.9$/m);
+
+  const stat = await fs.promises.stat(written as string);
+  assert.equal(stat.mode & 0o777, 0o600);
+});
+
+// An empty file and "this run needed no overrides" are different facts, and the
+// caller logs them differently.
+test("writeCurlResolveConfig writes nothing when there are no entries", async () => {
+  const dir = await tmpDir();
+  const written = await writeCurlResolveConfig(dir, []);
+  assert.equal(written, undefined);
+  assert.deepEqual(await fs.promises.readdir(dir), []);
+});
+
+// Overwriting must land the new content at the same path with the same mode —
+// `mode` is honoured only on create, which is why the write is staged+renamed.
+test("writeCurlResolveConfig replaces an existing config", async () => {
+  const dir = await tmpDir();
+  await fs.promises.writeFile(path.join(dir, CURL_CONFIG_FILE), "stale\n", { mode: 0o644 });
+  const written = await writeCurlResolveConfig(dir, [
+    { host: "a.localhost", port: 80, address: GATEWAY },
+  ]);
+  const body = await fs.promises.readFile(written as string, "utf8");
+  assert.doesNotMatch(body, /stale/);
+  assert.equal((await fs.promises.stat(written as string)).mode & 0o777, 0o600);
+  // The staging directory must not survive the write.
+  assert.deepEqual(await fs.promises.readdir(dir), [CURL_CONFIG_FILE]);
+});
+
+/** A fetch stub that answers each call with the next queued status, or throws. */
+function stubFetch(outcomes: (number | Error)[]) {
+  const seen: { url: string; redirect?: string }[] = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    seen.push({ url: String(url), redirect: init?.redirect });
+    const next = outcomes.shift();
+    if (next instanceof Error) throw next;
+    return new Response("body", { status: next ?? 200 });
+  }) as unknown as typeof fetch;
+  return { impl, seen };
+}
+
+// Status is deliberately not evidence: an api-configuration-gated endpoint
+// answers 401 and an API root answers 404, both from a perfectly healthy
+// deployment. Only a transport failure means the platform cannot show the agent
+// the system it is meant to validate.
+test("probeEndpoints treats any HTTP answer as reachable", async () => {
+  const { impl } = stubFetch([401, 404, 500, 302]);
+  const unreachable = await probeEndpoints(
+    [
+      { component: "a", url: "http://a.localhost/" },
+      { component: "b", url: "http://b.localhost/" },
+      { component: "c", url: "http://c.localhost/" },
+      { component: "d", url: "http://d.localhost/" },
+    ],
+    { fetchImpl: impl },
+  );
+  assert.deepEqual(unreachable, []);
+});
+
+test("probeEndpoints reports a transport failure, with its code", async () => {
+  const refused = Object.assign(new Error("fetch failed"), {
+    cause: { code: "ECONNREFUSED" },
+  });
+  const { impl } = stubFetch([200, refused]);
+  const unreachable = await probeEndpoints(
+    [
+      { component: "up", url: "http://up.localhost/" },
+      { component: "down", url: "http://down.localhost/" },
+    ],
+    { fetchImpl: impl },
+  );
+  assert.equal(unreachable.length, 1);
+  assert.equal(unreachable[0].component, "down");
+  assert.equal(unreachable[0].reason, "ECONNREFUSED");
+});
+
+// A login redirect points at the IdP on the CONTROL plane — a different hop with
+// its own resolution story. Following it here would turn an endpoint that
+// answered into a false negative.
+test("probeEndpoints does not follow redirects", async () => {
+  const { impl, seen } = stubFetch([302]);
+  await probeEndpoints([{ component: "a", url: "http://a.localhost/" }], { fetchImpl: impl });
+  assert.equal(seen[0].redirect, "manual");
+});

--- a/runners/remote-worker/src/lib/endpoint_access.ts
+++ b/runners/remote-worker/src/lib/endpoint_access.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Makes the validation run's deployed endpoints usable, and proves they answer,
+// before the agent starts.
+//
+// Two different problems, both of which used to be the agent's:
+//
+//  1. `*.localhost` is unreachable from the two clients that matter. curl (>=7.77)
+//     and Chromium both implement RFC 6761: they resolve `localhost` and every
+//     `*.localhost` name to loopback THEMSELVES, consulting neither DNS nor
+//     `/etc/hosts`. On a local plane every deployed endpoint is
+//     `*.openchoreoapis.localhost`, so inside the runner pod both dial 127.0.0.1
+//     — where nothing listens — however healthy the deployment is. The cluster's
+//     CoreDNS rewrite is correct and simply never gets asked. Node is NOT
+//     affected (`dns.lookup` returns the real address), which is why the probe
+//     below needs no override of its own.
+//
+//     The fix is a `resolve` entry per endpoint in curl's own config file, so a
+//     plain `curl <url>` works with the real hostname, through the real gateway,
+//     carrying the real Host header the HTTPRoute matches on. Rewriting the URL
+//     was the alternative and is worse: an IP in the URL sends `Host: <ip>` and
+//     matches no route, and a Service-DNS URL bypasses the gateway altogether —
+//     dropping the api-configuration trait's auth, CORS and path rewrites, so an
+//     auth-gated criterion could pass through a side door.
+//
+//  2. Whether the deployment answers at all is a PLATFORM fact. It used to be a
+//     `curl` in the aep-validation skill with prose telling the agent to stop if
+//     it failed; the agent did not stop — it read RFC 6761's connection refused
+//     as a broken deployment and went hunting through the pod's DNS
+//     configuration. Same reasoning, and the same shape, as the context fetch in
+//     validation_context.ts: an unanswerable platform question never reaches the
+//     agent.
+//
+// On a cloud plane the endpoints are real DNS names, nothing special-cases them,
+// and `curlResolveEntries` returns nothing — so no config is written and the
+// whole local-plane concession costs the cloud path exactly nothing.
+
+import dns from "node:dns";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { ComponentEndpoint } from "./validation_context.js";
+
+/** curl's per-user config file, read from `$CURL_HOME` then `$HOME`. */
+export const CURL_CONFIG_FILE = ".curlrc";
+
+/**
+ * Where the config goes, and what `CURL_HOME` is set to in the agent's env.
+ *
+ * One function so the writer and the env record cannot drift — a config written
+ * somewhere curl is not told to look is indistinguishable from no config at all.
+ *
+ * The home directory, deliberately: it is outside the git work tree, so unlike
+ * `.aep/` there is no path by which this file could be committed, and it is not
+ * world-writable, so the staged-rename below is guarding against far less than
+ * it would under /tmp.
+ */
+export function curlConfigHome(): string {
+  return os.homedir();
+}
+
+/** One `resolve = host:port:address` override. */
+export interface CurlResolveEntry {
+  host: string;
+  port: number;
+  address: string;
+}
+
+/** An endpoint that did not answer, and what stopped it. */
+export interface UnreachableEndpoint {
+  component: string;
+  url: string;
+  reason: string;
+}
+
+/** The lookup shape used here — `dns.promises.lookup`'s options overload. */
+type LookupFn = (host: string, options: { family: 4 }) => Promise<{ address: string }>;
+
+/**
+ * How long a single probe may take. Generous on purpose: this runs once per
+ * endpoint on a cold gateway, and a false "unreachable" costs a whole validation
+ * cycle, while a slow one costs seconds.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** The port a URL implies when it does not name one. */
+function defaultPort(protocol: string): number {
+  return protocol === "https:" ? 443 : 80;
+}
+
+/**
+ * Which endpoints need a curl override, and what address to pin them to.
+ *
+ * Only `.localhost` hosts qualify — that is the exact set RFC 6761 captures, and
+ * pinning anything else would freeze a name curl already resolves correctly (and
+ * would go stale the moment the address changed). DNS is the discovery channel:
+ * the CoreDNS rewrite answers any `*.openchoreoapis.localhost` with the
+ * data-plane gateway's address, so the answer is resolved per run rather than
+ * configured — a baked-in IP passes once and then silently points at nothing.
+ *
+ * Forgiving by design. An unparseable URL or a name that will not resolve is
+ * warned about and skipped, never thrown: `probeEndpoints` is what decides
+ * whether the run may proceed, and it reports the endpoint that actually failed
+ * rather than the lookup that preceded it.
+ */
+export async function curlResolveEntries(
+  endpoints: readonly ComponentEndpoint[],
+  lookup: LookupFn = dns.promises.lookup as LookupFn,
+  log: (line: string) => void = () => {},
+): Promise<CurlResolveEntry[]> {
+  const entries: CurlResolveEntry[] = [];
+  // Components can share a gateway host:port, and a duplicate `resolve` line is
+  // noise in a file a human may well have to read.
+  const seen = new Set<string>();
+
+  for (const ep of endpoints) {
+    let parsed: URL;
+    try {
+      parsed = new URL(ep.url);
+    } catch {
+      log(`[endpoints] ⚠️  ${ep.component}: not a URL, no curl override written: ${ep.url}`);
+      continue;
+    }
+    if (!parsed.hostname.endsWith(".localhost")) {
+      continue;
+    }
+    const port = parsed.port === "" ? defaultPort(parsed.protocol) : Number(parsed.port);
+    const key = `${parsed.hostname}:${port}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    try {
+      const { address } = await lookup(parsed.hostname, { family: 4 });
+      seen.add(key);
+      entries.push({ host: parsed.hostname, port, address });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`[endpoints] ⚠️  ${ep.component}: cannot resolve ${parsed.hostname}: ${msg}`);
+    }
+  }
+  return entries;
+}
+
+/**
+ * Write the overrides to `<dir>/.curlrc`, or nothing when there are none.
+ *
+ * Staged in a private directory and renamed into place, for the same reasons
+ * validation_context.ts stages its write: `mode` is honoured only on create, so
+ * writing over an existing path would keep whatever permissions it already had,
+ * and rename is atomic and does not follow a symlink at the destination.
+ *
+ * Returns the path written, or undefined when there was nothing to write — an
+ * empty file would be indistinguishable from a run whose endpoints needed no
+ * override, and callers log the difference.
+ */
+export async function writeCurlResolveConfig(
+  dir: string,
+  entries: readonly CurlResolveEntry[],
+): Promise<string | undefined> {
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const file = path.join(dir, CURL_CONFIG_FILE);
+  const body =
+    `# Written by the AEP validation runner. Deployed endpoints are\n` +
+    `# *.openchoreoapis.localhost, which curl resolves to loopback itself\n` +
+    `# (RFC 6761) — these pin them to the gateway DNS actually answers with.\n` +
+    entries.map((e) => `resolve = ${e.host}:${e.port}:${e.address}`).join("\n") +
+    `\n`;
+
+  await fs.promises.mkdir(dir, { recursive: true });
+  const staging = await fs.promises.mkdtemp(path.join(dir, ".aep-curlrc-"));
+  try {
+    const staged = path.join(staging, CURL_CONFIG_FILE);
+    await fs.promises.writeFile(staged, body, { mode: 0o600 });
+    await fs.promises.rename(staged, file);
+  } finally {
+    await fs.promises.rm(staging, { recursive: true, force: true });
+  }
+  return file;
+}
+
+/**
+ * Probe every endpoint and report the ones that did not answer.
+ *
+ * ANY HTTP response counts as reachable — status is deliberately not evidence.
+ * An endpoint behind the api-configuration trait legitimately answers 401, an
+ * API root legitimately answers 404, and a gateway holding no matching
+ * HTTPRoute also answers 404, indistinguishably from the app's own. Reading a
+ * status as a verdict would therefore manufacture failures against healthy
+ * deployments, which is the exact fault this preflight exists to remove. Only a
+ * transport failure — refused, unroutable, timed out, unresolvable — means the
+ * platform cannot show the agent the system it is meant to validate.
+ *
+ * Redirects are NOT followed. A login redirect points at the IdP on the control
+ * plane, which is a different hop with its own resolution story; chasing it here
+ * would turn an answered endpoint into a false negative. A 302 is an answer.
+ */
+export async function probeEndpoints(
+  endpoints: readonly ComponentEndpoint[],
+  opts: { timeoutMs?: number; fetchImpl?: typeof fetch } = {},
+): Promise<UnreachableEndpoint[]> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? PROBE_TIMEOUT_MS;
+  const unreachable: UnreachableEndpoint[] = [];
+
+  for (const ep of endpoints) {
+    try {
+      const res = await doFetch(ep.url, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      // Nothing here reads the body; leaving it unconsumed holds the socket.
+      await res.body?.cancel().catch(() => {});
+    } catch (err) {
+      const cause = (err as { cause?: { code?: string } }).cause;
+      const reason = cause?.code ?? (err instanceof Error ? err.message : String(err));
+      unreachable.push({ component: ep.component, url: ep.url, reason });
+    }
+  }
+  return unreachable;
+}

--- a/runners/remote-worker/src/lib/runner.ts
+++ b/runners/remote-worker/src/lib/runner.ts
@@ -32,6 +32,7 @@ import { createWorkspaceWriteGuard } from "./workspace_guard.js";
 import { createWebFetchGuardHook } from "./webfetch_guard.js";
 import { checkPreload, preloadWarning } from "./skills_preload_check.js";
 import { SKILLS_MIRROR_DIR, requireWorkflowBodies } from "./skills_presence.js";
+import { curlConfigHome } from "./endpoint_access.js";
 
 /**
  * The mirror the BFF wrote into the project clone, as an absolute path.
@@ -346,6 +347,12 @@ export function runClaudeQuery(
     AEP_PLATFORM_URL: process.env.AEP_PLATFORM_URL ?? "",
     AEP_GIT_SERVICE_URL: req.gitServiceUrl,
     AEP_CORRELATION_ID: req.correlationId ?? "",
+    // Where curl looks for `.curlrc`. Named explicitly rather than left to the
+    // inherited HOME: a validation run writes `resolve` overrides there for its
+    // deployed endpoints (endpoint_access.ts), and a config curl was never told
+    // to look for is indistinguishable from no config at all. Harmless on a
+    // coding run, which writes no such file.
+    CURL_HOME: curlConfigHome(),
   };
 
   // NO plugins. Every skill this session reads is a directory in the project's

--- a/runners/remote-worker/src/oneshot.ts
+++ b/runners/remote-worker/src/oneshot.ts
@@ -46,6 +46,13 @@ import {
   fetchValidationContext,
   VALIDATION_CONTEXT_FILE,
 } from "./lib/validation_context.js";
+import type { ComponentEndpoint } from "./lib/validation_context.js";
+import {
+  curlConfigHome,
+  curlResolveEntries,
+  probeEndpoints,
+  writeCurlResolveConfig,
+} from "./lib/endpoint_access.js";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -217,25 +224,33 @@ async function main(): Promise<number> {
   // Scope: an implementation run is a MILESTONE cycle — one branch, one PR,
   // any component in the milestone — so it takes the union of every component's
   // skillsPinned. Its AEP_COMPONENT_NAME is the `aep-milestone` sentinel and
-  // must not be used to pick a design file. A validation run applies no design
-  // skills at all: it is black-box verification driven by the `aep-validation`
-  // skill (AEP_TASK_KIND), and builds nothing.
-  // A validation run applies no DESIGN skills: nothing is pinned and nothing
-  // is pinned, so the allowlist below leaves the design skills out entirely.
+  // must not be used to pick a design file.
+  //
+  // A validation run (AEP_TASK_KIND) applies no DESIGN skills at all — it is
+  // black-box verification and builds nothing — so both values below stay empty
+  // for it: nothing is pinned, and the Skill allowlist is left empty on purpose.
+  // `aep-validation` reaches the run a different way: alwaysOnSkills() names it
+  // as this run's workflow and requireWorkflowBodies() injects its whole SKILL.md
+  // into the system prompt, so it is in context from the first token rather than
+  // invocable through the Skill tool.
   let availableSkillNames: string[] = [];
   let pinnedBodies = "";
   if (req.taskKind === "validation") {
-    console.log("[oneshot] validation run — no design skills apply; using the aep-validation skill only");
+    console.log(
+      "[oneshot] validation run — no design skills apply; aep-validation is injected as this run's workflow",
+    );
     // PREFLIGHT: where the deployed system is, fetched by the platform before the
     // agent starts. Fatal on purpose — an agent that cannot learn its targets has
     // no honest way forward, and when this was the skill's own `curl` a 404 sent
     // it scanning the pod network for half an hour instead of stopping.
+    let endpoints: ComponentEndpoint[];
     try {
       const ctx = await fetchValidationContext({
         platformUrl: platformURL,
         cycleId: req.taskId,
         bearer: req.bearer,
       });
+      endpoints = ctx.endpoints;
       console.log(
         `[oneshot] validation context: ${ctx.endpoints.length} deployed endpoint(s) → ${VALIDATION_CONTEXT_FILE}`,
       );
@@ -245,6 +260,44 @@ async function main(): Promise<number> {
       console.error(`[oneshot] validation context unavailable — not starting the agent: ${msg}`);
       return 2;
     }
+
+    // Make those URLs work for curl before the agent can reach for it. Fatal for
+    // the same reason the fetch above is: without the override a plain `curl`
+    // against a `.localhost` endpoint is refused by loopback (RFC 6761 — see
+    // endpoint_access.ts), and the skill no longer carries the ~20 lines that used
+    // to explain that away. An agent handed a URL it cannot dial and no
+    // explanation is exactly the state that sent the last one hunting.
+    try {
+      const entries = await curlResolveEntries(endpoints, undefined, (l) => console.log(l));
+      const written = await writeCurlResolveConfig(curlConfigHome(), entries);
+      if (written === undefined) {
+        // No `.localhost` endpoints — a cloud plane resolves them normally and
+        // there is nothing to pin. Logged so the absence is a decision on the
+        // record rather than a step that looks like it did not run.
+        console.log("[oneshot] endpoints need no curl resolve override");
+      } else {
+        console.log(`[oneshot] pinned ${entries.length} endpoint host(s) for curl → ${written}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      emit({ kind: "result", status: "failure", error: `endpoint_access: ${msg}` });
+      console.error(`[oneshot] cannot make the endpoints reachable — not starting the agent: ${msg}`);
+      return 2;
+    }
+
+    // PREFLIGHT: does the deployed system actually answer? Also a platform fact,
+    // and one the agent used to be told to establish itself — which it got wrong
+    // in the one way that matters, reading a resolver quirk as a dead deployment.
+    // Proving it here means an unreachable endpoint costs no agent tokens and is
+    // reported as a platform fault instead of a validation verdict.
+    const unreachable = await probeEndpoints(endpoints);
+    if (unreachable.length > 0) {
+      const detail = unreachable.map((u) => `${u.component} (${u.url}): ${u.reason}`).join("; ");
+      emit({ kind: "result", status: "failure", error: `endpoint_unreachable: ${detail}` });
+      console.error(`[oneshot] deployed endpoint(s) did not answer — not starting the agent: ${detail}`);
+      return 2;
+    }
+    console.log(`[oneshot] ${endpoints.length} deployed endpoint(s) answered`);
   } else {
     const pinned = await resolveTaskSkills({
       workspace: layout.workspace,

--- a/skills/aep-validation/SKILL.md
+++ b/skills/aep-validation/SKILL.md
@@ -105,28 +105,14 @@ probe, scan, or infer endpoints, and do not call the platform for them
 yourself; the URL is not something you can work out from inside the cluster.
 
 - **Endpoints** become `tests/e2e/targets.json` (step 5) and your target
-  list. Probe each URL (`curl -sf -o /dev/null <url>` or a playwright-cli
-  visit) before authoring. Never start, build, or deploy the app — you
-  validate what is already running; an unreachable endpoint → issue
-  comment + exit failure.
-- **A `.localhost` endpoint fails that probe for a reason that is not the
-  app.** curl and Chromium both implement RFC 6761: they resolve
-  `*.localhost` to loopback THEMSELVES, ignoring DNS and `/etc/hosts`. Inside
-  the runner pod loopback is the pod, so a plain `curl` gets connection
-  refused however healthy the deployment is. Do not read that as an
-  unreachable endpoint, and do not go hunting for the cause — resolve the
-  gateway from DNS and pin it per request:
-
-  ```bash
-  GW=$(getent ahostsv4 development-default.openchoreoapis.localhost | awk 'NR==1{print $1}')
-  curl -sf -o /dev/null --resolve "<host>:19080:$GW" "<url>"
-  ```
-
-  The browser needs the same override, which
-  `playwright.config.template.ts` already applies for you via
-  `--host-resolver-rules` — copy that file unedited and it self-configures.
-  Only treat an endpoint as genuinely down if it still fails WITH the
-  mapping.
+  list. Each one is reachable exactly as written: the runner probed them all
+  and exits before starting you if any did not answer, so there is no
+  unreachable-endpoint case for you to detect or report. Use the URL as
+  given — do not rewrite it to an IP or a cluster-internal name, which would
+  route around the gateway and stop testing what a user actually reaches.
+  Never start, build, or deploy the app; you validate what is already
+  running. If a request fails once you are authoring, that is a finding
+  about the app, not a target to go re-derive.
 - **Test credentials (on demand):** request them only when a criterion
   needs a login — POST the test-credentials endpoint with an optional
   `role` hint (the role the flow requires). `AEP_TASK_ID` is this run's


### PR DESCRIPTION
Closes #558.

A validation agent's first action — probing the endpoint the platform handed it —
failed against a healthy deployment, because curl and Chromium both implement
RFC 6761 and resolve `*.localhost` to loopback themselves, ignoring DNS and
`/etc/hosts`. The skill made an unreachable endpoint a reportable failure, so
validation outcomes were luck-dependent on the agent choosing to investigate
rather than believe its own probe. Full analysis in #558.

This moves reachability out of the skill and into runner code, and makes the
endpoints usable so a plain `curl <url>` works.

## What changed

**New `runners/remote-worker/src/lib/endpoint_access.ts`**

- `curlResolveEntries` — resolves each `.localhost` endpoint host via DNS, **per
  run**. DNS is the discovery channel (the CoreDNS rewrite answers with the
  data-plane gateway), never configuration: a baked-in IP passes once and then
  silently points at nothing after a cluster rebuild. Non-`.localhost` hosts
  yield nothing, so a cloud plane is untouched.
- `writeCurlResolveConfig` — writes `resolve = host:port:address` lines to
  `$CURL_HOME/.curlrc` at `0600`, staged-and-renamed for the same reasons
  `validation_context.ts` stages its write (mode is honoured only on create;
  rename is atomic and does not follow a destination symlink).
- `probeEndpoints` — plain `fetch`; Node resolves these names correctly, so no
  pinning is needed here. **Any HTTP answer counts as reachable, only a transport
  failure does not.** An `api-configuration`-gated endpoint legitimately answers
  401, an API root legitimately answers 404, and a gateway with no matching
  HTTPRoute answers 404 indistinguishably from the app's own — so reading status
  as a verdict would manufacture failures against healthy deployments, which is
  the fault being removed. Redirects are not followed: a login redirect points at
  the control-plane IdP, a different hop, and chasing it would turn an endpoint
  that answered into a false negative.

**`oneshot.ts`** — after the context fetch, pin then probe. An unreachable
endpoint fails the run with `endpoint_unreachable` **before** `agent_started`, so
it costs no agent tokens and is reported as a platform fault rather than a
validation verdict. A `.curlrc` write failure is fatal too — proceeding would
start an agent holding a URL it cannot dial and no explanation of why.

**`runner.ts`** — `CURL_HOME` in the agent's env, from the same
`curlConfigHome()` the writer uses, so a config written where curl is not told to
look cannot happen.

**`skills/aep-validation/SKILL.md`** — the probe step and the ~20-line RFC 6761
block are **deleted, not reworded** (30 lines → 8). Rewording would have left a
correct instruction beside a wrong one; deleting the probe removes the trap and
pinning the endpoints removes the need to explain it. The `--resolve` recipe went
with it — it also hardcoded `development-default.openchoreoapis.localhost` rather
than the endpoint's own host, working only by accident of the rewrite answering
every `*.openchoreoapis.localhost` with the same IP.

**ADR-0006** — records the decision most likely to be undone later: why the URL
stays truthful.

## Why the URL is not rewritten

The obvious shortcut is to put a working address in the validation context. Both
forms are worse:

- **IP in the URL** → `Host: <ip>`, matches no HTTPRoute, gateway 404s. Every
  criterion then fails for a reason that is not the app.
- **Service-DNS URL** → resolves natively but bypasses the gateway, dropping the
  `api-configuration` trait's end-user auth, CORS and path rewrites.
  Indistinguishable on a static webapp; on `p24-todo-auth` it would let an
  auth-gated criterion pass through a side door while the real user path is
  broken.

Validation is black-box verification of the deployed system, so the URL stays
real and the environment is fixed instead. Nothing enters
`packages/contracts/api/internal/v1/openapi.yaml` either — this is a
local-plane-only condition, and `services/aep-api` has no Kubernetes client with
which to learn the gateway address anyway.

## Proof of execution

**In-cluster, against the real deployed p26 endpoint through the real gateway:**

```
$ kubectl -n dp-default-p26-bare-mini-development-2140ae2f exec <webapp-pod> -- sh -c '…'
--- WITHOUT the config (what happened on 2026-08-18) ---
EXIT=7
--- WITH the config, real gateway 10.43.246.32 ---
HTTP 200
EXIT=0
```

**In the runner image, fed this PR's own `writeCurlResolveConfig` output** (file
generated by calling the module, then handed to curl in `aep-runner:dev`):

```
--- file as the module wrote it ---
# Written by the AEP validation runner. Deployed endpoints are
# *.openchoreoapis.localhost, which curl resolves to loopback itself
# (RFC 6761) — these pin them to the gateway DNS actually answers with.
resolve = http-p26-bare-mini-development-default-1d5ff39f.openchoreoapis.localhost:19080:10.99.99.99

--- curl WITH CURL_HOME ---
* Added http-p26-…openchoreoapis.localhost:19080:10.99.99.99 to DNS cache
*   Trying 10.99.99.99:19080...

--- curl WITHOUT ---
EXIT=7
```

`EXIT=7` is byte-for-byte the failure recorded at seq 15 of the 2026-08-18 run.

## Tests

12 new tests in `endpoint_access.test.ts`, covering: only `.localhost` hosts are
pinned; a cloud-shaped endpoint list produces no entries and writes no file;
default ports per scheme; one entry per `host:port`; an unresolvable name and a
malformed URL are skipped rather than thrown; `.curlrc` contents and `0600` mode;
an existing config is replaced with the mode reasserted and no staging directory
left behind; 401/404/500/302 all count as reachable; a transport failure is
reported with its code; redirects are not followed.

| Gate | Result |
|---|---|
| `runners/remote-worker` tests | **366 pass** (12 new) |
| `tsc --noEmit` | clean |
| `make lint` | 27/27 tasks, golangci-lint 0 issues |
| `make license-check` | clean |
| `make deadcode-ts-check` | clean |
| `go test ./internal/spec/` | `ok` — the package that reads the real skill library |

## Not yet verified

The runner image has **not** been rebuilt (`make build-runner FORCE=1`) and no
live validation cycle has been run against this change. Skills are baked into
`aep-runner:dev`, so the `SKILL.md` edit does not reach a run until that rebuild.
Outstanding end-to-end checks:

- happy path: a p26 validation cycle showing no DNS-forensics tool calls and no
  agent-side probe, verdict unchanged;
- negative path: webapp scaled to 0 replicas → run fails with
  `endpoint_unreachable` before `agent_started`, burning no agent tokens.

Note when re-running: completed agent Jobs are currently resurrected on reconcile
(#554), so confirm which pod generation a log stream belongs to before reading it
as the run of record.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
