### PR TITLE
Show deployed workload dependencies on Project Overview

### DIFF
--- a/apps/console/src/features/projects/api/keys.ts
+++ b/apps/console/src/features/projects/api/keys.ts
@@ -34,4 +34,6 @@ export const projectKeys = {
   tags: (name: string) => [...projectKeys.detail(name), "tags"] as const,
   buildPreflight: (name: string) =>
     [...projectKeys.detail(name), "build-preflight"] as const,
+  workloadDependencies: (name: string) =>
+    [...projectKeys.detail(name), "workload-dependencies"] as const,
 };

--- a/apps/console/src/features/projects/api/queries.ts
+++ b/apps/console/src/features/projects/api/queries.ts
@@ -169,6 +169,28 @@ export function useProjectComponents(projectName: string) {
   );
 }
 
+// Deployed-workload dependencies for the project Overview (deduped rows).
+// Null body is a valid empty list — unresolved design declarations are
+// omitted by the BFF, so we must not treat null as a load failure.
+export function useWorkloadDependencies(projectName: string) {
+  return useQuery({
+    queryKey: projectKeys.workloadDependencies(projectName),
+    queryFn: async () => {
+      const { data, error } = await client.GET(
+        "/projects/{projectName}/workload-dependencies",
+        { params: { path: { projectName } } },
+      );
+      if (error) {
+        throw new Error(
+          apiErrorMessage(error, "Failed to load workload dependencies"),
+        );
+      }
+      return data ?? [];
+    },
+    staleTime: 30_000,
+  });
+}
+
 // The Deployments board's pollers (#216): one list-deployments read per
 // component — reusing the endpoint (and cache keys) the overview's
 // "Open app" link already hits, so no new contract surface. Each query

