### PR TITLE
fix(remote-worker): pin playwright-cli to the baked chromium, and stop baking browsers it cannot launch

### DIFF
--- a/runners/remote-worker/Dockerfile
+++ b/runners/remote-worker/Dockerfile
@@ -92,8 +92,17 @@ ENV PATH="/usr/lib/ballerina/bin:${PATH}"
 # the browsers baked here always match the version the specs run with.
 ARG PLAYWRIGHT_VERSION=1.61.1
 ARG PLAYWRIGHT_CLI_VERSION=0.1.15
+# PLAYWRIGHT_MCP_BROWSER names the browser TYPE for playwright-cli, whose own
+# default is the pair (chromium, channel `chrome`) — one branch sets both, so
+# the default engine cannot be had without Google's branded build at the system
+# path /opt/google/chrome/chrome, which this image neither carries (Chrome is a
+# vendor install, not a Playwright download) nor may redistribute. Naming the
+# type selects the chromium baked below, and with it the sandbox default that
+# can start as the non-root `aep` user. A `--browser=` flag still wins, so this
+# is the default rather than a lid.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
-    AEP_PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}
+    AEP_PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION} \
+    PLAYWRIGHT_MCP_BROWSER=chromium
 RUN npm install -g "@playwright/test@${PLAYWRIGHT_VERSION}" "@playwright/cli@${PLAYWRIGHT_CLI_VERSION}" \
     && playwright install --with-deps chromium \
     # playwright-cli may bundle a different playwright build; bake its

--- a/runners/remote-worker/Dockerfile
+++ b/runners/remote-worker/Dockerfile
@@ -105,10 +105,15 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     PLAYWRIGHT_MCP_BROWSER=chromium
 RUN npm install -g "@playwright/test@${PLAYWRIGHT_VERSION}" "@playwright/cli@${PLAYWRIGHT_CLI_VERSION}" \
     && playwright install --with-deps chromium \
-    # playwright-cli may bundle a different playwright build; bake its
-    # browser too so first use at task time stays offline. Non-fatal:
+    # playwright-cli bundles a different playwright build, and browser
+    # revisions are pinned per build (it wants chromium 1229 where
+    # @playwright/test above wants 1228), so this second install is not
+    # redundant — it is what keeps the CLI's first use at task time offline.
+    # Named explicitly: with no argument it also fetches firefox and webkit,
+    # ~546MB whose system dependencies the chromium-only line above never
+    # installs, so they could be downloaded but never launched. Non-fatal:
     # worst case it downloads at runtime.
