### PR TITLE
fix: close MCP auth holes from the #512 review

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -181,9 +181,10 @@ Pre-provisioned Thunder OAuth2 M2M client (client_credentials grant) in
 cloud's platform-idp, secret in Vault as
 `aep-bff-to-remote-worker-client-secret`. **Provisioned for the
 now-removed long-lived `remote-worker` service component**; not used by the OC
-job-Component dispatch that replaced it — a cycle pod authenticates to aep-api
-with a per-cycle bearer subject, and app-factory calls no proxy. Kept in the
-deployment configs as historical bookkeeping; consider for cleanup later.
+job-Component dispatch that replaced it. A cycle pod authenticates to aep-api
+with the org's publisher `client_credentials` token (MCP and internal
+callbacks); app-factory calls no proxy. Kept in the deployment configs as
+historical bookkeeping; consider for cleanup later.
 
 ---
 

--- a/runners/remote-worker/src/lib/auth_retry.test.ts
+++ b/runners/remote-worker/src/lib/auth_retry.test.ts
@@ -157,6 +157,24 @@ test("fetchWith401Retry: remint failure is fatal", async () => {
   }
 });
 
+test("fetchWith401Retry: first getToken failure is fatal", async () => {
+  const source = {
+    getToken: async () => {
+      throw new Error("thunder down");
+    },
+    invalidate: () => {
+      throw new Error("invalidate must not run");
+    },
+  };
+  await assert.rejects(
+    () =>
+      fetchWith401Retry("http://127.0.0.1:1/", { method: "GET" }, { source, canRefresh: true, fetchImpl: async () => {
+        throw new Error("fetch must not run");
+      } }),
+    (err: unknown) => err instanceof FatalAuthError && /token mint failed: thunder down/.test(err.message),
+  );
+});
+
 test("ClientCredentialsTokenProvider: invalidate forces a remint", async () => {
   let n = 0;
   const idp = await listen((_req, res) => {

--- a/runners/remote-worker/src/lib/auth_retry.ts
+++ b/runners/remote-worker/src/lib/auth_retry.ts
@@ -64,7 +64,13 @@ export async function fetchWith401Retry(
   },
 ): Promise<Response> {
   const doFetch = opts.fetchImpl ?? fetch;
-  const first = await opts.source.getToken();
+  let first: string;
+  try {
+    first = await opts.source.getToken();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new FatalAuthError(`token mint failed: ${msg}`);
+  }
   await opts.onToken?.(first);
   const res = await authorizedFetch(url, init, first, doFetch);
   if (res.status !== 401) {

--- a/runners/remote-worker/src/lib/credhelper.test.ts
+++ b/runners/remote-worker/src/lib/credhelper.test.ts
@@ -350,6 +350,28 @@ test("credhelper: names the missing bearer instead of failing mutely", async () 
     assert.notEqual(r.code, 0);
     assert.equal(r.stdout, "");
     assert.match(r.stderr, /no platform credential/);
+    assert.match(r.stderr, /PUBLISHER_\* unset/);
+    assert.equal(stub.requests(), 0);
+  } finally {
+    await stub.close();
+  }
+});
+
+test("credhelper: names a failed publisher mint when PUBLISHER_* is set", async () => {
+  const stub = await startStub({ token: GH_TOKEN, taskId: TASK_ID });
+  const f = await fixture(stub.url, { bearer: "" });
+  try {
+    const r = await run(withStdin(f.helper, "get"), {
+      ...f.env,
+      PUBLISHER_CLIENT_ID: "id",
+      PUBLISHER_CLIENT_SECRET: "sec",
+      PUBLISHER_TOKEN_URL: "http://aep-token.invalid/oauth2/token",
+    });
+
+    assert.notEqual(r.code, 0);
+    assert.equal(r.stdout, "");
+    assert.match(r.stderr, /PUBLISHER_\* mint failed/);
+    assert.doesNotMatch(r.stderr, /PUBLISHER_\* unset/);
     assert.equal(stub.requests(), 0);
   } finally {
     await stub.close();

--- a/runners/remote-worker/src/lib/credhelper.ts
+++ b/runners/remote-worker/src/lib/credhelper.ts
@@ -87,7 +87,7 @@ export function credHelperScript(params: CredHelperParams): string {
 # Authenticates to the platform with the org publisher client_credentials token
 # (POST /internal/v1/executions/{executionId}/credentials/refresh). When
 # PUBLISHER_CLIENT_ID/SECRET/TOKEN_URL are set, mint a Thunder access token.
-# If that mint fails, read the CC snapshot oneshot wrote to \$AEP_BEARER_FILE.
+# If that mint fails, read the CC snapshot oneshot wrote to $AEP_BEARER_FILE.
 #
 # Diagnostics go to stderr deliberately. An earlier version stayed silent on
 # every failure "so git's own error message reaches the user"; git's message for
@@ -132,48 +132,52 @@ case "\${1:-get}" in
 esac
 
 corr_header=()
-if [ -n "\$AEP_CORRELATION_ID" ]; then
-  corr_header=(-H "X-Correlation-ID: \$AEP_CORRELATION_ID")
+if [ -n "$AEP_CORRELATION_ID" ]; then
+  corr_header=(-H "X-Correlation-ID: $AEP_CORRELATION_ID")
 fi
 
 # Tier 1 — the platform credential. Prefer publisher client_credentials, fall
 # back to the staged bearer. Minted per invocation, so a long run never serves
 # git an expired token.
 bearer=""
-if [ -n "\$PUBLISHER_CLIENT_ID" ] && [ -n "\$PUBLISHER_CLIENT_SECRET" ] && [ -n "\$PUBLISHER_TOKEN_URL" ]; then
-  cc_resp="\$(curl -fsS -X POST \\
-    -u "\$PUBLISHER_CLIENT_ID:\$PUBLISHER_CLIENT_SECRET" \\
+if [ -n "$PUBLISHER_CLIENT_ID" ] && [ -n "$PUBLISHER_CLIENT_SECRET" ] && [ -n "$PUBLISHER_TOKEN_URL" ]; then
+  cc_resp="$(curl -fsS -X POST \\
+    -u "$PUBLISHER_CLIENT_ID:$PUBLISHER_CLIENT_SECRET" \\
     -H "Content-Type: application/x-www-form-urlencoded" \\
     -d 'grant_type=client_credentials' \\
-    "\$PUBLISHER_TOKEN_URL" 2>/dev/null || true)"
-  if [ -n "\$cc_resp" ]; then
+    "$PUBLISHER_TOKEN_URL" 2>/dev/null || true)"
+  if [ -n "$cc_resp" ]; then
     if command -v python3 >/dev/null 2>&1; then
-      bearer="\$(printf '%s' "\$cc_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+      bearer="$(printf '%s' "$cc_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
     else
-      bearer="\$(printf '%s' "\$cc_resp" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')"
+      bearer="$(printf '%s' "$cc_resp" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')"
     fi
   fi
-  if [ -z "\$bearer" ]; then
-    echo "credhelper: publisher client_credentials mint failed; trying \\\$AEP_BEARER_FILE (CC snapshot)" >&2
+  if [ -z "$bearer" ]; then
+    echo "credhelper: publisher client_credentials mint failed; trying \\$AEP_BEARER_FILE (CC snapshot)" >&2
   fi
 fi
-if [ -z "\$bearer" ]; then
-  bearer="\$(cat "\$AEP_BEARER_FILE" 2>/dev/null || true)"
+if [ -z "$bearer" ]; then
+  bearer="$(cat "$AEP_BEARER_FILE" 2>/dev/null || true)"
 fi
-if [ -z "\$bearer" ]; then
-  echo "credhelper: no platform credential — PUBLISHER_* mint failed and \\\$AEP_BEARER_FILE is missing or empty" >&2
+if [ -z "$bearer" ]; then
+  if [ -n "$PUBLISHER_CLIENT_ID" ] && [ -n "$PUBLISHER_CLIENT_SECRET" ] && [ -n "$PUBLISHER_TOKEN_URL" ]; then
+    echo "credhelper: no platform credential — PUBLISHER_* mint failed and \\$AEP_BEARER_FILE is missing or empty" >&2
+  else
+    echo "credhelper: no platform credential — PUBLISHER_* unset and \\$AEP_BEARER_FILE is missing or empty" >&2
+  fi
   exit 1
 fi
 
 # Tier 2 — exchange the platform credential for a GitHub token.
-resp="\$(curl -fsS -X POST \\
-  -H "Authorization: Bearer \$bearer" \\
+resp="$(curl -fsS -X POST \\
+  -H "Authorization: Bearer $bearer" \\
   -H "Content-Type: application/json" \\
   "\${corr_header[@]}" \\
   -d '{}' \\
-  "\$refresh_url" 2>/dev/null || true)"
-if [ -z "\$resp" ]; then
-  echo "credhelper: credential refresh failed — POST \$refresh_url returned nothing" >&2
+  "$refresh_url" 2>/dev/null || true)"
+if [ -z "$resp" ]; then
+  echo "credhelper: credential refresh failed — POST $refresh_url returned nothing" >&2
   exit 1
 fi
 
@@ -192,7 +196,7 @@ if command -v python3 >/dev/null 2>&1; then
     read -r resp_login || true
     read -r resp_name || true
     read -r resp_email || true
-  } < <(printf '%s' "\$resp" | python3 -c '
+  } < <(printf '%s' "$resp" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 i = d.get("identity") or d.get("Identity") or {}
@@ -209,11 +213,11 @@ print(pick("Name", "name"))
 print(pick("Email", "email"))
 ' 2>/dev/null)
 else
-  resp_token="\$(printf '%s' "\$resp" | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')"
-  resp_task_id="\$(printf '%s' "\$resp" | sed -n 's/.*"taskId":"\\([^"]*\\)".*/\\1/p')"
+  resp_token="$(printf '%s' "$resp" | sed -n 's/.*"token":"\\([^"]*\\)".*/\\1/p')"
+  resp_task_id="$(printf '%s' "$resp" | sed -n 's/.*"taskId":"\\([^"]*\\)".*/\\1/p')"
 fi
 
-if [ -z "\$resp_token" ]; then
+if [ -z "$resp_token" ]; then
   echo "credhelper: refresh response carried no token" >&2
   exit 1
 fi
@@ -221,8 +225,8 @@ fi
 # Anti-misroute tripwire (PR D §6.6). Empty taskId in the response is
 # tolerated — older git-service versions may not echo it; in that mode the
 # workspace bearer's signature is the only credential check.
-if [ -n "\$resp_task_id" ] && [ "\$resp_task_id" != "\$expected_task_id" ]; then
-  echo "credhelper: refusing — response.taskId (\$resp_task_id) != bound task (\$expected_task_id)" >&2
+if [ -n "$resp_task_id" ] && [ "$resp_task_id" != "$expected_task_id" ]; then
+  echo "credhelper: refusing — response.taskId ($resp_task_id) != bound task ($expected_task_id)" >&2
   exit 1
 fi
 
@@ -231,16 +235,16 @@ fi
 # — the git op continues with the credential even if the rewrite fails
 # (subsequent commits would still attribute under the old identity in that case,
 # surfaced in audit later). No-ops during the provisioning clone, where
-# \$workspace_dir does not exist yet.
-if [ -n "\$resp_login" ] && [ -d "\$workspace_dir/.git" ]; then
-  current_name="\$(git -C "\$workspace_dir" config user.name 2>/dev/null || true)"
-  current_email="\$(git -C "\$workspace_dir" config user.email 2>/dev/null || true)"
-  new_name="\${resp_name:-\$resp_login}"
-  new_email="\${resp_email:-\$resp_login@users.noreply.github.com}"
-  if [ "\$current_name" != "\$new_name" ] || [ "\$current_email" != "\$new_email" ]; then
-    echo "credhelper: identity drift detected (\$current_name → \$new_name); rewriting .git/config" >&2
-    git -C "\$workspace_dir" config user.name "\$new_name" >/dev/null 2>&1 || true
-    git -C "\$workspace_dir" config user.email "\$new_email" >/dev/null 2>&1 || true
+# $workspace_dir does not exist yet.
+if [ -n "$resp_login" ] && [ -d "$workspace_dir/.git" ]; then
+  current_name="$(git -C "$workspace_dir" config user.name 2>/dev/null || true)"
+  current_email="$(git -C "$workspace_dir" config user.email 2>/dev/null || true)"
+  new_name="\${resp_name:-$resp_login}"
+  new_email="\${resp_email:-$resp_login@users.noreply.github.com}"
+  if [ "$current_name" != "$new_name" ] || [ "$current_email" != "$new_email" ]; then
+    echo "credhelper: identity drift detected ($current_name → $new_name); rewriting .git/config" >&2
+    git -C "$workspace_dir" config user.name "$new_name" >/dev/null 2>&1 || true
+    git -C "$workspace_dir" config user.email "$new_email" >/dev/null 2>&1 || true
   fi
 fi
 
@@ -248,13 +252,13 @@ fi
 # here is silently useless — git answers it with \`warning: invalid credential
 # line\` and then fails the operation for want of a username.
 echo "username=x-access-token"
-echo "password=\$resp_token"
+echo "password=$resp_token"
 `;
 }
 
 export function ghWrapperScript(realGhPath: string): string {
   return `#!/usr/bin/env bash
-# gh CLI wrapper. Rewrites \$GH_CONFIG_DIR/hosts.yml with a fresh GitHub token on
+# gh CLI wrapper. Rewrites $GH_CONFIG_DIR/hosts.yml with a fresh GitHub token on
 # every invocation, then execs the real binary. Phase 0's long-lived PAT makes
 # that redundant; Phase 2's 1h App tokens require it for any task that runs > 1h
 # between gh calls.
@@ -262,28 +266,28 @@ export function ghWrapperScript(realGhPath: string): string {
 # The token comes from credhelper.sh through its own \`get\` contract rather than
 # from a second copy of the exchange. One script owns the refresh, so git and
 # \`gh\` share the anti-misroute tripwire without it being reimplemented. The
-# duplicate this replaces read \$AEP_BEARER_FILE only, so it served whatever
+# duplicate this replaces read $AEP_BEARER_FILE only, so it served whatever
 # token was minted at pod start and degraded silently once that expired, while
 # \`git\` kept working.
 #
 # A refresh failure is not fatal: hosts.yml from an earlier call may still be
 # valid, so we warn and let gh report its own auth error if it isn't.
 set -e
-helper="\$(dirname "\${BASH_SOURCE[0]}")/${CREDHELPER_FILE}"
+helper="$(dirname "\${BASH_SOURCE[0]}")/${CREDHELPER_FILE}"
 
-creds="\$("\$helper" get </dev/null || true)"
-token="\$(printf '%s\\n' "\$creds" | sed -n 's/^password=//p')"
-if [ -n "\$token" ]; then
-  mkdir -p "\$GH_CONFIG_DIR"
-  cat > "\$GH_CONFIG_DIR/hosts.yml" <<EOF
+creds="$("$helper" get </dev/null || true)"
+token="$(printf '%s\\n' "$creds" | sed -n 's/^password=//p')"
+if [ -n "$token" ]; then
+  mkdir -p "$GH_CONFIG_DIR"
+  cat > "$GH_CONFIG_DIR/hosts.yml" <<EOF
 github.com:
-    oauth_token: \$token
+    oauth_token: $token
     user: x-access-token
     git_protocol: https
 EOF
 else
   echo "gh: credential refresh failed — proceeding with the auth already on disk" >&2
 fi
-exec ${JSON.stringify(realGhPath)} "\$@"
+exec ${JSON.stringify(realGhPath)} "$@"
 `;
 }

--- a/runners/remote-worker/src/lib/mcp_auth_proxy.test.ts
+++ b/runners/remote-worker/src/lib/mcp_auth_proxy.test.ts
@@ -147,3 +147,63 @@ test("mcp auth proxy: gzipped upstream is forwarded as decoded body", async () =
     await upstream.close();
   }
 });
+
+test("mcp auth proxy: first mint failure calls onFatal and returns 401", async () => {
+  const upstream = await listen((_req, res) => {
+    res.writeHead(200).end("ok");
+  });
+  const fatals: string[] = [];
+  const proxy = await startMcpAuthProxy({
+    upstreamUrl: upstream.url,
+    source: {
+      getToken: async () => {
+        throw new Error("thunder down");
+      },
+      invalidate: () => {
+        throw new Error("invalidate must not run");
+      },
+    },
+    canRefresh: true,
+    onFatal: (err) => {
+      fatals.push(err.message);
+    },
+  });
+  try {
+    const res = await fetch(proxy.url, { method: "POST", body: "{}" });
+    assert.equal(res.status, 401);
+    assert.equal(fatals.length, 1);
+    assert.match(fatals[0]!, /token mint failed: thunder down/);
+  } finally {
+    await proxy.close();
+    await upstream.close();
+  }
+});
+
+test("mcp auth proxy: oversized body is 413 and never reaches upstream", async () => {
+  let hits = 0;
+  const upstream = await listen((_req, res) => {
+    hits++;
+    res.writeHead(200).end("ok");
+  });
+  const proxy = await startMcpAuthProxy({
+    upstreamUrl: upstream.url,
+    source: {
+      getToken: async () => "tok",
+      invalidate: () => {
+        throw new Error("invalidate must not run");
+      },
+    },
+    canRefresh: true,
+    onFatal: () => {
+      throw new Error("onFatal must not run");
+    },
+  });
+  try {
+    const res = await fetch(proxy.url, { method: "POST", body: "x".repeat(1024 * 1024 + 1) });
+    assert.equal(res.status, 413);
+    assert.equal(hits, 0);
+  } finally {
+    await proxy.close();
+    await upstream.close();
+  }
+});

--- a/runners/remote-worker/src/lib/mcp_auth_proxy.ts
+++ b/runners/remote-worker/src/lib/mcp_auth_proxy.ts
@@ -77,17 +77,13 @@ async function handle(
   res: http.ServerResponse,
   opts: StartMcpAuthProxyOpts,
 ): Promise<void> {
-  const chunks: Buffer[] = [];
-  for await (const c of req) {
-    chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
-  }
-  const body = Buffer.concat(chunks);
-  const headers: Record<string, string> = {};
-  for (const [k, v] of Object.entries(req.headers)) {
-    if (v === undefined || HOP.has(k.toLowerCase())) continue;
-    headers[k] = Array.isArray(v) ? v.join(", ") : v;
-  }
   try {
+    const body = await readRequestBody(req);
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (v === undefined || HOP.has(k.toLowerCase())) continue;
+      headers[k] = Array.isArray(v) ? v.join(", ") : v;
+    }
     const upstream = await fetchWith401Retry(
       opts.upstreamUrl,
       {
@@ -105,6 +101,15 @@ async function handle(
     res.writeHead(upstream.status, outHeaders);
     res.end(Buffer.from(await upstream.arrayBuffer()));
   } catch (err) {
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    if (err instanceof PayloadTooLargeError) {
+      res.writeHead(413, { "content-type": "text/plain" });
+      res.end("payload too large");
+      return;
+    }
     if (err instanceof FatalAuthError) {
       opts.onFatal(err);
       res.writeHead(401, { "content-type": "text/plain" });
@@ -115,4 +120,35 @@ async function handle(
     res.writeHead(502, { "content-type": "text/plain" });
     res.end(msg);
   }
+}
+
+// MCP JSON-RPC is small (initialize / tools/list / tools/call). Cap the
+// inbound buffer so a stuck or hostile client cannot grow the Job RSS.
+const MAX_MCP_PROXY_BODY = 1024 * 1024;
+
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super("payload too large");
+    this.name = "PayloadTooLargeError";
+  }
+}
+
+async function readRequestBody(req: http.IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let n = 0;
+  try {
+    for await (const c of req) {
+      const b = Buffer.isBuffer(c) ? c : Buffer.from(c);
+      n += b.length;
+      if (n > MAX_MCP_PROXY_BODY) {
+        throw new PayloadTooLargeError();
+      }
+      chunks.push(b);
+    }
+  } catch (err) {
+    if (err instanceof PayloadTooLargeError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`mcp proxy request body: ${msg}`);
+  }
+  return Buffer.concat(chunks);
 }

--- a/runners/remote-worker/src/lib/runner.ts
+++ b/runners/remote-worker/src/lib/runner.ts
@@ -17,7 +17,6 @@
  */
 
 import path from "node:path";
-import fs from "node:fs";
 import { query, type McpServerConfig, type Query } from "@anthropic-ai/claude-agent-sdk";
 import { openDebugSinks, type DebugSinks, type TaskLog } from "./logger.js";
 import type { DispatchRequest } from "./types.js";
@@ -426,8 +425,6 @@ export async function runClaudeQuery(
     mcpToken = "loopback";
   }
   const { mcpServers, allowedTools } = buildMcpOptions(mcpUrl, mcpToken);
-
-  // D9 secure search (Task 12) — DLP gate for the server-side WebSearch
   // tool. Secret candidates are read from childEnv, the SAME env record
   // injected into this run (see websearch_dlp.ts's stagedSecretValues doc
   // comment): staged dependency secrets (Tasks 9-11's per-run K8s Secrets,
@@ -478,7 +475,9 @@ export async function runClaudeQuery(
   // prompt-bearing debug log out of the cluster — see DispatchRequest.debug.
   const debugSinks = req.debug ? openDebugSinks(log.dir, (line) => scrubber.scrub(line)) : undefined;
 
-  const q = query({
+  let q: Query;
+  try {
+    q = query({
     prompt: promptWithProjectRoot(req.prompt, layout.workspace, contractReferencePath(layout.workspace)),
     options: {
       cwd: layout.workspace,
@@ -536,7 +535,11 @@ export async function runClaudeQuery(
         ],
       },
     },
-  });
+    });
+  } catch (err) {
+    await mcpProxy?.close();
+    throw err;
+  }
 
   // One translator per run — it carries this run's subagent labels and
   // in-flight tool calls (see createSdkTranslator).

--- a/runners/remote-worker/src/lib/workspace.test.ts
+++ b/runners/remote-worker/src/lib/workspace.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeBearerFile } from "./workspace.js";
+
+test("writeBearerFile: concurrent writers do not share a tmp path", async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aep-bearer-"));
+  const file = path.join(dir, "bearer");
+  try {
+    const tokens = Array.from({ length: 20 }, (_, i) => `tok-${i}-${"x".repeat(32)}`);
+    await Promise.all(tokens.map((t) => writeBearerFile(file, t)));
+    const got = await fs.promises.readFile(file, "utf8");
+    assert.ok(tokens.includes(got), `final token ${got} was not one of the writers`);
+    const leftovers = (await fs.promises.readdir(dir)).filter((n) => n.includes(".tmp"));
+    assert.deepEqual(leftovers, []);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/runners/remote-worker/src/lib/workspace.ts
+++ b/runners/remote-worker/src/lib/workspace.ts
@@ -48,6 +48,7 @@
 // The agent runs with cwd=<workspace> and PATH prefixed with <workspace>/.aep
 // so `gh ...` resolves to the wrapper.
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { exec } from "node:child_process";
 import path from "node:path";
@@ -97,9 +98,13 @@ export async function writeBearerFile(file: string, token: string, previous?: st
   if (previous !== undefined && token === previous) {
     return token;
   }
-  const tmp = `${file}.tmp`;
-  await fs.promises.writeFile(tmp, token, { mode: 0o600 });
-  await fs.promises.rename(tmp, file);
+  const tmp = `${file}.${randomUUID()}.tmp`;
+  try {
+    await fs.promises.writeFile(tmp, token, { mode: 0o600 });
+    await fs.promises.rename(tmp, file);
+  } finally {
+    await fs.promises.unlink(tmp).catch(() => undefined);
+  }
   return token;
 }
 

--- a/services/aep-api/internal/delivery/build/build_test.go
+++ b/services/aep-api/internal/delivery/build/build_test.go
@@ -60,6 +60,7 @@ type fakeTagger struct {
 	res    *spec.SpecSaveResult
 	err    error
 	called int
+	seq    *[]string
 }
 
 func (f *fakeTagger) BuildScopeAtTag(ctx context.Context, orgID, projectID, tag string) (spec.BuildScope, error) {
@@ -68,6 +69,9 @@ func (f *fakeTagger) BuildScopeAtTag(ctx context.Context, orgID, projectID, tag 
 
 func (f *fakeTagger) TagSpec(context.Context, string, string) (*spec.SpecSaveResult, error) {
 	f.called++
+	if f.seq != nil {
+		*f.seq = append(*f.seq, "tag")
+	}
 	return f.res, f.err
 }
 
@@ -206,9 +210,13 @@ func mustDelivery(h *deliveryhttpapi.Handlers, err error) *deliveryhttpapi.Handl
 type provisionSpy struct {
 	orgs []string
 	err  error
+	seq  *[]string
 }
 
 func (p *provisionSpy) ProvisionPublisherForBuild(_ context.Context, orgID string) error {
+	if p.seq != nil {
+		*p.seq = append(*p.seq, "provision")
+	}
 	p.orgs = append(p.orgs, orgID)
 	return p.err
 }
@@ -408,9 +416,10 @@ func TestBuild_NoClaims401(t *testing.T) {
 // handler, not the service, calls it, since only the handler still has the
 // console JWT that ProvisionPublisherForBuild needs.
 func TestBuild_PublisherProvisionerRunsBeforeTag(t *testing.T) {
-	tagger := &fakeTagger{res: &spec.SpecSaveResult{Tag: "v1", Status: "approved"}}
+	var seq []string
+	tagger := &fakeTagger{res: &spec.SpecSaveResult{Tag: "v1", Status: "approved"}, seq: &seq}
 	svc := newSvc(fakeRepos{}, tagger)
-	spy := &provisionSpy{}
+	spy := &provisionSpy{seq: &seq}
 	resp := newHarnessWithPublisher(t, svc, spy).AsOrg("acme").Post("/api/v1/projects/shop/build", `{}`)
 	if resp.Code != 200 {
 		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
@@ -420,6 +429,9 @@ func TestBuild_PublisherProvisionerRunsBeforeTag(t *testing.T) {
 	}
 	if tagger.called != 1 {
 		t.Fatalf("Run must still tag after provision, called=%d", tagger.called)
+	}
+	if len(seq) != 2 || seq[0] != "provision" || seq[1] != "tag" {
+		t.Fatalf("order=%v want provision then tag", seq)
 	}
 }
 

--- a/services/aep-api/internal/edge/surfaces.go
+++ b/services/aep-api/internal/edge/surfaces.go
@@ -81,10 +81,12 @@ func mountSurfaces(params AppParams) *http.ServeMux {
 		w.Write([]byte(`{"status":"ok"}`)) //nolint:errcheck
 	})
 
-	// Task-JWT public key set (JWKS) — unauthenticated discovery, fetched by
-	// MCP/S2S verifiers before any auth. A plain handler (not a contract op) so it
-	// stays off the /api/v1 server base path: the public contract is base-pathed
-	// at /api/v1, and this endpoint deliberately lives outside that subtree.
+	// Task-JWT public key set (JWKS) — unauthenticated discovery for BFF-signed
+	// tokens (design-agent MCP / IssueServiceToken). Publisher CC tokens verify
+	// against platform-idp JWKS, not this endpoint. A plain handler (not a
+	// contract op) so it stays off the /api/v1 server base path: the public
+	// contract is base-pathed at /api/v1, and this endpoint deliberately lives
+	// outside that subtree.
 	mux.HandleFunc("GET /auth/external/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if tt := params.Deps.TaskTokens; tt != nil {


### PR DESCRIPTION
## Summary
- Follow-up to #512 CodeRabbit review. First `getToken()` failure is now `FatalAuthError` (proxy `onFatal` / 401, not 502); MCP proxy body read is inside `try` with a 1MiB cap; `query()` throw closes the loopback proxy; concurrent `writeBearerFile` uses a unique tmp.
- Credhelper distinguishes `PUBLISHER_*` unset vs mint failed, and drops useless `\$` in the TS template. Glossary + JWKS comment match the publisher-CC path.
- Left out of this PR (same pushbacks as on #512): source-text oneshot lock, mounting MCP without `TaskTokens`, and a DB-backed publisher lock.

## Test plan
- [x] `npm test` in `runners/remote-worker` (382 pass)
- [x] `go test ./internal/delivery/build/ ./internal/edge/` in `services/aep-api`
- [ ] CI green on this branch