### PR TITLE
fix(platform-chart): add observability-alert-rule to service ComponentType allowedTraits

### DIFF
--- a/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-service.yaml
+++ b/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-service.yaml
@@ -20,6 +20,8 @@ spec:
   allowedTraits:
     - kind: ClusterTrait
       name: api-configuration
+    - kind: ClusterTrait
+      name: observability-alert-rule
   environmentConfigs:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
## Summary

- The platform Helm chart's `componenttype-service.yaml` was missing `observability-alert-rule` in `allowedTraits`, causing every service deploy to fail with an OC validation error.
- AEP's `DeploymentSpec` auto-attaches **two** ClusterTraits to every service: `api-configuration` and `observability-alert-rule`. The ComponentType must list both for OC's release generation to accept them.
- The chart comment claims it mirrors `setup-aep.sh` verbatim — `setup-aep.sh:128-132` does list both traits — the chart had silently drifted.

## Root cause

`services/aep-api/internal/projects/deployment_spec.go:104` calls `DesiredObservabilityAlertRuleTraits` for every service component. `alert_rule_trait.go:52` attaches `observability-alert-rule` unconditionally. OpenChoreo validates traits against `ComponentType.spec.allowedTraits` at release generation time — missing entry → infinite `DeployCycle` retry with:

```
traits [ClusterTrait:observability-alert-rule] are not in the allowed list [ClusterTrait:api-configuration]
```

## Fix

Added the missing `allowedTraits` entry to `deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-service.yaml`:

```yaml
allowedTraits:
  - kind: ClusterTrait
    name: api-configuration
  - kind: ClusterTrait
    name: observability-alert-rule
```

## Test plan

- [ ] `aectl platform install` on a fresh cluster → deploy a service component → release generation succeeds, no `DeployCycle` error in `aep-api` logs
- [ ] Existing installs: live-patch via `kubectl patch componenttype service -n <org-ns> --type=merge -p '{"spec":{"allowedTraits":[{"kind":"ClusterTrait","name":"api-configuration"},{"kind":"ClusterTrait","name":"observability-alert-rule"}]}}'`, then redeploy — self-heals on next retry cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)