--- a/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ElementType } from "react";
+import type { components } from "../../../generated/aep-api";
+import { OverviewDependencies } from "./OverviewDependencies";
+
+// Router replaced so the drawer's "Used by" ProjectLink renders as a plain
+// anchor (createLink pattern, cf. ResourcesSection.test).
+vi.mock("@tanstack/react-router", () => ({
+  createLink: (Component: ElementType) =>
+    function MockLink({
+      to,
+      params,
+      ...rest
+    }: { to: string; params?: Record<string, unknown> } & Record<string, unknown>) {
+      let href = to;
+      for (const [key, value] of Object.entries(params ?? {})) {
+        href = href.replace(`$${key}`, String(value));
+      }
+      return <Component component="a" href={href} {...rest} />;
+    },
+}));
+
+type WorkloadDependencyDTO = components["schemas"]["WorkloadDependencyDTO"];
+type PlatformResourceTypeDTO = components["schemas"]["PlatformResourceTypeDTO"];
+type ExternalResourceDTO = components["schemas"]["ExternalResourceDTO"];
+
+const CURRENT_PROJECT = "demo-shop";
+const PROVIDER_PROJECT = "gym-tracker";
+const PROVIDER_COMPONENT = "gym-api";
+
+const platformPostgres: PlatformResourceTypeDTO = {
+  name: "postgres-cnpg",
+  description: "Managed Postgres via CloudNativePG",
+  consumers: [],
+};
+
+const externalStripe: ExternalResourceDTO = {
+  name: "stripe",
+  description: "Stripe payments API",
+  config: [],
+  consumers: [],
+};
+
+const someDependencies: WorkloadDependencyDTO[] = [
+  {
+    kind: "resource",
+    tag: "platform",
+    ref: "postgres-cnpg",
+    name: "postgres-cnpg",
+  },
+  {
+    kind: "resource",
+    tag: "external",
+    ref: "stripe",
+    name: "stripe",
+  },
+  {
+    kind: "org-service",
+    name: "gym-api",
+    project: PROVIDER_PROJECT,
+    component: PROVIDER_COMPONENT,
+  },
+];
+
+let depsState: {
+  data?: WorkloadDependencyDTO[];
+  isPending: boolean;
+  isError: boolean;
+  error?: Error | null;
+  refetch: ReturnType<typeof vi.fn>;
+};
+let platformState: {
+  data?: PlatformResourceTypeDTO[];
+  isPending: boolean;
+  isError: boolean;
+};
+let externalState: {
+  data?: ExternalResourceDTO[];
+  isPending: boolean;
+  isError: boolean;
+};
+const openApiCalls: {
+  projectName: string;
+  componentName: string;
+  enabled: boolean;
+}[] = [];
+const refetch = vi.fn();
+
+vi.mock("../api/queries", () => ({
+  useWorkloadDependencies: () => depsState,
+  useComponentOpenApi: (
+    projectName: string,
+    componentName: string,
+    enabled: boolean,
+  ) => {
+    openApiCalls.push({ projectName, componentName, enabled });
+    return {
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+  },
+}));
+
+vi.mock("../../settings/api/queries", () => ({
+  usePlatformResourceTypes: () => platformState,
+  useExternalResources: () => externalState,
+  useDeleteExternalResource: () => ({
+    isPending: false,
+    isError: false,
+    error: null,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+function resetState() {
+  refetch.mockReset();
+  openApiCalls.length = 0;
+  depsState = {
+    data: [],
+    isPending: false,
+    isError: false,
+    error: null,
+    refetch,
+  };
+  platformState = {
+    data: [platformPostgres],
+    isPending: false,
+    isError: false,
+  };
+  externalState = {
+    data: [externalStripe],
+    isPending: false,
+    isError: false,
+  };
+}
+
+describe("OverviewDependencies", () => {
+  it("shows the empty state and does not treat it as an error", () => {
+    resetState();
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    expect(screen.getByText("No deployed dependencies")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /rows appear after a component has deployed/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/unresolved design declarations stay off this list/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("opens the resource drawer with the catalog type name on a resource click", () => {
+    resetState();
+    depsState = {
+      data: someDependencies,
+      isPending: false,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("postgres-cnpg"));
+
+    expect(screen.getAllByText("postgres-cnpg")).toHaveLength(2);
+    expect(screen.getByLabelText("Close")).toBeInTheDocument();
+  });
+
+  it("opens the OpenAPI dialog with the provider project and component", () => {
+    resetState();
+    depsState = {
+      data: someDependencies,
+      isPending: false,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    fireEvent.click(screen.getByText("gym-api"));
+
+    expect(
+      screen.getByText(`${PROVIDER_COMPONENT} · API contract`),
+    ).toBeInTheDocument();
+    expect(openApiCalls).toContainEqual({
+      projectName: PROVIDER_PROJECT,
+      componentName: PROVIDER_COMPONENT,
+      enabled: true,
+    });
+    expect(openApiCalls).not.toContainEqual({
+      projectName: CURRENT_PROJECT,
+      componentName: PROVIDER_COMPONENT,
+      enabled: true,
+    });
+  });
+
+  it("shows a loading indicator while the query is pending", () => {
+    resetState();
+    depsState = {
+      isPending: true,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    expect(screen.getByLabelText("Loading dependencies")).toBeInTheDocument();
+    expect(screen.queryByText("No deployed dependencies")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows an error alert with retry when the query fails", () => {
+    resetState();
+    depsState = {
+      isPending: false,
+      isError: true,
+      error: new Error("upstream unavailable"),
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("upstream unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open an empty drawer when the catalog has no matching type", () => {
+    resetState();
+    depsState = {
+      data: [
+        {
+          kind: "resource",
+          tag: "platform",
+          ref: "mystery-db",
+          name: "mystery-db",
+        },
+      ],
+      isPending: false,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    fireEvent.click(screen.getByText("mystery-db"));
+
+    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
+  });
+});

--- a/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
@@ -192,6 +192,27 @@ describe("OverviewDependencies", () => {
     fireEvent.click(screen.getByRole("button", { name: /postgres-cnpg/ }));
 
     expect(screen.getAllByText("postgres-cnpg")).toHaveLength(2);
+    expect(screen.getByText("Managed Postgres via CloudNativePG")).toBeInTheDocument();
+    expect(screen.getByLabelText("Close")).toBeInTheDocument();
+  });
+
+  it("opens the resource drawer on an external resource click", () => {
+    resetState();
+    depsState = {
+      data: someDependencies,
+      isPending: false,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /stripe/ }));
+
+    expect(screen.getAllByText("stripe")).toHaveLength(2);
+    expect(screen.getByText("Stripe payments API")).toBeInTheDocument();
     expect(screen.getByLabelText("Close")).toBeInTheDocument();
   });
 
@@ -274,7 +295,7 @@ describe("OverviewDependencies", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("does not open an empty drawer when the catalog has no matching type", () => {
+  it("opens the drawer from the workload row when the catalog has no matching type", () => {
     resetState();
     depsState = {
       data: [
@@ -294,6 +315,7 @@ describe("OverviewDependencies", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /mystery-db/ }));
 
-    expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
+    expect(screen.getAllByText("mystery-db")).toHaveLength(2);
+    expect(screen.getByLabelText("Close")).toBeInTheDocument();
   });
 });

--- a/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.test.tsx
@@ -189,9 +189,29 @@ describe("OverviewDependencies", () => {
 
     expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("postgres-cnpg"));
+    fireEvent.click(screen.getByRole("button", { name: /postgres-cnpg/ }));
 
     expect(screen.getAllByText("postgres-cnpg")).toHaveLength(2);
+    expect(screen.getByLabelText("Close")).toBeInTheDocument();
+  });
+
+  it("exposes each row as a button a keyboard user can activate", () => {
+    resetState();
+    depsState = {
+      data: someDependencies,
+      isPending: false,
+      isError: false,
+      refetch,
+    };
+
+    render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
+
+    const row = screen.getByRole("button", { name: /postgres-cnpg/ });
+    expect(row.tagName).toBe("BUTTON");
+    row.focus();
+    expect(row).toHaveFocus();
+    fireEvent.click(row);
+
     expect(screen.getByLabelText("Close")).toBeInTheDocument();
   });
 
@@ -206,7 +226,7 @@ describe("OverviewDependencies", () => {
 
     render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
 
-    fireEvent.click(screen.getByText("gym-api"));
+    fireEvent.click(screen.getByRole("button", { name: /gym-api/ }));
 
     expect(
       screen.getByText(`${PROVIDER_COMPONENT} · API contract`),
@@ -272,7 +292,7 @@ describe("OverviewDependencies", () => {
 
     render(<OverviewDependencies projectName={CURRENT_PROJECT} />);
 
-    fireEvent.click(screen.getByText("mystery-db"));
+    fireEvent.click(screen.getByRole("button", { name: /mystery-db/ }));
 
     expect(screen.queryByLabelText("Close")).not.toBeInTheDocument();
   });

--- a/apps/console/src/features/projects/components/OverviewDependencies.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.tsx
@@ -21,6 +21,7 @@ import {
   Alert,
   Box,
   Button,
+  ButtonBase,
   Chip,
   Skeleton,
   Stack,
@@ -123,17 +124,19 @@ export function OverviewDependencies({ projectName }: { projectName: string }) {
       ) : (
         <Stack spacing={0.5}>
           {rows.map((row) => (
-            <Box
+            <ButtonBase
               key={`${row.kind}-${row.ref ?? row.name}-${row.project ?? ""}-${row.component ?? ""}`}
               onClick={() => onRow(row)}
               sx={{
                 display: "flex",
                 alignItems: "center",
+                justifyContent: "flex-start",
                 gap: 1,
                 px: 1,
                 py: 0.75,
                 borderRadius: 1,
-                cursor: "pointer",
+                width: "100%",
+                textAlign: "left",
                 "&:hover": { bgcolor: "action.hover" },
               }}
             >
@@ -151,7 +154,7 @@ export function OverviewDependencies({ projectName }: { projectName: string }) {
                   {row.component ? ` / ${row.component}` : ""}
                 </Typography>
               )}
-            </Box>
+            </ButtonBase>
           ))}
         </Stack>
       )}

--- a/apps/console/src/features/projects/components/OverviewDependencies.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.tsx
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { SectionTitle } from "../../../components/SectionTitle";
+import { EmptyState } from "../../../components/EmptyState";
+import { ResourceDrawer } from "../../settings/components/ResourceDrawer";
+import {
+  useExternalResources,
+  usePlatformResourceTypes,
+} from "../../settings/api/queries";
+import { useWorkloadDependencies } from "../api/queries";
+import { ComponentOpenApiDialog } from "./ComponentOpenApiDialog";
+import type { components } from "../../../generated/aep-api";
+
+type WorkloadDependencyDTO = components["schemas"]["WorkloadDependencyDTO"];
+type PlatformResourceTypeDTO = components["schemas"]["PlatformResourceTypeDTO"];
+type ExternalResourceDTO = components["schemas"]["ExternalResourceDTO"];
+
+type ResourceSelection =
+  | { kind: "platform"; resource: PlatformResourceTypeDTO }
+  | { kind: "external"; resource: ExternalResourceDTO }
+  | { kind: null; resource: null };
+
+function rowLabel(row: WorkloadDependencyDTO): string {
+  if (row.kind === "org-service") {
+    return row.name ?? row.component ?? "org-service";
+  }
+  return row.name ?? row.ref ?? "resource";
+}
+
+function rowChipLabel(row: WorkloadDependencyDTO): string {
+  if (row.kind === "org-service") return "Org-service";
+  if (row.tag === "platform") return "Platform";
+  return "External";
+}
+
+export function OverviewDependencies({ projectName }: { projectName: string }) {
+  const deps = useWorkloadDependencies(projectName);
+  const platform = usePlatformResourceTypes();
+  const external = useExternalResources();
+  const [selection, setSelection] = useState<ResourceSelection>({
+    kind: null,
+    resource: null,
+  });
+  const [openapi, setOpenapi] = useState<{
+    project: string;
+    component: string;
+  } | null>(null);
+
+  const rows = deps.data ?? [];
+  const empty = useMemo(
+    () => !deps.isPending && !deps.isError && rows.length === 0,
+    [deps.isPending, deps.isError, rows.length],
+  );
+
+  const onRow = (row: WorkloadDependencyDTO) => {
+    if (row.kind === "org-service") {
+      if (row.project && row.component) {
+        setOpenapi({ project: row.project, component: row.component });
+      }
+      return;
+    }
+    const key = row.ref ?? row.name;
+    if (!key) return;
+    if (row.tag === "platform") {
+      const resource = platform.data?.find((r) => r.name === key);
+      if (resource) setSelection({ kind: "platform", resource });
+      return;
+    }
+    const resource = external.data?.find((r) => r.name === key);
+    if (resource) setSelection({ kind: "external", resource });
+  };
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <SectionTitle>Dependencies</SectionTitle>
+      {deps.isError ? (
+        <Alert
+          severity="error"
+          action={<Button onClick={() => void deps.refetch()}>Retry</Button>}
+        >
+          Failed to load workload dependencies
+          {deps.error instanceof Error ? `: ${deps.error.message}` : ""}
+        </Alert>
+      ) : deps.isPending ? (
+        <Skeleton
+          variant="rounded"
+          height={72}
+          aria-label="Loading dependencies"
+        />
+      ) : empty ? (
+        <EmptyState
+          compact
+          bordered
+          title="No deployed dependencies"
+          description="Rows appear after a component has deployed. Unresolved design declarations stay off this list."
+        />
+      ) : (
+        <Stack spacing={0.5}>
+          {rows.map((row) => (
+            <Box
+              key={`${row.kind}-${row.ref ?? row.name}-${row.project ?? ""}-${row.component ?? ""}`}
+              onClick={() => onRow(row)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                px: 1,
+                py: 0.75,
+                borderRadius: 1,
+                cursor: "pointer",
+                "&:hover": { bgcolor: "action.hover" },
+              }}
+            >
+              <Chip
+                size="small"
+                variant="outlined"
+                label={rowChipLabel(row)}
+              />
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {rowLabel(row)}
+              </Typography>
+              {row.kind === "org-service" && row.project && (
+                <Typography variant="caption" color="text.secondary">
+                  {row.project}
+                  {row.component ? ` / ${row.component}` : ""}
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Stack>
+      )}
+      <ResourceDrawer
+        {...selection}
+        open={selection.kind !== null}
+        onClose={() => setSelection({ kind: null, resource: null })}
+      />
+      <ComponentOpenApiDialog
+        projectName={openapi?.project ?? projectName}
+        componentName={openapi?.component ?? null}
+        onClose={() => setOpenapi(null)}
+      />
+    </Box>
+  );
+}

--- a/apps/console/src/features/projects/components/OverviewDependencies.tsx
+++ b/apps/console/src/features/projects/components/OverviewDependencies.tsx
@@ -89,12 +89,17 @@ export function OverviewDependencies({ projectName }: { projectName: string }) {
     const key = row.ref ?? row.name;
     if (!key) return;
     if (row.tag === "platform") {
-      const resource = platform.data?.find((r) => r.name === key);
-      if (resource) setSelection({ kind: "platform", resource });
+      const resource =
+        platform.data?.find((r) => r.name === key) ?? { name: key };
+      setSelection({ kind: "platform", resource });
       return;
     }
-    const resource = external.data?.find((r) => r.name === key);
-    if (resource) setSelection({ kind: "external", resource });
+    const resource = external.data?.find((r) => r.name === key) ?? {
+      name: key,
+      config: [],
+      consumers: [],
+    };
+    setSelection({ kind: "external", resource });
   };
 
   return (

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -38,6 +38,7 @@ import { projectChip } from "../lib/projectChip";
 import { RecentActivity } from "./RecentActivity";
 import { ComponentsList } from "./ComponentsList";
 import { OverviewPipeline } from "./OverviewPipeline";
+import { OverviewDependencies } from "./OverviewDependencies";
 
 function SectionError({
   what,
@@ -173,6 +174,7 @@ export function ProjectOverview({ projectName }: { projectName: string }) {
                 items={componentsQuery.data.items ?? []}
               />
             )}
+            <OverviewDependencies projectName={projectName} />
           </Grid>
         </Grid>
       </Stack>

--- a/apps/console/src/mocks/browser.ts
+++ b/apps/console/src/mocks/browser.ts
@@ -8,17 +8,21 @@ import { settingsHandlers } from "./handlers/settings";
 import { marketplaceHandlers } from "./handlers/marketplace";
 import { alertsHandlers } from "./handlers/alerts";
 import { usageHandlers } from "./handlers/usage";
+import { workloadDependenciesHandlers } from "./handlers/workload-dependencies";
+import { resourcesHandlers } from "./handlers/resources";
 
 // Order matters: project-scoped routes (/projects/:name/...) are more
 // specific than /projects/:name, so they register first.
 export const worker = setupWorker(
   ...agentChatHandlers,
   ...activityHandlers,
+  ...workloadDependenciesHandlers,
   ...projectHandlers,
   ...projectsHandlers,
   ...organizationsHandlers,
   ...settingsHandlers,
   ...marketplaceHandlers,
+  ...resourcesHandlers,
   ...alertsHandlers,
   ...usageHandlers,
 );

--- a/apps/console/src/mocks/fixtures/resources.ts
+++ b/apps/console/src/mocks/fixtures/resources.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../generated/aep-api";
+
+type PlatformResourceTypeDTO = components["schemas"]["PlatformResourceTypeDTO"];
+type ExternalResourceDTO = components["schemas"]["ExternalResourceDTO"];
+
+// Minimal catalog so a mock-mode resource click on Overview Dependencies
+// can resolve into Settings ResourceDrawer. Do not grow ExternalResourceDTO.
+export const seedPlatformResourceTypes: PlatformResourceTypeDTO[] = [
+  {
+    name: "postgres-cnpg",
+    description: "Managed Postgres via CloudNativePG",
+    consumers: [],
+  },
+];
+
+export const seedExternalResources: ExternalResourceDTO[] = [
+  {
+    name: "stripe",
+    description: "Stripe payments API",
+    config: [],
+    consumers: [],
+  },
+];

--- a/apps/console/src/mocks/fixtures/workload-dependencies.ts
+++ b/apps/console/src/mocks/fixtures/workload-dependencies.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../generated/aep-api";
+
+type WorkloadDependencyDTO = components["schemas"]["WorkloadDependencyDTO"];
+type ApiError = components["schemas"]["Error"];
+
+// Scenario switch (api-guidelines: mocks must produce empty AND error
+// states). Default empty is honest — nothing is deployed until it is.
+// Toggle in the browser devtools:
+//   localStorage.setItem('aep:mock:workload-dependencies',
+//     'empty' | 'some' | 'error')
+export type WorkloadDependenciesScenario = "empty" | "some" | "error";
+
+export const emptyWorkloadDependencies: WorkloadDependencyDTO[] = [];
+
+// A platform resource, an external resource, and a cross-project
+// org-service with provider coords (gym-tracker / gym-api).
+export const someWorkloadDependencies: WorkloadDependencyDTO[] = [
+  {
+    kind: "resource",
+    tag: "platform",
+    ref: "postgres-cnpg",
+    name: "postgres-cnpg",
+  },
+  {
+    kind: "resource",
+    tag: "external",
+    ref: "stripe",
+    name: "stripe",
+  },
+  {
+    kind: "org-service",
+    name: "gym-api",
+    project: "gym-tracker",
+    component: "gym-api",
+  },
+];
+
+export const workloadDependenciesError: ApiError = {
+  code: "internal_error",
+  message: "Mock error scenario for workload dependencies",
+};

--- a/apps/console/src/mocks/handlers/resources.ts
+++ b/apps/console/src/mocks/handlers/resources.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { http, HttpResponse } from "msw";
+import {
+  seedExternalResources,
+  seedPlatformResourceTypes,
+} from "../fixtures/resources";
+
+export const resourcesHandlers = [
+  http.get("*/api/v1/dependencies/platform-resource-types", () => {
+    return HttpResponse.json(seedPlatformResourceTypes);
+  }),
+  http.get("*/api/v1/dependencies/external-resources", () => {
+    return HttpResponse.json(seedExternalResources);
+  }),
+];

--- a/apps/console/src/mocks/handlers/workload-dependencies.ts
+++ b/apps/console/src/mocks/handlers/workload-dependencies.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { http, HttpResponse } from "msw";
+import {
+  emptyWorkloadDependencies,
+  someWorkloadDependencies,
+  workloadDependenciesError,
+  type WorkloadDependenciesScenario,
+} from "../fixtures/workload-dependencies";
+
+function scenario(): WorkloadDependenciesScenario {
+  return (
+    (localStorage.getItem(
+      "aep:mock:workload-dependencies",
+    ) as WorkloadDependenciesScenario | null) ?? "empty"
+  );
+}
+
+export const workloadDependenciesHandlers = [
+  http.get("*/api/v1/projects/:projectName/workload-dependencies", () => {
+    if (scenario() === "error") {
+      return HttpResponse.json(workloadDependenciesError, { status: 500 });
+    }
+    if (scenario() === "some") {
+      return HttpResponse.json(someWorkloadDependencies);
+    }
+    return HttpResponse.json(emptyWorkloadDependencies);
+  }),
+];

--- a/packages/contracts/api/v1/openapi.yaml
+++ b/packages/contracts/api/v1/openapi.yaml
@@ -1607,6 +1607,38 @@ paths:
       summary: List every component's dependencies with read-time computed status/reason
       tags:
       - Dependencies
+  /projects/{projectName}/workload-dependencies:
+    get:
+      operationId: list-workload-dependencies
+      parameters:
+      - description: Project name (DNS-label slug)
+        in: path
+        name: projectName
+        required: true
+        schema:
+          description: Project name (DNS-label slug)
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/WorkloadDependencyDTO'
+                type: array
+                nullable: true
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Error
+      security:
+      - userJWT: []
+      summary: list deployed-workload dependencies for the project Overview (deduped rows)
+      tags:
+      - Dependencies
   /projects/{projectName}/files:
     get:
       operationId: list-files
@@ -3361,6 +3393,33 @@ components:
       required:
       - componentName
       - dependencies
+      type: object
+    WorkloadDependencyDTO:
+      additionalProperties: false
+      properties:
+        kind:
+          enum:
+          - resource
+          - org-service
+          type: string
+        ref:
+          description: Resource type (resource rows)
+          type: string
+        tag:
+          enum:
+          - platform
+          - external
+          type: string
+        name:
+          type: string
+        project:
+          description: Provider project (org-service rows)
+          type: string
+        component:
+          description: Provider component (org-service rows)
+          type: string
+      required:
+      - kind
       type: object
     ComponentList:
       additionalProperties: false

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -1019,6 +1019,7 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 		ExtProv:   externalProvisioner,
 		PlatProv:  platformProvisioner,
 		Bindings:  resourceClient,
+		Workloads: resourceClient,
 		Projects:  provisionProjects{repos: repoRepo},
 		Access:    dependencies.NewAccessRequestRepository(db),
 		Providers: orgEndpointCatalog,

--- a/services/aep-api/internal/clients/openchoreo/mocks/resource_client_mock.go
+++ b/services/aep-api/internal/clients/openchoreo/mocks/resource_client_mock.go
@@ -53,6 +53,9 @@ var _ openchoreo.ResourceClient = &ResourceClientMock{}
 //			ListResourceTypesFunc: func(ctx context.Context, namespace string) ([]openchoreo.ResourceType, error) {
 //				panic("mock out the ListResourceTypes method")
 //			},
+//			ListWorkloadConsumerDepsFunc: func(ctx context.Context, orgHandle string, projectName string) ([]openchoreo.WorkloadConsumerDep, error) {
+//				panic("mock out the ListWorkloadConsumerDeps method")
+//			},
 //			ListWorkloadEndpointsFunc: func(ctx context.Context, orgHandle string) ([]openchoreo.WorkloadEndpointInfo, error) {
 //				panic("mock out the ListWorkloadEndpoints method")
 //			},
@@ -98,6 +101,9 @@ type ResourceClientMock struct {
 
 	// ListResourceTypesFunc mocks the ListResourceTypes method.
 	ListResourceTypesFunc func(ctx context.Context, namespace string) ([]openchoreo.ResourceType, error)
+
+	// ListWorkloadConsumerDepsFunc mocks the ListWorkloadConsumerDeps method.
+	ListWorkloadConsumerDepsFunc func(ctx context.Context, orgHandle string, projectName string) ([]openchoreo.WorkloadConsumerDep, error)
 
 	// ListWorkloadEndpointsFunc mocks the ListWorkloadEndpoints method.
 	ListWorkloadEndpointsFunc func(ctx context.Context, orgHandle string) ([]openchoreo.WorkloadEndpointInfo, error)
@@ -200,6 +206,15 @@ type ResourceClientMock struct {
 			// Namespace is the namespace argument value.
 			Namespace string
 		}
+		// ListWorkloadConsumerDeps holds details about calls to the ListWorkloadConsumerDeps method.
+		ListWorkloadConsumerDeps []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OrgHandle is the orgHandle argument value.
+			OrgHandle string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+		}
 		// ListWorkloadEndpoints holds details about calls to the ListWorkloadEndpoints method.
 		ListWorkloadEndpoints []struct {
 			// Ctx is the ctx argument value.
@@ -230,6 +245,7 @@ type ResourceClientMock struct {
 	lockGetResourceType                sync.RWMutex
 	lockListClusterResourceTypes       sync.RWMutex
 	lockListResourceTypes              sync.RWMutex
+	lockListWorkloadConsumerDeps       sync.RWMutex
 	lockListWorkloadEndpoints          sync.RWMutex
 	lockPatchBindingEnvironmentConfigs sync.RWMutex
 }
@@ -659,6 +675,46 @@ func (mock *ResourceClientMock) ListResourceTypesCalls() []struct {
 	mock.lockListResourceTypes.RLock()
 	calls = mock.calls.ListResourceTypes
 	mock.lockListResourceTypes.RUnlock()
+	return calls
+}
+
+// ListWorkloadConsumerDeps calls ListWorkloadConsumerDepsFunc.
+func (mock *ResourceClientMock) ListWorkloadConsumerDeps(ctx context.Context, orgHandle string, projectName string) ([]openchoreo.WorkloadConsumerDep, error) {
+	if mock.ListWorkloadConsumerDepsFunc == nil {
+		panic("ResourceClientMock.ListWorkloadConsumerDepsFunc: method is nil but ResourceClient.ListWorkloadConsumerDeps was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		OrgHandle   string
+		ProjectName string
+	}{
+		Ctx:         ctx,
+		OrgHandle:   orgHandle,
+		ProjectName: projectName,
+	}
+	mock.lockListWorkloadConsumerDeps.Lock()
+	mock.calls.ListWorkloadConsumerDeps = append(mock.calls.ListWorkloadConsumerDeps, callInfo)
+	mock.lockListWorkloadConsumerDeps.Unlock()
+	return mock.ListWorkloadConsumerDepsFunc(ctx, orgHandle, projectName)
+}
+
+// ListWorkloadConsumerDepsCalls gets all the calls that were made to ListWorkloadConsumerDeps.
+// Check the length with:
+//
+//	len(mockedResourceClient.ListWorkloadConsumerDepsCalls())
+func (mock *ResourceClientMock) ListWorkloadConsumerDepsCalls() []struct {
+	Ctx         context.Context
+	OrgHandle   string
+	ProjectName string
+} {
+	var calls []struct {
+		Ctx         context.Context
+		OrgHandle   string
+		ProjectName string
+	}
+	mock.lockListWorkloadConsumerDeps.RLock()
+	calls = mock.calls.ListWorkloadConsumerDeps
+	mock.lockListWorkloadConsumerDeps.RUnlock()
 	return calls
 }
 

--- a/services/aep-api/internal/clients/openchoreo/resource_client.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client.go
@@ -135,6 +135,14 @@ type ResourceClient interface {
 	// each row's namespace visibility. orgHandle is the org's namespace name
 	// (OC namespaces are 1:1 with orgs).
 	ListWorkloadEndpoints(ctx context.Context, orgHandle string) ([]WorkloadEndpointInfo, error)
+
+	// ListWorkloadConsumerDeps enumerates consumer-side dependency refs declared
+	// by Workloads owned by projectName in the org's namespace. It GETs the same
+	// /workloads collection as ListWorkloadEndpoints but parses
+	// spec.dependencies.resources[].ref and spec.dependencies.endpoints[] —
+	// generated WorkloadSpec.Dependencies currently has endpoints only.
+	// Workloads whose spec.owner.projectName does not match are omitted.
+	ListWorkloadConsumerDeps(ctx context.Context, orgHandle, projectName string) ([]WorkloadConsumerDep, error)
 }
 
 // WorkloadEndpointInfo is one provider-side endpoint discovered by enumerating
@@ -157,6 +165,24 @@ type WorkloadEndpointInfo struct {
 	// or a directly-authored Workload CR). Empty for app-factory BYO-image workloads.
 	SchemaType    string // e.g. "openapi", "proto", "graphql" (endpoint.Schema.Type)
 	SchemaContent string // the inlined spec document (endpoint.Schema.Content)
+}
+
+// WorkloadConsumerDep is one Workload's consumer-side dependency refs —
+// resources[].ref (OC Resource instance names) and endpoints[] (provider
+// project/component + visibility). OwnerProject is spec.owner.projectName.
+type WorkloadConsumerDep struct {
+	OwnerProject   string
+	OwnerComponent string
+	ResourceRefs   []string
+	Endpoints      []WorkloadConsumerEndpoint
+}
+
+// WorkloadConsumerEndpoint is one spec.dependencies.endpoints[] entry.
+type WorkloadConsumerEndpoint struct {
+	Project    string // provider project; empty means same project as the consumer
+	Component  string
+	Name       string
+	Visibility string // project | namespace
 }
 
 // NamespaceVisible reports whether this endpoint is consumable cross-project
@@ -742,6 +768,73 @@ func (c *resourceClient) ListWorkloadEndpoints(ctx context.Context, orgHandle st
 		}
 	}
 	return infos, nil
+}
+
+// workloadConsumerList is a separate decode shape from workloadList so
+// ListWorkloadEndpoints keeps parsing only provider-side spec.endpoints.
+type workloadConsumerList struct {
+	Items []workloadConsumerItem `json:"items"`
+}
+
+type workloadConsumerItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Owner struct {
+			ProjectName   string `json:"projectName"`
+			ComponentName string `json:"componentName"`
+		} `json:"owner"`
+		Dependencies struct {
+			Resources []struct {
+				Ref string `json:"ref"`
+			} `json:"resources"`
+			Endpoints []struct {
+				Project    string `json:"project"`
+				Component  string `json:"component"`
+				Name       string `json:"name"`
+				Visibility string `json:"visibility"`
+			} `json:"endpoints"`
+		} `json:"dependencies"`
+	} `json:"spec"`
+}
+
+func (c *resourceClient) ListWorkloadConsumerDeps(ctx context.Context, orgHandle, projectName string) ([]WorkloadConsumerDep, error) {
+	out := &workloadConsumerList{}
+	if _, err := c.do(ctx, http.MethodGet, nsBase(orgHandle)+"/workloads", nil, out); err != nil {
+		return nil, fmt.Errorf("list workloads in %q: %w", orgHandle, err)
+	}
+	deps := make([]WorkloadConsumerDep, 0)
+	for _, w := range out.Items {
+		if w.Spec.Owner.ProjectName != projectName {
+			continue
+		}
+		refs := make([]string, 0, len(w.Spec.Dependencies.Resources))
+		for _, r := range w.Spec.Dependencies.Resources {
+			if r.Ref != "" {
+				refs = append(refs, r.Ref)
+			}
+		}
+		eps := make([]WorkloadConsumerEndpoint, 0, len(w.Spec.Dependencies.Endpoints))
+		for _, ep := range w.Spec.Dependencies.Endpoints {
+			if ep.Component == "" {
+				continue
+			}
+			eps = append(eps, WorkloadConsumerEndpoint{
+				Project:    ep.Project,
+				Component:  ep.Component,
+				Name:       ep.Name,
+				Visibility: ep.Visibility,
+			})
+		}
+		deps = append(deps, WorkloadConsumerDep{
+			OwnerProject:   w.Spec.Owner.ProjectName,
+			OwnerComponent: w.Spec.Owner.ComponentName,
+			ResourceRefs:   refs,
+			Endpoints:      eps,
+		})
+	}
+	return deps, nil
 }
 
 // WaitForReleaseChange polls GetResource until status.latestRelease.Name is

--- a/services/aep-api/internal/clients/openchoreo/resource_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client_test.go
@@ -759,6 +759,106 @@ func TestListWorkloadEndpoints_EmptyList(t *testing.T) {
 	}
 }
 
+func TestListWorkloadConsumerDeps_FiltersProjectAndParsesRefs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/namespaces/wc-abc/workloads" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		fmt.Fprint(w, `{
+			"items": [
+				{
+					"metadata": {"name": "shop-orders"},
+					"spec": {
+						"owner": {"projectName": "shop", "componentName": "orders"},
+						"endpoints": {"http": {"type": "HTTP", "port": 8080}},
+						"dependencies": {
+							"resources": [{"ref": "shop-pg"}, {"ref": "shop-stripe"}],
+							"endpoints": [
+								{"project": "inventory", "component": "inventory-api", "name": "http", "visibility": "namespace"},
+								{"component": "web", "name": "http", "visibility": "project"}
+							]
+						}
+					}
+				},
+				{
+					"metadata": {"name": "other-api"},
+					"spec": {
+						"owner": {"projectName": "other", "componentName": "api"},
+						"dependencies": {"resources": [{"ref": "other-pg"}]}
+					}
+				}
+			]
+		}`)
+	}))
+	defer srv.Close()
+
+	c := newTestResourceClient(t, srv)
+	got, err := c.ListWorkloadConsumerDeps(context.Background(), "wc-abc", "shop")
+	if err != nil {
+		t.Fatalf("ListWorkloadConsumerDeps: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 shop workload, got %+v", got)
+	}
+	w := got[0]
+	if w.OwnerProject != "shop" || w.OwnerComponent != "orders" {
+		t.Errorf("owner = %s/%s", w.OwnerProject, w.OwnerComponent)
+	}
+	if len(w.ResourceRefs) != 2 || w.ResourceRefs[0] != "shop-pg" || w.ResourceRefs[1] != "shop-stripe" {
+		t.Errorf("resource refs = %v", w.ResourceRefs)
+	}
+	if len(w.Endpoints) != 2 {
+		t.Fatalf("endpoints = %+v", w.Endpoints)
+	}
+	if w.Endpoints[0].Project != "inventory" || w.Endpoints[0].Component != "inventory-api" || w.Endpoints[0].Visibility != "namespace" {
+		t.Errorf("cross-project endpoint = %+v", w.Endpoints[0])
+	}
+	if w.Endpoints[1].Project != "" || w.Endpoints[1].Component != "web" || w.Endpoints[1].Visibility != "project" {
+		t.Errorf("same-project endpoint = %+v", w.Endpoints[1])
+	}
+}
+
+func TestListWorkloadConsumerDeps_EmptyList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	c := newTestResourceClient(t, srv)
+	got, err := c.ListWorkloadConsumerDeps(context.Background(), "wc-abc", "shop")
+	if err != nil {
+		t.Fatalf("ListWorkloadConsumerDeps: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("expected empty slice, got %+v", got)
+	}
+}
+
+func TestListWorkloadEndpoints_IgnoresConsumerDependencies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+			"items": [{
+				"metadata": {"name": "shop-orders"},
+				"spec": {
+					"owner": {"projectName": "shop", "componentName": "orders"},
+					"endpoints": {"http": {"type": "HTTP", "port": 8080, "visibility": ["namespace"]}},
+					"dependencies": {"resources": [{"ref": "shop-pg"}]}
+				}
+			}]
+		}`)
+	}))
+	defer srv.Close()
+
+	c := newTestResourceClient(t, srv)
+	got, err := c.ListWorkloadEndpoints(context.Background(), "wc-abc")
+	if err != nil {
+		t.Fatalf("ListWorkloadEndpoints: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "http" || got[0].Project != "shop" {
+		t.Fatalf("provider endpoints changed when consumer deps present: %+v", got)
+	}
+}
+
 // ---- constructor -------------------------------------------------------------------
 
 func TestNewResourceClient_PanicsWithoutBaseURL(t *testing.T) {

--- a/services/aep-api/internal/dependencies/README.md
+++ b/services/aep-api/internal/dependencies/README.md
@@ -43,7 +43,7 @@ three services are sub-package slices that import only that root.
 
 | Slice | Ops / role | Reaches |
 |---|---|---|
-| `provisioning` | 8 HTTP ops: list/delete/collect-values external resources, project readiness, provision-platform, dependency-status, request/list org-service access + the `provision` gate lifecycle, watcher, teardown | root cores; delivery (provision execution rows); sourcecontrol (gate issues) |
+| `provisioning` | 9 HTTP ops: list/delete/collect-values external resources, list-workload-dependencies, project readiness, provision-platform, dependency-status, request/list org-service access + the `provision` gate lifecycle, watcher, teardown | root cores; delivery (provision execution rows); sourcecontrol (gate issues); `WorkloadDepSource` (deployed Workload consumer refs) |
 | `mcpdiscovery` | the MCP discovery server + `ListPlatformResourceTypes` and `ListOrgEndpoints` HTTP reads | root `ResourceTypeLister` / endpoint catalog |
 | `runtimeconfig` | the SPA `env-config.js` convergence service + its watcher (no HTTP op) | root naming/markers; spec (design at HEAD); repositories (execution enumerate) |
 
@@ -57,11 +57,12 @@ slices.
 |---|---|---|
 | SecretWriter | needs | `platform/secrets` — SM-API vault writes for external-resource secret values |
 | OC `Resource`/`ResourceReleaseBinding` CRUD · `ClusterResourceType` discovery | needs | `openchoreo` client — OC is the store |
+| WorkloadDepSource | needs | `openchoreo` client — deployed Workload consumer refs (resource + endpoint) for Overview `list-workload-dependencies`; GetResource 404s are dangling and omitted |
 | ExecutionStore (admit/finish) | needs | `delivery` — a gate's provisioning run is the last remaining execution row, and this is its write surface |
 | IssueClient (provision gate · endpoint-wiring comment) | needs | `sourcecontrol` — gate issues closed via a no-secrets reference, and the ADR-0004 endpoint comment + its `aep:wired` completeness marker on the working set |
 | ProviderResolver (endpoint targets) | needs | root `Catalog` — any-visibility provider lookup for an access request, namespace/project-visible resolves for the wiring block |
 | DesignReader / DesignBundleReader | needs | `spec` — design at HEAD (what to provision) + provider design bundles |
-| the 10 public ops (provisioning 8 + mcpdiscovery `ListPlatformResourceTypes` and `ListOrgEndpoints`) | offers | the edge (`dependenciesHandlers`) |
+| the 11 public ops (provisioning 9 + mcpdiscovery `ListPlatformResourceTypes` and `ListOrgEndpoints`) | offers | the edge (`dependenciesHandlers`) |
 
 ## Owns
 - `ExternalResource` (an in-memory definition, NOT a DB row — see Persistence), `AccessRequest`, the

--- a/services/aep-api/internal/dependencies/provisioning/handlers.go
+++ b/services/aep-api/internal/dependencies/provisioning/handlers.go
@@ -48,11 +48,16 @@ func errProvisioningUnavailable() error {
 	return apierr.ServiceUnavailable("provisioning is not configured")
 }
 
-func (h *Handler) ListWorkloadDependencies(ctx context.Context, _ gen.ListWorkloadDependenciesRequestObject) (gen.ListWorkloadDependenciesResponseObject, error) {
+func (h *Handler) ListWorkloadDependencies(ctx context.Context, request gen.ListWorkloadDependenciesRequestObject) (gen.ListWorkloadDependenciesResponseObject, error) {
 	if h.svc == nil {
 		return nil, errProvisioningUnavailable()
 	}
-	return nil, errProvisioningUnavailable()
+	org := tenant.BoundOrgFromContext(ctx)
+	views, err := h.svc.ListWorkloadDependencies(ctx, org, request.ProjectName)
+	if err != nil {
+		return nil, mapProvisionError(err)
+	}
+	return gen.ListWorkloadDependencies200JSONResponse(toWorkloadDependencyDTOs(views)), nil
 }
 
 func (h *Handler) ListExternalResources(ctx context.Context, _ gen.ListExternalResourcesRequestObject) (gen.ListExternalResourcesResponseObject, error) {
@@ -251,6 +256,21 @@ func toExternalResourceDTOs(views []ExternalResourceView) []gen.ExternalResource
 			Description: v.Description,
 			Config:      keys,
 			Consumers:   consumers,
+		})
+	}
+	return out
+}
+
+func toWorkloadDependencyDTOs(views []WorkloadDependencyView) []gen.WorkloadDependencyDTO {
+	out := make([]gen.WorkloadDependencyDTO, 0, len(views))
+	for _, v := range views {
+		out = append(out, gen.WorkloadDependencyDTO{
+			Kind:      gen.WorkloadDependencyDTOKind(v.Kind),
+			Ref:       v.Ref,
+			Tag:       gen.WorkloadDependencyDTOTag(v.Tag),
+			Name:      v.Name,
+			Project:   v.Project,
+			Component: v.Component,
 		})
 	}
 	return out

--- a/services/aep-api/internal/dependencies/provisioning/handlers.go
+++ b/services/aep-api/internal/dependencies/provisioning/handlers.go
@@ -48,6 +48,13 @@ func errProvisioningUnavailable() error {
 	return apierr.ServiceUnavailable("provisioning is not configured")
 }
 
+func (h *Handler) ListWorkloadDependencies(ctx context.Context, _ gen.ListWorkloadDependenciesRequestObject) (gen.ListWorkloadDependenciesResponseObject, error) {
+	if h.svc == nil {
+		return nil, errProvisioningUnavailable()
+	}
+	return nil, errProvisioningUnavailable()
+}
+
 func (h *Handler) ListExternalResources(ctx context.Context, _ gen.ListExternalResourcesRequestObject) (gen.ListExternalResourcesResponseObject, error) {
 	org := tenant.BoundOrgFromContext(ctx)
 	if h.svc == nil {

--- a/services/aep-api/internal/dependencies/provisioning/ports.go
+++ b/services/aep-api/internal/dependencies/provisioning/ports.go
@@ -136,6 +136,17 @@ type BindingReader interface {
 	GetBinding(ctx context.Context, namespace, name string) (*openchoreo.ResourceReleaseBinding, error)
 }
 
+// WorkloadDepSource is the deployed-Workload consumer-dependency reader the
+// Overview list uses. openchoreo.ResourceClient satisfies it (the same client
+// Bindings and the external-resource catalog already share — not a second
+// HTTP stack). List is org-scoped then filtered to projectName; GetResource
+// 404s are dangling refs the service omits.
+type WorkloadDepSource interface {
+	ListWorkloadConsumerDeps(ctx context.Context, orgHandle, projectName string) ([]openchoreo.WorkloadConsumerDep, error)
+	GetResource(ctx context.Context, namespace, name string) (*openchoreo.Resource, error)
+	GetResourceType(ctx context.Context, namespace, name string) (*openchoreo.ResourceType, error)
+}
+
 // ProviderResolver resolves a dependency's provider endpoint in OpenChoreo. It
 // has two readers with different visibility rules, so all three resolves live on
 // one port (*dependencies.Catalog satisfies all of them):

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
@@ -101,11 +101,18 @@ type cWorkloads struct {
 	listErr   error
 }
 
-func (f *cWorkloads) ListWorkloadConsumerDeps(_ context.Context, _, _ string) ([]openchoreo.WorkloadConsumerDep, error) {
+func (f *cWorkloads) ListWorkloadConsumerDeps(_ context.Context, _, projectName string) ([]openchoreo.WorkloadConsumerDep, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	return f.deps, nil
+	// Mirror ResourceClient: org-scoped list, keep spec.owner.projectName == path.
+	out := make([]openchoreo.WorkloadConsumerDep, 0)
+	for _, d := range f.deps {
+		if d.OwnerProject == projectName {
+			out = append(out, d)
+		}
+	}
+	return out, nil
 }
 
 func (f *cWorkloads) GetResource(_ context.Context, _, name string) (*openchoreo.Resource, error) {
@@ -160,6 +167,21 @@ func stripeConsumerDesign() []spec.DesignComponent {
 			{Kind: spec.DependencyKindExternal, Name: "stripe", Config: []spec.ConfigKey{
 				{Key: "api_key", Secret: true}, {Key: "region"},
 			}},
+		},
+	}}
+}
+
+// designWithUnconsumedGhost is design.json with a unique unresolved name that
+// no deployed Workload carries. Used to pin that workload-dependencies does
+// not consult DesignReader.
+func designWithUnconsumedGhost() []spec.DesignComponent {
+	return []spec.DesignComponent{{
+		Name: "orders",
+		Dependencies: []spec.Dependency{
+			{Kind: spec.DependencyKindExternal, Name: "stripe", Config: []spec.ConfigKey{
+				{Key: "api_key", Secret: true}, {Key: "region"},
+			}},
+			{Kind: spec.DependencyKindExternal, Name: "ghost"},
 		},
 	}}
 }
@@ -401,7 +423,12 @@ func TestProvisioningComponent_ListWorkloadDependencies_NoClaims401(t *testing.T
 
 func TestProvisioningComponent_ListWorkloadDependencies_Empty200(t *testing.T) {
 	t.Parallel()
-	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+	// Org has deployed workloads, but none owned by path project "shop".
+	// A nil Workloads port short-circuits without listing; this fake must
+	// list-and-filter so other projects' rows cannot leak.
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{
+		Workloads: otherProjectWorkloadSource(),
+	}))
 
 	resp := h.AsOrg("acme").Get(workloadDepsPath)
 	if resp.Code != 200 {
@@ -414,7 +441,14 @@ func TestProvisioningComponent_ListWorkloadDependencies_Empty200(t *testing.T) {
 
 func TestProvisioningComponent_ListWorkloadDependencies_UnknownProject200Empty(t *testing.T) {
 	t.Parallel()
-	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+	// Shop workloads exist in the org. GET a name that was never created must
+	// still be 200 []: listing is org-scoped then filtered by path projectName
+	// (sibling policy to components when OC does not 404). Wiring the shop
+	// source pins that the path name is passed through — an unfiltered fake
+	// would return shop rows.
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{
+		Workloads: shopWorkloadSource(),
+	}))
 
 	// Listing org workloads filtered by owner.projectName naturally yields []
 	// when the project has no deployed workloads — including a name that was
@@ -427,6 +461,29 @@ func TestProvisioningComponent_ListWorkloadDependencies_UnknownProject200Empty(t
 	}
 	if body := strings.TrimSpace(resp.Body.String()); body != "[]" {
 		t.Fatalf("unknown project must serialize as [], got %s", body)
+	}
+}
+
+// otherProjectWorkloadSource is deployed Workloads owned by "other", not "shop".
+// GET /projects/shop must list-and-filter to [] — if the fake ignored
+// projectName these rows would leak (platform postgres + org-service).
+func otherProjectWorkloadSource() *cWorkloads {
+	return &cWorkloads{
+		deps: []openchoreo.WorkloadConsumerDep{
+			{
+				OwnerProject:   "other",
+				OwnerComponent: "api",
+				ResourceRefs:   []string{"other-pg"},
+				Endpoints: []openchoreo.WorkloadConsumerEndpoint{
+					{Project: "inventory", Component: "inventory-api", Name: "http", Visibility: "namespace"},
+				},
+			},
+		},
+		resources: map[string]*openchoreo.Resource{
+			"other-pg": {Spec: openchoreo.ResourceSpec{
+				Type: openchoreo.ResourceTypeRef{Kind: "ClusterResourceType", Name: "postgres-cnpg"},
+			}},
+		},
 	}
 }
 
@@ -472,9 +529,11 @@ func TestProvisioningComponent_ListWorkloadDependencies_ResourceAndOrgServiceRow
 	t.Parallel()
 	svc := provisioning.NewService(provisioning.Deps{
 		Workloads: shopWorkloadSource(),
-		// Design declares an extra unresolved dep that no Workload consumes —
-		// it must not appear (source is deployed Workloads, not design.json).
-		Design: cDesign{comps: stripeConsumerDesign()},
+		// Design declares an extra unresolved name ("ghost") that no Workload
+		// consumes — it must not appear (source is deployed Workloads, not
+		// design.json). "stripe" is already a Workload consumer, so it cannot
+		// pin DesignReader absence: a duplicate would collapse under dedup.
+		Design: cDesign{comps: designWithUnconsumedGhost()},
 	})
 	h := newProvHarness(t, svc)
 

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
@@ -424,7 +424,7 @@ func TestProvisioningComponent_ListWorkloadDependencies_NoClaims401(t *testing.T
 func TestProvisioningComponent_ListWorkloadDependencies_Empty200(t *testing.T) {
 	t.Parallel()
 	// Org has deployed workloads, but none owned by path project "shop".
-	// A nil Workloads port short-circuits without listing; this fake must
+	// A nil Workloads port is a lister failure, not 200 []; this fake must
 	// list-and-filter so other projects' rows cannot leak.
 	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{
 		Workloads: otherProjectWorkloadSource(),
@@ -616,5 +616,61 @@ func TestProvisioningComponent_ListWorkloadDependencies_ListerFailure500(t *test
 	e := componenttest.DecodeEnvelope(t, resp.Body.String())
 	if e.Code != "internal_error" {
 		t.Fatalf("500 envelope = %+v, want code internal_error", e)
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_NilWorkloadsPort500(t *testing.T) {
+	t.Parallel()
+	// Non-nil service, unwired Workloads port: not "nothing deployed" (200 []).
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+
+	resp := h.AsOrg("acme").Get(workloadDepsPath)
+	if resp.Code != 500 {
+		t.Fatalf("nil Workloads port: want 500, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	e := componenttest.DecodeEnvelope(t, resp.Body.String())
+	if e.Code != "internal_error" {
+		t.Fatalf("500 envelope = %+v, want code internal_error", e)
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_ExternalFallsBackToTypeName(t *testing.T) {
+	t.Parallel()
+	svc := provisioning.NewService(provisioning.Deps{
+		Workloads: &cWorkloads{
+			deps: []openchoreo.WorkloadConsumerDep{
+				{
+					OwnerProject:   "shop",
+					OwnerComponent: "orders",
+					ResourceRefs:   []string{"shop-custom", "shop-gone"},
+				},
+			},
+			resources: map[string]*openchoreo.Resource{
+				"shop-custom": {Spec: openchoreo.ResourceSpec{
+					Type: openchoreo.ResourceTypeRef{Kind: "ResourceType", Name: "custom-rt"},
+				}},
+			},
+			types: map[string]*openchoreo.ResourceType{
+				"custom-rt": {Metadata: openchoreo.OCObjectMeta{Name: "custom-rt"}},
+			},
+		},
+	})
+	h := newProvHarness(t, svc)
+
+	resp := h.AsOrg("acme").Get(workloadDepsPath)
+	if resp.Code != 200 {
+		t.Fatalf("list: got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var got []gen.WorkloadDependencyDTO
+	if err := json.Unmarshal(resp.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v\n%s", err, resp.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("rows = %+v, want 1 live ResourceType (dangling GetResource 404 omitted)", got)
+	}
+	row := got[0]
+	if row.Kind != gen.Resource || row.Tag != gen.External || row.Ref != "custom-rt" || row.Name != "custom-rt" {
+		t.Fatalf("external without annotation = %+v, want ref/name custom-rt (spec.type.Name)", row)
 	}
 }

--- a/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/provisioning_component_test.go
@@ -32,6 +32,7 @@ package provisioning_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -89,6 +90,36 @@ type cBindings struct {
 
 func (f *cBindings) GetBinding(_ context.Context, _, name string) (*openchoreo.ResourceReleaseBinding, error) {
 	return f.byName[name], nil
+}
+
+// cWorkloads fakes provisioning.WorkloadDepSource — deployed Workload consumer
+// refs plus GetResource / GetResourceType, in place of live OC.
+type cWorkloads struct {
+	deps      []openchoreo.WorkloadConsumerDep
+	resources map[string]*openchoreo.Resource
+	types     map[string]*openchoreo.ResourceType
+	listErr   error
+}
+
+func (f *cWorkloads) ListWorkloadConsumerDeps(_ context.Context, _, _ string) ([]openchoreo.WorkloadConsumerDep, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.deps, nil
+}
+
+func (f *cWorkloads) GetResource(_ context.Context, _, name string) (*openchoreo.Resource, error) {
+	if r, ok := f.resources[name]; ok {
+		return r, nil
+	}
+	return nil, openchoreo.ErrNotFound
+}
+
+func (f *cWorkloads) GetResourceType(_ context.Context, _, name string) (*openchoreo.ResourceType, error) {
+	if rt, ok := f.types[name]; ok {
+		return rt, nil
+	}
+	return nil, openchoreo.ErrNotFound
 }
 
 type cIssues struct{}
@@ -157,6 +188,11 @@ func TestProvisioningComponent_Unconfigured503(t *testing.T) {
 	e := componenttest.DecodeEnvelope(t, resp.Body.String())
 	if e.Code != "service_unavailable" || e.Message != "provisioning is not configured" {
 		t.Fatalf("503 envelope = %+v", e)
+	}
+
+	resp = h.AsOrg("acme").Get("/api/v1/projects/shop/workload-dependencies")
+	if resp.Code != 503 {
+		t.Fatalf("workload-dependencies nil svc: want 503, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }
 
@@ -349,5 +385,177 @@ func TestProvisioningComponent_AccessRequests(t *testing.T) {
 	}
 	if body := strings.TrimSpace(resp.Body.String()); body != "[]" {
 		t.Fatalf("empty list must serialize as [], got %s", body)
+	}
+}
+
+const workloadDepsPath = "/api/v1/projects/shop/workload-dependencies"
+
+func TestProvisioningComponent_ListWorkloadDependencies_NoClaims401(t *testing.T) {
+	t.Parallel()
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+
+	if resp := h.NoAuth().Get(workloadDepsPath); resp.Code != 401 {
+		t.Fatalf("claimless: want the gate's ENFORCE 401, got %d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_Empty200(t *testing.T) {
+	t.Parallel()
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+
+	resp := h.AsOrg("acme").Get(workloadDepsPath)
+	if resp.Code != 200 {
+		t.Fatalf("no deployed workloads: want 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	if body := strings.TrimSpace(resp.Body.String()); body != "[]" {
+		t.Fatalf("empty list must serialize as [], got %s", body)
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_UnknownProject200Empty(t *testing.T) {
+	t.Parallel()
+	h := newProvHarness(t, provisioning.NewService(provisioning.Deps{}))
+
+	// Listing org workloads filtered by owner.projectName naturally yields []
+	// when the project has no deployed workloads — including a name that was
+	// never created. GET /projects/{name} 404s because it is a point-get;
+	// ListComponents 404s only when OC's project-scoped list 404s. This list
+	// is org-scoped, so unknown project is 200 [].
+	resp := h.AsOrg("acme").Get("/api/v1/projects/does-not-exist-xyz/workload-dependencies")
+	if resp.Code != 200 {
+		t.Fatalf("unknown project: want 200 [], got %d body=%s", resp.Code, resp.Body.String())
+	}
+	if body := strings.TrimSpace(resp.Body.String()); body != "[]" {
+		t.Fatalf("unknown project must serialize as [], got %s", body)
+	}
+}
+
+func shopWorkloadSource() *cWorkloads {
+	return &cWorkloads{
+		deps: []openchoreo.WorkloadConsumerDep{
+			{
+				OwnerProject:   "shop",
+				OwnerComponent: "orders",
+				ResourceRefs:   []string{"shop-pg", "shop-stripe", "shop-gone"},
+				Endpoints: []openchoreo.WorkloadConsumerEndpoint{
+					{Project: "inventory", Component: "inventory-api", Name: "http", Visibility: "namespace"},
+					{Project: "shop", Component: "web", Name: "http", Visibility: "project"},
+				},
+			},
+			{
+				OwnerProject:   "shop",
+				OwnerComponent: "billing",
+				ResourceRefs:   []string{"shop-pg"},
+				Endpoints: []openchoreo.WorkloadConsumerEndpoint{
+					{Project: "inventory", Component: "inventory-api", Name: "grpc", Visibility: "namespace"},
+				},
+			},
+		},
+		resources: map[string]*openchoreo.Resource{
+			"shop-pg": {Spec: openchoreo.ResourceSpec{
+				Type: openchoreo.ResourceTypeRef{Kind: "ClusterResourceType", Name: "postgres-cnpg"},
+			}},
+			"shop-stripe": {Spec: openchoreo.ResourceSpec{
+				Type: openchoreo.ResourceTypeRef{Kind: "ResourceType", Name: "stripe-rt"},
+			}},
+		},
+		types: map[string]*openchoreo.ResourceType{
+			"stripe-rt": {Metadata: openchoreo.OCObjectMeta{
+				Name:        "stripe-rt",
+				Annotations: map[string]string{"aep.wso2.com/external-name": "stripe"},
+			}},
+		},
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_ResourceAndOrgServiceRows(t *testing.T) {
+	t.Parallel()
+	svc := provisioning.NewService(provisioning.Deps{
+		Workloads: shopWorkloadSource(),
+		// Design declares an extra unresolved dep that no Workload consumes —
+		// it must not appear (source is deployed Workloads, not design.json).
+		Design: cDesign{comps: stripeConsumerDesign()},
+	})
+	h := newProvHarness(t, svc)
+
+	resp := h.AsOrg("acme").Get(workloadDepsPath)
+	if resp.Code != 200 {
+		t.Fatalf("list: got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var got []gen.WorkloadDependencyDTO
+	if err := json.Unmarshal(resp.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v\n%s", err, resp.Body.String())
+	}
+
+	// Not the design-dependencies wrapper (componentName + dependencies[]).
+	var wrapper []map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &wrapper); err != nil {
+		t.Fatalf("body objects: %v", err)
+	}
+	for _, item := range wrapper {
+		if _, ok := item["componentName"]; ok {
+			t.Fatalf("payload must not be design-dependencies shape, got %s", resp.Body.String())
+		}
+		if _, ok := item["dependencies"]; ok {
+			t.Fatalf("payload must not wrap dependencies[], got %s", resp.Body.String())
+		}
+		if _, ok := item["kind"]; !ok {
+			t.Fatalf("items must have kind, got %s", resp.Body.String())
+		}
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("rows = %+v, want 3 (platform + external + org-service, deduped; dangling omitted)", got)
+	}
+
+	var platform, external, orgSvc *gen.WorkloadDependencyDTO
+	for i := range got {
+		row := &got[i]
+		switch {
+		case row.Kind == gen.Resource && row.Tag == gen.Platform:
+			platform = row
+		case row.Kind == gen.Resource && row.Tag == gen.External:
+			external = row
+		case row.Kind == gen.OrgService:
+			orgSvc = row
+		}
+	}
+	if platform == nil || platform.Ref != "postgres-cnpg" || platform.Name != "postgres-cnpg" {
+		t.Fatalf("platform resource row = %+v, want ref/name postgres-cnpg", platform)
+	}
+	if external == nil || external.Ref != "stripe" || external.Name != "stripe" {
+		t.Fatalf("external resource row = %+v, want ref/name stripe (logical catalog name)", external)
+	}
+	if orgSvc == nil || orgSvc.Project != "inventory" || orgSvc.Component != "inventory-api" {
+		t.Fatalf("org-service row = %+v, want provider inventory/inventory-api", orgSvc)
+	}
+	if orgSvc.Name == "" {
+		t.Fatalf("org-service row must carry a name, got %+v", orgSvc)
+	}
+	for _, row := range got {
+		if row.Kind == gen.OrgService && row.Project == "shop" {
+			t.Fatalf("same-project visibility:project endpoint must be omitted, got %+v", row)
+		}
+		if row.Name == "ghost" || row.Ref == "ghost" || row.Name == "orders" && row.Kind != gen.OrgService {
+			t.Fatalf("design-only dep must not appear: %+v", row)
+		}
+	}
+}
+
+func TestProvisioningComponent_ListWorkloadDependencies_ListerFailure500(t *testing.T) {
+	t.Parallel()
+	svc := provisioning.NewService(provisioning.Deps{
+		Workloads: &cWorkloads{listErr: errors.New("oc workloads down")},
+	})
+	h := newProvHarness(t, svc)
+
+	resp := h.AsOrg("acme").Get(workloadDepsPath)
+	if resp.Code != 500 {
+		t.Fatalf("lister failure: want 500, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	e := componenttest.DecodeEnvelope(t, resp.Body.String())
+	if e.Code != "internal_error" {
+		t.Fatalf("500 envelope = %+v, want code internal_error", e)
 	}
 }

--- a/services/aep-api/internal/dependencies/provisioning/service.go
+++ b/services/aep-api/internal/dependencies/provisioning/service.go
@@ -47,6 +47,7 @@ type Service struct {
 	extProv   ExternalProvisioner
 	platProv  PlatformProvisioner
 	bindings  BindingReader
+	workloads WorkloadDepSource
 	projects  ProjectLister
 	access    AccessStore
 	providers ProviderResolver
@@ -90,6 +91,7 @@ type Deps struct {
 	ExtProv   ExternalProvisioner
 	PlatProv  PlatformProvisioner
 	Bindings  BindingReader
+	Workloads WorkloadDepSource
 	Projects  ProjectLister
 	Access    AccessStore
 	Providers ProviderResolver
@@ -106,6 +108,7 @@ func NewService(d Deps) *Service {
 		extProv:   d.ExtProv,
 		platProv:  d.PlatProv,
 		bindings:  d.Bindings,
+		workloads: d.Workloads,
 		projects:  d.Projects,
 		access:    d.Access,
 		providers: d.Providers,

--- a/services/aep-api/internal/dependencies/provisioning/workload_deps.go
+++ b/services/aep-api/internal/dependencies/provisioning/workload_deps.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package provisioning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+)
+
+const (
+	kindClusterResourceType = "ClusterResourceType"
+	kindResourceType        = "ResourceType"
+	visibilityNamespace     = "namespace"
+	annotationExternalName  = "aep.wso2.com/external-name"
+
+	depKindResource   = "resource"
+	depKindOrgService = "org-service"
+	depTagPlatform    = "platform"
+	depTagExternal    = "external"
+)
+
+// WorkloadDependencyView is one deduped Overview row sourced from deployed
+// Workload consumer refs (not design.json).
+type WorkloadDependencyView struct {
+	Kind      string
+	Ref       string
+	Tag       string
+	Name      string
+	Project   string
+	Component string
+}
+
+// ListWorkloadDependencies returns the project's deployed-workload dependencies
+// as deduped Overview rows. A nil Workloads port (unwired) is an empty list —
+// no deployed consumer refs. Dangling GetResource 404s are omitted. Lister
+// transport failures propagate so the handler can map them to the default 500.
+func (s *Service) ListWorkloadDependencies(ctx context.Context, orgID, projectName string) ([]WorkloadDependencyView, error) {
+	if s.workloads == nil {
+		return []WorkloadDependencyView{}, nil
+	}
+	consumers, err := s.workloads.ListWorkloadConsumerDeps(ctx, orgID, projectName)
+	if err != nil {
+		return nil, fmt.Errorf("provisioning: list workload consumer deps: %w", err)
+	}
+
+	seenResource := map[string]struct{}{}
+	seenOrgService := map[string]struct{}{}
+	out := make([]WorkloadDependencyView, 0)
+
+	for _, wl := range consumers {
+		for _, ref := range wl.ResourceRefs {
+			row, ok, err := s.resolveResourceRow(ctx, orgID, ref)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+			key := row.Tag + "\x00" + row.Ref
+			if _, dup := seenResource[key]; dup {
+				continue
+			}
+			seenResource[key] = struct{}{}
+			out = append(out, row)
+		}
+		for _, ep := range wl.Endpoints {
+			row, ok := orgServiceRow(projectName, ep)
+			if !ok {
+				continue
+			}
+			key := row.Project + "\x00" + row.Component
+			if _, dup := seenOrgService[key]; dup {
+				continue
+			}
+			seenOrgService[key] = struct{}{}
+			out = append(out, row)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Ref != out[j].Ref {
+			return out[i].Ref < out[j].Ref
+		}
+		if out[i].Project != out[j].Project {
+			return out[i].Project < out[j].Project
+		}
+		return out[i].Component < out[j].Component
+	})
+	return out, nil
+}
+
+func (s *Service) resolveResourceRow(ctx context.Context, orgID, instanceName string) (WorkloadDependencyView, bool, error) {
+	if instanceName == "" {
+		return WorkloadDependencyView{}, false, nil
+	}
+	res, err := s.workloads.GetResource(ctx, orgID, instanceName)
+	if err != nil {
+		if errors.Is(err, openchoreo.ErrNotFound) {
+			return WorkloadDependencyView{}, false, nil
+		}
+		return WorkloadDependencyView{}, false, fmt.Errorf("provisioning: get resource %q: %w", instanceName, err)
+	}
+	if res == nil {
+		return WorkloadDependencyView{}, false, nil
+	}
+
+	typeKind := res.Spec.Type.Kind
+	if typeKind == "" {
+		typeKind = kindResourceType
+	}
+	typeName := res.Spec.Type.Name
+	if typeName == "" {
+		return WorkloadDependencyView{}, false, nil
+	}
+
+	switch typeKind {
+	case kindClusterResourceType:
+		return WorkloadDependencyView{
+			Kind: depKindResource,
+			Tag:  depTagPlatform,
+			Ref:  typeName,
+			Name: typeName,
+		}, true, nil
+	case kindResourceType:
+		rt, err := s.workloads.GetResourceType(ctx, orgID, typeName)
+		if err != nil {
+			if errors.Is(err, openchoreo.ErrNotFound) {
+				return WorkloadDependencyView{}, false, nil
+			}
+			return WorkloadDependencyView{}, false, fmt.Errorf("provisioning: get resource type %q: %w", typeName, err)
+		}
+		if rt == nil {
+			return WorkloadDependencyView{}, false, nil
+		}
+		logical := ""
+		if rt.Metadata.Annotations != nil {
+			logical = rt.Metadata.Annotations[annotationExternalName]
+		}
+		if logical == "" {
+			return WorkloadDependencyView{}, false, nil
+		}
+		return WorkloadDependencyView{
+			Kind: depKindResource,
+			Tag:  depTagExternal,
+			Ref:  logical,
+			Name: logical,
+		}, true, nil
+	default:
+		return WorkloadDependencyView{}, false, nil
+	}
+}
+
+func orgServiceRow(consumerProject string, ep openchoreo.WorkloadConsumerEndpoint) (WorkloadDependencyView, bool) {
+	if ep.Visibility != visibilityNamespace || ep.Component == "" {
+		return WorkloadDependencyView{}, false
+	}
+	providerProject := ep.Project
+	if providerProject == "" || providerProject == consumerProject {
+		return WorkloadDependencyView{}, false
+	}
+	return WorkloadDependencyView{
+		Kind:      depKindOrgService,
+		Name:      ep.Component,
+		Project:   providerProject,
+		Component: ep.Component,
+	}, true
+}

--- a/services/aep-api/internal/dependencies/provisioning/workload_deps.go
+++ b/services/aep-api/internal/dependencies/provisioning/workload_deps.go
@@ -49,12 +49,13 @@ type WorkloadDependencyView struct {
 }
 
 // ListWorkloadDependencies returns the project's deployed-workload dependencies
-// as deduped Overview rows. A nil Workloads port (unwired) is an empty list —
-// no deployed consumer refs. Dangling GetResource 404s are omitted. Lister
-// transport failures propagate so the handler can map them to the default 500.
+// as deduped Overview rows. A nil Workloads port on a non-nil service is a
+// lister failure (the handler maps it to the default 500). Dangling GetResource
+// 404s are omitted. Lister transport failures propagate so the handler can map
+// them to the default 500. A nil handler service stays 503.
 func (s *Service) ListWorkloadDependencies(ctx context.Context, orgID, projectName string) ([]WorkloadDependencyView, error) {
 	if s.workloads == nil {
-		return []WorkloadDependencyView{}, nil
+		return nil, fmt.Errorf("provisioning: list workload consumer deps: workloads port is nil")
 	}
 	consumers, err := s.workloads.ListWorkloadConsumerDeps(ctx, orgID, projectName)
 	if err != nil {
@@ -158,7 +159,7 @@ func (s *Service) resolveResourceRow(ctx context.Context, orgID, instanceName st
 			logical = rt.Metadata.Annotations[annotationExternalName]
 		}
 		if logical == "" {
-			return WorkloadDependencyView{}, false, nil
+			logical = typeName
 		}
 		return WorkloadDependencyView{
 			Kind: depKindResource,

--- a/services/aep-api/internal/edge/method_origin_test.go
+++ b/services/aep-api/internal/edge/method_origin_test.go
@@ -122,6 +122,7 @@ var opOwner = map[string]string{
 	"ListSkillUpdates":              embedSpec,
 	"ListSkills":                    embedSpec,
 	"ListTasks":                     embedDelivery,
+	"ListWorkloadDependencies":      embedDependencies,
 	"PromoteTaskFromIssue":          embedDelivery,
 	"ProvisionPlatformResource":     embedDependencies,
 	"PutProjectReferences":          embedSpec,

--- a/services/aep-api/internal/gen/models_gen.go
+++ b/services/aep-api/internal/gen/models_gen.go
@@ -607,6 +607,42 @@ func (e TurnConflictCode) Valid() bool {
 	}
 }
 
+// Defines values for WorkloadDependencyDTOKind.
+const (
+	OrgService WorkloadDependencyDTOKind = "org-service"
+	Resource   WorkloadDependencyDTOKind = "resource"
+)
+
+// Valid indicates whether the value is a known member of the WorkloadDependencyDTOKind enum.
+func (e WorkloadDependencyDTOKind) Valid() bool {
+	switch e {
+	case OrgService:
+		return true
+	case Resource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WorkloadDependencyDTOTag.
+const (
+	External WorkloadDependencyDTOTag = "external"
+	Platform WorkloadDependencyDTOTag = "platform"
+)
+
+// Valid indicates whether the value is a known member of the WorkloadDependencyDTOTag enum.
+func (e WorkloadDependencyDTOTag) Valid() bool {
+	switch e {
+	case External:
+		return true
+	case Platform:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListTasksParamsState.
 const (
 	All    ListTasksParamsState = "all"
@@ -2116,6 +2152,27 @@ type WorkflowRunTask struct {
 	Phase       string `json:"phase,omitempty"`
 	StartedAt   string `json:"startedAt,omitempty"`
 }
+
+// WorkloadDependencyDTO defines model for WorkloadDependencyDTO.
+type WorkloadDependencyDTO struct {
+	// Component Provider component (org-service rows)
+	Component string                    `json:"component,omitempty"`
+	Kind      WorkloadDependencyDTOKind `json:"kind"`
+	Name      string                    `json:"name,omitempty"`
+
+	// Project Provider project (org-service rows)
+	Project string `json:"project,omitempty"`
+
+	// Ref Resource type (resource rows)
+	Ref string                   `json:"ref,omitempty"`
+	Tag WorkloadDependencyDTOTag `json:"tag,omitempty"`
+}
+
+// WorkloadDependencyDTOKind defines model for WorkloadDependencyDTO.Kind.
+type WorkloadDependencyDTOKind string
+
+// WorkloadDependencyDTOTag defines model for WorkloadDependencyDTO.Tag.
+type WorkloadDependencyDTOTag string
 
 // WriteOp defines model for WriteOp.
 type WriteOp struct {

--- a/services/aep-api/internal/gen/server_gen.go
+++ b/services/aep-api/internal/gen/server_gen.go
@@ -218,6 +218,9 @@ type ServerInterface interface {
 	// Attach to a turn's event stream (SSE replay + live tail)
 	// (GET /projects/{projectName}/turns/{turnId}/stream)
 	StreamTurn(w http.ResponseWriter, r *http.Request, projectName string, turnID string, params StreamTurnParams)
+	// list deployed-workload dependencies for the project Overview (deduped rows)
+	// (GET /projects/{projectName}/workload-dependencies)
+	ListWorkloadDependencies(w http.ResponseWriter, r *http.Request, projectName string)
 	// List RCA-agent alert reports across the caller's org, newest first
 	// (GET /rca-agent/reports)
 	ListRcaAgentReports(w http.ResponseWriter, r *http.Request, params ListRcaAgentReportsParams)
@@ -2875,6 +2878,38 @@ func (siw *ServerInterfaceWrapper) StreamTurn(w http.ResponseWriter, r *http.Req
 	handler.ServeHTTP(w, r)
 }
 
+// ListWorkloadDependencies operation middleware
+func (siw *ServerInterfaceWrapper) ListWorkloadDependencies(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "projectName" -------------
+	var projectName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "projectName", r.PathValue("projectName"), &projectName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projectName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, UserJWTScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListWorkloadDependencies(w, r, projectName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRcaAgentReports operation middleware
 func (siw *ServerInterfaceWrapper) ListRcaAgentReports(w http.ResponseWriter, r *http.Request) {
 
@@ -3411,6 +3446,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/active", wrapper.GetActiveTurn)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/{turnId}", wrapper.GetTurn)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/turns/{turnId}/stream", wrapper.StreamTurn)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/projects/{projectName}/workload-dependencies", wrapper.ListWorkloadDependencies)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/rca-agent/reports", wrapper.ListRcaAgentReports)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/rca-agent/reports", wrapper.CreateRcaAgentReport)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/rca-agent/reports/{reportId}", wrapper.GetRcaAgentReport)
@@ -6165,6 +6201,45 @@ func (response StreamTurndefaultJSONResponse) VisitStreamTurnResponse(w http.Res
 	return err
 }
 
+type ListWorkloadDependenciesRequestObject struct {
+	ProjectName string `json:"projectName"`
+}
+
+type ListWorkloadDependenciesResponseObject interface {
+	VisitListWorkloadDependenciesResponse(w http.ResponseWriter) error
+}
+
+type ListWorkloadDependencies200JSONResponse []WorkloadDependencyDTO
+
+func (response ListWorkloadDependencies200JSONResponse) VisitListWorkloadDependenciesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListWorkloadDependenciesdefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response ListWorkloadDependenciesdefaultJSONResponse) VisitListWorkloadDependenciesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response.Body); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListRcaAgentReportsRequestObject struct {
 	Params ListRcaAgentReportsParams
 }
@@ -6864,6 +6939,9 @@ type StrictServerInterface interface {
 	// Attach to a turn's event stream (SSE replay + live tail)
 	// (GET /projects/{projectName}/turns/{turnId}/stream)
 	StreamTurn(ctx context.Context, request StreamTurnRequestObject) (StreamTurnResponseObject, error)
+	// list deployed-workload dependencies for the project Overview (deduped rows)
+	// (GET /projects/{projectName}/workload-dependencies)
+	ListWorkloadDependencies(ctx context.Context, request ListWorkloadDependenciesRequestObject) (ListWorkloadDependenciesResponseObject, error)
 	// List RCA-agent alert reports across the caller's org, newest first
 	// (GET /rca-agent/reports)
 	ListRcaAgentReports(ctx context.Context, request ListRcaAgentReportsRequestObject) (ListRcaAgentReportsResponseObject, error)
@@ -8734,6 +8812,32 @@ func (sh *strictHandler) StreamTurn(w http.ResponseWriter, r *http.Request, proj
 	}
 }
 
+// ListWorkloadDependencies operation middleware
+func (sh *strictHandler) ListWorkloadDependencies(w http.ResponseWriter, r *http.Request, projectName string) {
+	var request ListWorkloadDependenciesRequestObject
+
+	request.ProjectName = projectName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListWorkloadDependencies(ctx, request.(ListWorkloadDependenciesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListWorkloadDependencies")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListWorkloadDependenciesResponseObject); ok {
+		if err := validResponse.VisitListWorkloadDependenciesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListRcaAgentReports operation middleware
 func (sh *strictHandler) ListRcaAgentReports(w http.ResponseWriter, r *http.Request, params ListRcaAgentReportsParams) {
 	var request ListRcaAgentReportsRequestObject
@@ -9428,179 +9532,182 @@ var swaggerSpec = []string{
 	"FJr74cMFWVZup/kBR16f3WuIyZF5DedjoPgzATVoxebyQeQDjN2pp9rKdzWI6zsMa00lqD9faW19W/ut",
 	"JBImWm9oG5X/yI3ntzub9PP2O2XTfVNSlZvNRxLeIs9H3V7r0LW5mxR6cVWpnYdPd0v7zRd55XkX1GQn",
 	"BiXZ1s43YFQ+zePruL3bnrUnSwPpQ9vw+E3r+wTAiDjOXQe884WEHTxCITeU3fUUKunYrY2yVSeBdIcg",
-	"bCCNNmDS1gl7Dn1R7lq8gVuxQatxXdkkOx5obOintkoVVmSVkW557ckBB+UVyv/48QbGJ7gR5mVgof7X",
-	"dT8O6gxC5QNQRf/jxxvWu7r+6g//3mf/8eP314N7YSACd3+Poj3g0EPLNTueOVfuvXsH18pEw9wwpnnv",
-	"6PSSffPyJTu6PEuAdw73vhw+Hz6nmGrFS7l3uPf74fPh7/cSAfoAbd8HocCM/41sSDES20uxe4TzJo7h",
-	"/SOIZMG6KnwunPCy3V/WbOTwribNCTyhZ/5OLkU2QHejNlN0NtLfxKMI0gSKtPipC57DUiDp7v3vAfhn",
-	"QarFU9pin3//vtdoZ7WPb2CLUKR60TAfBPsH4sKCJTWk9XRN6ohweUJSRtfEntrp6mx+8kfBllpZJOqv",
-	"nj9P4PHhmJZlITMYD1QiAZCfOKpNLBMXP5BMYh8E+l0xpX2PaVuQwffBRnAKAaQt3YUH9cEGwo1H+i8/",
-	"+ZWJsUpxWwSkTqzRVA8d3AOnB/gvIByA8PlLkwYxqfUAi+10HrNvhUMla++jbo/vgXCN/dA+vW35VrgA",
-	"N84VHZpnGLw0pf3BlWY9lFyEhbB+2weRH0oX2XSvLsyU0cr/hPcHxvo3tydVgynARdho+v6QmwP9v2te",
-	"WF7gePeZLjbRBazbtpRRCjOIgKnc6bnMOkmiPrsHU+kGwc3pf1MicwMrrA05paW2LUcbsN6+le6SPiXY",
-	"t49ERu1Qer8yQXXA2316ZAUTYUdlCSo2SymAEQWw3oW/Kwa5kfdC7UxHubTUUDcFncR3EjJ6TAiLg44h",
-	"zwoBJfusjvIkLMQEy3KiEbHOMCMGPNeY8dGjHbLMk84+hGyWBWjcJL6DbPPXSoAPlkSbSlH7K2INbTbq",
-	"Ub/qqFcU68SEM7B3shxoCg8blBriYWl6H1dqqrf3kz4r9TRgk6bS1UEhvYzbjOdiP7p4tJlucVRkXh6E",
-	"RBq4u7sPyRUElJ7l5TG8jzUMP6o0lfTzSW8crhzsytnJZUR9NcHBRgUfe1i4F5AvMrG/5e4Bf7sXGP/f",
-	"Kvqe0BtnefkYT7s4OznG5GcDFYecJlwOUoewpzpOaaLNlqwKG92gfj2t619T+Qrr+OkzEcIiSZYcXLWO",
-	"59zxTXSX4u0ciAcnjOflRlhdGfLgtJLgK2ndKb1+Fd9+z73aEkGz2evJzcUWxsZPbVf9+iZVotZ2JtQF",
-	"S/b2JNnK7XaX4lnx6BYCbVorrAZ+X13zx7hOeJ/F4VIVJmAkZEskPkJPmqJ2N1fpbPpxxvF1C/aU9sfB",
-	"EQzPv+4Zh12A4LYuQkAoAtb7+vmfmJwwCak1+zuQhzbTgVA5iHGbz/2FmZ7GF3+NI590+Bs+7a+5uRMO",
-	"ChezuL6sB6hyJc/EIMBs+Z0KISdHl2d2l12OtXYC/YAov3m/L+mbcPpv4ItfY+Pbev6N8/u4QREHB4vh",
-	"42HHcPa6mCZBC2RFZR26QLrpIDXzPHrAkzc/ogCWdgTeyU904/TKgiXiVvI7bkNIJtl85MJLj4n3Jf9r",
-	"JVjJp1KRxa4ydmsZPr7cKcN3t/+oz+eYWzGQygpFWCK2GuPbGBfridePA6Li8iSmd7uxW8FNNtvk13p6",
-	"/4/O7TV/kPNqTskOTE8Y8DOs/4ZpkJTPR4SLdhmMeN3WGFTIOfijuib43oNYC1/5mMoWkfSnfMzL+lSG",
-	"Ex4PKrhCWs0sENEj6MWP5QpJ+7jCDrYzYX/5oTe4bbVxePm/9A7jGOvMuvZNTjn4wS9JoNAWWlRNAht5",
-	"Or2GvKl3cn49QDA7W1TT/XYdKg1Y2l6Veqyj/xs0qs273e90Pf/29vL5r8EIPgFf+ZMZwAEAQUi33CjZ",
-	"HYWXPlXKaZOFIPXYNSSPIHL84XmfzfkD++r5c0jo+kCCzw49bhG1u4ZcJpZWOJJ1D0MP1KVfCUg70kUe",
-	"8psgh0NngCuSHznWu3p5/Pvf//5P+y8g4QzTzTDPBNPNtlkGfH/DOqwMM+mfsuyhWCUMm1kh1HCb7Ww0",
-	"ypwUYyP43eEKqs5Ky6y3Os393Wa5EqH2a7KrcCJfCi+hfJqSaQo+ENhQoNdeWu2sTxs7IJUOQymfxucO",
-	"MEW/k91hvYLfHsO7vj4F5Ku5iEcvHgksWCJzOhX1kfybzPeH7EpQzqT/2hL2PCYqtoY6vuLWDQBNdnB2",
-	"8p4nBGAKgCYG9cbtdkSozMY60folwUYDg2ihx4kQ+SHjikklnQQTPqyGnjAjMs9KAsV6zmrdAHEVyca1",
-	"kEaE8rrNUipMKqZNLsx+H8ugEIKQ47JgHGozhJa5EZRWKfIhu1CC5dzxQ4R2acwSajXAbvaZzFPm+jeZ",
-	"+42M4Ux8EvIacVQAP0IFYYb/4rE6sGO8a7NYj3bod/WC7vsVvb4+3Z1rQK7kQQNWa6OkdNx487Og3Slo",
-	"pwv1KZtXVjDaMC0aAcB6WgkmanRcvow5uAHLDV/ts4L/lyyWoSSw5x7IRvzTF6wsKsOLAYBe13XUARCq",
-	"gfjGJpWrTMOB9q1QR2cb7DwYFJJuxm+IaL/8mESLxUHWqehmBkBPdrayyUMGa03IRrQkg4XMa0ioXMy1",
-	"q7EArdOeJUM9/dCW33xE35qL+ViY4ScQV8nhMmsSKtEwYk4FWKgeLoBtPSJz8CxyWlutWsn8cVb+SzNx",
-	"+t0B5VLZR2L2P/3zsSYSvjwdZDNthWruTVXJvH2caznn2w51c08f+vZZTfL65AL1xGyZG7TrwoXSWLRe",
-	"IFiInd2F16Ox+KYyn2n416HhD+8yaYKhepKKsJAH4ICH0DlAZKC6QIe/1BB3NIQbijpIRqEzJ6KG9e5d",
-	"f9fh1CCYW/lvvvqgC7I5EvKIgOP8kf/6A8qxncf9ClC9RJ4idgqCFa+UrUoEuYewiL6/0GQhAActoLvN",
-	"EdiFqwQFTpv053bIN4BxG7Lzi5vvzs6/9VKGjQWkNAHm2ICz019RS+eg4QNcZY3YbkVBlQzqgnOQ45ob",
-	"L5rg2Ie4sn/6oHsaQaDbdjTOJWDzEXQLiRW1eNXfGrV5KRwschOUuXHSt4BmJsGt1waBvP9piGo1fvAB",
-	"KjNgpgaks7//t19oy3KBGJ8vCJMJ4KdrzCCs4bqbcAZlNbqD/r/xj38T3qsPfyXA2uzkPX/+ofvG1j9B",
-	"SevGyOkU8L6CCoKEuKuZCL46KI2YFHI6c5tUCSLl8OZnC1EHVdVL9OmR1bGelxWl2mDBoBjOuhzkhi+E",
-	"YWVCAk8gtlRdXbc/hLK0VEfQc24dCr+Bjdi34RDeLbzr+LTPml4XgG0FjPEAB4mIuWQtp5frKp0I5Mod",
-	"3LALbe4Izu/kmwHA4fWUpkw+SNOmAND9WhQh7G8vi1AhXrCk52IOiLcqB6hNwM6dAdo0dCkRnHKIpcMy",
-	"XQWjeZ5CZ2ME2Yu2onGIBxyh76CSAqDesEDjgFtLwsZMFzlAL3VGQH6DO/T5bHec7d9AOB0bhz1+yuE9",
-	"+MXx6bsDLBh38Av89yzf6mjjKwg96j+DlCkzFWktPaf77OT06uyH0xOk6otSqOOZNkInKPmE9A64u8IM",
-	"4soRy8Kj7k9yQCz1fVJIt+cApnIzgqIObWW6XPoDCBzPLlU2MxqKjsazRWd+pZDv+cUNm+gi9/xCOY0n",
-	"EIYx8BJnAjMbWMkKx8i4iqwhmwleFsHWDoj/3A/NEjYtDCCU2Ws2A0wHUFgRvxNruSL8b2RsocTy9XdH",
-	"Q3ZET0M5VmCDAtE6I6yzn047wzj2H3/i7GLd1bxyrbDe6B4xeM6p9Mh+P1SRzhHNtb5DKC7YzYyuprNQ",
-	"6hLqeA7bZ+n4dIfZrQ5uq6Bw2GKZ9xkPBYSgDudVpeDRD1IshjIPTl8Yr+B5x3jptO8w5tD/rw3zE4nz",
-	"U3fQEdPkKywz1C1NuPhVpXbh4LEa0uZwkqC/hspJnw/6xoMOrJtqhywTPHLpCmEZn3KprCNJ8tdiCh81",
-	"VKVBH53xKhfnpyyJWbFO0sKgQxAvIj2hP9uEcbgOaZ59JhWDC1oXegrVgPwnEJNCKNVhRaieFUodhJV9",
-	"L5pY6TbWmquLWWN1CYhHQYEcR+7v9EE4Oc9sHwtEczYylRoFsHWtUP1QfB6Uj1AnAidal3mNNY+/Pzs/",
-	"Yb1RLu5H7G9s5EV4+EdSzX0/KV2Fls05N3ehRmRTLRiyEZRHRYatcvEwSosoESvBqsNasR/Pbr47O2dn",
-	"N9fs6s05LOGoZyo19BdH3cb+KFTaCCO4E8tgpMWpgcyC5wMvGvQBgxwDdQohCGgEUUAjqvAEIVxetcP4",
-	"xh5n60QFAAZGzjGGzjc88mTuTymsdYDWHcn8kFHBMPFXOsov2OiQ3QlRDrjXtkZQZQlspyXP/O3kpSAu",
-	"He06ESkoS0yXUOTHq2xH5/+JdKZWiurXnEGGYgMK6hDBocfSB2yUayVGNNuomY4Q7fuQKf3Wf/nWE1Kf",
-	"Foj95eTi/PSnUZBUMbkoK7QVASMY+6wrkksLEilHGRjDNzCwo1atAXZdSTsTeZ+NRcYrqK2P6DQ1wYFN",
-	"2aulfs5erx0LxnMowxzlBTC1x+mvaqh+7YhecElh0J7c/TEqQCfxkq+dec6plUjivPDUyVzMS+3ZVB1/",
-	"gkb/qrTCOBsqV0P0F2aWYTgYlnMdE285y39nxV8/keiwmrBAuYFzhQDYsRQk1WuI7LK/HiW2ozhgRAq0",
-	"GWzZq9Va7hrDw8JGXGWCZUY6YSTHK64fbzrY/KV1Yh6NELkoC70U+ZCdUemEOjYCjte9oMrhbScMyfz0",
-	"/Ob06prdfHfKXl1cXLKjG/bD0auzEyjP1uTuLkJT+/NmBVJSLDvs+RWalIAb2wUxVDBKS62gFtOPeBmV",
-	"QM+1P+lemFxmLjBFP/hC6/KZ9VcRVPthYzHj91JX/l4CjxQxr/qYHWGhbjs6RE7xZT+RxEsNq1NzE7re",
-	"JlwWlRFUo0hR3U4smkkSI81wyH4MtQmJ8vueGWF1gFGcAjaE7MRWyI6pQjdtLSDRqXpmVFccyXMiH0So",
-	"oYg8IJwTUsnxZPqNr6sLJfwo0F6OhEMFsKKdjrhuKoPphbKrVEKToTWqKdqTKu5sqOfW5N/4cAi1VzFl",
-	"MxjnAs0CUw915eMYekkFzBmH4usT/29PYJ7LhcUl5jnTlbGML/gSfKJ8Wdf8E/v+p1hzo+7COlkUIAfh",
-	"ReS3uYe1rnTJFmCvgB+xBAYaP+uifrT6GP/cp5rocWGkVvtD9vVXX9U9hz0hR2PLCfdi8aSyIm8cM79e",
-	"sOojeyfLMiUtKg3ijzXUPoQRYAHHdcvCVdy0b8id8Vnh+DQVjg/vLqxpI/EZfswIjbrDOhKjLWgikZko",
-	"ROFfWtAI6MeMx7s4bigQzHtIEZXayr0Ta3YC38BSpNYZLqezpJBPwOag0uhQWgsJnuJIN7pvUo3RKxXg",
-	"MoLRhrQFtWRSZQBOzSIkYyyu2pRt91s9TLF0OV6DmOoAES2h3hFqpdGR1Oow2uAZitZZW1I1VsKTNNwJ",
-	"VFcS6ksEEu41OUaQ9aikBXuy18NeYNl4igyxwnNZ12grYBO1W3/RfV6pzyah36hJ6H0jK6pPOjWCt+oe",
-	"EEJE0qs0pHruxCzrgT+SihNf++yJbUMDp58+ZRLL0j2ucfnjj1vS0cEvjcI77zbnAtCbvx2mHae0y1ib",
-	"pYp2cGY92tk/5RR8ssAPWUKPH+4ErIcidIgv9vMx+A0cg9WCW5/6dbAentM4El0ZMhQP+huzmnxydP3l",
-	"x6DrTxXiq45RXqHuj8HvD36B/+JPhZ7aR0OZX/mXPh+VX+eorJcoA8t0QuW7jDtu9Q5j3r7DR8d+hQBF",
-	"EGgnlDNS2OiBPnp5c3qFxidR6mw2mMuikDYA/Pzj7/+NWA9jnt1RLo64l7qqI3afWTZS4sEdwxejITuC",
-	"+F+KZYjWsbGYSsgdGrLX2EWzAjzUK9eTiRUuenkpO9kPZF5Zx2xl7iXVLJlxlQ/A+Ua17sH+VOocgT3I",
-	"Kpbx0lVG5MwqXtqZBneDMCJ0CDHMTFo2F9wPrhDWsnHlxT0n5wJL2qJXAyxjlmXaGJG5YhmNH6vIo1Jl",
-	"m2CZTteXeSsYqo8fLOwZzKcpnKPfqEAO+QF5NdbdsFtpqbGY2WcO/ZvRVWlPP81DUUsxWSDN+mjUBfoq",
-	"112e7zNp/9NI+8M7JNOai/+MInaf/qnCFdzqYD3tvmkUY/glF2WA1MuEtQMiig0lu/CFCzO9xgIQ25YX",
-	"VraaQ6rcr3SCt+5xi6NMLWWNY/ahj3BXJ4+OL63GUecm0nwptz2UP6S2O1aaqGGHYT+x71/TbIAE2kiq",
-	"/vQMBzR8hscUfa0Q8TgI5N2+E5sLcnww7hFLhXQzjsvwympJld/inQ/BhZgbrEuB9fcAScKJBxexfj6K",
-	"BLBd14/O5XK1TM/q8f5QHGSbjn4l6SWSaBBdPmYo1TWUun5tp4/h3Pzr1m8Oy8U4KzftYo/bpcr2fyVe",
-	"hDXEN+nTsfclbsJnDvSvyIFOPg6/OXmUu6yN5FTdS6MV5I4EkPdDlot7UehyvkM9HVE3tMl6t013v2qV",
-	"0tXz8qm612ue9MyyKLNAFgRMjPU0wI9ZNuf2DmPaoPrdx+BdhV7OH417Okne+2wb+fTNfvV+/jZc83mD",
-	"Pj+gWdzfHLyUW5nFL+jdzwfkN2QX95t6dHnWfUQ+JErhNr3epFlcGCbuGFfs6PJsIB5KbTGbDjRwzPsc",
-	"63xJEBO2/vRmWYqImeyX9v9j79qb2six/VdRcbcqpsZtk+zMbi35y0nIDnUTkgIyt24tc8tyt2xrkaUe",
-	"SY3xJPnut3TOUXfbbj+AQDCbvzB2P/Q4Ojov/X4ZIYvAAdXOLlWpPXOMBgzOEtxCA8zZ8PMxSLeBxagW",
-	"1XlK4cffH4LWdiEm9jTJbDkcKalPAp3QdY7ZSnBubtdtR2reveKqwDlcAeFslBLpEon9b3jbk9nMlvnS",
-	"W5Udvn+fvOxN73mgUNIZv6KJXB1LOniYWNKjx1eEVVCnlp/303AZIWBgGXGS/u4r1wqeSb0O8KeiWaxc",
-	"4NPyru+3Qr9NxOImEYrvQCrTNORNodLRyIoR96JJfFB40LJ69IZVtBTKHaXWD8wCFyibzNZk8DaLwMmR",
-	"nlsLG2IQ4fq55/+nnsHayrgqbd+5IXuiRhbBVdU8grpc4XHgIK6JlxP0nwovMoq3dRHr51ZSXBIhrJTb",
-	"t1I9JTvqg1aIPslCcxwrNJJ/AkK+GMpr1hKdUQc8MRcX+baRaXzCOh7+2779uyzBMPXvhedPddXByX1E",
-	"qOGe/XrUe1NbQyj3mxdPN/Rmtto/6YWfd3sR3ZN1DyPznWD66d0uCOeDxMbghZHCozn3o0XJaYJCOTFX",
-	"ImM5R7wradmAO3E25nNIU9Ak8cgZKnveTGTKlZpBe2eMswGiWAwZgPcEZaeEF461HFT3A5aeBPSsCZd6",
-	"/zYrc1DoTImVuCFHiHImeBYUG5LOoELuozLut3HnpbEEeMgPJ0cVBDrAXnAfvrzQ2OAOO/qjkFdcIcMh",
-	"4jbjdA6NUmaKQF0ct3N4J0AUam9nbSauU5EjtN6FrtjgsCMItEE4EdwzzuaHKkgFYCXlhRszxRHXYyKz",
-	"JLzrQhNg0kwKlQHIxDWAVk8N81YIVwFoIVpzsC8A3NkKxpWKB0Q4IDpf6HAPFqeFeRX2mSvFM7ciNToD",
-	"DEg4wBJMm7GwwWMCCK5TRM+0go0AnCvCaSt5KaqBOcSDMPWdEvdFRMf0Y3Gh4WK4jIfBRfA/QPjTqSqA",
-	"HbanZ7hShHICSIHGAnocxtMg7mAbgTQudPCfg2zDYEYxAIBPM3VsOoZhxw6zKdfeIS4ZeE6ZSGUm6CoJ",
-	"8FwXesyvBPS5j5PYRxAVJT0ggzoxAvcSu8ehszjIoXF+LOxUAoqit1wqqUcXeipVlnKLOHcp1xG7fMwz",
-	"M40gWGFcDknKQLrhwVxN+cxFcLwg2xe6j2PaR3TO+sLpl+H58Jh0XK0SogNqgtniWVier3DlPS2rkUTq",
-	"RqZbhx1BVoLuJWhFQncbkwYB6QEITNf5ppbmQ7V4m1QcKfOoMlucjcV1hLYNvSrfjOfRIPVjuU7HzMu8",
-	"w87C3OF7XaUjnoXPQ2Cjrj2KljNi0mGoS1znQWSl0dsOcdgX1+b7HlWPHjK0VFvhu0glybMIcNqw9fO4",
-	"NnCfo731NtbH57DqVuOmRFX5dJTkqchNYoVCKGw0bcKu04p7F4tb1yHAk7mca2IEVCLuhK7NZEd0wObi",
-	"UjOnuBsLB5z70WhwqcmxrKhuD3DmJsFOaTQJwnZOlHRqFmG0tLAJL/wYiDpqEGWIjwoQr8J5161+6uJP",
-	"nSC7KzC16L9tR33VoIExh70zNiiDqjMiq/WRRnhNO/dvoaDDAEFbeucd9oGwmSstRos7qWmzC33smbiW",
-	"zrsK+1kzbr0c8tSjvTqU1+DQ+PG8eVNosijCakQS/uXpCHcQ1qcXOhjRNZhiZyici5uUl3nJOeLn8F5B",
-	"vQa3zyGcKWhVW2g2MwXDcjU+MIXvsI9SMxwSsMfw3qpZBKAMtAnB6G3NUV/Er/fD/SPhaeuEjsTHMZ76",
-	"AnyiyLrQudC9xU0EjeAgDnPcTSXk6uJmQEiA0kWAVMSmDR5XsGGFjUDI2J5njo0lICUi6h/ZieXCwSPV",
-	"86atqzRnmFalVp2wXtxCc+69sOHC//vXQfIPngx7ydvfP/+9/befv/7lO2xir+lBO7qL8SqCxVprtURc",
-	"hvu3C3QBdvP6MPExXvKIs3lBxfEkQlJmEfASGgBngYZSeQBTXCHNeOXejV7632I2NTZjTnCbjnHpIRI2",
-	"4DR2ByabtZnl+hLjApl0XurUJ17YCVyueM5acDGbCjkah6Znphgosd9mKc9zDAa8+AVA7rlSyUByRyxW",
-	"gKcc9snCDnkaVryCvuOEsoEYUrQJIklASk/wyU0D8Me9JjO3CkmDmB3roXmiMekuCQoJJ80THg4pq2+C",
-	"3q4tYFp6m1jO4bJHtEDvKapc6+x3ii3Tu9fHlh9vJQmMH+NzIritBK7ZQ6wYCit0Ol/LtYAw65HQOygq",
-	"upplJi2QVAWplSuSkBRbehXsLXZaPh5chPPT3snZ8dHJOTv/dHrCjk8+fjo/Q6B62DPjhujgSA0gJvfe",
-	"nCYHB8//XvLhzOBJJZY+WcEVWyAExSLALnsFnOOAbSNhsIQtT5Vm0oo02Fglv8mYB59jauylA66YK6OK",
-	"SVXQWo20kkMBSV/garGC9gRJtIDQhGDnPnMlck7YDiiqVyf0rs1At18H81fOMJfyYZ1usGYe9jsj6eVI",
-	"Gyv6CySFpvBOZjhjMY6YkHcGZgXrfTzGUGotV9YHDB/HLvaqGH9838VeDENLF/kvTA6EQqJTo4+P9cAl",
-	"23sJgB3GHSwiJcOzgx08Fuklig3ERpEdHiL72kDQ+m8/M6mHCtZdEKVc8ZTYHDAAX+TK8GxxeqBnnDmI",
-	"dkNUuGIjiPw04Fs60QB3/bGIZVGV7D7NFGE5bV043JhxD28UGrk+wueyDoFuO6etvKYPTepFySMG+qzy",
-	"KxCOnEpwymctetpLKqXDzqeGjawpctdmA0NVFuDZDDBMMDGZUO6QDZCdBLxjDc56MKtd9Nht0CT9Tp4N",
-	"+23W7+R6BH//nce/Aj+MJF4wFYO8v0+yLq49RRFdTSVg0qjV70wyuMVfe/ibuiv8n/6GfQI+zPhE4Qf6",
-	"e01/x54+WOf7+x3W82xinGfPD6qhIOB5Tj/9wt7LV2GdOgDlijSOcbV12IfhUKagsCacSJXAJaUjtyWt",
-	"Eo4fywz8HIMLk3IMOxc6yG20/Up0LRzvZUlr70349TFe/vxgyearS/i/SBJ+L69Ct3o7e+DnNRLkaGFj",
-	"kvjg/jfxU/Fv5PgBo167Is+NDf+HjrUZL+cRPQyYvTamkgG1bX6muWaFLiDYQsHloNemdEqP4hMiK1IR",
-	"VDPSxYAeC7932EnFcYTfv5zHm3MC1K4SQx82E576x06QZQBnrm7eLKmKG9Ma20K77mdb6OPsazflOhVq",
-	"DQPWgOss2FiaSZ3iht1hr+GuchsEVMDrXNoygPnMsUIPTKHDvj3l0lcUxZAdlA6CRldAmgc8vWfH/zzp",
-	"vVtA9JsSdiHDZuI+WG6oQKVBnHPSI2WGNVNQXcAZV31NfIuoLEpGp7AfddiLgxe078PGKEeaKzYFksTI",
-	"QU7MBmyoZA4eeZ8aJLJ+RSXkilzYK+mMZWDAQR1zh/1y8NfqmrJHQo8kctkVukpi1usnpkBgS68pU+CU",
-	"4p3woPK9nS1v3zg5p4V+OgH893O8J0Cu29A4EOkbNKvhqZtDBy8aMm64GlBy1CNHdaDG8nmWhxtxOswp",
-	"kC1ZdU8L/fQ4dR+RWH5DgtvaVN2Z3paU5yHjrA9f9mvsp3UKIdZaoLkEfst9IgIFbtf6rcAOmSgzKuuT",
-	"go2IeKyRaTS8W2axFTVi+JjUYGFbWuamR0ZZsC54GtoGNFfE/1q2u8OOyleCoxodP65ZX4BLbvssHcsc",
-	"3cwJl7pf+mm4RYbvsCtt1nfFAD7iRUBxJz0bcg0IG4VHvzDcfM7dJfPGqO24ZRfn86GYZT+cvPtfxpkX",
-	"NrxKzW3XFUXq4dIl8DVu3ejjUhoIOayEzhoZZhcpZNsNHLLtknAKoiH4Nj4jqkGpMzGUWvpg/P/gZV3c",
-	"Itays96ci9XlIu2mRik+SBwmCNed0zrLRfoarj6ji5/MLvJKcBtMXnMpNJqbmXS54kGQhPbSz9BcTk0w",
-	"pqHYEeo+oAdjwTNhqz70oGpA/gmDt6ZK6LYvfVisgNp8fwDklgp0dOfgaXCbCT0ydMyLxJ7FZxtb7g8Q",
-	"Ci4jLnMH72tP2LDCNgJlkejuOErWA5xV3HFcpCp+cPbm3Ws6nHXjuAFevSbTTo8556MfwtQ0q+d8tMuo",
-	"QG6BZfE2EuQu14vQOVzxZLb2/4FUFnQKK9iARSOe2Aazc9sTfHjGeXVbt32VLiZhwsL/e+09MIuDh8mV",
-	"qoWjV/foLZaiUGIMX2eGGIoNFh3SKMyRikIp99Vf97GMK3xVPy6ymVa0RopbMozGaBhVxsg6aeX7o/ev",
-	"jk7Pfj3+WCMi5VjWgmykixykZTE01uWhD0t92LYoG2lHV83OHYatDSSqZe8mIgyQG8t8Y7M3TuYxVeGD",
-	"2wfp9GcuViSWfl0UIcfCYtnvsF+NNpR7UTPMv/c9H5X5VUillE4SPoYNhaekrk6xrHWRXL4ksecZFOAC",
-	"bh/1xkV69hhSdgKSs8ERHhrbYR+5cwxmB4qKLmUOD4/UweEu5q3Mq0AsxVEzIxwlgOgQgphsO+VxiBbm",
-	"nXQ4qpaHGvDafA+MUYKH1X2djEwSvk3CiCTI98xVAjTHwlLnHqhAKgj9b1JMny4cUWVmUXVUC8IM4Dyh",
-	"JO63WZwENatVi6/RA6sXP9YYQ3IEI09BrGGDSjJhZVCufXEt0sIb+1px5/pzoS6KaEGaAsoFwKUPPgek",
-	"7SKb94h7TMNxNuBWsHEx4ZopkY3KgsFwdzz4xoZSC8v6l1Jn/SDKJSQJ+8IGxYh9AawLJdPwRa2W+kuF",
-	"/rJfhcnMlKjQU+jzAvt3sCeCThHXeKSOtSRRgedj7uoByHYsNMyqMBrVTRODOKmjCvAw3rH/ko2ET+Bd",
-	"WHMMISXHpA+TgxtWh72rjYjDIGRQWGgweMNAd7BByYeONTywojPpUnMlLGSA4s7XNOkY0spzwe1GXUCG",
-	"GRpUm62y7mdo+Qn0Zi2nbnji07HQ5mrJyPggsaGONrS1NlQ3aOvmV31fBq/QiDfCc6l21NENiwVi47DE",
-	"pXdsWCjFjkAHBn1BgeQ7L4+uMqMN+a7w4Hdm9GOhPNqFcocMWWgFTvPKBFktOVZr+jPHhPbSCkxAYE0E",
-	"HKiCkEybiSirLuYvCi2HMlgJciIw2QS8IHDwnXsvJjnkWrbIAy20elUa6BC31S9VW9gXTHN9YZnR4lun",
-	"iXqUFMpw7dbTP7B8V2R/5rM9pUNYT/e4aO9oNHXWJHUOmzI6YRy61Sg0Z3ZgP8eJtCIRVIsLFZ30LihH",
-	"4kMB5osV8OaFE1PU7ARqVtGndaxVvvo46wZ7Cut/0c0rU52yVuXCvbdygK0t60XI3MNaQkB4QKmh3sI7",
-	"dyQfRUuotnZaBOz+U23lsJ+WFs3+cobqlpo/t2ZivEiCUZ/AL2spccK14U1vrZk8tmMOW6l4bxh1GSWf",
-	"3IK7qfst1fe9MMCErpSzcaNzGA2VP73FotJhobVQ5TAJx0zhEzNMBlw/ciSc88JCmR/PkrFJ5w9ZQOU9",
-	"Z1gVjXq6Lg3BFVomgdlmhRVWuy5PvbwS63yOHlwRWvgjsdBkjxRWb0pRNdYNnxg4bQ7VMmFwdyGHWiuG",
-	"rTWdtV4c/IzRPR2MlJoc/lPo3vE2cvg5/DnO1nu/uyyDSxof1rzMKortFwcv4umlKK3NDcahukFbt3zV",
-	"Y1s2j97hjUesFnO6N5b6buUFrfNrf8j/g8p/E5aJ4rP4GOkYHzijCi/I0ZM6E9esNZUaUSnYO+58Ah5f",
-	"cvxmFS50eNzeWiyQO750IrWcFJO9w+T5krm3faJiaTSCm80Lb5LK27LCFZNI+n9IQXHnySOWWd3Tc3z6",
-	"klnsHN7nGB9CRtF32Iec/1GgEx3uAZc+FykV6etEFxNhZVoimAePEk4jZqwFris+mRKfMHgYBYbVw2C0",
-	"YMeC813h9twKJ7TvrKrumhvWO5553xD/WBAAPqUEAaqBj9zSiAZ3C/RQrOGER7aZzBKKELysee3orjfI",
-	"+a6p3x4c+cXsNalgXAoU9GkFaSHJ+gk9Vs+lWmWX2JQnML6Ej7O+SuI05b1w8Sldu0EfRznmI6kxcYKL",
-	"Y9s0Z7x4JaLb6udvLqHn10Ev1MJ8kEyslzBQSCdWMsCK4QN3A14+OHC7pgN3bsSDxunnZ3+XK4pOX/dQ",
-	"6hlXwnqCIXIxxDkH4WnsqB1T5UNpXR35bHE9bAKcmL9+7z7hHuZfdaN4w/N7kpjd5ciGgyIIBtMsOqwF",
-	"9oLmqktMXQCjJrQPbRcZQvralxjWWCtBjVq5+xk/bHASl+RrrXo+fd0rkcRWHSGit94Evm3hqQ/pWG2W",
-	"t50omyUQ42ZR2yg87lIqtX4fP8NL7pM5KLzhDPu107WncaTimNPQbdL0cNm9Knh4w7HOiwfX6vBmTNiv",
-	"OhaxC2q9hPVJC+fNBKe6aaarRdWVE1iCKzMvx/D75snfEv/jG8J/NGS7/5R5EgbYCudExkCVYKeZ53bA",
-	"oQ8b4ScaACYa8SXuUyJx2FcDTO2COGIfgPizcSLWiaWb6XS1UJ7NdPpQGn+mUzwwtYMKPzSeDQqpfCI1",
-	"aX7WwlAZAU7Y0TMXfwnbMZNDNpEubNj7G+aoyLPwnM378ie68L7nCt+zy5szv+JSITTR3KyxohzCdTOC",
-	"dJqoGJXwYnlO3sD3UZ2vNabhIgoIr4k335B7sump39qg5hnyUnD1sb5rfG3ECNopIcHpq3Z4Yxlu4CJb",
-	"vdu3Vx8FftpycEeTbzc8q9WzjuUly5snzfuRDoome+TTfztno1kDUFxz3pQUNAxV5D+e+lg0BOOVt8Ma",
-	"+yG6leii6AXtlUmEKFsvyEWD+sLNfhc02Lf3l2t9v4G//EMCKwnEEdzSVS4cH4ky9b+Sa+yDHSVTmUVI",
-	"D7iLtf7rxT+e77eRZ4TbDHKg9Kh48ujd8W9HJd4ogPrbjCrhoLzXaOFYSxt68JhDwc4+or0B3OlfDqqj",
-	"Q1zPmJM6FQkagVn5aIDswYM3JbYqRIJFFlvrxlD9Gh4c7w6t2e+wt3JUWMrNloC1rpjA6ctcWId49Lmw",
-	"iTVTerB7yVLj/CeX4aXB5eATU2jvyqpn7lnKc19YAUWmrEUgvc+hGROhM0HoRdIxXSgVa5PmTmxxfN4y",
-	"hlvtOP2n0Me9+8c4gPfsshtSxzWuCfOKU+rwbHsVdW9h1d7hXpfnsnv1fO/r71//PwAA//8=",
+	"bCCNNmDSrgkXmucnIRdqeXJz8YRpxwySlbIWwe4Y32E9baaDIMUavbD7bewwxPcEP6YRVlcmE4h0Hr5v",
+	"DQF87KhtGGUwdG83RqDO9RpcOFC0wvbCuLtbcXyaTjR4TMDv7oRRvHjcC3vX5ZiHC/ii3LU2B7dig9Lq",
+	"upKFduTX2NBPbYVIrMgqI93y2p92HFRlhfmPH29gfIIbYV6GG9L/uu6mQ5VQqHwAlob/+PGG9a6uv/rD",
+	"v/fZf/z4/fXgXhgIsPabAkwFeDq0XG/TzLly7907kBomGuaGIet7R6eX7JuXL9nR5VmCq3S49+Xw+fA5",
+	"hcwrXsq9w73fD58Pf7+X6EcH6No4CPWD/G9kIoyB9l5J2SMYP3EM7x9BoBKWzeFz4YQX3f+y5gKBdzUp",
+	"xuDoPvMiVymyAXqTtZmiL5n+JqonxBqoweOnLngOS4Hnae9/D8D9DkoLMuEW98v7971GO6t9fANbhBLz",
+	"i4Z1KJi3EPYXDOUha6trUkcEuxRybrom9tROV2fzkz8KttTKIlF/9fx5Uv0AjmlZFjKD8UChGcBwiqPa",
+	"dCPi4geSScy/QL8rltLvMSsPEjQ/2AhOIT64pbvwoD7YQLjxSP/lJ78yMRQtbouAzJg1muph/MLA6QH+",
+	"CwgHEJr+0qRBzFk+wFpKncfsW+FQh977qNvjeyDYaj+0T29bvhUuoMlzRYfmGcamTWl/cKVZDwVTYSFr",
+	"w/ZBo4PKVDbdqwszZbTyP+H9gakcze1JrRwUvyRs9Gx8yM2B/t81LywvT777TBeb6ALWbVvKKIUZRDxc",
+	"7vRcZp0kUZ/dg6l0g+DF9r8pkbmBFdaGlOFS25ajDVB+30oXRDxC9ftIZNSOlPgrE1QHeuGnR1YwEXZU",
+	"lmBBYSkFMKIA1rvwd8UgN/JeqJ3pKJeWGuqmoJP4TkJGjwlhcdAxol0hXmif1UG8BHWZQJVONAISGmbE",
+	"gOcaE3p6tEOWedLZB82gLMCgQuI7yDZ/rQS42Em0qRS1vyLW0GajmvyrjnrFbpJY6Ab2TpYDTdF/g1JD",
+	"uDNN7+NKTfX2ftJnpZ4GbNJUujrmp5dxm/Fc7EcPnjbTLY6KzMuDkCcFd3f3IbmCeOGzvDyG97FE5UeV",
+	"ppJ+PumNw5WDXTk7uYygvib4T6meZw/rMgOwSSb2t9w94G/3AtM7WkXfE3rjLC8f42kXZyfHmNtuoKCU",
+	"0wS7QuoQ9lSHoU202ZJVYaMb1K+ndf1rKl9hHT99JkJQM8mSgyfe8Zw7vonuUjilg2C7GgQDmO0kwVfS",
+	"ulN6/Sq+/Z57tSVAarPXk5uLLWzJn9qu+vVNioCt7Uwo+5bs7UmyldvtLoUr49EtBNq0VlgN/L665o9x",
+	"nfA+i8OlIlvASMiWSHyEnjRF7W6u0tn044zj6xZoMe2PgyOUpX/dMw67ALGLXYSASBOs9/XzPzE5YRIy",
+	"p/Z3IA9tpgOhchDjNp/7CzM9jS/+Gkc+6fA3fNpfc3MnHNSlZnF9WQ9AA0ueiUFAUUv9HEeXZ3aXXY6l",
+	"lAL9gCi/eb8v6Ztw+m/gi19j49t6/o3z+7hBEeYIkPsS/5Rlda1UQo7Iiso6dIF000Fq5nn0gCdvfkQB",
+	"LO0InM+f6MbplQVLxK3kd9yGkCu0+ciFlx4T70v+10qwkk+lIotdZezWMnx8uVOG727/UZ/PMbdiIJUV",
+	"iqBibDXGtzHs2ROvHwcEPeZJyPZ2Y7eCm2y2ya/19P4fndtr/iDn1ZxyWZieMOBnWN4Ps1wpXZMIF+0y",
+	"GNC8rTGokHPwR3VN8L0HsRad9DGVLSLpT/mYl/WpDCc8HlRwhbSaWSBgS9CLH8sVkvZxhR1sZ8L+8kNv",
+	"cNtq4/Dyf+kdxjHWiZPtm5xy8INfkjiwLbSomgQ28nR6DXlT7+T8eoBYhbaopvvtOlQaj7a9KvVYR/83",
+	"aFSbd7vf6Xr+7e3l81+DEXwCvvInM4ADwPmQbrlRsjsKL32qlNMmC0FmuWtIHkHk+MPzPpvzB/bV8+eQ",
+	"r/eBBJ8detwiKHsNmE4srXAk6x6GHqhLvxKQVaaLPKSvQYqOzgA2Jj9yrHf18vj3v//9n/ZfQD4hZhNi",
+	"GhFmE26zDPj+hnVYGWbSP4EoQC1SGDazQqjhNtvZaJQ5KcZG8LvDFdCklZZZb3Wa+7vNciVC7ddkV+FE",
+	"vhReQvk0JdMUWyKwoUCvvbSYXZ82dkAqHYZSPo3PHSACQye7w3IUvz2Gd319CsBmcxGPXjwSWI9G5nQq",
+	"6iP5N5nvD9mVoJRY/7Wl0gKYh9oa6viKWzcAsODB2cl7nhBAoQCaGNQbt9sRoSoq60TrlwQbDQyihR4n",
+	"QuSHjCsmlXQSTPiwGnrCjMg8KwkU6zmrdQOEzSQb10IaEaonNyvlMKmYNrkw+32sckMAUY7LgnEovRFa",
+	"5kZQ1qzIh+xCCZZzxw8RuacxSyjFAbvZZzJPmevfZO43MoYz8UlIW8VRAboM1fsZ/ovH6sCO8a7NYj3a",
+	"od/VC7rvV/T6+nR3rgGpsAcN1LSNktJx483PgnanoJ0u1KdsXlmB4MOsd8R362klmKjBj/kyplgHqD58",
+	"tc8K/l+yWIaKz557IBvxT1+wsqgMLwaAaV6XyQe8rwagH5tUrjINB9q3Qh2dbbDzYFBIuhm/IaL98mMS",
+	"LdZ+WaeimxngeNnZyiYPGaw1AVfRkgwWMq8Rv3Ix166GerROe5YsAEGN2vKbj+BqczEfCzP8BOIqOVxm",
+	"TUIlGkZIsZgMhQtgW4/IHDyLnNZWq1Yyf5yV/9LMi393QKly9pGY/U//fKyJhC9PB9lMW6Gae1NVMm8f",
+	"5xqkwLZD3dzTh759VpO8PrlAPTFb5gbtunChNBatFwgWYmd34fVoLL6pzGca/nVo+MO7TJpYt56kIurn",
+	"ATjgIXQOkjyp7NPhLzWCIQ3hhqIOklHozImoYb171991ODXG6Vb+m68+6IJsjoQ8IlxAf+S//oBybOdx",
+	"vwLQNpGngKyCUOMrZasSaxhAWETfX2iyEABzF8D75ojbw1UC8qdN+nM7oh+g9A3Z+cXNd2fn33opw8b6",
+	"YJrwkGyAUeqvqKVz0PABjbQG5LeioEIVdT1ByHHNjRdNcOxDXNk/fdA9jRjfbTsa5xKgFwmZh8SKWrzq",
+	"bw3KvRQOFrmJud046Vsgb5Pg1mtDuN7/NES1Gh76AJUZMFMDkN3f/9svtGW5QAjXFwS5BejiNSQUlujd",
+	"TTiDqindQf/f+Me/Ce/Vh78SYG128p4//9B9Y+ufoKR1Y+R0CnBuQQVBQtzVTARfHZRGTAo5nblNqgSR",
+	"cnjzs4Wog6rqJfr0yOpYz8uKUm2wHlQMZ10OcsMXAABSk8ATiC1VV9ftD6HqMJWJ9Jxbh7p+YCP2bThE",
+	"7wvvOj7ts6bXBVB5AUI+oH0iIDJZy+nluggr4vRyBzfsQps7Qms8+WYAaIc9pSmTD9K0KQB0vxZFCNrd",
+	"yyJUZxks6bmYA6CxygFJFaCRZwAmDl1KxB4dYmW4TFfBaJ6nyOgYQfairSYgwj1HZEMolAGgRizQOMAS",
+	"k7Ax00UOyFqdEZDf4A59PtsdZ/s3EE7HxmGPn3J4D35xfPruAOsBHvwC/z3Ltzra+Aoiy/rPIGXKTEVa",
+	"KtHpPjs5vTr74fQEqfqiFOp4po3QSREEAvIHWGVhBjVuErIsPOr+JAdAWt8nhXR7DmAqNyOk8dBWpsul",
+	"P4DA8exSZTOjoaZsPFt05lfqNJ9f3LCJLnLPL5TTeAJhGAMvcSYowoGVrHCMjKvIGrKZ4GURbO1Q0IH7",
+	"oVmCHoYBhCqKzWaA6QDILsKzYqleRHeOjC1U0L7+7mjIjuhpqLYLbFAgGGtE7fbTaWcYx/7jT5xdrLua",
+	"V64V1hvdIwbPOVWW2e+HIuE5gvXWdwjFBbuZ0dV0FiqZAqjVsH2Wjk93mN3q4LYKCoctlnmf8VAfCsqs",
+	"XlUKHv0gxWIo8+D0hfEKnneMl077DmMO/f/aMD+ROD91Bx0xTb7CMkNZ2oSLX1VqFw4ei11tDicJ+mso",
+	"jPX5oG886MC6qTTMMoGbl64QlvEpl8o6kiR/LabwUUNVGvTRGa9ycX7KkpgV6yQtDDoE8SLSE/qzTRiH",
+	"65Dm2WdSMbigdaGnUOzJfwIxKQRCHlaEypWh1EFQ6PeiCYVvYynBulY5Fg+BeBQUyHHk/k4fhJPzzPax",
+	"/jdnI1OpUcDS1wrVD8XnQfkIZUBwonUV31jS+vuz8xPWG+XifsT+xkZehId/JMX695PKZGjZnHNzF0qA",
+	"NtWCIRtB9Vtk2CoXD6O0RhaxEiwqrRX78ezmu7NzdnZzza7enMMSjnqmUkN/cdRt7I9CIZUwgjuxDEZa",
+	"nBrILHg+8KJBHzDIMVCGEoKARhAFNKICXhDC5VU7jG/scbZOVABgYOQcY+h8wyNP5v6UwloH5OSRzA8Z",
+	"1YMTf6Wj/IKNDtmdEOWAe21rBEW0wHZa8szfTl4K4tLRrhORgrLEdAk1nLzKdnT+n0hnuJdEYp4lR84g",
+	"Qy0JBWWm4NBjZQs2yrUSI5pt1ExHCOZ+yJR+67986wmpTwvE/nJycX760yhIqphclBXaigABjX3WBeel",
+	"BYmUowyM4RsY2FGr1oCqr6SdibzPxiLjlfX6KKLT1AQHNmWvlvo5e712LBjPocp2lBfA1B6nv6qh+rUj",
+	"esElhUF7cvfHqACdxEu+duY5p1YiifPCUydzMS+1Z1N1/Aka/avSCuNsKEwO0V+YWYbhYFitd0y85Sz/",
+	"nRV//USiw2rCAuUGzhXim8dKn1SOI7LL/nqU2I7igBEp0GawZa8W47lrDA/rVnGVCZYZ6YSRHK+4frzp",
+	"YPOX1ol5NELkoiz0UuRDdkaVMerYCDhe94IKw7edMCTz0/Ob06trdvPdKXt1cXHJjm7YD0evzk6g+l6T",
+	"u7uIPO7PmxVISbGqtOdXaFICbmwXxFDBKC21glJbP+JlVAI91/6ke2FymbnAFP3gC63LZ9ZfRVDMiY3F",
+	"jN9LXfl7CTxSxLzqY3aEddjt6BA5xZf9RBIvNaxOzU3oeptwWVRGUAkqRWVZsSYqSYw0wyH7MZSeJMrv",
+	"e2aExR9GcQrYELITWyE7pgLstLWARKfqmVHZeCTPiXwQoUQm8oBwTkglx5PpN74uHpXwo0B7ORIO1TeL",
+	"djriuqkMphfKrlIJTYbWqKZoT6q4s6FcX5N/48MhlNbFlM1gnAs0C0ydeF49hl5S4HTGobb+xP/bE5jn",
+	"cmFxiXnOdGUs4wu+BJ8oX9YlHcW+/ymWVKm7sE4WBchBeBH5be5hKTNdsgXYK+BHrHCCxs+6ZiOtPsY/",
+	"96nkfVwYqdX+kH391Vd1z2FPyNHYcsK9WDyprMgbx8yvF6z6yN7JskxJiyq/+GMNpS1hBFifc92ycBU3",
+	"7RtyZ3xWOD5NhePDuwtr2kh8hh8zQqPusI7EaAuaSGQmClH4lxY0Avox4/EujhsKBPMeUkSltnLvxJKs",
+	"wDew0qx1hsvpLKnTFLA5qPI9VE5Dgqc40o3um1Rj9EoFuIxgtCFtQS2ZVBmAU7MIyRhr5zZl2/1WD1Os",
+	"TI/XIKY6QERLKGeFWml0JLU6jDZ4hqJ11pZUbJfwJA13AtWVhPoSgYR7TY4RZD0qacGe7PUwENWNoMgQ",
+	"KzyXdY22AjZRu/UX3eeV+mwS+o2ahN43sqL6pFMjeKvuASFEJL1KQ6rnTsyyHvgjqTjxtc+e2DY0cPrp",
+	"UyaxLN3jGpc//rglHR380qir9G5zLkCoQfObYdpxSruMtVmJagdn1qOd/VNOwScL/JAl9PjhTsB6KEKH",
+	"+GI/H4PfwDFYraf2qV8H6+E5jSPRlSFD8aC/MavJJ0fXX34Muv5UIb7qGOUV6v4Y/P7gF/gv/lToqX00",
+	"lPmVf+nzUfl1jsp6iTKwTCdUvsu441bvMObtO3x07FcIUASBdkI5I4WNHuijlzenV2h8EqXOZoO5LApp",
+	"A8DPP/7+34j1MObZHeXiiHupqzpi95llIyUe3DF8MRqyI4j/pViGaB0bi6mE3KEhe41dNAv8Qzl6PZlY",
+	"4aKXl7KT/UDmlXXMVuZeUs2SGVf5AJxv0AWBepQ6R2APsoplvHSVETmzipd2psHdIIwIHUIMM5OWzQX3",
+	"gyuEtWxceXHPybnAisXo1QDLmGWZNkZkrlhG48cq8qhU2SZYptP1Zd4KhurjBwt7BvNpCufoNyqQQ35A",
+	"Xo11N+xWWmosZvaZQ/9mdFXa00/zUNRSTBZIsz4adYG+ynWX5/tM2v800v7wDsm05uI/o4jdp3+qcAW3",
+	"OlhPu28axRh+yUUZIPUyYe2AiGJDyS584cJMr7EAxLblhZWt5kmt7I9+grfucYujTC1ljWP2oY9wVyeP",
+	"ji+txlHnJtJ8Kbd9pZx6x0oTNeww7Cf2/WuaDZBAG0nVn57hgIbP8JiirxUiHgeBvNt3YnNBjg/GPWKp",
+	"kG7GcRleWS2p8lu88yG4EHODdSmw/h4gSTjx4CLWz0eRALbr+tG5XK6W6Vk93h+Kg2zT0a8kvUQSDaLL",
+	"xwyluoZS16/t9DGcm3/d+s1huRhn5aZd7HG7VNn+r8SLsIb4Jn069r7ETfjMgf4VOdDJx+E3J49yl7WR",
+	"nKp7abSC3JEA8n7IcnEvCl3Od6inI+qGNlnvtunuV61SunpePlX3es2TnlkWZRbIgoCJsZ4G+DHL5tze",
+	"YUwbVL/7GLyr0Mv5o3FP/x97197USI7kv4qC24g2sS6b7p3ZjaX/8nQzO47rAQKY2bhY5sJylWxrkaUa",
+	"SYXxds93v1Bmqqr8NtDQ2MdfGLseeqRS+dLv97F23WtsZPfDftV87kdqPpuRz68YFg87B8/lVmHxM7r2",
+	"dYHsUVw8TGrnvLt6iXxNlMJt3npVP8WFZeKecc06591E3OXG4Wk68MDx3GffZFOCmHDVrVfTXJSYyWFo",
+	"M0IWgQOqrV2qUnvjGA0YnCV4gAaYseFnY5BuA4tRLaqzT+HH356D1nYuJrafZLYcjpTUJ4FO6DrHbCU4",
+	"97frtiM1b99yVeAcroBwNkqJdIHE/le8bW82s0W+9EZlhx8+JS/7svc8Uyjpkt/SRK6OJR09TyzpxeMr",
+	"wiqoU8vP+mm4jBAwsIw4Sf/4lWsFz6ReB/hT0SxWLvBFede3W6FfJ2JxnwjFNyCVWTbky0Klw6EVQ+7F",
+	"MvFB4UHL6sUbVtFSKHeUWj8wC1ygbDJbk8GHLAInh3pmLWyIQYTrZ57///UM1lbGVWn7zgzZnhpZBFdV",
+	"8wjqcoXHgYO4Jl6O0X8qvMgo3tZGrJ8HSXFJhLBSbn+Uap/sqDOtEH2SheY4Vmgk/wSEfDGQd6whWsMW",
+	"eGIuLvJtI9P4hHU8/A99+zdZgmHqfxae7+uqg5P7iFDDPfvppPOxtoZQ7jcvnnbozXS1f9IJP+/2Inoi",
+	"6x5G5hvB9NO7XRDOZ4mNwQsjhcfy3I8WJacJCuXY3IqM5RzxrqRlfe7E5YjPIE1Bk8QLZ6jseDOWKVdq",
+	"Cu2dMs76iGIxYADeE5SdEl441nBQ3Q9YehLQs8Zc6sOHrMx+oTMlVuKGnCDKmeBZUGxIOoMKuYfKuNfE",
+	"nZfGEuAhz05PKgh0gL3gPnx5rbHBLXbyeyFvuUKGQ8RtxukcGKXMBIG6OG7n8E6AKNTeTptM3KUiR2i9",
+	"a12xwWFHEGiDcCK4Z5zNDlWQCsBKygs3YoojrsdYZkl417UmwKSpFCoDkIk7AK2eGOatEK4C0EK05mBf",
+	"ALizFYwrFQ+IcEB0vtbhHixOC/Mq7BtXimduRWp0BhiQcIAlmDYjYYPHBBBcF4ieaQUbAjhXhNNW8kZU",
+	"A3OMB2HqOyXui4iO6UfiWsPFcBkPg4vgf4Dwp1NVADtsR09xpQjlBJACjQT0OIynQdzBJgJpXOvgPwfZ",
+	"hsGMYgAAn2bi2GQEw44dZhOuvUNcMvCcMpHKTNBVEuC5rvWI3wrocw8nsYcgKkp6QAZ1YgjuJXaPQ2dx",
+	"kEPj/EjYiQQURW+5VFIPr/VEqizlFnHuUq4jdvmIZ2YSQbDCuByTlIF0w4O5mvCpi+B4QbavdQ/HtIfo",
+	"nPWF0yvD8+Ex6ahaJUQHtAxmi2dhef6AK2+/rEYSqXuZbi12AlkJupegFQndbUQaBKQHIDBd66tams/V",
+	"4m1ScaTMo8pscDYSdxHaNvSqfDOeR4PUj+U6HTEv8xa7DHOH73WVjngTPg+Ajbr2KFrOiEmHoS5xlweR",
+	"lUZvO8RhX1yb73tRPXrO0FJthe8ilSTPIsDpkq2fx7WB+xztrQ+xPj6HVbcaNyWqyv1RkhciN4kVCqGw",
+	"0bQJu04j7l0sbl3HAE/mcq6JEVCJuBO6JpMt0QKbi0vNnOJuJBxw7kejwaUmx7Kiuj3AmRsHO2WpSRC2",
+	"c6KkU9MIo6WFTXjhR0DUUYMoQ3xUgHgVzrt29VMbf2oF2V2BqUX/bTvqqwYNjDnsnbFBGVSdEVmtjzTC",
+	"a9p5+AAFHQYI2tK5arEzwmautBgt7qSmza511zNxJ513FfazZtx6OeCpR3t1IO/AofGjWfOm0GRRhNWI",
+	"JPyL0xHuIKxPL3Qwomswxc5QOBc3KS/zknPEz+C9gnoNbp9DOFPQqrbQbGoKhuVqvG8K32LnUjMcErDH",
+	"8N6qWQSgDLQJwehtzFBfxK8Pw/1D4WnrhI7ExzGe+gJ8osi60LrWnflNBI3gIA4z3E0l5Or8ZkBIgNJF",
+	"gFTEpg0eV7BhhY1AyNieN46NJCAlIuof2YnlwsEj1bOmras0Z5hWpVadsJ7fQnPuvbDhwv/911Hyd54M",
+	"OsmPv33+W/Ov3/3xp2+wiX2gB+3oLsarCBZrrNUScRkePizQBdjN68PEXbzkBWfzgorjSYSkzCLgJTQA",
+	"zgINpPIAprhCmvHKg3u99L/FdGJsxpzgNh3h0kMkbMBpbPdNNm0yy/UNxgUy6bzUqU+8sGO4XPGcNeBi",
+	"NhFyOApNz0zRV+KwyVKe5xgMePc9gNxzpZK+5I5YrABPOeyThR3wNKx4BX3HCWV9MaBoE0SSgJSe4JOX",
+	"DcDvT5rM3CokDWLW1QOzpzHpNgkKCSfNEx4OKatvgt6uLWBaeptYzuGyF7RAnyiqXOvsN4ot07vXx5Zf",
+	"biUJjB/jMyK4rQSu2UOsGAgrdDpbyzWHMOuR0DsoKrqaZSYtkFQFqZUrkpAUW3ob7C12UT4eXISri87p",
+	"Zffk9Ipd/XJxyrqn579cXSJQPeyZcUN0cKQGEJM7Hy+So6O3fyv5cKbwpBJLn6zgii0QgmIRYJf9AJzj",
+	"gG0jYbCELU+VZtKKNNhYJb/JiAefY2LsjQOumFujinFV0FqNtJIDAUlf4GqxgvYESbSA0IRg575xJXJO",
+	"2A4oqlcn9K7NQLtXB/NXzjCX8kGdbrBmHvZaQ+nlUBsrenMkhabwTmY4YzGOmJB3BmYF65x3MZRay5X1",
+	"AMPHseuDKsYf33d9EMPQ0kX+C5MDoZBo1ejjYz1wyfZeAmCHcQeLSMnw7GAHj0R6g2IDsVFkh4fIvjYQ",
+	"tP7rd0zqgYJ1F0QpVzwlNgcMwBe5Mjybnx7oGWcOot0QFa7YCCI/DfiWTiyBuz4vYllUJbv7mSIsp60N",
+	"hxsz7uGNQiPXR/hc1iHQbVe0ldf0oUm9KHnEQJ9VfgXCkVMJTvmseU97QaW02NXEsKE1Re6arG+oygI8",
+	"mz6GCcYmE8odsz6yk4B3rMFZD2a1ix67DZqk18qzQa/Jeq1cD+Hvv/P4V+CHocQLJqKf9w5J1sWdpyii",
+	"q6kETBo1eq1xBrf4Ow9/U3eL/9PfsE/AhykfK/xAf+/o78jTB+t877DFOp6NjfPs7VE1FAQ8z+mn79nP",
+	"8oewTh2AckUax7jaWuxsMJApKKwxJ1IlcEnpyG1Jq4TjxzIDP8fgwrgcw9a1DnIbbb8SXQvHe1HSmgdj",
+	"ftfFy98eLdh8dQn/F0nCb+VV6FZvZw98t0aCHC1sTBIfPf0mfiH+jRw/YNRrV+S5seH/0LEm4+U8oocB",
+	"s9fEVDKgts3ONNes0AUEWyi4HPTahE7pUXxCZEUqgmpGuhjQY+H3FjutOI7w+/ezeHNOgNpVYuDDZsJT",
+	"/9IJsgzgzNXNmwVVcW9aY1to1/5sC93N/minXKdCrWHA6nOdBRtLM6lT3LBb7APcVW6DgAp4l0tbBjDf",
+	"OFbovil02LcnXPqKohiyg9JB0OgWSPOAp/ey+4/Tzqc5RL8JYRcybCbug+WGClQaxDknPVJmWDMB1QWc",
+	"cdXXxLeIyqJkdAr7UYu9O3pH+z5sjHKouWITIEmMHOTEbMAGSubgkfeoQSLrVVRCrsiFvZXOWAYGHNQx",
+	"t9j3R3+pril7JPRQIpddoaskZr1+YgIEtvSaMgVOKd4xDyrf2+ni9o2Tc1Ho/Qng/zzDewLkuksaByJ9",
+	"j2Yteerm0MG7JRk3XA0oOeqFozpQY/ksy8O9OB1mFMiWrLoXhd4/Tt0XJJZfkeC2NlWPprcl5XnMOOvB",
+	"l70a+2mdQog15mgugd/ykIhAgdu1fiuwQybKDMv6pGAjIh5rZBoN75ZZbEWNGD4mNVjYlha56ZFRFqwL",
+	"noa2Ac0V8b+W7W6xk/KV4KhGx49r1hPgktseS0cyRzdzzKXulX4abpHhO+xKk/Vc0YePeBFQ3EnPBlwD",
+	"wkbh0S8MN19xd8O8MWo7btn5+XwuZtmz00//wzjzwoZXqZntuqJIPV64BL7GrRt9XEoDIYeV0NlShtl5",
+	"CtnmEg7ZZkk4BdEQfBufEtWg1JkYSC19MP5feVnnt4i17Kz352J1uUjbqVGK9xOHCcJ157Quc5F+gKsv",
+	"6eK92UV+ENwGk9fcCI3mZiZdrngQJKG99FM0l1MTjGkodoS6D+jBSPBM2KoPHagakP+BwVtTJfTQlz4v",
+	"VkBtvs8AuaUCHd05eBrcZkKPDB3zIrFn8dnGlvsDhILLiMvMwfvaEzassI1AWSS6O46S9QxnFXccF6mK",
+	"H1x+/PSBDmfdO26AV6/JtNNjrvjwVZiWzeoVH+4yKpCbY1l8iAS5m/UidAVX7M3W/k9IZUGnsIINWDTi",
+	"iW0wO7c9wYdnnFe3ddtX6WIcJiz8f9A8ALM4eJhcqVo4enWPfsRSFEqM4evMAEOxwaJDGoUZUlEo5b79",
+	"yyGWcYWv6sdFNtOK1khxS4bRGA2jyhhZJ638+eTnH04uLn/qnteISDmWtSAb6TwHaVkMjXV56MNSH7Yt",
+	"ykba0VWz84hhawKJatm7sQgD5EYy39jsjZPZpSp8cPsgnf7GxYrE0q+LIuRYWCyHLfaT0YZyL2qK+fee",
+	"58MyvwqplNJJwsewgfCU1NUplrXOk8uXJPY8gwJcwO2j3rhIzx5Dyk5AcjY4wgNjW+ycO8dgdqCo6Ebm",
+	"8PBIHRzuYt7KvArEUhw1M8JRAogOIYjxtlMeh2hu3kmHo2p5rgGvzXffGCV4WN13ydAk4dskjEiCfM9c",
+	"JUBzLCx17pkKpILQ/yrFZH/hiCozi6qjGhBmAOcJJfGwyeIkqGmtWnyNHli9+LHGGJIjGHkKYg0bVJIJ",
+	"K4Ny7Yk7kRbe2A+KO9ebCXVRRAvSFFAuAC598DkgbRfZvIfcYxqOsz63go2KMddMiWxYFgyGu+PBNzaQ",
+	"WljWu5E66wVRLiFJ2BfWL4bsC2BdKJmGL2q11F8q9JfDKkxmJkSFnkKf59i/gz0RdIq4wyN1rCGJCjwf",
+	"cVcPQDZjoWFWhdGobpoYxEkdVYCH8Y7D92wofALvwppjCCk5Jn2YHNywWuxTbUQcBiGDwkKDwRsGuoP1",
+	"Sz50rOGBFZ1Jl5pbYSEDFHe+ZZOOIa08F9xu1AVkmKFBtdkqa3+Glp9Cb9Zy6oYn7o+FNlNLRsYHiQ11",
+	"dElba0N1j7ZuftW3ZfAKjfgoPJdqRx3dsFggNg5LXHrHBoVS7AR0YNAXFEh+9PJoKzPckO8KD/5khq8L",
+	"5cUulEdkyEIrcJpXJshqybFa0984JrSXVmACAmsi4EAVhGSaTERZdTF/UWg5kMFKkGOBySbgBYGD79x7",
+	"Mc4h17JFHmiu1avSQMe4rX6p2sK+YJrrC8uMFl87TdShpFCGa7ee/oHluyL7M5vtKR3CerrHRXtHo6mz",
+	"JqlzvCyjE8ahXY3C8swO7Oc4kVYkgmpxoaKT3gXlSHwgwHyxAt48d2KKmp1AzSr6tI41yld3s3awp7D+",
+	"F928MtUpa1Uu3Hsr+9jasl6EzD2sJQSEB5Qa6i28c0fyUbSEamunQcDuf66tHPbnhUVzuJiheqDmz60Z",
+	"Gy+SYNQn8MtaSpxwbXjTj9aMX9oxh61UvDeMuoyST27B49T9lur7SRhgQlfK2bjXOYwllT+d+aLSQaG1",
+	"UOUwCcdM4RMzSPpcv3AknKvCQpkfz5KRSWcPWUDlPWdYFY16ui4NwRVaJIHZZoUVVrs2T728Fet8jg5c",
+	"EVr4mlhYZo8UVm9KUS2tGz41cNocqmXC4O5CDrVWDFtrOmu8O/oOo3s6GCk1OfyH0J3uNnL4OfzpZuu9",
+	"312WwQWND2teZhXF9rujd/H0UpTW5Q3GobpHW7d81UtbNi/e4Y1HrOZzuveW+nblBa3za1/l/1nlfxmW",
+	"ieLT+BjpGO87owovyNGTOhN3rDGRGlEp2CfufAIeX9L9uAoXOjzuYC0WyCNfOpZajovxwXHydsHc2z5R",
+	"sTAawc3mhTdJ5W1Z4YpxJP0/pqC48+QRy6zu6Tk+ec8sdg7vc4wPIKPoW+ws578X6ESHe8Clz0VKRfo6",
+	"0cVYWJmWCObBo4TTiBlrgOuKT6bEJwweRoFh9TAYLdix4HxXuD23wgntW6uqu2aG9ZFn3jfEP+YEgE8o",
+	"QYBq4JxbGtHgboEeijWc8Mgmk1lCEYL3Na8d3fUlcr5r6rcDR34xe00qGJcCBX0aQVpIsv6MHqvnUt3T",
+	"LpkYe6MMz5Ktwbz/SXe8wnlvm5dcGLHpx6uzPUxSAmgOprdElkTJmoXznj9GfHYr7K0UE9aAkJfIoPpi",
+	"A1ueTXkCuoKwntYL7EXKO+HiC7p2g6xGncyHUmMSEBX9tin7ePFKdMLVz998HITfhT2uFrIGAayX41B4",
+	"MlblgPbnfXcPjkk4PL6mA49uxLPmnGZnf5er4y4+dFDqGVfCeoLUcjFcPwNHa+ywGcs+BtK6Oorf/HrY",
+	"BJ4ye/3BU0KXzL7qXrGzt08kMbvL9w6HnhDYaLnosAbYvpqrNrHOASSg0D60XWQIT23fY4hurQQt1crt",
+	"z/hhQ8BjQb7WqueLD50SFW/VcTh6632gCOee+pxBgs3ythMl4ATIvVzUNgqPu5FKrd/HL/GSp2TBCm+4",
+	"xH7tdB11HKk45jR0mzQ9XPakCh7e0NV58exaHd6MxSerjvjsglovIarSwnkzxqleNtPVomrLMSzBlVnE",
+	"Lvy+efK3xLL5ilA2Syo3/iPzJAywFc6JjIEqwU4zz22fQx82QqksAUtZipXylBKJw74aLG0XxBH7ACS2",
+	"SydinVi6qU5XC+XlVKfPpfGnOsXDfzuo8EPjWb+QyidSk+ZnDQz7EniKHb5x8ZewHTM5YGPpwoZ9uGGO",
+	"ijwLz9m8L/9CFz71XOF7dnlz5rdcKoTZmpk1VpRDuG5GkBoWFaMSXizOyUf4PqrztcY0XETBsjWxuHvy",
+	"qC576tc2qHmGHCtcndd3jT+W4l3tlJDg9FU7vLEMN3CRrd7tm6uPte+3HDzS5NsNz2r1rGOp1OLmSfN+",
+	"ooOiyV749D/M2ViuASiuOWtKChqGKosVTzDNG4Lxyofh5r2KbiW6KHpBe2US4fbWC3KxRH3hZr8LGuzr",
+	"+8u1vt/DX36VwEoCcQS3dJULx4eiTJKu5M07s8NkIrMITwN3scZ/vfv728MmcuZwm0E+nx4VT9F96v56",
+	"Uia9gKDCZlTVCaXqRgvHGtrQg0ccis8OEbkQoHv/dFQdg+N6ypzUqUjQCMzKRwP8FB4iK3GCIRIsstha",
+	"N4JK7vDgeHdozWGL/SiHhaU6gxJ82RVjOEmcC+uQWyEXNrFmQg9271lqnP/FZXhpcDn42BTau7KCn3uW",
+	"8twXVkDBNGsQ4PRbaMZY6EwQEpd0TBdKxTq7mdOHHJ+3iEdYg4b4JfTx4OnxOuA9u+yG1DG6a8K8AnEB",
+	"nm1vo+4trDo4PmjzXLZv3x788dsf/xcAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,


### PR DESCRIPTION
## Summary

On a project's Overview page, under the component cards, this adds a quieter **Dependencies** section. It lists the platform/external resources and other projects' services that this project's **already-deployed** workloads actually consume.

That is different from "what the spec still says we might use." Only running Workloads count. If nothing has been deployed yet, the section is empty — that is expected, not an error.

- A **resource** row opens the existing resource-type details drawer (the same drawer Settings uses). If the catalog has no matching type, the drawer still opens from the row itself.
- An **org-service** row (a service owned by another project, visible at namespace scope) opens that provider component's OpenAPI dialog. Same-project services are not listed here.

## API

New: `GET /api/v1/projects/{projectName}/workload-dependencies`

- Auth: user JWT. Path parameter is `projectName` only.
- 200 body is a JSON array of `WorkloadDependencyDTO`. No deployments → `[]`.
- Resource rows: unique type (`ref`), `tag` of `platform` or `external`, and a display `name`.
- Org-service rows: provider `project` + `component`, and a display `name`.
- This is not the existing design-dependencies endpoint. That one describes declared dependencies; this one reads deployed Workloads from OpenChoreo.

Unknown project names currently return `200 []` (same org-scoped list-and-filter pattern as this handler). Provisioning not configured returns 503.

## Test plan

- [ ] API: empty `[]`; resource vs org-service rows; a declared-but-not-deployed dependency does not appear; unauthenticated request is 401
- [ ] Console: empty state is not an error; loading; error + retry
- [ ] Resource click opens the drawer (platform, external, and when the catalog has no match)
- [ ] Org-service click opens the OpenAPI dialog for the **provider** project and component
- [ ] Rows are real buttons (keyboard-reachable)
- [ ] The section sits under the component cards and is denser than the component grid

Draft PR targeting `main` (`marketplace/03-overview`).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>