-    && (playwright-cli install-browser || true) \
+    && (playwright-cli install-browser chromium || true) \
     && chmod -R a+rX /ms-playwright
 
 RUN groupadd -r aep \

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -1,0 +1,195 @@
+# ADR-0007 — The runner image names playwright-cli's browser
+
+**Status:** Accepted
+
+## Context
+
+A validation run explores the deployed app with `playwright-cli` before it
+authors anything, then runs the specs it wrote with `npx playwright test`. The
+`aep-validation` skill instructs the bare form —
+`playwright-cli open <url>` (`references/authoring.md:37`).
+
+In the runner image that command could not work. The p26-bare-minimum-hello run
+of 2026-08-18 hit it as its first browser action and got:
+
+```
+Error: Daemon pid=296: Daemon process exited with code 1
+```
+
+That is a wrapper: playwright-cli launches the browser in a detached daemon and
+surfaces only its exit code, never its stderr. Reproduced against
+`aep-runner:dev`, the daemon's actual error is:
+
+```
+PlaywrightError: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
+```
+
+**Playwright separates the engine from the build of it.** `browserName` picks
+the engine (`chromium`, `firefox`, `webkit` — Playwright's own downloads under
+`PLAYWRIGHT_BROWSERS_PATH`); `channel` picks *which build* of that engine
+(unset = Playwright's own; `chrome`/`msedge` = the vendor's, at a system path).
+The error names both: engine chromium, distribution `chrome`.
+
+**playwright-cli's default is the pair, not the engine.** In the playwright-core
+vendored by `@playwright/cli@0.1.15` (`coreBundle.js:71050-71056`):
+
+```js
+let browserName = browser.browserName;
+if (!browserName) {
+  browserName = "chromium";                    // engine
+  if (browser.launchOptions.channel === void 0)
+    browser.launchOptions.channel = "chrome";  // …and the branded build of it
+}
+```
+
+Both assignments live in one `if (!browserName)` branch, so the default engine
+cannot be had without the `chrome` distribution. That distribution is a **vendor
+install**, not a Playwright download — `playwright install --dry-run chrome`
+reports `Install location: <system>` and prints no download URL — and
+`Dockerfile:98` bakes only Playwright's chromium. It was never going to be there.
+
+**A second blocker sits behind the first.** Channel `chrome` also leaves the
+sandbox on (`:71057-71059`):
+
+```js
+browser.launchOptions.chromiumSandbox =
+  channel !== "chromium" && channel !== "chrome-for-testing";
+```
+
+The Chromium sandbox cannot start as the unprivileged `aep` user the pod runs
+as. So installing Chrome would not have fixed this; it would have moved the
+failure one layer deeper, with a less legible message.
+
+`npx playwright test` was unaffected throughout — `@playwright/test` never forces
+a channel — which is why the same pod that failed at seq 52 passed its test runs
+at seq 102-105. The agent recovered by reading the CLI's own source
+(`program.js`, `session.js`) and retrying with `--browser=chromium`, at a cost of
+roughly two minutes of a six-minute run. Every validation run paid this, and paid
+it differently.
+
+## Decision
+
+**1. The image names the browser type, as an ENV.**
+`PLAYWRIGHT_MCP_BROWSER=chromium` in `Dockerfile`, beside the version pins.
+`resolveBrowserParam` maps `chromium` → `{browserName: "chromium", channel:
+"chrome-for-testing"}` (`:71101-71102`), and `chrome-for-testing` is the alias
+for the baked build (`chromiumAliases`, `:28590`) — so one value corrects the
+distribution *and* takes the non-root-safe sandbox branch.
+
+An ENV rather than a flag or a config file, because:
+
+- `runner.ts:342` spreads `process.env` into the agent's child env, so an image
+  ENV reaches every agent shell with no plumbing and no entrypoint change.
+- It is a documented public knob — the package README's env table and
+  `configFromEnv` (`:71201`) — not an internal detail read off the source.
+- It is a **default, not a lid**: an explicit `--browser=` still wins, so an
+  agent with a reason to choose otherwise keeps that ability.
+- It makes the skill's existing instruction correct **as written**, so no
+  documentation has to change and none can drift out of step with the image.
+
+**2. Chromium, not Chrome.** Three independent reasons, any one sufficient:
+
+- *The tests already run on it.* `playwright.config.template.ts` sets no
+  `browserName` and no `projects`, so `npx playwright test` uses Playwright's
+  default, chromium. Exploration must use the same engine and build the
+  assertions will execute against, or the agent validates behaviour it never
+  observed.
+- *The pinned version only has it.* `playwright install --list` shows Playwright
+  1.61.1 (`@playwright/test`, i.e. `AEP_PLAYWRIGHT_VERSION` — the contract the
+  skill pins `tests/e2e/package.json` to) carrying only `chromium-1228` and its
+  headless shell.
+- *Chrome cannot be used, only added.* Root plus Google's apt repo, a few hundred
+  megabytes, and a browser that auto-versions independently of
+  `AEP_PLAYWRIGHT_VERSION` — which breaks the "pinned as a pair" contract stated
+  at `Dockerfile:90-92`.
+
+There is also a licensing question, and this ADR deliberately does not answer it.
+Chromium is open source; Chrome and Edge are proprietary, and the runner image is
+**redistributed** into customer clusters, so baking one in is redistribution
+rather than a local download. That needs legal review before anyone does it, not
+a Dockerfile decision. Staying on chromium avoids the question entirely.
+
+**3. Not a `.playwright/cli.config.json`.** The obvious-looking simplification —
+a config file setting `browser.browserName: "chromium"` — **still fails**. Naming
+the type there leaves `channel` undefined, and the expression at `:71057-71059`
+then evaluates true and re-enables the sandbox. Verified: that config dies, and
+adding `launchOptions.chromiumSandbox: false` to it launches. Recorded here so
+the ENV is not later "tidied" into a config file that reintroduces the failure.
+
+**4. No skill change.** The bare command in `references/authoring.md:37` becomes
+correct by construction. Adding a "do not override the browser" line would
+document a trap the image no longer has.
+
+## Consequences
+
+- `playwright-cli open <url>` works as the skill instructs, on the same build the
+  specs execute on. No image growth, no new dependency, no new license surface.
+- The exploration session and the test run can no longer diverge on browser
+  build: both resolve to `/ms-playwright/chromium-<rev>/chrome-linux/chrome`.
+- **Explicit overrides still fail, by design and by omission.**
+  `--browser=chrome` and `--browser=msedge` fail — absent, per this decision.
+  `--browser=firefox` and `--browser=webkit` also fail, for an unrelated reason:
+  `playwright-cli install-browser` (`Dockerfile:102`) downloads those binaries
+  but `Dockerfile:98` installs system dependencies for chromium only, so they
+  report *"Host system is missing dependencies to run browsers"*. The image
+  therefore carries browser bytes it cannot launch. Left as-is here; removing
+  them is a separate change.
+- The upstream `--browser` help string and env-table both read *"possible values:
+  chrome, firefox, webkit, msedge"*, omitting `chromium`, while the README's
+  config schema documents `browserName?: 'chromium' | 'firefox' | 'webkit'`.
+  Upstream's own vocabulary is inconsistent; the value we set is the one its
+  config schema and its code (`case "chromium"`) both support.
+
+## Relationship to ADR-0006
+
+ADR-0006's Consequences state *"Chromium is unchanged:
+`playwright.config.template.ts` still applies `--host-resolver-rules` … `.curlrc`
+is a curl mechanism and does not reach the browser."* That remains true and is
+not contradicted here. The two decisions are orthogonal:
+
+- ADR-0006 is about **name resolution** — teaching curl which address a
+  `.localhost` host is at.
+- This ADR is about **which binary launches** — nothing to do with resolution.
+
+They compose, and it was checked rather than assumed: with the ENV set, a
+`--config` carrying only `browser.launchOptions.args` (the shape a
+`--host-resolver-rules` override takes) opens successfully; without it, the same
+config fails on the missing Chrome. Before this change the config-file route
+alone could not work at all.
+
+## How this is verified
+
+CI has no Docker step and never builds `aep-runner:dev`, so — as with ADR-0006's
+curl half — this is checked by hand against the image after
+`make build-runner FORCE=1`, and re-checked whenever `PLAYWRIGHT_CLI_VERSION`
+moves (the line numbers above are `@playwright/cli@0.1.15`).
+
+```sh
+# 1. The documented bare command opens a browser.
+docker run --rm --entrypoint sh aep-runner:dev -c \
+  'playwright-cli open "http://example.invalid/" 2>&1 | grep -E "opened with pid|not found at"'
+# expect: "### Browser `default` opened with pid N"
+#   (before this change: "Chromium distribution 'chrome' is not found at
+#    /opt/google/chrome/chrome")
+
+# 2. It is a default, not a lid — an explicit channel still wins, and still fails.
+docker run --rm --entrypoint sh aep-runner:dev -c \
+  'playwright-cli --browser=chrome open "http://example.invalid/" 2>&1 | grep -E "not found at"'
+# expect: the /opt/google/chrome/chrome error
+
+# 3. It composes with a resolver-override config (ADR-0006's browser half).
+docker run --rm --entrypoint sh aep-runner:dev -c '
+  cd /tmp && printf "%s" \
+    "{\"browser\":{\"launchOptions\":{\"args\":[\"--host-resolver-rules=MAP a.localhost 10.0.0.1\"]}}}" > c.json
+  playwright-cli --config=c.json open "http://example.invalid/" 2>&1 | grep -E "opened with pid|not found at"'
+# expect: "opened with pid N"  (with PLAYWRIGHT_MCP_BROWSER unset: the chrome error)
+
+# 4. The binary is the baked one, not a runtime download.
+#    chromium.executablePath() → /ms-playwright/chromium-1228/chrome-linux/chrome
+```
+
+End to end, the signal is the absence of a detour: in the archived NDJSON for a
+validation cycle the agent should go `agent_started` → `playwright-cli open` →
+`snapshot`, with no `/etc/hosts`, `ss -tlnp` or `program.js` inspection in
+between. The 2026-08-18 p26 run, seq 52-81, is the baseline that shows the
+detour.

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -59,7 +59,7 @@ sandbox branch that works unprivileged — both blockers, one value.
   locator or aria snapshot captured while exploring is asserted in a different
   chromium than it was observed in, so a version-sensitive difference would
   surface as a brittle spec rather than as a version error. Closing the gap is a
