### PR TITLE
feat(aectl): operator-first addon bootstrap for platform install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,11 +158,19 @@ jobs:
 
           helm package /tmp/platform --destination /tmp/charts
 
+      - name: Package thunder-app-operator chart
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          cp -r deployments/single-cluster/resource-types/thunder-app/operator/helm /tmp/thunder-app-operator
+          yq -i '.version = strenv(VERSION)' /tmp/thunder-app-operator/Chart.yaml
+          yq -i '.appVersion = strenv(VERSION)' /tmp/thunder-app-operator/Chart.yaml
+          helm package /tmp/thunder-app-operator --destination /tmp/charts
+
       - name: Push charts to GHCR
         run: |
-          for chart in /tmp/charts/*.tgz; do
-            helm push "$chart" oci://${{ env.REGISTRY }}/wso2/aep/charts
-          done
+          helm push /tmp/charts/aep-platform-*.tgz oci://${{ env.REGISTRY }}/wso2/aep/charts
+          helm push /tmp/charts/thunder-app-operator-*.tgz oci://${{ env.REGISTRY }}/wso2
 
   # ─── Platform: create GitHub release ────────────────────────────────────────
   create-platform-release:


### PR DESCRIPTION
## Summary

- Adds a `thunder-app` addon (ThunderApplication ClusterResourceType + RBAC) with `thunder-app-operator` as its Helm prerequisite
- Replaces the static "requires CloudNativePG pre-installed" warning on `postgres-cnpg` with an active operator-install phase
- Before applying addon manifests, `aectl platform install` now lists required operators, prompts for confirmation (`[y/N]`), installs them via `helm upgrade --install --wait --timeout 5m`, and handles partial failures — addons whose operator failed are skipped while others continue
- Fixes OAuth client registration spinner race: one spinner per client
- Validates `consoleURL` before deriving redirect URIs (requires absolute `http`/`https` URL)
- Publishes the `thunder-app-operator` Helm chart on each release (alongside the platform chart) so the addon flow can install it from `oci://ghcr.io/wso2/thunder-app-operator`

## New user flow

```
? Optional platform resources
  [✓] thunder-app     ThunderApplication ClusterResourceType + RBAC
  [✓] postgres-cnpg   PostgreSQL via CloudNativePG (ClusterResourceType + RBAC)

  The following operators will be installed:
    · thunder-app-operator   (for thunder-app)
    · CloudNativePG v0.29.0  (for postgres-cnpg)

  Install these operators? [y/N]: y

  ✗ CloudNativePG v0.29.0 install failed

    ✓ thunder-app-operator:  installed
    ✗ cnpg:                  failed — skipping postgres-cnpg

  ⠸ Applying thunder-app...
  ✓ thunder-app applied
    · ClusterResourceType/thunder-app
    · ClusterRole/openchoreo-dataplane-thunder-app
    · ClusterRoleBinding/openchoreo-dataplane-thunder-app
```

## Files changed

| File | Change |
|---|---|
| `tools/aectl/internal/addons/addons.go` | `OperatorSpec` struct; `thunder-app` addon with embedded manifests; `postgres-cnpg` operator spec |
| `tools/aectl/internal/helm/install.go` | New package — `InstallOperator` via `helm upgrade --install --wait --timeout 5m` |
| `tools/aectl/internal/ui/prompt.go` | New `Confirm(prompt)` `[y/N]` helper |
| `tools/aectl/cmd/platform.go` | `runAddonInstall` with injectable `addonDeps`; lazy k8s applier; `manifestApplier` interface |
| `tools/aectl/cmd/thunder_cli.go` | Per-client spinner fix; `consoleURL` validation |
| `.github/workflows/release.yml` | Package + push `thunder-app-operator` Helm chart on release |

## Tests

- `internal/addons`: operator metadata validated for every `Available` entry; pinned values for `thunder-app` and `postgres-cnpg`
- `internal/helm`: argument construction via fake helm binary — base args, `--wait`/`--timeout`, `--version`, `--set`, `--kubeconfig`, failure output
- `internal/ui`: `Confirm` affirmative/negative/EOF cases
- `cmd`: `runAddonInstall` workflow — declined confirmation, operator failure skips addon (asserts `newApplier` not called), success applies all manifests

## Test plan

- [ ] `go build ./...` and `go test ./...` pass (verified)
- [ ] Select both addons, confirm `y` → both operators install, both manifests applied
- [ ] Break one chart URL → partial failure summary shown, failed addon skipped, other applied
- [ ] Type `n` at operator prompt → nothing installed, returns cleanly
- [ ] Press Esc at addon selector → returns cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)