### PR TITLE
fix(helm): always provision service/web-application ComponentTypes on install

### DIFF
--- a/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-service.yaml
+++ b/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-service.yaml
@@ -1,9 +1,5 @@
-{{- if .Values.localOrgProvisioning.enabled }}
-# LOCAL ORG PROVISIONING (local stand-in for cloud platform-api ProvisionOrgUnit).
 # Per-org NAMESPACED ComponentType that aep-api references (kind=ComponentType).
-# Derived verbatim from the AEP ClusterComponentType spec in
-# deployments/scripts/setup-aep.sh. Gated off in prod (ProvisionOrgUnit creates
-# these per-org there). See values.yaml localOrgProvisioning.
+# Derived from the AEP ClusterComponentType spec in deployments/scripts/setup-aep.sh.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentType
 metadata:
@@ -220,4 +216,3 @@ spec:
               backendRefs:
                 - name: "${metadata.componentName}"
                   port: "${workload.endpoints[endpoint].port}"
-{{- end }}

--- a/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-web-application.yaml
+++ b/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-web-application.yaml
@@ -1,9 +1,5 @@
-{{- if .Values.localOrgProvisioning.enabled }}
-# LOCAL ORG PROVISIONING (local stand-in for cloud platform-api ProvisionOrgUnit).
 # Per-org NAMESPACED ComponentType that aep-api references (kind=ComponentType).
-# Derived verbatim from the AEP ClusterComponentType spec in
-# deployments/scripts/setup-aep.sh. Gated off in prod (ProvisionOrgUnit creates
-# these per-org there). See values.yaml localOrgProvisioning.
+# Derived from the AEP ClusterComponentType spec in deployments/scripts/setup-aep.sh.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ComponentType
 metadata:
@@ -193,4 +189,3 @@ spec:
               backendRefs:
                 - name: "${metadata.componentName}"
                   port: "${workload.endpoints[endpoint].port}"
-{{- end }}

--- a/deployments/helm-charts/platform/values.local.yaml
+++ b/deployments/helm-charts/platform/values.local.yaml
@@ -28,9 +28,7 @@ codingAgentDispatch:
   openBaoDirect:
     enabled: true
 
-# Provision per-org OC ComponentTypes locally (cloud does this via platform-api).
 localOrgProvisioning:
-  enabled: true
   orgNamespace: default
 
 # GitHub webhooks are OFF by default locally. To trigger component builds on PR

--- a/deployments/helm-charts/platform/values.yaml
+++ b/deployments/helm-charts/platform/values.yaml
@@ -155,11 +155,8 @@ webhook:
 # does. This provisions the api-configuration ClusterTrait + the namespaced
 # service/web-application ComponentTypes in the org's control-plane namespace.
 localOrgProvisioning:
-  # LOCAL DEV ONLY (single-org). PROD: false — platform-api ProvisionOrgUnit
-  # creates these per-org, so the chart must not.
-  enabled: false
   # The org's OpenChoreo control-plane namespace where the namespaced
-  # ComponentTypes are created. For the local single-org install this is the OC
+  # ComponentTypes are created. For a single-org install this is the OC
   # control-plane namespace ("default"), NOT the platform release namespace.
   orgNamespace: "default"
 

--- a/tools/aectl/cmd/platform.go
+++ b/tools/aectl/cmd/platform.go
@@ -272,8 +272,6 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 	if u := viper.GetString("webhook.delivery_url"); u != "" {
 		helmArgs = append(helmArgs, "--set", "webhook.deliveryURL="+u)
 	}
-	helmArgs = append(helmArgs, "--set",
-		fmt.Sprintf("localOrgProvisioning.enabled=%t", viper.GetBool("oc.local_org_provisioning.enabled")))
 	if ns := viper.GetString("oc.org_namespace"); ns != "" {
 		helmArgs = append(helmArgs, "--set", "localOrgProvisioning.orgNamespace="+ns)
 	}


### PR DESCRIPTION
## Summary

- Removes the `localOrgProvisioning.enabled` gate from `componenttype-service.yaml` and `componenttype-web-application.yaml` — these ComponentTypes are required for any platform installation, not just local dev
- Drops the `enabled` flag from `values.yaml`, `values.local.yaml`, and the `aectl platform install` `--set` args; keeps `orgNamespace` which remains a useful per-install tunable
- The `aectl platform install` path was passing `localOrgProvisioning.enabled=false` (config key defaulted to false), so the ComponentTypes were never created — component builds failed immediately with `component type "deployment/service" not found`

## Root cause

`aectl platform install` explicitly reads `oc.local_org_provisioning.enabled` from config via viper, defaulting to `false`, and passes that as a `--set` arg — overriding the chart default. The Skaffold path worked because `values.local.yaml` had `enabled: true`, but `aectl platform install` bypassed that file.

## Test plan

- [ ] `aectl platform install` on a fresh cluster: `kubectl get componenttype -n default` shows `service` and `web-application`
- [ ] Skaffold path (`make dev-cluster`): same check passes
- [ ] `helm template` with no extra values renders both ComponentTypes unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)