-  `PLAYWRIGHT_VERSION`/`PLAYWRIGHT_CLI_VERSION` alignment, tracked separately.
+  `PLAYWRIGHT_VERSION`/`PLAYWRIGHT_CLI_VERSION` alignment, outside this ADR.
 - Explicit overrides still fail, and now fail honestly. `--browser=chrome`/
   `msedge` are absent by this decision; `--browser=firefox`/`webkit` are absent
   because `playwright-cli install-browser` is given `chromium` explicitly. With

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -12,7 +12,7 @@ authors anything, then runs the specs it wrote with `npx playwright test`. The
 In the runner image that command could not work. The p26-bare-minimum-hello run
 of 2026-08-18 hit it as its first browser action and got:
 
-```
+```text
 Error: Daemon pid=296: Daemon process exited with code 1
 ```
 
@@ -20,7 +20,7 @@ That is a wrapper: playwright-cli launches the browser in a detached daemon and
 surfaces only its exit code, never its stderr. Reproduced against
 `aep-runner:dev`, the daemon's actual error is:
 
-```
+```text
 PlaywrightError: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
 ```
 
@@ -45,8 +45,9 @@ if (!browserName) {
 Both assignments live in one `if (!browserName)` branch, so the default engine
 cannot be had without the `chrome` distribution. That distribution is a **vendor
 install**, not a Playwright download — `playwright install --dry-run chrome`
-reports `Install location: <system>` and prints no download URL — and
-`Dockerfile:98` bakes only Playwright's chromium. It was never going to be there.
+reports `Install location: <system>` and prints no download URL — and the
+Dockerfile's `playwright install --with-deps chromium` bakes only Playwright's
+chromium. It was never going to be there.
 
 **A second blocker sits behind the first.** Channel `chrome` also leaves the
 sandbox on (`:71057-71059`):
@@ -101,7 +102,7 @@ An ENV rather than a flag or a config file, because:
 - *Chrome cannot be used, only added.* Root plus Google's apt repo, a few hundred
   megabytes, and a browser that auto-versions independently of
   `AEP_PLAYWRIGHT_VERSION` — which breaks the "pinned as a pair" contract stated
-  at `Dockerfile:90-92`.
+  in the Dockerfile's Playwright-toolchain comment.
 
 There is also a licensing question, and this ADR deliberately does not answer it.
 Chromium is open source; Chrome and Edge are proprietary, and the runner image is
@@ -129,11 +130,11 @@ document a trap the image no longer has.
 - **Explicit overrides still fail, by design and by omission.**
   `--browser=chrome` and `--browser=msedge` fail — absent, per this decision.
   `--browser=firefox` and `--browser=webkit` also fail, for an unrelated reason:
-  `playwright-cli install-browser` (`Dockerfile:102`) downloads those binaries
-  but `Dockerfile:98` installs system dependencies for chromium only, so they
-  report *"Host system is missing dependencies to run browsers"*. The image
-  therefore carries browser bytes it cannot launch. Left as-is here; removing
-  them is a separate change.
+  the Dockerfile's `playwright-cli install-browser` downloads those binaries, but
+  its `playwright install --with-deps chromium` installs system dependencies for
+  chromium only, so they report *"Host system is missing dependencies to run
+  browsers"*. The image therefore carries browser bytes it cannot launch. Left
+  as-is here; removing them is a separate change.
 - The upstream `--browser` help string and env-table both read *"possible values:
   chrome, firefox, webkit, msedge"*, omitting `chromium`, while the README's
   config schema documents `browserName?: 'chromium' | 'firefox' | 'webkit'`.

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -50,11 +50,12 @@ sandbox branch that works unprivileged — both blockers, one value.
   resolve to `/ms-playwright/chromium-<rev>/chrome-linux/chrome`.
   `@playwright/test` is untouched — it never forces a channel and does not read
   this variable.
-- Explicit overrides still fail. `--browser=chrome`/`msedge` are absent by this
-  decision; `--browser=firefox`/`webkit` fail for an unrelated reason — the
-  Dockerfile's `playwright-cli install-browser` downloads those binaries but
-  system dependencies are installed for chromium only, so the image carries
-  browser bytes it cannot launch. Separate cleanup.
+- Explicit overrides still fail, and now fail honestly. `--browser=chrome`/
+  `msedge` are absent by this decision; `--browser=firefox`/`webkit` are absent
+  because `playwright-cli install-browser` is given `chromium` explicitly. With
+  no argument it also fetched firefox and webkit — ~546MB the chromium-only
+  `--with-deps` line never gave system libraries, so they were downloadable but
+  unlaunchable.
 - CI has no Docker step and never builds `aep-runner:dev`, so a
   `PLAYWRIGHT_CLI_VERSION` bump has to be re-checked by hand: `playwright-cli
   open <url>` in the built image should print ``Browser `default` opened with pid

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -34,9 +34,11 @@ sandbox branch that works unprivileged — both blockers, one value.
   An explicit `--browser=` still wins, so this is a default, not a lid.
 - **Chromium, not Chrome.** The generated specs already run on it
   (`playwright.config.template.ts` sets no `browserName`, so `playwright test`
-  takes Playwright's default), the pinned `AEP_PLAYWRIGHT_VERSION` ships only
-  chromium, and exploration must use the build the assertions will execute
-  against. Chrome would additionally need root plus Google's apt repo,
+  takes Playwright's default), and the pinned `AEP_PLAYWRIGHT_VERSION` ships only
+  chromium. It is the closest launchable match to what runs the specs — the same
+  family of Playwright-built chromium, where Chrome is a separate distribution
+  with its own flags, codecs and update channel. Not the *same* build, though;
+  see Consequences. Chrome would additionally need root plus Google's apt repo,
   auto-version independently of the "pinned as a pair" contract, and — as a
   proprietary browser in an image the platform redistributes — raise a licensing
   question that needs legal review rather than a Dockerfile edit.
@@ -46,10 +48,18 @@ sandbox branch that works unprivileged — both blockers, one value.
 
 ## Consequences
 
-- Exploration and the test run can no longer diverge on browser build: both
-  resolve to `/ms-playwright/chromium-<rev>/chrome-linux/chrome`.
-  `@playwright/test` is untouched — it never forces a channel and does not read
+- `@playwright/test` is untouched — it never forces a channel and does not read
   this variable.
+- **Exploration and the test run are still two different chromium builds, and
+  this ADR does not change that.** playwright-cli pins its own playwright-core
+  (1.62.0-alpha → revision 1229, Chromium 150.0.7871.0); the specs run under
+  `AEP_PLAYWRIGHT_VERSION` (1.61.1 → revision 1228, Chromium 149.0.7827.0).
+  Each client/browser pair is internally consistent, which is what Playwright's
+  revision pinning protects and why the two installs cannot be collapsed — but a
+  locator or aria snapshot captured while exploring is asserted in a different
+  chromium than it was observed in, so a version-sensitive difference would
+  surface as a brittle spec rather than as a version error. Closing the gap is a
+  `PLAYWRIGHT_VERSION`/`PLAYWRIGHT_CLI_VERSION` alignment, tracked separately.
 - Explicit overrides still fail, and now fail honestly. `--browser=chrome`/
   `msedge` are absent by this decision; `--browser=firefox`/`webkit` are absent
   because `playwright-cli install-browser` is given `chromium` explicitly. With

--- a/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
+++ b/runners/remote-worker/design/decisions/ADR-0007-the-runner-image-names-the-cli-browser.md
@@ -2,195 +2,65 @@
 
 **Status:** Accepted
 
-## Context
-
-A validation run explores the deployed app with `playwright-cli` before it
-authors anything, then runs the specs it wrote with `npx playwright test`. The
-`aep-validation` skill instructs the bare form —
-`playwright-cli open <url>` (`references/authoring.md:37`).
-
-In the runner image that command could not work. The p26-bare-minimum-hello run
-of 2026-08-18 hit it as its first browser action and got:
-
-```text
-Error: Daemon pid=296: Daemon process exited with code 1
-```
-
-That is a wrapper: playwright-cli launches the browser in a detached daemon and
-surfaces only its exit code, never its stderr. Reproduced against
-`aep-runner:dev`, the daemon's actual error is:
-
-```text
-PlaywrightError: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
-```
-
-**Playwright separates the engine from the build of it.** `browserName` picks
-the engine (`chromium`, `firefox`, `webkit` — Playwright's own downloads under
-`PLAYWRIGHT_BROWSERS_PATH`); `channel` picks *which build* of that engine
-(unset = Playwright's own; `chrome`/`msedge` = the vendor's, at a system path).
-The error names both: engine chromium, distribution `chrome`.
-
-**playwright-cli's default is the pair, not the engine.** In the playwright-core
-vendored by `@playwright/cli@0.1.15` (`coreBundle.js:71050-71056`):
-
-```js
-let browserName = browser.browserName;
-if (!browserName) {
-  browserName = "chromium";                    // engine
-  if (browser.launchOptions.channel === void 0)
-    browser.launchOptions.channel = "chrome";  // …and the branded build of it
-}
-```
-
-Both assignments live in one `if (!browserName)` branch, so the default engine
-cannot be had without the `chrome` distribution. That distribution is a **vendor
-install**, not a Playwright download — `playwright install --dry-run chrome`
-reports `Install location: <system>` and prints no download URL — and the
+A validation run explores the deployed app with `playwright-cli` before authoring
+specs, and the `aep-validation` skill instructs the bare `playwright-cli open
+<url>`. That could not work in this image. Playwright separates the *engine*
+(`browserName` — chromium/firefox/webkit, its own builds under
+`PLAYWRIGHT_BROWSERS_PATH`) from the *build* of that engine (`channel` — unset
+for Playwright's own, `chrome`/`msedge` for the vendor's, found at a system
+path), and playwright-cli defaults to the **pair** (`chromium`, channel
+`chrome`), both set in one branch. So its default engine cannot be had without
+Google's branded build at `/opt/google/chrome/chrome`, which this image does not
+carry: Chrome is a vendor install rather than a Playwright download, and the
 Dockerfile's `playwright install --with-deps chromium` bakes only Playwright's
-chromium. It was never going to be there.
+own chromium. The daemon died at launch and surfaced nothing but `Daemon process
+exited with code 1`, so every validation run spent turns rediscovering it (#570).
 
-**A second blocker sits behind the first.** Channel `chrome` also leaves the
-sandbox on (`:71057-71059`):
-
-```js
-browser.launchOptions.chromiumSandbox =
-  channel !== "chromium" && channel !== "chrome-for-testing";
-```
-
-The Chromium sandbox cannot start as the unprivileged `aep` user the pod runs
-as. So installing Chrome would not have fixed this; it would have moved the
-failure one layer deeper, with a less legible message.
-
-`npx playwright test` was unaffected throughout — `@playwright/test` never forces
-a channel — which is why the same pod that failed at seq 52 passed its test runs
-at seq 102-105. The agent recovered by reading the CLI's own source
-(`program.js`, `session.js`) and retrying with `--browser=chromium`, at a cost of
-roughly two minutes of a six-minute run. Every validation run paid this, and paid
-it differently.
+Channel `chrome` also leaves `chromiumSandbox` enabled, and the sandbox cannot
+start as the non-root `aep` user the pod runs as — so installing Chrome would
+have moved the failure one layer deeper rather than fixing it.
 
 ## Decision
 
-**1. The image names the browser type, as an ENV.**
-`PLAYWRIGHT_MCP_BROWSER=chromium` in `Dockerfile`, beside the version pins.
-`resolveBrowserParam` maps `chromium` → `{browserName: "chromium", channel:
-"chrome-for-testing"}` (`:71101-71102`), and `chrome-for-testing` is the alias
-for the baked build (`chromiumAliases`, `:28590`) — so one value corrects the
-distribution *and* takes the non-root-safe sandbox branch.
+**The image names the browser type: `PLAYWRIGHT_MCP_BROWSER=chromium`.**
+`resolveBrowserParam` maps `chromium` onto channel `chrome-for-testing`, the
+alias for the baked build, which corrects the distribution *and* takes the
+sandbox branch that works unprivileged — both blockers, one value.
 
-An ENV rather than a flag or a config file, because:
-
-- `runner.ts:342` spreads `process.env` into the agent's child env, so an image
-  ENV reaches every agent shell with no plumbing and no entrypoint change.
-- It is a documented public knob — the package README's env table and
-  `configFromEnv` (`:71201`) — not an internal detail read off the source.
-- It is a **default, not a lid**: an explicit `--browser=` still wins, so an
-  agent with a reason to choose otherwise keeps that ability.
-- It makes the skill's existing instruction correct **as written**, so no
-  documentation has to change and none can drift out of step with the image.
-
-**2. Chromium, not Chrome.** Three independent reasons, any one sufficient:
-
-- *The tests already run on it.* `playwright.config.template.ts` sets no
-  `browserName` and no `projects`, so `npx playwright test` uses Playwright's
-  default, chromium. Exploration must use the same engine and build the
-  assertions will execute against, or the agent validates behaviour it never
-  observed.
-- *The pinned version only has it.* `playwright install --list` shows Playwright
-  1.61.1 (`@playwright/test`, i.e. `AEP_PLAYWRIGHT_VERSION` — the contract the
-  skill pins `tests/e2e/package.json` to) carrying only `chromium-1228` and its
-  headless shell.
-- *Chrome cannot be used, only added.* Root plus Google's apt repo, a few hundred
-  megabytes, and a browser that auto-versions independently of
-  `AEP_PLAYWRIGHT_VERSION` — which breaks the "pinned as a pair" contract stated
-  in the Dockerfile's Playwright-toolchain comment.
-
-There is also a licensing question, and this ADR deliberately does not answer it.
-Chromium is open source; Chrome and Edge are proprietary, and the runner image is
-**redistributed** into customer clusters, so baking one in is redistribution
-rather than a local download. That needs legal review before anyone does it, not
-a Dockerfile decision. Staying on chromium avoids the question entirely.
-
-**3. Not a `.playwright/cli.config.json`.** The obvious-looking simplification —
-a config file setting `browser.browserName: "chromium"` — **still fails**. Naming
-the type there leaves `channel` undefined, and the expression at `:71057-71059`
-then evaluates true and re-enables the sandbox. Verified: that config dies, and
-adding `launchOptions.chromiumSandbox: false` to it launches. Recorded here so
-the ENV is not later "tidied" into a config file that reintroduces the failure.
-
-**4. No skill change.** The bare command in `references/authoring.md:37` becomes
-correct by construction. Adding a "do not override the browser" line would
-document a trap the image no longer has.
+- **An ENV, not a flag or a config file.** `runner.ts` already spreads
+  `process.env` into the agent's child env, so an image ENV reaches every agent
+  shell with no plumbing, and the skill's existing instruction becomes correct as
+  written rather than growing guidance that can drift out of step with the image.
+  An explicit `--browser=` still wins, so this is a default, not a lid.
+- **Chromium, not Chrome.** The generated specs already run on it
+  (`playwright.config.template.ts` sets no `browserName`, so `playwright test`
+  takes Playwright's default), the pinned `AEP_PLAYWRIGHT_VERSION` ships only
+  chromium, and exploration must use the build the assertions will execute
+  against. Chrome would additionally need root plus Google's apt repo,
+  auto-version independently of the "pinned as a pair" contract, and — as a
+  proprietary browser in an image the platform redistributes — raise a licensing
+  question that needs legal review rather than a Dockerfile edit.
+- **Not a `.playwright/cli.config.json`.** Setting `browser.browserName` there
+  leaves `channel` undefined, which re-enables the sandbox and still fails.
+  Recorded because it is the obvious-looking simplification of this ADR.
 
 ## Consequences
 
-- `playwright-cli open <url>` works as the skill instructs, on the same build the
-  specs execute on. No image growth, no new dependency, no new license surface.
-- The exploration session and the test run can no longer diverge on browser
-  build: both resolve to `/ms-playwright/chromium-<rev>/chrome-linux/chrome`.
-- **Explicit overrides still fail, by design and by omission.**
-  `--browser=chrome` and `--browser=msedge` fail — absent, per this decision.
-  `--browser=firefox` and `--browser=webkit` also fail, for an unrelated reason:
-  the Dockerfile's `playwright-cli install-browser` downloads those binaries, but
-  its `playwright install --with-deps chromium` installs system dependencies for
-  chromium only, so they report *"Host system is missing dependencies to run
-  browsers"*. The image therefore carries browser bytes it cannot launch. Left
-  as-is here; removing them is a separate change.
-- The upstream `--browser` help string and env-table both read *"possible values:
-  chrome, firefox, webkit, msedge"*, omitting `chromium`, while the README's
-  config schema documents `browserName?: 'chromium' | 'firefox' | 'webkit'`.
-  Upstream's own vocabulary is inconsistent; the value we set is the one its
-  config schema and its code (`case "chromium"`) both support.
+- Exploration and the test run can no longer diverge on browser build: both
+  resolve to `/ms-playwright/chromium-<rev>/chrome-linux/chrome`.
+  `@playwright/test` is untouched — it never forces a channel and does not read
+  this variable.
+- Explicit overrides still fail. `--browser=chrome`/`msedge` are absent by this
+  decision; `--browser=firefox`/`webkit` fail for an unrelated reason — the
+  Dockerfile's `playwright-cli install-browser` downloads those binaries but
+  system dependencies are installed for chromium only, so the image carries
+  browser bytes it cannot launch. Separate cleanup.
+- CI has no Docker step and never builds `aep-runner:dev`, so a
+  `PLAYWRIGHT_CLI_VERSION` bump has to be re-checked by hand: `playwright-cli
+  open <url>` in the built image should print ``Browser `default` opened with pid
+  …``.
 
-## Relationship to ADR-0006
-
-ADR-0006's Consequences state *"Chromium is unchanged:
-`playwright.config.template.ts` still applies `--host-resolver-rules` … `.curlrc`
-is a curl mechanism and does not reach the browser."* That remains true and is
-not contradicted here. The two decisions are orthogonal:
-
-- ADR-0006 is about **name resolution** — teaching curl which address a
-  `.localhost` host is at.
-- This ADR is about **which binary launches** — nothing to do with resolution.
-
-They compose, and it was checked rather than assumed: with the ENV set, a
-`--config` carrying only `browser.launchOptions.args` (the shape a
-`--host-resolver-rules` override takes) opens successfully; without it, the same
-config fails on the missing Chrome. Before this change the config-file route
-alone could not work at all.
-
-## How this is verified
-
-CI has no Docker step and never builds `aep-runner:dev`, so — as with ADR-0006's
-curl half — this is checked by hand against the image after
-`make build-runner FORCE=1`, and re-checked whenever `PLAYWRIGHT_CLI_VERSION`
-moves (the line numbers above are `@playwright/cli@0.1.15`).
-
-```sh
-# 1. The documented bare command opens a browser.
-docker run --rm --entrypoint sh aep-runner:dev -c \
-  'playwright-cli open "http://example.invalid/" 2>&1 | grep -E "opened with pid|not found at"'
-# expect: "### Browser `default` opened with pid N"
-#   (before this change: "Chromium distribution 'chrome' is not found at
-#    /opt/google/chrome/chrome")
-
-# 2. It is a default, not a lid — an explicit channel still wins, and still fails.
-docker run --rm --entrypoint sh aep-runner:dev -c \
-  'playwright-cli --browser=chrome open "http://example.invalid/" 2>&1 | grep -E "not found at"'
-# expect: the /opt/google/chrome/chrome error
-
-# 3. It composes with a resolver-override config (ADR-0006's browser half).
-docker run --rm --entrypoint sh aep-runner:dev -c '
-  cd /tmp && printf "%s" \
-    "{\"browser\":{\"launchOptions\":{\"args\":[\"--host-resolver-rules=MAP a.localhost 10.0.0.1\"]}}}" > c.json
-  playwright-cli --config=c.json open "http://example.invalid/" 2>&1 | grep -E "opened with pid|not found at"'
-# expect: "opened with pid N"  (with PLAYWRIGHT_MCP_BROWSER unset: the chrome error)
-
-# 4. The binary is the baked one, not a runtime download.
-#    chromium.executablePath() → /ms-playwright/chromium-1228/chrome-linux/chrome
-```
-
-End to end, the signal is the absence of a detour: in the archived NDJSON for a
-validation cycle the agent should go `agent_started` → `playwright-cli open` →
-`snapshot`, with no `/etc/hosts`, `ss -tlnp` or `program.js` inspection in
-between. The 2026-08-18 p26 run, seq 52-81, is the baseline that shows the
-detour.
+Related: ADR-0006 pins endpoint *resolution* for curl and leaves the browser to
+`playwright.config.template.ts`; this ADR is about which binary launches, and the
+two compose. #570 carries the diagnosis and the code references; PR #571 carries
+the before/after evidence.


### PR DESCRIPTION
Closes #570.

## What was broken

`playwright-cli open <url>` — the command `skills/aep-validation/references/authoring.md:37` instructs — could not launch a browser in the runner image, so every validation run hit it as its first browser action. The log showed only `Daemon pid=296: Daemon process exited with code 1`, because playwright-cli runs the browser in a detached daemon and discards its stderr. The real error:

```
PlaywrightError: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
```

playwright-cli's default is not the chromium engine alone but the **pair** — `browserName: chromium` *and* `channel: "chrome"`, both set in one `if (!browserName)` branch (`coreBundle.js:71050-71056`). So the default engine cannot be had without Google's branded build at a system path. Chrome is a vendor install rather than a Playwright download (`playwright install --dry-run chrome` → `Install location: <system>`, no download URL), and `Dockerfile:98` bakes only Playwright's own chromium.

Channel `chrome` also leaves the Chromium sandbox **enabled** (`:71057-71059`), which cannot start as the non-root `aep` user the pod runs as — so installing Chrome would have moved the failure one layer deeper rather than fixing it.

`npx playwright test` was never affected: `@playwright/test` never forces a channel.

Issue #570 has the full write-up, including why chromium rather than Chrome is the right target independently (the specs already run on it, `AEP_PLAYWRIGHT_VERSION` ships only chromium, and Chrome would raise a redistribution/licensing question for an image we ship).

## The change

```dockerfile
ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
    AEP_PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION} \
    PLAYWRIGHT_MCP_BROWSER=chromium
```

`resolveBrowserParam` maps `chromium` → channel `chrome-for-testing` (`:71101-71102`), the alias for the baked build (`chromiumAliases`, `:28590`) — so one value corrects the distribution **and** takes the sandbox branch that works unprivileged.

An image ENV rather than a flag or a config file because:

- `runner.ts:342` already spreads `process.env` into the agent's child env — no plumbing, no entrypoint change.
- It is a documented public knob (package README env table; `configFromEnv`, `:71201`).
- It makes the skill's existing instruction correct **as written**, so no docs change and none can drift.
- An explicit `--browser=` still wins, so it is a default, not a lid.
- A `.playwright/cli.config.json` setting `browser.browserName` **does not work** — it leaves `channel` undefined, which re-enables the sandbox. Recorded in the ADR so it is not "simplified" into one later.

Plus `ADR-0007-the-runner-image-names-the-cli-browser.md` (67 lines), scoped to the decision per `.agents/skills/domain-modeling/ADR-FORMAT.md` and sized against `docs/decisions/ADR-0012` (67 lines, the closest analogue). It keeps only what the code cannot tell a future reader: the engine/channel pair, the sandbox layer behind it, and the `cli.config.json` trap. The diagnosis and code references live in #570; the evidence below lives here.

## Second change: stop baking browsers the runner cannot launch

Reviewing the block above surfaced adjacent dead weight. `playwright-cli install-browser` with **no argument** fetched chromium, firefox *and* webkit — but the line above it installs system dependencies for chromium alone, so firefox (271 MB) and webkit (275 MB) landed as binaries that can only ever fail with *"Host system is missing dependencies to run browsers"*. Naming `chromium` drops both.

```dockerfile
&& (playwright-cli install-browser chromium || true) \
```

**`/ms-playwright` 2.5 G → 1.9 G; the image 6.72 GB → 5.94 GB.**

The second install itself **stays**, and its comment now says why, because it reads redundant next to `playwright install --with-deps chromium` and is not: playwright-cli bundles its own playwright build, and browser revisions are pinned per build, so it resolves chromium **1229** where `@playwright/test` resolves **1228**. Verified by deleting 1229 and leaving 1228 in place:

```text
remaining: chromium-1228  chromium_headless_shell-1228  ffmpeg-1011  firefox-1533  webkit-2317

Error: Browser "chrome-for-testing" is not installed.
       Run `playwright-cli install-browser chrome-for-testing` to install
```

It refuses rather than falling back, so the two installs are genuinely not interchangeable.

Forcing the CLI onto 1228 via `launchOptions.executablePath` **does** work and would free a further ~974 MB (chromium-1229 plus its headless shell). Deliberately not done: it runs a 1.62-alpha client against a browser built for 1.61.1, which is exactly the coupling Playwright pins revisions to prevent, and it contradicts the "pinned as a pair" invariant stated three lines above in the same file. A page opening under a version mismatch says nothing about aria snapshots, `generate-locator` or tracing — the operations validation actually depends on, and where a mismatch would surface as intermittent failures inside agent runs.

## Proof of real execution

Rebuilt with `make build-runner FORCE=1` (exit 0, imported and pinned into k3d) and re-run after the second change, so the table below is against the final image — firefox and webkit removed, both chromium revisions retained:

| # | Check | Result |
|---|---|---|
| 0 | ENV baked into the image | `PLAYWRIGHT_MCP_BROWSER=chromium` |
| 1 | The documented bare command | `### Browser 'default' opened with pid 22` |
| 2 | `--browser=chrome` still wins and still fails | the `/opt/google/chrome/chrome` error — confirms a default, not a lid |
| 3 | Composes with an ADR-0006-shaped resolver `--config` | **with** ENV → opens; **ENV cleared** → the old chrome error |
| 4 | Binary is the baked one | `/ms-playwright/chromium-1228/chrome-linux/chrome` |
| 5 | `npx playwright test` unaffected | `chromium`, `149.0.7827.0`, `1 passed` |
| 6 | Import pinned against kubelet image GC | `"pinned": true` |

Raw output for the two that matter most:

```
===== 1. documented bare command opens a browser =====
### Browser `default` opened with pid 22.

===== 3. composes with an ADR-0006-shaped resolver config =====
-- with the baked ENV:
### Browser `default` opened with pid 22.
-- with the ENV cleared (the old behaviour):
[PlaywrightError: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
```

Check 3 is the before/after in one run, and it also shows these two fixes are not merely independent: the `--host-resolver-rules` config route **could not work at all** before this change.

Check 5 closes the one risk this could have introduced — I confirmed `@playwright/test` does not read `PLAYWRIGHT_MCP_BROWSER` (the string appears in its tree only because its bundled core also carries the CLI/MCP code paths) by running a real spec with the variable set: unchanged browser, still green.

Note the two toolchains pin **different** browsers, and this PR does not change that: `@playwright/test` (1.61.1) runs the specs on chromium revision 1228 / Chromium 149.0.7827.0, while `playwright-cli` (playwright-core 1.62.0-alpha) explores on revision 1229 / Chromium 150.0.7871.0. Each client/browser pair is internally consistent — which is what Playwright's revision pinning protects, and why the two installs cannot be collapsed — but the agent does explore in one chromium and assert in another. ADR-0007's Consequences records that; aligning the two is a `PLAYWRIGHT_VERSION`/`PLAYWRIGHT_CLI_VERSION` question and not attempted here.

## Relationship to ADR-0006

ADR-0006 states *"Chromium is unchanged … `.curlrc` is a curl mechanism and does not reach the browser."* Still true and not contradicted — that ADR is about **name resolution**, this one is about **which binary launches**. Orthogonal, and verified to compose (check 3).

## Gates

No TypeScript or Go changed, so `make lint` / `make build` / `make test` are unaffected; the Dockerfile keeps its Apache header and `.md` is outside `LICENSE_MATCH`. **CI has no Docker step and never builds `aep-runner:dev`**, so the image behaviour is hand-verified above — the same convention ADR-0006 established for its curl half.

## Not in scope

- **The `chromium_headless_shell` downloads** (334 MB + 341 MB, one per revision). Our channel is `chrome-for-testing`, which resolved to the full browser in every check above, so these may be dead weight too — but I have not verified which code paths use them, and `--no-shell` semantics differ between the two installs. Flagged rather than done.
- **Installing Chrome** — needs legal review first, given the image is redistributed.
- **An end-to-end validation cycle** on a live project has not been run; the signal to look for is the absence of the seq 54-81 detour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
