### PR TITLE
feat(aectl): make platform install CI-friendly

### DIFF
--- a/tools/aectl/cmd/platform.go
+++ b/tools/aectl/cmd/platform.go
@@ -76,6 +76,7 @@ var (
 	initSkipOCVersionCheck  bool
 	initOpenBaoDirect       bool
 	initReuseSecrets        bool
+	initAddons              string
 )
 
 var initCmd = &cobra.Command{
@@ -117,6 +118,7 @@ func init() {
 	initCmd.Flags().String("openbao-addr", "", "In-cluster URL of the OpenBao service (overrides config)")
 	_ = viper.BindPFlag("openbao.addr", initCmd.Flags().Lookup("openbao-addr"))
 	initCmd.Flags().BoolVar(&initReuseSecrets, "reuse-secrets", false, "Skip secret prompts and reuse secrets already seeded in OpenBao (for reinstall or upgrade)")
+	initCmd.Flags().StringVar(&initAddons, "addons", "", `Comma-separated addon IDs to install without prompting (e.g. "thunder-app,postgres-cnpg"). Use "none" to skip addons, "all" to install everything. Omit for interactive selection.`)
 	registerThunderFlags(initCmd)
 }
 
@@ -350,6 +352,10 @@ type addonDeps struct {
 	// context deadline is exceeded. Nil skips the wait (tests that do not
 	// exercise credential synchronization may omit this dep).
 	waitForSecrets func(ctx context.Context, namespace string, names []string) error
+	// addonsFlag, when non-empty, bypasses the interactive multi-select and
+	// operator-install confirmation. Accepted values: "none", "all", or a
+	// comma-separated list of addon IDs (e.g. "thunder-app,postgres-cnpg").
+	addonsFlag string
 }
 
 var defaultAddonDeps = addonDeps{
@@ -367,6 +373,7 @@ var defaultAddonDeps = addonDeps{
 // platformVersion is used as the Helm --version for operators whose OperatorSpec.Version is empty.
 func installAddons(ctx context.Context, client *kubernetes.Clientset, platformVersion string) error {
 	deps := defaultAddonDeps
+	deps.addonsFlag = initAddons
 	deps.waitForSecrets = func(ctx context.Context, namespace string, names []string) error {
 		return waitForSecretsReady(ctx, client, namespace, names, 3*time.Minute)
 	}
@@ -378,23 +385,48 @@ func runAddonInstall(ctx context.Context, platformVersion string, deps addonDeps
 		return nil
 	}
 
-	// Phase 0: addon selection
-	items := make([]ui.SelectItem, len(addons.Available))
-	for i, a := range addons.Available {
-		items[i] = ui.SelectItem{Label: a.Label, Description: a.Description}
-	}
-
-	selected, confirmed := deps.multiSelect("Optional platform resources", items)
-	if !confirmed {
-		return nil
-	}
-
+	// Phase 0: addon selection — CI path or interactive.
 	var chosen []addons.Addon
-	for i, a := range addons.Available {
-		if selected[i] {
-			chosen = append(chosen, a)
+	if deps.addonsFlag != "" {
+		switch deps.addonsFlag {
+		case "none":
+			return nil
+		case "all":
+			chosen = append(chosen, addons.Available...)
+		default:
+			byID := make(map[string]addons.Addon, len(addons.Available))
+			for _, a := range addons.Available {
+				byID[a.ID] = a
+			}
+			for _, id := range strings.Split(deps.addonsFlag, ",") {
+				id = strings.TrimSpace(id)
+				a, ok := byID[id]
+				if !ok {
+					known := make([]string, 0, len(addons.Available))
+					for _, av := range addons.Available {
+						known = append(known, av.ID)
+					}
+					return fmt.Errorf("unknown addon %q — valid IDs: %s", id, strings.Join(known, ", "))
+				}
+				chosen = append(chosen, a)
+			}
+		}
+	} else {
+		items := make([]ui.SelectItem, len(addons.Available))
+		for i, a := range addons.Available {
+			items[i] = ui.SelectItem{Label: a.Label, Description: a.Description}
+		}
+		selected, confirmed := deps.multiSelect("Optional platform resources", items)
+		if !confirmed {
+			return nil
+		}
+		for i, a := range addons.Available {
+			if selected[i] {
+				chosen = append(chosen, a)
+			}
 		}
 	}
+
 	if len(chosen) == 0 {
 		return nil
 	}
@@ -417,7 +449,8 @@ func runAddonInstall(ctx context.Context, platformVersion string, deps addonDeps
 		}
 		fmt.Println()
 
-		if !deps.confirm("Install these operators?") {
+		// When --addons flag is set, auto-confirm operator installs.
+		if deps.addonsFlag == "" && !deps.confirm("Install these operators?") {
 			ui.Warn("Operator installation skipped — addons will not be applied")
 			fmt.Println()
 			return nil

--- a/tools/aectl/cmd/platform_addons_test.go
+++ b/tools/aectl/cmd/platform_addons_test.go
@@ -381,6 +381,61 @@ func TestRunAddonInstall_AddonsFlag_Specific(t *testing.T) {
 	}
 }
 
+// TestRunAddonInstall_AddonsFlag_MultipleIDs verifies that a comma-separated
+// list with more than one ID installs exactly those addons — both operators are
+// invoked, all their manifests are applied, and no interactive callback fires.
+func TestRunAddonInstall_AddonsFlag_MultipleIDs(t *testing.T) {
+	first := addonByID(t, "thunder-app")
+	second := addonByID(t, "postgres-cnpg")
+
+	existing := existingForAddon(first)
+	for k, v := range existingForAddon(second) {
+		existing[k] = v
+	}
+	fa := &fakeApplier{existing: existing}
+	var installedOps []string
+
+	deps := addonDeps{
+		addonsFlag: "thunder-app,postgres-cnpg",
+		multiSelect: func(string, []ui.SelectItem) ([]bool, bool) {
+			t.Error("multiSelect must not be called when --addons flag is set")
+			return nil, false
+		},
+		confirm: func(string) bool {
+			t.Error("confirm must not be called when --addons flag is set")
+			return false
+		},
+		installOperator: func(_ context.Context, _ string, op addons.OperatorSpec) error {
+			installedOps = append(installedOps, op.ReleaseName)
+			return nil
+		},
+		newApplier:     func(string) (manifestApplier, error) { return fa, nil },
+		waitForSecrets: func(context.Context, string, []string) error { return nil },
+	}
+
+	if err := runAddonInstall(context.Background(), "", deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both operators must have been installed.
+	wantOps := []string{first.Operator.ReleaseName, second.Operator.ReleaseName}
+	if len(installedOps) != len(wantOps) {
+		t.Fatalf("installed operators = %v, want %v", installedOps, wantOps)
+	}
+	for i, want := range wantOps {
+		if installedOps[i] != want {
+			t.Errorf("installedOps[%d] = %q, want %q", i, installedOps[i], want)
+		}
+	}
+
+	// All manifests for both addons must have been applied.
+	wantApplied := len(first.Operator.PreManifests) + len(first.Manifests) +
+		len(second.Operator.PreManifests) + len(second.Manifests)
+	if got := len(fa.applied); got != wantApplied {
+		t.Errorf("applied %d manifests, want %d (thunder-app + postgres-cnpg)", got, wantApplied)
+	}
+}
+
 // TestRunAddonInstall_AddonsFlag_UnknownID verifies that an unrecognised addon
 // ID is rejected immediately with a descriptive error.
 func TestRunAddonInstall_AddonsFlag_UnknownID(t *testing.T) {

--- a/tools/aectl/cmd/platform_addons_test.go
+++ b/tools/aectl/cmd/platform_addons_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/wso2/aep/aectl/internal/addons"
@@ -283,6 +284,115 @@ func TestRunAddonInstall_SecretSyncTimeout(t *testing.T) {
 	// No addon manifests should have been applied either (operator failed → addon skipped).
 	if len(fa.applied) != 0 {
 		t.Errorf("applied %d manifests, want 0 (addon skipped after sync failure)", len(fa.applied))
+	}
+}
+
+// TestRunAddonInstall_AddonsFlag_None verifies that --addons=none returns
+// immediately without calling multiSelect or any other dep.
+func TestRunAddonInstall_AddonsFlag_None(t *testing.T) {
+	deps := addonDeps{
+		addonsFlag: "none",
+		multiSelect: func(string, []ui.SelectItem) ([]bool, bool) {
+			t.Error("multiSelect must not be called when --addons=none")
+			return nil, false
+		},
+		confirm: func(string) bool {
+			t.Error("confirm must not be called when --addons=none")
+			return false
+		},
+	}
+	if err := runAddonInstall(context.Background(), "", deps); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestRunAddonInstall_AddonsFlag_All verifies that --addons=all installs every
+// available addon without calling the multiSelect prompt or the confirm dialog.
+func TestRunAddonInstall_AddonsFlag_All(t *testing.T) {
+	existing := make(map[string]bool)
+	for _, a := range addons.Available {
+		for _, v := range a.VerifyResources {
+			existing[v.Kind+"/"+v.Name] = true
+		}
+	}
+	fa := &fakeApplier{existing: existing}
+
+	deps := addonDeps{
+		addonsFlag: "all",
+		multiSelect: func(string, []ui.SelectItem) ([]bool, bool) {
+			t.Error("multiSelect must not be called when --addons=all")
+			return nil, false
+		},
+		confirm: func(string) bool {
+			t.Error("confirm must not be called when --addons=all")
+			return false
+		},
+		installOperator: func(context.Context, string, addons.OperatorSpec) error { return nil },
+		newApplier:      func(string) (manifestApplier, error) { return fa, nil },
+		waitForSecrets:  func(context.Context, string, []string) error { return nil },
+	}
+
+	if err := runAddonInstall(context.Background(), "", deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Every addon's manifests must have been applied.
+	wantApplied := 0
+	for _, a := range addons.Available {
+		wantApplied += len(a.Operator.PreManifests) + len(a.Manifests)
+	}
+	if got := len(fa.applied); got != wantApplied {
+		t.Errorf("applied %d manifests, want %d (all addons)", got, wantApplied)
+	}
+}
+
+// TestRunAddonInstall_AddonsFlag_Specific verifies that a comma-separated list
+// installs exactly those addons without prompting.
+func TestRunAddonInstall_AddonsFlag_Specific(t *testing.T) {
+	target := addonByID(t, "thunder-app")
+	fa := &fakeApplier{existing: existingForAddon(target)}
+	installedOps := []string{}
+
+	deps := addonDeps{
+		addonsFlag: "thunder-app",
+		multiSelect: func(string, []ui.SelectItem) ([]bool, bool) {
+			t.Error("multiSelect must not be called when --addons flag is set")
+			return nil, false
+		},
+		confirm: func(string) bool {
+			t.Error("confirm must not be called when --addons flag is set")
+			return false
+		},
+		installOperator: func(_ context.Context, _ string, op addons.OperatorSpec) error {
+			installedOps = append(installedOps, op.ReleaseName)
+			return nil
+		},
+		newApplier:     func(string) (manifestApplier, error) { return fa, nil },
+		waitForSecrets: func(context.Context, string, []string) error { return nil },
+	}
+
+	if err := runAddonInstall(context.Background(), "", deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only thunder-app's operator should have been installed.
+	if len(installedOps) != 1 || installedOps[0] != target.Operator.ReleaseName {
+		t.Errorf("installed operators = %v, want [%s]", installedOps, target.Operator.ReleaseName)
+	}
+}
+
+// TestRunAddonInstall_AddonsFlag_UnknownID verifies that an unrecognised addon
+// ID is rejected immediately with a descriptive error.
+func TestRunAddonInstall_AddonsFlag_UnknownID(t *testing.T) {
+	deps := addonDeps{
+		addonsFlag: "not-a-real-addon",
+	}
+	err := runAddonInstall(context.Background(), "", deps)
+	if err == nil {
+		t.Fatal("expected an error for unknown addon ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "not-a-real-addon") {
+		t.Errorf("error message should name the unknown ID, got: %v", err)
 	}
 }
 

--- a/tools/aectl/cmd/platform_gateway.go
+++ b/tools/aectl/cmd/platform_gateway.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/wso2/aep/aectl/internal/ui"
@@ -34,6 +35,9 @@ type gatewayIngressDeps struct {
 	applyConfig     func(ctx context.Context, gwName, gwNamespace, hostname string) error
 	confirm         func(string) bool
 	prompt          func(label, defaultValue string) (string, error)
+	// hostnameOverride, when non-empty, bypasses the interactive hostname prompt
+	// and confirmation — used by the CI path (gateway.hostname in config).
+	hostnameOverride string
 }
 
 var defaultGatewayIngressDeps = gatewayIngressDeps{
@@ -138,7 +142,9 @@ func execKubectl(ctx context.Context, args ...string) ([]byte, error) {
 }
 
 func checkOrConfigureGatewayIngress(ctx context.Context, _ *kubernetes.Clientset) error {
-	return runGatewayIngressCheck(ctx, defaultGatewayIngressDeps)
+	deps := defaultGatewayIngressDeps
+	deps.hostnameOverride = viper.GetString("gateway.hostname")
+	return runGatewayIngressCheck(ctx, deps)
 }
 
 func runGatewayIngressCheck(ctx context.Context, deps gatewayIngressDeps) error {
@@ -156,6 +162,24 @@ func runGatewayIngressCheck(ctx context.Context, deps gatewayIngressDeps) error 
 	}
 	sp.Fail("External gateway ingress not configured")
 
+	// CI path: hostname provided via config — auto-configure without prompting.
+	if deps.hostnameOverride != "" {
+		fmt.Println()
+		gwName, gwNamespace, err := deps.discoverGateway(ctx)
+		if err != nil {
+			return fmt.Errorf("discover data-plane gateway: %w", err)
+		}
+		sp2 := ui.NewSpinner(fmt.Sprintf("Configuring external gateway ingress (%s)", deps.hostnameOverride))
+		sp2.Start()
+		if err := deps.applyConfig(ctx, gwName, gwNamespace, deps.hostnameOverride); err != nil {
+			sp2.Fail("Failed to configure gateway ingress")
+			return err
+		}
+		sp2.Success(fmt.Sprintf("External gateway ingress configured (ClusterDataPlane + Environment/development: %s → %s, port 19080)", deps.hostnameOverride, gwName))
+		return nil
+	}
+
+	// Interactive path.
 	fmt.Println()
 	ui.Warn("Components with external endpoints will fail to render without a configured gateway ingress.")
 	ui.Detail("ComponentType templates use gateway.ingress.external to generate HTTPRoute hostnames.")

--- a/tools/aectl/cmd/platform_gateway_test.go
+++ b/tools/aectl/cmd/platform_gateway_test.go
@@ -123,7 +123,13 @@ func TestRunGatewayIngressCheck(t *testing.T) {
 				isConfigured:     func(context.Context) (bool, error) { return false, nil },
 				discoverGateway:  func(context.Context) (string, string, error) { return "gateway-default", "openchoreo-data-plane", nil },
 				hostnameOverride: "myapis.example.com",
-				applyConfig: func(_ context.Context, _, _, hostname string) error {
+				applyConfig: func(_ context.Context, gwName, gwNamespace, hostname string) error {
+					if gwName != "gateway-default" {
+						return fmt.Errorf("unexpected gwName: %s", gwName)
+					}
+					if gwNamespace != "openchoreo-data-plane" {
+						return fmt.Errorf("unexpected gwNamespace: %s", gwNamespace)
+					}
 					if hostname != "myapis.example.com" {
 						return fmt.Errorf("unexpected hostname: %s", hostname)
 					}
@@ -152,5 +158,40 @@ func TestRunGatewayIngressCheck(t *testing.T) {
 				t.Errorf("runGatewayIngressCheck() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestRunGatewayIngressCheck_HostnameOverride_GatewayForwarding verifies that
+// in the CI override path discoverGateway is actually invoked and that both the
+// gateway name and namespace it returns are forwarded unchanged to applyConfig.
+func TestRunGatewayIngressCheck_HostnameOverride_GatewayForwarding(t *testing.T) {
+	discoverCalled := false
+	var capturedGwName, capturedGwNs string
+
+	deps := gatewayIngressDeps{
+		isConfigured: func(context.Context) (bool, error) { return false, nil },
+		discoverGateway: func(context.Context) (string, string, error) {
+			discoverCalled = true
+			return "gateway-default", "openchoreo-data-plane", nil
+		},
+		hostnameOverride: "myapis.example.com",
+		applyConfig: func(_ context.Context, gwName, gwNamespace, _ string) error {
+			capturedGwName = gwName
+			capturedGwNs = gwNamespace
+			return nil
+		},
+	}
+
+	if err := runGatewayIngressCheck(context.Background(), deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !discoverCalled {
+		t.Error("discoverGateway must be called in the CI override path")
+	}
+	if capturedGwName != "gateway-default" {
+		t.Errorf("applyConfig received gwName = %q, want %q", capturedGwName, "gateway-default")
+	}
+	if capturedGwNs != "openchoreo-data-plane" {
+		t.Errorf("applyConfig received gwNamespace = %q, want %q", capturedGwNs, "openchoreo-data-plane")
 	}
 }

--- a/tools/aectl/cmd/platform_gateway_test.go
+++ b/tools/aectl/cmd/platform_gateway_test.go
@@ -115,6 +115,34 @@ func TestRunGatewayIngressCheck(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			// CI path: hostnameOverride bypasses prompt and confirm entirely.
+			// prompt and confirm are nil — a call to either would panic.
+			name: "hostname override auto-configures without prompting",
+			deps: gatewayIngressDeps{
+				isConfigured:     func(context.Context) (bool, error) { return false, nil },
+				discoverGateway:  func(context.Context) (string, string, error) { return "gateway-default", "openchoreo-data-plane", nil },
+				hostnameOverride: "myapis.example.com",
+				applyConfig: func(_ context.Context, _, _, hostname string) error {
+					if hostname != "myapis.example.com" {
+						return fmt.Errorf("unexpected hostname: %s", hostname)
+					}
+					return nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// CI path: an applyConfig error must propagate even with override set.
+			name: "hostname override propagates apply error",
+			deps: gatewayIngressDeps{
+				isConfigured:     func(context.Context) (bool, error) { return false, nil },
+				discoverGateway:  func(context.Context) (string, string, error) { return "gateway-default", "openchoreo-data-plane", nil },
+				hostnameOverride: "myapis.example.com",
+				applyConfig:      func(context.Context, string, string, string) error { return fmt.Errorf("kubectl error") },
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/aectl/internal/config/config.go
+++ b/tools/aectl/internal/config/config.go
@@ -60,6 +60,7 @@ var ConfigMapKeys = []string{
 	"openbao.addr",
 	"webhook.delivery_url",
 	"webhook.local_smee.enabled",
+	"gateway.hostname",
 }
 
 // keyKind describes the expected type of a config value for validation.
@@ -95,6 +96,9 @@ var keyRegistry = map[string]configKeyMeta{
 	"openbao.addr":                      {required: false, kind: kindURL},
 	"webhook.delivery_url":              {required: false, kind: kindURL},
 	"webhook.local_smee.enabled":        {required: false, kind: kindBool},
+	// gateway.hostname, when set, lets `aectl platform install` configure the
+	// external gateway ingress non-interactively (CI-friendly path).
+	"gateway.hostname": {required: false, kind: kindString},
 }
 
 // Init sets env-var bindings. All config values must come from the cluster

--- a/tools/aectl/internal/config/config_test.go
+++ b/tools/aectl/internal/config/config_test.go
@@ -106,3 +106,72 @@ func TestLoadThunderSecretFromCluster_EnvOverridesDefault(t *testing.T) {
 		t.Errorf("thunder.admin_client_secret = %q, want %q (SetDefault must not clobber existing value)", got, "override-secret")
 	}
 }
+
+func TestGatewayHostname_InConfigMapKeys(t *testing.T) {
+	found := false
+	for _, k := range ConfigMapKeys {
+		if k == "gateway.hostname" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("gateway.hostname must be present in ConfigMapKeys")
+	}
+}
+
+func TestGatewayHostname_InKeyRegistry(t *testing.T) {
+	meta, ok := keyRegistry["gateway.hostname"]
+	if !ok {
+		t.Fatal("gateway.hostname must be present in keyRegistry")
+	}
+	if meta.required {
+		t.Error("gateway.hostname must be optional (required=false)")
+	}
+	if meta.kind != kindString {
+		t.Errorf("gateway.hostname kind = %v, want kindString", meta.kind)
+	}
+}
+
+func TestLoadFromCluster_GatewayHostname_Populated(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName, Namespace: "aep"},
+		Data:       map[string]string{"gateway.hostname": "myapis.example.com"},
+	}
+	client := fake.NewSimpleClientset(cm)
+	viper.Reset()
+
+	n, err := LoadFromCluster(context.Background(), client, "aep")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n == 0 {
+		t.Error("LoadFromCluster should report at least one key loaded")
+	}
+	if got := viper.GetString("gateway.hostname"); got != "myapis.example.com" {
+		t.Errorf("gateway.hostname = %q, want %q", got, "myapis.example.com")
+	}
+}
+
+func TestLoadFromCluster_GatewayHostname_Absent(t *testing.T) {
+	// ConfigMap exists but does not include gateway.hostname.
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName, Namespace: "aep"},
+		Data:       map[string]string{"thunder.namespace": "wso2-thunder"},
+	}
+	client := fake.NewSimpleClientset(cm)
+	viper.Reset()
+
+	if _, err := LoadFromCluster(context.Background(), client, "aep"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := viper.GetString("gateway.hostname"); got != "" {
+		t.Errorf("gateway.hostname should be empty when absent from ConfigMap, got %q", got)
+	}
+	// Optional key absence must not surface as a validation error.
+	for _, e := range ValidateLoaded() {
+		if strings.Contains(e, "gateway.hostname") {
+			t.Errorf("optional gateway.hostname must not cause a validation error, got: %s", e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Gateway ingress**: adds `gateway.hostname` to the config file schema. When set via `aectl platform config import`, `aectl platform install` auto-discovers the data-plane gateway and applies the ingress config without any interactive prompt or confirmation dialog.
- **Addon selection**: adds `--addons` flag accepting comma-separated addon IDs (`thunder-app,postgres-cnpg`), `"all"`, or `"none"`. When provided, the interactive multi-select and operator-install confirmation are bypassed. Unknown IDs are rejected immediately with a descriptive error listing valid options.
- The three secret inputs (`ANTHROPIC_API_KEY`, `AEP_THUNDER_ADMIN_CLIENT_SECRET`, `AEP_OPENBAO_TOKEN`) were already env-var friendly — no change needed there.

Interactive mode is completely unchanged when the flag/config key is absent.

## CI invocation

```bash
# Import cluster config (includes gateway.hostname for the target cluster)
aectl platform config import --config ci/cluster.yaml

# Fresh install
ANTHROPIC_API_KEY="$ANTHROPIC_KEY" \
AEP_THUNDER_ADMIN_CLIENT_SECRET="$THUNDER_SECRET" \
  aectl platform install --addons=thunder-app,postgres-cnpg

# Upgrade (secrets already seeded in OpenBao)
aectl platform install --reuse-secrets --addons=thunder-app,postgres-cnpg
```

## Test plan

- [ ] 6 new test cases: gateway override auto-applies without calling `prompt`/`confirm`; gateway override propagates `applyConfig` errors; `--addons=none` returns immediately; `--addons=all` installs all without calling `multiSelect`/`confirm`; `--addons=thunder-app` installs only that addon; unknown addon ID returns descriptive error
- [ ] All existing addon and gateway tests continue to pass (`go test ./tools/aectl/cmd/... ./tools/aectl/internal/config/...`)
- [ ] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)