### PR TITLE
feat(aectl): check WSO2 API Platform is installed before platform install

### DIFF
--- a/tools/aectl/cmd/platform.go
+++ b/tools/aectl/cmd/platform.go
@@ -162,6 +162,10 @@ func runAEPInit(cmd *cobra.Command, args []string) error {
 	}
 	ui.Success(fmt.Sprintf("Build registry %s/%s", initBuildPlaneNamespace, initRegistryService))
 
+	if err := checkAPIPlatform(ctx, k8sClient); err != nil {
+		return err
+	}
+
 	openBaoDirect := viper.GetBool("codingagent.openbao_direct.enabled")
 
 	if initReuseSecrets {

--- a/tools/aectl/cmd/platform_apiplatform.go
+++ b/tools/aectl/cmd/platform_apiplatform.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/wso2/aep/aectl/internal/ui"
+)
+
+type apiPlatformDeps struct {
+	isInstalled func(context.Context, *kubernetes.Clientset) (bool, error)
+}
+
+var defaultAPIPlatformDeps = apiPlatformDeps{
+	isInstalled: isAPIPlatformInstalled,
+}
+
+// checkAPIPlatform verifies the WSO2 API Platform operator is installed on the
+// cluster before proceeding with the AEP platform install. AEP services that
+// use the api-configuration trait emit RestApi CRs; without the operator those
+// CRs have no CRD and every deploy fails at the data-plane agent.
+func checkAPIPlatform(ctx context.Context, client *kubernetes.Clientset) error {
+	return runAPIPlatformCheck(ctx, client, defaultAPIPlatformDeps)
+}
+
+func runAPIPlatformCheck(ctx context.Context, client *kubernetes.Clientset, deps apiPlatformDeps) error {
+	sp := ui.NewSpinner("Checking WSO2 API Platform")
+	sp.Start()
+
+	installed, err := deps.isInstalled(ctx, client)
+	if err != nil {
+		sp.Fail("WSO2 API Platform check failed")
+		return err
+	}
+	if installed {
+		sp.Success("WSO2 API Platform")
+		return nil
+	}
+	sp.Fail("WSO2 API Platform not found")
+	return fmt.Errorf("WSO2 API Platform is not installed on this cluster — install it and re-run 'aectl platform install'")
+}
+
+// isAPIPlatformInstalled checks whether the WSO2 API Platform operator CRDs are
+// registered by querying the discovery API for the gateway.api-platform.wso2.com
+// API group. It returns false (not an error) when the group is absent.
+func isAPIPlatformInstalled(ctx context.Context, client *kubernetes.Clientset) (bool, error) {
+	_, err := client.Discovery().ServerResourcesForGroupVersion("gateway.api-platform.wso2.com/v1alpha1")
+	if err != nil {
+		if isNotFoundDiscoveryError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("check API Platform CRDs: %w", err)
+	}
+	return true, nil
+}
+
+// isNotFoundDiscoveryError returns true when the discovery client error indicates
+// the requested API group/version is not registered on the cluster. The k8s
+// discovery client does not wrap these as apierrors.StatusError consistently
+// across server versions, so we also check the message text.
+func isNotFoundDiscoveryError(err error) bool {
+	return apierrors.IsNotFound(err) ||
+		strings.Contains(err.Error(), "not found") ||
+		strings.Contains(err.Error(), "404")
+}

--- a/tools/aectl/cmd/platform_apiplatform_test.go
+++ b/tools/aectl/cmd/platform_apiplatform_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestRunAPIPlatformCheck_AlreadyInstalled(t *testing.T) {
+	deps := apiPlatformDeps{
+		isInstalled: func(context.Context, *kubernetes.Clientset) (bool, error) {
+			return true, nil
+		},
+	}
+	if err := runAPIPlatformCheck(context.Background(), nil, deps); err != nil {
+		t.Fatalf("expected nil when API Platform is installed, got %v", err)
+	}
+}
+
+func TestRunAPIPlatformCheck_NotInstalled(t *testing.T) {
+	deps := apiPlatformDeps{
+		isInstalled: func(context.Context, *kubernetes.Clientset) (bool, error) {
+			return false, nil
+		},
+	}
+	if err := runAPIPlatformCheck(context.Background(), nil, deps); err == nil {
+		t.Fatal("expected error when API Platform is not installed, got nil")
+	}
+}
+
+func TestRunAPIPlatformCheck_DetectionError(t *testing.T) {
+	deps := apiPlatformDeps{
+		isInstalled: func(context.Context, *kubernetes.Clientset) (bool, error) {
+			return false, errors.New("api server unreachable")
+		},
+	}
+	if err := runAPIPlatformCheck(context.Background(), nil, deps); err == nil {
+		t.Fatal("expected error when detection fails, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `aectl platform install` could complete successfully while the cluster was left in a broken state: if the WSO2 API Platform operator is not installed, any service component that attaches the `api-configuration` trait fails at deploy time with `ResourceApplyFailed` because the `restapis.gateway.api-platform.wso2.com` CRD does not exist — a silent failure that surfaces only after the full install appears to have succeeded
- Adds an explicit prerequisite check in `runAEPInit`, after the build registry check and before OpenBao provisioning, that queries the Kubernetes discovery API for `gateway.api-platform.wso2.com/v1alpha1`
- If absent, fails fast:
  ```
  ✗ WSO2 API Platform not found
  Error: WSO2 API Platform is not installed on this cluster — install it and re-run 'aectl platform install'
  ```
- Detection logic is in `platform_apiplatform.go` with an injectable `apiPlatformDeps` struct so the check is fully unit-testable without a live cluster

## Files changed

| File | Change |
|---|---|
| `cmd/platform.go` | Wire `checkAPIPlatform` after `checkBuildRegistry` |
| `cmd/platform_apiplatform.go` | Detection via discovery API + spinner/error output |
| `cmd/platform_apiplatform_test.go` | 3 unit tests (installed / not installed / detection error) |

## Test

```
ok  github.com/wso2/aep/aectl/cmd  (TestRunAPIPlatformCheck_*)
```

All three cases pass: already-installed returns nil, not-installed returns error, detection failure returns error.