### PR TITLE
fix(platform-chart): add observability-alert-rule to web-application ComponentType allowedTraits

### DIFF
--- a/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-web-application.yaml
+++ b/deployments/helm-charts/platform/templates/openchoreo-org-types/componenttype-web-application.yaml
@@ -14,6 +14,9 @@ spec:
   allowedWorkflows:
     - kind: ClusterWorkflow
       name: dockerfile-builder
+  allowedTraits:
+    - kind: ClusterTrait
+      name: observability-alert-rule
   environmentConfigs:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
## Summary

- `deployment_spec.go` attaches the `observability-alert-rule` ClusterTrait to **all** deployment components (`service` and `web-application`) when `ResolveAutoRCAEnabled` is true (see `alert_rule_trait.go:DesiredObservabilityAlertRuleTraits`)
- The `web-application` ComponentType had **no `allowedTraits` field at all**, so OC rejected release generation for every webapp component with: `traits [ClusterTrait:observability-alert-rule] are not in the allowed list []`
- This is the same class of bug as #590 (which fixed `service`), just for the `web-application` ComponentType
- Web-application components don't expose a managed API gateway path, so only `observability-alert-rule` is needed (no `api-configuration`)

## Proof

Live cluster blocked with this error (expense-webapp in mm1):
```
run: deploy failed: component "expense-webapp": cut release: generate release: bad request: validation error: traits [ClusterTrait:observability-alert-rule] are not in the allowed list []
```

Live fix applied:
```bash
kubectl patch componenttype web-application -n default --type=merge \
  -p '{"spec":{"allowedTraits":[{"kind":"ClusterTrait","name":"observability-alert-rule"}]}}'
```

componenttype.openchoreo.dev/web-application patched ✓

## Related

- Companion fix for `service` ComponentType: #590