### PR TITLE
Let org members draft a third-party resource with agent chat

### DIFF
--- a/apps/console/src/features/agent-chat/registerDraftStore.ts
+++ b/apps/console/src/features/agent-chat/registerDraftStore.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Cross-subtree handoff for register-form drafts (#05 Task 2). runTurn folds
+// a `draftExternalResource` tool-call into this Map; RegisterFormPage
+// subscribes. Lives next to chatStore so runTurn does not import marketplace.
+
+import type { RegisterDraft } from "../marketplace/lib/registerDraft.js";
+
+export {
+  parseRegisterDraft,
+  DRAFT_EXTERNAL_RESOURCE_TOOL,
+  type RegisterDraft,
+} from "../marketplace/lib/registerDraft.js";
+
+const drafts = new Map<string, RegisterDraft>();
+const listeners = new Map<string, Set<() => void>>();
+
+function notify(chatKey: string): void {
+  for (const fn of listeners.get(chatKey) ?? []) fn();
+}
+
+export function publishRegisterDraft(chatKey: string, draft: RegisterDraft): void {
+  drafts.set(chatKey, draft);
+  notify(chatKey);
+}
+
+export function peekRegisterDraft(chatKey: string): RegisterDraft | null {
+  return drafts.get(chatKey) ?? null;
+}
+
+export function subscribeRegisterDraft(chatKey: string, fn: () => void): () => void {
+  const set = listeners.get(chatKey) ?? new Set();
+  set.add(fn);
+  listeners.set(chatKey, set);
+  return () => set.delete(fn);
+}
+
+/** Drop any draft for this key — tests drain the module-scoped map. */
+export function clearRegisterDraft(chatKey: string): void {
+  if (!drafts.has(chatKey)) return;
+  drafts.delete(chatKey);
+  notify(chatKey);
+}

--- a/apps/console/src/features/agent-chat/runTurn.test.ts
+++ b/apps/console/src/features/agent-chat/runTurn.test.ts
@@ -72,6 +72,7 @@ vi.mock("./chatStore.js", () => ({
 import { attachAndFoldTurn } from "./runTurn";
 import { TurnStreamAttachError } from "./api/turns.js";
 import { addMessage, upsertToolMessage } from "./chatStore.js";
+import { clearRegisterDraft, peekRegisterDraft } from "./registerDraftStore.js";
 
 const KEY = "aep.chat.v1.acme.proj1";
 
@@ -250,6 +251,36 @@ describe("attachAndFoldTurn — a file card settles on its OWN input-end, not th
       { type: "tool-input-end", id: "c1" } as StreamPart,
     ];
     await attachAndFoldTurn(KEY, "proj1", "t1", new AbortController().signal);
+    expect(upsertToolMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachAndFoldTurn — draftExternalResource publishes a register draft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queuedParts = [];
+    notified.length = 0;
+    mockOpenTurnStream.mockResolvedValue(new ReadableStream());
+    clearRegisterDraft(KEY);
+  });
+
+  it("publishes a parsed draft from a complete draftExternalResource tool-call", async () => {
+    const draft = {
+      name: "stripe",
+      description: "Payments API",
+      consumptionInstructions: "Use the secret key as Bearer.",
+      config: [{ key: "API_KEY", description: "Secret", secret: true }],
+    };
+    queuedParts = [
+      {
+        type: "tool-call",
+        toolCallId: "d1",
+        toolName: "draftExternalResource",
+        input: draft,
+      } as StreamPart,
+    ];
+    await attachAndFoldTurn(KEY, "proj1", "t1", new AbortController().signal);
+    expect(peekRegisterDraft(KEY)).toEqual(draft);
     expect(upsertToolMessage).not.toHaveBeenCalled();
   });
 });

--- a/apps/console/src/features/agent-chat/runTurn.ts
+++ b/apps/console/src/features/agent-chat/runTurn.ts
@@ -37,8 +37,26 @@ import {
 } from "./chatStore.js";
 import { extractStreamingQuestions, isQuestionTool, parseQuestionsInput } from "./questionCards.js";
 import { getTurn, isTurnStreamNotFound, openTurnStream } from "./api/turns.js";
+import {
+  DRAFT_EXTERNAL_RESOURCE_TOOL,
+  parseRegisterDraft,
+  publishRegisterDraft,
+} from "./registerDraftStore.js";
 
 const FILE_TOOLS = new Set(["addFile", "editFile", "removeFile"]);
+
+function publishDraftFromInput(chatKey: string, input: unknown): void {
+  let value = input;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value) as unknown;
+    } catch {
+      return;
+    }
+  }
+  const draft = parseRegisterDraft(value);
+  if (draft) publishRegisterDraft(chatKey, draft);
+}
 
 const ATTACH_404_MAX_ATTEMPTS = 8;
 const ATTACH_404_BASE_MS = 250; // 250, 500, 1000, ... capped
@@ -167,7 +185,13 @@ export async function attachAndFoldTurn(
         appendAssistantText(chatKey, turnId, part.delta ?? part.text ?? "");
         break;
       case "tool-input-start":
-        if (part.toolName && part.id && (FILE_TOOLS.has(part.toolName) || isQuestionTool(part.toolName))) {
+        if (
+          part.toolName &&
+          part.id &&
+          (FILE_TOOLS.has(part.toolName) ||
+            isQuestionTool(part.toolName) ||
+            part.toolName === DRAFT_EXTERNAL_RESOURCE_TOOL)
+        ) {
           inputs.set(part.id, { toolName: part.toolName, buf: "", carded: false, shownQuestions: 0 });
         }
         break;
@@ -189,6 +213,7 @@ export async function attachAndFoldTurn(
           }
           break;
         }
+        if (st.toolName === DRAFT_EXTERNAL_RESOURCE_TOOL) break;
         if (st.carded) break;
         const path = readToolInputPath(st.buf);
         if (path) {
@@ -208,6 +233,10 @@ export async function attachAndFoldTurn(
         // off the result made all five cards spin for the whole batch and then
         // settle together, long after the earlier files were done.
         const st = part.id ? inputs.get(part.id) : undefined;
+        if (st?.toolName === DRAFT_EXTERNAL_RESOURCE_TOOL) {
+          publishDraftFromInput(chatKey, st.buf);
+          break;
+        }
         if (!st || !st.carded) break; // no card was ever shown (path never resolved)
         const path = readToolInputPath(st.buf);
         if (!path) break;
@@ -215,6 +244,10 @@ export async function attachAndFoldTurn(
         break;
       }
       case "tool-call": {
+        if (part.toolName === DRAFT_EXTERNAL_RESOURCE_TOOL) {
+          publishDraftFromInput(chatKey, part.input);
+          break;
+        }
         // ask_question / ask_questions (ADR-0012): the COMPLETE call is the
         // authoritative card — it replaces whatever prefix streamed above and
         // clears the `streaming` gate. Malformed input → the streamed prefix

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
@@ -428,6 +428,56 @@ describe("RegisterFormPage", () => {
       "Patched consumption instructions",
     );
   });
+
+  it("leaves the form empty until a draft arrives when the composer prompt is present", () => {
+    render(<RegisterFormPage prompt="an API" />);
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("");
+    expect(screen.getByLabelText(/^Description/)).toHaveValue("");
+    expect(screen.getByLabelText(/Consumption instructions/i)).toHaveValue("");
+    expect(screen.queryByLabelText(/development ·/)).not.toBeInTheDocument();
+  });
+
+  it("fills non-secret fields from the draft after answers", () => {
+    render(<RegisterFormPage prompt="an API" />);
+    act(() => {
+      publishRegisterDraft(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT), {
+        name: "stripe",
+        description: "Payments API",
+        consumptionInstructions: "Use the secret key as Bearer.",
+        config: [{ key: "API_KEY", description: "Secret API key", secret: true }],
+        resourceDocs: [{ type: "openapi", url: "https://example.com/stripe/openapi.yaml" }],
+      });
+    });
+    expect(screen.getByLabelText(/^Name/)).toHaveValue("stripe");
+    expect(screen.getAllByLabelText(/^Description/)[0]).toHaveValue("Payments API");
+    expect(screen.getByLabelText(/Consumption instructions/i)).toHaveValue(
+      "Use the secret key as Bearer.",
+    );
+    expect(screen.getByLabelText("development · API_KEY")).toHaveValue("");
+  });
+
+  it("does not change a human-typed env value when a later draft patches description only", () => {
+    render(<RegisterFormPage prompt="an API" />);
+    const chatKey = chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT);
+    act(() => {
+      publishRegisterDraft(chatKey, {
+        name: "stripe",
+        description: "Payments API",
+        consumptionInstructions: "Use the secret key as Bearer.",
+        config: [{ key: "API_KEY", description: "Secret API key", secret: true }],
+      });
+    });
+    fireEvent.change(screen.getByLabelText("development · API_KEY"), {
+      target: { value: "human-secret" },
+    });
+    act(() => {
+      publishRegisterDraft(chatKey, {
+        description: "Patched after answers",
+      });
+    });
+    expect(screen.getByLabelText("development · API_KEY")).toHaveValue("human-secret");
+    expect(screen.getAllByLabelText(/^Description/)[0]).toHaveValue("Patched after answers");
+  });
 });
 
 describe("RegisterFormPage edit mode", () => {

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
@@ -65,6 +65,31 @@ vi.mock("../api/queries", () => ({
   useExternalResources: () => resourcesState,
 }));
 
+vi.mock("../../../auth/SessionContext", () => ({
+  useSession: () => ({
+    user: { name: "Test", email: "t@example.com" },
+    orgHandle: "acme",
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock("../../agent-chat/components/AgentChatPanel", () => ({
+  AgentChatPanel: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="agent-chat-panel">
+      <button type="button" onClick={onClose}>
+        Close agent chat
+      </button>
+    </div>
+  ),
+}));
+
+import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
+import {
+  chatKeyFor,
+  consumePendingSeed,
+  peekPendingSeed,
+} from "../../agent-chat/chatStore";
+import { MARKETPLACE_CHAT_PROJECT } from "../constants";
 import { RegisterFormPage } from "./RegisterFormPage";
 
 function resetState() {
@@ -171,6 +196,7 @@ function submittedBody(): RegisterExternalResourceRequest {
 beforeEach(() => {
   vi.clearAllMocks();
   resetState();
+  consumePendingSeed(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT));
 });
 
 describe("RegisterFormPage", () => {
@@ -352,6 +378,33 @@ describe("RegisterFormPage", () => {
       { type: "documentation", fileName: "README.md", content: "# Hello\n" },
     ]);
   });
+
+  it("seeds /register-external-resource with the composer prompt on first open", () => {
+    const prompt = "Register Stripe as a payments API.";
+    render(<RegisterFormPage prompt={prompt} />);
+    const seed = peekPendingSeed(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT));
+    expect(seed).toEqual({
+      message: `${REGISTER_EXTERNAL_RESOURCE_COMMAND} ${prompt}`,
+      guarded: true,
+    });
+  });
+
+  it("opens agent chat on the register form and allows dismiss then reopen", () => {
+    render(<RegisterFormPage prompt="Register Twilio for SMS." />);
+    expect(screen.getByTestId("agent-chat-panel")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close agent chat" }));
+    expect(screen.queryByTestId("agent-chat-panel")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open agent chat" }));
+    expect(screen.getByTestId("agent-chat-panel")).toBeInTheDocument();
+  });
+
+  it("Register stays submittable after the chat is closed", () => {
+    render(<RegisterFormPage prompt="" />);
+    fireEvent.click(screen.getByRole("button", { name: "Close agent chat" }));
+    fillRequired();
+    fireEvent.click(screen.getByRole("button", { name: "Register" }));
+    expect(registerState.mutate).toHaveBeenCalled();
+  });
 });
 
 describe("RegisterFormPage edit mode", () => {
@@ -402,5 +455,10 @@ describe("RegisterFormPage edit mode", () => {
     expect(updateState.mutate).toHaveBeenCalledTimes(1);
     expect(registerState.mutate).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith({ to: "/resources" });
+  });
+
+  it("does not seed the register command in edit mode", () => {
+    renderEdit();
+    expect(peekPendingSeed(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT))).toBeNull();
   });
 });

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.test.tsx
@@ -18,7 +18,7 @@
 
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../../../generated/aep-api";
 
@@ -89,6 +89,10 @@ import {
   consumePendingSeed,
   peekPendingSeed,
 } from "../../agent-chat/chatStore";
+import {
+  clearRegisterDraft,
+  publishRegisterDraft,
+} from "../../agent-chat/registerDraftStore";
 import { MARKETPLACE_CHAT_PROJECT } from "../constants";
 import { RegisterFormPage } from "./RegisterFormPage";
 
@@ -197,6 +201,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetState();
   consumePendingSeed(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT));
+  clearRegisterDraft(chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT));
 });
 
 describe("RegisterFormPage", () => {
@@ -404,6 +409,24 @@ describe("RegisterFormPage", () => {
     fillRequired();
     fireEvent.click(screen.getByRole("button", { name: "Register" }));
     expect(registerState.mutate).toHaveBeenCalled();
+  });
+
+  it("leaves env value fields unchanged after a chat draft that only patches description and consumption instructions", () => {
+    render(<RegisterFormPage prompt="" />);
+    const env = screen.getByLabelText("development · API_KEY");
+    fireEvent.change(env, { target: { value: "human-secret" } });
+    const chatKey = chatKeyFor("acme", MARKETPLACE_CHAT_PROJECT);
+    act(() => {
+      publishRegisterDraft(chatKey, {
+        description: "Patched description",
+        consumptionInstructions: "Patched consumption instructions",
+      });
+    });
+    expect(screen.getByLabelText("development · API_KEY")).toHaveValue("human-secret");
+    expect(screen.getAllByLabelText(/^Description/)[0]).toHaveValue("Patched description");
+    expect(screen.getByLabelText(/Consumption instructions/i)).toHaveValue(
+      "Patched consumption instructions",
+    );
   });
 });
 

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
   Alert,
   Box,
@@ -41,6 +41,10 @@ import { EmptyState } from "../../../components/EmptyState";
 import { PageHeader } from "../../../components/PageHeader";
 import type { components } from "../../../generated/aep-api";
 import { chatKeyFor, setPendingSeed } from "../../agent-chat/chatStore";
+import {
+  peekRegisterDraft,
+  subscribeRegisterDraft,
+} from "../../agent-chat/registerDraftStore";
 import { AgentChatPanel } from "../../agent-chat/components/AgentChatPanel";
 import {
   useExternalResources,
@@ -50,6 +54,7 @@ import {
 } from "../api/queries";
 import { MARKETPLACE_CHAT_PROJECT } from "../constants";
 import { isRegisteredExternal } from "../kind";
+import { applyRegisterDraft } from "../lib/registerDraft";
 import {
   rowsFromPointers,
   writesFromRows,
@@ -159,6 +164,42 @@ export function RegisterFormPage({
   const [values, setValues] = useState<Record<string, string>>({});
   const [docs, setDocs] = useState<ResourceDocRow[]>([]);
   const [prefilledName, setPrefilledName] = useState<string | null>(null);
+
+  const chatKey = chatKeyFor(orgHandle ?? "default", MARKETPLACE_CHAT_PROJECT);
+  const draft = useSyncExternalStore(
+    useCallback((fn: () => void) => subscribeRegisterDraft(chatKey, fn), [chatKey]),
+    () => peekRegisterDraft(chatKey),
+  );
+  const formRef = useRef({
+    name,
+    description,
+    consumptionInstructions,
+    keys,
+    values,
+    docs,
+  });
+  formRef.current = {
+    name,
+    description,
+    consumptionInstructions,
+    keys,
+    values,
+    docs,
+  };
+
+  useEffect(() => {
+    if (!draft) return;
+    const next = applyRegisterDraft(formRef.current, draft, {
+      freezeName: isEdit,
+      freezeKeys: isEdit,
+    });
+    setName(next.name);
+    setDescription(next.description);
+    setConsumptionInstructions(next.consumptionInstructions);
+    setKeys(next.keys);
+    setValues(next.values);
+    setDocs(next.docs);
+  }, [draft, isEdit]);
 
   useEffect(() => {
     if (seededRef.current || !seedRegister) return;

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -24,6 +24,7 @@ import {
   Checkbox,
   Chip,
   CircularProgress,
+  Collapse,
   Divider,
   FormControlLabel,
   IconButton,
@@ -34,15 +35,20 @@ import {
 } from "@wso2/oxygen-ui";
 import { Plus, Trash2 } from "@wso2/oxygen-ui-icons-react";
 import { Link, useNavigate } from "@tanstack/react-router";
+import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
+import { useSession } from "../../../auth/SessionContext";
 import { EmptyState } from "../../../components/EmptyState";
 import { PageHeader } from "../../../components/PageHeader";
 import type { components } from "../../../generated/aep-api";
+import { chatKeyFor, setPendingSeed } from "../../agent-chat/chatStore";
+import { AgentChatPanel } from "../../agent-chat/components/AgentChatPanel";
 import {
   useExternalResources,
   useOrgEnvironments,
   useRegisterExternalResource,
   useUpdateExternalResource,
 } from "../api/queries";
+import { MARKETPLACE_CHAT_PROJECT } from "../constants";
 import { isRegisteredExternal } from "../kind";
 import {
   rowsFromPointers,
@@ -123,25 +129,46 @@ export function RegisterFormPage({
   name?: string;
 }) {
   const isEdit = Boolean(editName);
+  const promptTrimmed = prompt.trim();
+  const seedRegister = !isEdit && Boolean(promptTrimmed);
   const navigate = useNavigate();
+  const { orgHandle } = useSession();
   const environments = useOrgEnvironments();
   const register = useRegisterExternalResource();
   const update = useUpdateExternalResource(editName ?? "");
   const resources = useExternalResources();
+  const [chatOpen, setChatOpen] = useState(true);
+  const seededRef = useRef(false);
 
   const record = (resources.data ?? []).find((r) => r.name === editName);
   const editing =
     isEdit && record != null && isRegisteredExternal(record) ? record : undefined;
 
-  const [name, setName] = useState(isEdit ? (editName ?? "") : slugFrom(prompt));
-  const [description, setDescription] = useState(isEdit ? "" : prompt);
+  const [name, setName] = useState(
+    isEdit ? (editName ?? "") : seedRegister ? "" : slugFrom(prompt),
+  );
+  const [description, setDescription] = useState(
+    isEdit || seedRegister ? "" : prompt,
+  );
   const [consumptionInstructions, setConsumptionInstructions] = useState("");
   const [keys, setKeys] = useState<ConfigKeyDTO[]>(
-    isEdit ? [] : [{ key: "API_KEY", description: "API secret", secret: true }],
+    isEdit || seedRegister
+      ? []
+      : [{ key: "API_KEY", description: "API secret", secret: true }],
   );
   const [values, setValues] = useState<Record<string, string>>({});
   const [docs, setDocs] = useState<ResourceDocRow[]>([]);
   const [prefilledName, setPrefilledName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (seededRef.current || !seedRegister) return;
+    seededRef.current = true;
+    setPendingSeed(
+      chatKeyFor(orgHandle ?? "default", MARKETPLACE_CHAT_PROJECT),
+      `${REGISTER_EXTERNAL_RESOURCE_COMMAND} ${promptTrimmed}`,
+      true,
+    );
+  }, [orgHandle, promptTrimmed, seedRegister]);
 
   useEffect(() => {
     if (!editing || prefilledName === editing.name) return;
@@ -223,227 +250,261 @@ export function RegisterFormPage({
 
   return (
     <PageContent>
-      <PageHeader
-        title="Register External resource"
-        subtitle="Environment values are form-only."
-        backTo={{
-          link: <Link to="/resources" />,
-          label: "Back to Resources",
+      <Box
+        sx={{
+          display: "flex",
+          flexGrow: 1,
+          width: "100%",
+          minWidth: 0,
+          height: "100%",
+          minHeight: 0,
         }}
-      />
-      {environments.isError && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          Failed to load environments
-        </Alert>
-      )}
-      {submitError && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {submitError}
-        </Alert>
-      )}
-      <Stack spacing={3} sx={{ maxWidth: 720 }}>
-        <TextField
-          label="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          disabled={isEdit}
-        />
-        <TextField
-          label="Description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          required
-          multiline
-          minRows={2}
-        />
-
-        <Box>
-          <Stack direction="row" sx={{ justifyContent: "space-between", mb: 1 }}>
-            <Typography variant="subtitle1">Config keys</Typography>
-            {!isEdit && (
-              <Button
-                size="small"
-                startIcon={<Plus size={14} />}
-                onClick={() =>
-                  setKeys((prev) => [
-                    ...prev,
-                    { key: "", description: "", secret: false },
-                  ])
+      >
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          <PageHeader
+            title="Register External resource"
+            subtitle="Environment values are form-only."
+            backTo={{
+              link: <Link to="/resources" />,
+              label: "Back to Resources",
+            }}
+            {...(!chatOpen
+              ? {
+                  actions: (
+                    <Button onClick={() => setChatOpen(true)}>Open agent chat</Button>
+                  ),
                 }
-              >
-                Add key
-              </Button>
-            )}
-          </Stack>
-          <Stack spacing={2}>
-            {keys.map((cfg, index) => (
-              <Stack
-                key={index}
-                direction="row"
-                spacing={1}
-                sx={{ alignItems: "center" }}
-              >
-                <TextField
-                  label="Key"
-                  value={cfg.key}
-                  onChange={(e) =>
-                    setKeys((prev) =>
-                      prev.map((row, i) =>
-                        i === index ? { ...row, key: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  sx={{ flex: 1 }}
-                  disabled={isEdit}
-                />
-                <TextField
-                  label="Description"
-                  value={cfg.description ?? ""}
-                  onChange={(e) =>
-                    setKeys((prev) =>
-                      prev.map((row, i) =>
-                        i === index
-                          ? { ...row, description: e.target.value }
-                          : row,
-                      ),
-                    )
-                  }
-                  sx={{ flex: 2 }}
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={Boolean(cfg.secret)}
+              : {})}
+          />
+          {environments.isError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              Failed to load environments
+            </Alert>
+          )}
+          {submitError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {submitError}
+            </Alert>
+          )}
+          <Stack spacing={3} sx={{ maxWidth: 720 }}>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              disabled={isEdit}
+            />
+            <TextField
+              label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              multiline
+              minRows={2}
+            />
+
+            <Box>
+              <Stack direction="row" sx={{ justifyContent: "space-between", mb: 1 }}>
+                <Typography variant="subtitle1">Config keys</Typography>
+                {!isEdit && (
+                  <Button
+                    size="small"
+                    startIcon={<Plus size={14} />}
+                    onClick={() =>
+                      setKeys((prev) => [
+                        ...prev,
+                        { key: "", description: "", secret: false },
+                      ])
+                    }
+                  >
+                    Add key
+                  </Button>
+                )}
+              </Stack>
+              <Stack spacing={2}>
+                {keys.map((cfg, index) => (
+                  <Stack
+                    key={index}
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: "center" }}
+                  >
+                    <TextField
+                      label="Key"
+                      value={cfg.key}
+                      onChange={(e) =>
+                        setKeys((prev) =>
+                          prev.map((row, i) =>
+                            i === index ? { ...row, key: e.target.value } : row,
+                          ),
+                        )
+                      }
+                      sx={{ flex: 1 }}
                       disabled={isEdit}
+                    />
+                    <TextField
+                      label="Description"
+                      value={cfg.description ?? ""}
                       onChange={(e) =>
                         setKeys((prev) =>
                           prev.map((row, i) =>
                             i === index
-                              ? { ...row, secret: e.target.checked }
+                              ? { ...row, description: e.target.value }
                               : row,
                           ),
                         )
                       }
+                      sx={{ flex: 2 }}
                     />
-                  }
-                  label="Secret"
-                />
-                {!isEdit && (
-                  <IconButton
-                    aria-label="Remove key"
-                    disabled={keys.length === 1}
-                    onClick={() =>
-                      setKeys((prev) => prev.filter((_, i) => i !== index))
-                    }
-                  >
-                    <Trash2 size={16} />
-                  </IconButton>
-                )}
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={Boolean(cfg.secret)}
+                          disabled={isEdit}
+                          onChange={(e) =>
+                            setKeys((prev) =>
+                              prev.map((row, i) =>
+                                i === index
+                                  ? { ...row, secret: e.target.checked }
+                                  : row,
+                              ),
+                            )
+                          }
+                        />
+                      }
+                      label="Secret"
+                    />
+                    {!isEdit && (
+                      <IconButton
+                        aria-label="Remove key"
+                        disabled={keys.length === 1}
+                        onClick={() =>
+                          setKeys((prev) => prev.filter((_, i) => i !== index))
+                        }
+                      >
+                        <Trash2 size={16} />
+                      </IconButton>
+                    )}
+                  </Stack>
+                ))}
               </Stack>
-            ))}
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle1" gutterBottom>
+                Environment values
+              </Typography>
+              {environments.isLoading ? (
+                <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+                  <CircularProgress aria-label="Loading environments" />
+                </Box>
+              ) : environments.isError ? null : envNames.length === 0 ? (
+                <EmptyState
+                  compact
+                  bordered
+                  title="No OpenChoreo Environments"
+                  description="This organization has no OpenChoreo Environments, so environment values cannot be filled."
+                />
+              ) : (
+                <Stack spacing={2} sx={{ pl: 2 }}>
+                  {keys.map((cfg, index) => (
+                    <Box key={cfg.key || `pending-${index}`}>
+                      <Typography
+                        variant="subtitle2"
+                        color="text.secondary"
+                        sx={{ mb: 1 }}
+                      >
+                        {cfg.key || "(unnamed key)"}
+                      </Typography>
+                      <Stack spacing={1.5}>
+                        {envNames.map((environment) => {
+                          const status = cellStatus(envCells, environment, cfg.key);
+                          return (
+                            <Stack
+                              key={environment}
+                              direction="row"
+                              spacing={1}
+                              sx={{ alignItems: "flex-start" }}
+                            >
+                              <TextField
+                                label={envFieldLabel(environment, cfg.key)}
+                                type={cfg.secret ? "password" : "text"}
+                                value={values[cellKey(environment, cfg.key)] ?? ""}
+                                onChange={(e) =>
+                                  setValues((prev) => ({
+                                    ...prev,
+                                    [cellKey(environment, cfg.key)]: e.target.value,
+                                  }))
+                                }
+                                sx={{ flex: 1 }}
+                                {...(isEdit && cfg.secret
+                                  ? { helperText: KEEP_SECRET_HELPER }
+                                  : {})}
+                              />
+                              {isEdit && (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  label={
+                                    status === "configured" ? "Configured" : "Unset"
+                                  }
+                                  sx={{ mt: 1 }}
+                                />
+                              )}
+                            </Stack>
+                          );
+                        })}
+                      </Stack>
+                    </Box>
+                  ))}
+                </Stack>
+              )}
+            </Box>
+
+            <Divider />
+
+            <TextField
+              label="Consumption instructions"
+              value={consumptionInstructions}
+              onChange={(e) => setConsumptionInstructions(e.target.value)}
+              required
+              multiline
+              minRows={3}
+              fullWidth
+            />
+
+            <ResourceDocsFields docs={docs} onChange={setDocs} />
+
+            <Stack direction="row" spacing={2} sx={{ justifyContent: "flex-end" }}>
+              <Button onClick={() => void navigate({ to: "/resources" })}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                onClick={submit}
+                disabled={!canSubmit || submitPending}
+                loading={submitPending}
+              >
+                {isEdit ? "Save" : "Register"}
+              </Button>
+            </Stack>
           </Stack>
         </Box>
-
-        <Box>
-          <Typography variant="subtitle1" gutterBottom>
-            Environment values
-          </Typography>
-          {environments.isLoading ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-              <CircularProgress aria-label="Loading environments" />
-            </Box>
-          ) : environments.isError ? null : envNames.length === 0 ? (
-            <EmptyState
-              compact
-              bordered
-              title="No OpenChoreo Environments"
-              description="This organization has no OpenChoreo Environments, so environment values cannot be filled."
-            />
-          ) : (
-            <Stack spacing={2} sx={{ pl: 2 }}>
-              {keys.map((cfg, index) => (
-                <Box key={cfg.key || `pending-${index}`}>
-                  <Typography
-                    variant="subtitle2"
-                    color="text.secondary"
-                    sx={{ mb: 1 }}
-                  >
-                    {cfg.key || "(unnamed key)"}
-                  </Typography>
-                  <Stack spacing={1.5}>
-                    {envNames.map((environment) => {
-                      const status = cellStatus(envCells, environment, cfg.key);
-                      return (
-                        <Stack
-                          key={environment}
-                          direction="row"
-                          spacing={1}
-                          sx={{ alignItems: "flex-start" }}
-                        >
-                          <TextField
-                            label={envFieldLabel(environment, cfg.key)}
-                            type={cfg.secret ? "password" : "text"}
-                            value={values[cellKey(environment, cfg.key)] ?? ""}
-                            onChange={(e) =>
-                              setValues((prev) => ({
-                                ...prev,
-                                [cellKey(environment, cfg.key)]: e.target.value,
-                              }))
-                            }
-                            sx={{ flex: 1 }}
-                            {...(isEdit && cfg.secret
-                              ? { helperText: KEEP_SECRET_HELPER }
-                              : {})}
-                          />
-                          {isEdit && (
-                            <Chip
-                              size="small"
-                              variant="outlined"
-                              label={
-                                status === "configured" ? "Configured" : "Unset"
-                              }
-                              sx={{ mt: 1 }}
-                            />
-                          )}
-                        </Stack>
-                      );
-                    })}
-                  </Stack>
-                </Box>
-              ))}
-            </Stack>
-          )}
-        </Box>
-
-        <Divider />
-
-        <TextField
-            label="Consumption instructions"
-            value={consumptionInstructions}
-            onChange={(e) => setConsumptionInstructions(e.target.value)}
-            required
-            multiline
-            minRows={3}
-            fullWidth
-          />
-
-        <ResourceDocsFields docs={docs} onChange={setDocs} />
-
-        <Stack direction="row" spacing={2} sx={{ justifyContent: "flex-end" }}>
-          <Button onClick={() => void navigate({ to: "/resources" })}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            onClick={submit}
-            disabled={!canSubmit || submitPending}
-            loading={submitPending}
+        {chatOpen ? (
+          <Collapse
+            in
+            orientation="horizontal"
+            unmountOnExit
+            sx={{ height: "100%", flexShrink: 0 }}
           >
-            {isEdit ? "Save" : "Register"}
-          </Button>
-        </Stack>
-      </Stack>
+            <AgentChatPanel
+              org={orgHandle ?? "default"}
+              projectName={MARKETPLACE_CHAT_PROJECT}
+              onClose={() => setChatOpen(false)}
+            />
+          </Collapse>
+        ) : null}
+      </Box>
     </PageContent>
   );
 }

--- a/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
+++ b/apps/console/src/features/marketplace/components/RegisterFormPage.tsx
@@ -290,7 +290,11 @@ export function RegisterFormPage({
   };
 
   return (
-    <PageContent>
+    <PageContent
+      fullWidth
+      noPadding
+      sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+    >
       <Box
         sx={{
           display: "flex",
@@ -301,7 +305,16 @@ export function RegisterFormPage({
           minHeight: 0,
         }}
       >
-        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+        <Box
+          sx={{
+            flexGrow: 1,
+            minWidth: 0,
+            minHeight: 0,
+            overflow: "auto",
+            px: 3,
+            py: 2,
+          }}
+        >
           <PageHeader
             title="Register External resource"
             subtitle="Environment values are form-only."
@@ -536,7 +549,14 @@ export function RegisterFormPage({
             in
             orientation="horizontal"
             unmountOnExit
-            sx={{ height: "100%", flexShrink: 0 }}
+            sx={{
+              height: "100%",
+              flexShrink: 0,
+              alignSelf: "stretch",
+              "& .MuiCollapse-wrapper, & .MuiCollapse-wrapperInner": {
+                height: "100%",
+              },
+            }}
           >
             <AgentChatPanel
               org={orgHandle ?? "default"}

--- a/apps/console/src/features/marketplace/constants.ts
+++ b/apps/console/src/features/marketplace/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** Synthetic project so register chat reuses today’s thread APIs. Not a real project. */
+export const MARKETPLACE_CHAT_PROJECT = "__marketplace_register__";

--- a/apps/console/src/features/marketplace/lib/registerDraft.test.ts
+++ b/apps/console/src/features/marketplace/lib/registerDraft.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  applyRegisterDraft,
+  parseRegisterDraft,
+  type RegisterDraft,
+  type RegisterFormSnapshot,
+} from "./registerDraft";
+
+function snapshot(
+  overrides: Partial<RegisterFormSnapshot> = {},
+): RegisterFormSnapshot {
+  return {
+    name: "",
+    description: "",
+    consumptionInstructions: "",
+    keys: [],
+    values: {},
+    docs: [],
+    ...overrides,
+  };
+}
+
+describe("parseRegisterDraft", () => {
+  it("returns null when the input is not a plain object", () => {
+    expect(parseRegisterDraft(null)).toBeNull();
+    expect(parseRegisterDraft([])).toBeNull();
+    expect(parseRegisterDraft("stripe")).toBeNull();
+  });
+
+  it("ignores envValues and other unknown keys", () => {
+    const draft = parseRegisterDraft({
+      name: "stripe",
+      envValues: [
+        { environment: "development", key: "API_KEY", value: "sk-from-chat" },
+      ],
+      secretBytes: "nope",
+    });
+    expect(draft).toEqual({ name: "stripe" });
+    expect(JSON.stringify(draft)).not.toContain("sk-from-chat");
+  });
+
+  it("skips malformed config and docs entries", () => {
+    const draft = parseRegisterDraft({
+      config: [
+        { key: "API_KEY", description: "Secret", secret: true },
+        { key: 1, description: "bad", secret: false },
+        { description: "no key", secret: true },
+      ],
+      resourceDocs: [
+        { type: "openapi", url: "https://example.com/openapi.yaml" },
+        { type: "documentation", path: "docs/readme.md" },
+        { type: "bogus", url: "https://example.com/x" },
+      ],
+    });
+    expect(draft).toEqual({
+      config: [{ key: "API_KEY", description: "Secret", secret: true }],
+      resourceDocs: [
+        { type: "openapi", url: "https://example.com/openapi.yaml" },
+      ],
+    });
+  });
+});
+
+describe("applyRegisterDraft", () => {
+  it("does not copy env values or secret bytes from a draft", () => {
+    const current = {
+      name: "",
+      description: "",
+      consumptionInstructions: "",
+      keys: [],
+      values: { "development:API_KEY": "typed-by-human" },
+      docs: [],
+    };
+    const next = applyRegisterDraft(
+      current,
+      {
+        name: "stripe",
+        description: "Payments API",
+        consumptionInstructions: "Use the secret key as Bearer.",
+        config: [{ key: "API_KEY", description: "Secret", secret: true }],
+        envValues: [{ environment: "development", key: "API_KEY", value: "sk-from-chat" }],
+      } as RegisterDraft & { envValues: unknown },
+      { freezeName: false, freezeKeys: false },
+    );
+    expect(next.values).toEqual({ "development:API_KEY": "typed-by-human" });
+    expect(JSON.stringify(next)).not.toContain("sk-from-chat");
+  });
+
+  it("does not rename when freezeName is true", () => {
+    const current = { name: "stripe", description: "old", consumptionInstructions: "", keys: [], values: {}, docs: [] };
+    const next = applyRegisterDraft(current, { name: "renamed", description: "new" }, { freezeName: true, freezeKeys: true });
+    expect(next.name).toBe("stripe");
+    expect(next.description).toBe("new");
+  });
+
+  it("replaces keys from the draft on create", () => {
+    const current = snapshot({
+      keys: [{ key: "OLD", description: "old", secret: false }],
+    });
+    const next = applyRegisterDraft(
+      current,
+      { config: [{ key: "API_KEY", description: "Secret", secret: true }] },
+      { freezeName: false, freezeKeys: false },
+    );
+    expect(next.keys).toEqual([
+      { key: "API_KEY", description: "Secret", secret: true },
+    ]);
+  });
+
+  it("does not add keys when freezeKeys is true", () => {
+    const current = snapshot({
+      name: "stripe",
+      keys: [{ key: "API_KEY", description: "old desc", secret: true }],
+    });
+    const next = applyRegisterDraft(
+      current,
+      {
+        config: [
+          { key: "API_KEY", description: "new desc", secret: false },
+          { key: "NEW_KEY", description: "added", secret: false },
+        ],
+      },
+      { freezeName: true, freezeKeys: true },
+    );
+    expect(next.keys).toEqual([
+      { key: "API_KEY", description: "new desc", secret: true },
+    ]);
+  });
+
+  it("applies URL resource-docs from the draft", () => {
+    const next = applyRegisterDraft(
+      snapshot(),
+      { resourceDocs: [{ type: "openapi", url: "https://example.com/openapi.yaml" }] },
+      { freezeName: false, freezeKeys: false },
+    );
+    expect(next.docs).toEqual([
+      {
+        type: "openapi",
+        source: "url",
+        url: "https://example.com/openapi.yaml",
+        fileName: "",
+        content: "",
+        path: "",
+      },
+    ]);
+  });
+
+  it("drops file-row resource-docs from the draft", () => {
+    const next = applyRegisterDraft(
+      snapshot(),
+      {
+        resourceDocs: [
+          { type: "documentation", url: "https://example.com/docs.md" },
+          {
+            type: "documentation",
+            url: "",
+            path: "docs/readme.md",
+            fileName: "readme.md",
+            content: "# hi",
+          },
+        ],
+      } as RegisterDraft,
+      { freezeName: false, freezeKeys: false },
+    );
+    expect(next.docs).toEqual([
+      {
+        type: "documentation",
+        source: "url",
+        url: "https://example.com/docs.md",
+        fileName: "",
+        content: "",
+        path: "",
+      },
+    ]);
+    expect(JSON.stringify(next)).not.toContain("readme.md");
+    expect(JSON.stringify(next)).not.toContain("# hi");
+  });
+});

--- a/apps/console/src/features/marketplace/lib/registerDraft.test.ts
+++ b/apps/console/src/features/marketplace/lib/registerDraft.test.ts
@@ -163,6 +163,53 @@ describe("applyRegisterDraft", () => {
     ]);
   });
 
+  it("keeps existing file rows when a later draft patches URL docs", () => {
+    const fileRow = {
+      type: "documentation" as const,
+      source: "file" as const,
+      url: "",
+      fileName: "readme.md",
+      content: "# hi",
+      path: "docs/readme.md",
+    };
+    const next = applyRegisterDraft(
+      snapshot({
+        docs: [
+          fileRow,
+          {
+            type: "documentation",
+            source: "url",
+            url: "https://example.com/old.md",
+            fileName: "",
+            content: "",
+            path: "",
+          },
+        ],
+      }),
+      { resourceDocs: [{ type: "openapi", url: "https://example.com/openapi.yaml" }] },
+      { freezeName: false, freezeKeys: false },
+    );
+    expect(next.docs).toEqual([
+      fileRow,
+      {
+        type: "documentation",
+        source: "url",
+        url: "https://example.com/old.md",
+        fileName: "",
+        content: "",
+        path: "",
+      },
+      {
+        type: "openapi",
+        source: "url",
+        url: "https://example.com/openapi.yaml",
+        fileName: "",
+        content: "",
+        path: "",
+      },
+    ]);
+  });
+
   it("drops file-row resource-docs from the draft", () => {
     const next = applyRegisterDraft(
       snapshot(),

--- a/apps/console/src/features/marketplace/lib/registerDraft.ts
+++ b/apps/console/src/features/marketplace/lib/registerDraft.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { components } from "../../../generated/aep-api";
+import type { ResourceDocRow } from "../components/ResourceDocsFields";
+
+type ConfigKeyDTO = components["schemas"]["ConfigKeyDTO"];
+type ResourceDocPointerDTO = components["schemas"]["ResourceDocPointerDTO"];
+type DocType = ResourceDocPointerDTO["type"];
+
+export const DRAFT_EXTERNAL_RESOURCE_TOOL = "draftExternalResource";
+
+const DOC_TYPES = new Set<string>([
+  "documentation",
+  "openapi",
+  "graphql",
+  "asyncapi",
+  "protobuf",
+]);
+
+export type RegisterDraft = {
+  name?: string;
+  description?: string;
+  consumptionInstructions?: string;
+  config?: Array<{ key: string; description: string; secret: boolean }>;
+  resourceDocs?: Array<{ type: ResourceDocPointerDTO["type"]; url: string }>;
+};
+
+export type RegisterFormSnapshot = {
+  name: string;
+  description: string;
+  consumptionInstructions: string;
+  keys: ConfigKeyDTO[];
+  values: Record<string, string>;
+  docs: ResourceDocRow[];
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConfigEntry(
+  value: unknown,
+): { key: string; description: string; secret: boolean } | null {
+  if (!isPlainObject(value)) return null;
+  if (typeof value.key !== "string" || value.key === "") return null;
+  if (typeof value.description !== "string") return null;
+  if (typeof value.secret !== "boolean") return null;
+  return { key: value.key, description: value.description, secret: value.secret };
+}
+
+function hasFileRowFields(value: Record<string, unknown>): boolean {
+  return (
+    (typeof value.path === "string" && value.path !== "") ||
+    (typeof value.fileName === "string" && value.fileName !== "") ||
+    (typeof value.content === "string" && value.content !== "")
+  );
+}
+
+function parseDocEntry(
+  value: unknown,
+): { type: DocType; url: string } | null {
+  if (!isPlainObject(value)) return null;
+  if (typeof value.type !== "string" || !DOC_TYPES.has(value.type)) return null;
+  if (typeof value.url !== "string" || value.url === "") return null;
+  if (hasFileRowFields(value)) return null;
+  return { type: value.type as DocType, url: value.url };
+}
+
+export function parseRegisterDraft(input: unknown): RegisterDraft | null {
+  if (!isPlainObject(input)) return null;
+  const draft: RegisterDraft = {};
+  if (typeof input.name === "string") draft.name = input.name;
+  if (typeof input.description === "string") draft.description = input.description;
+  if (typeof input.consumptionInstructions === "string") {
+    draft.consumptionInstructions = input.consumptionInstructions;
+  }
+  if (Array.isArray(input.config)) {
+    draft.config = input.config.flatMap((entry) => {
+      const parsed = parseConfigEntry(entry);
+      return parsed ? [parsed] : [];
+    });
+  }
+  if (Array.isArray(input.resourceDocs)) {
+    draft.resourceDocs = input.resourceDocs.flatMap((entry) => {
+      const parsed = parseDocEntry(entry);
+      return parsed ? [parsed] : [];
+    });
+  }
+  return draft;
+}
+
+function urlDocRows(docs: unknown[]): ResourceDocRow[] {
+  const rows: ResourceDocRow[] = [];
+  for (const raw of docs) {
+    const parsed = parseDocEntry(raw);
+    if (!parsed) continue;
+    rows.push({
+      type: parsed.type,
+      source: "url",
+      url: parsed.url,
+      fileName: "",
+      content: "",
+      path: "",
+    });
+  }
+  return rows;
+}
+
+function applyKeys(
+  current: ConfigKeyDTO[],
+  config: RegisterDraft["config"],
+  freezeKeys: boolean,
+): ConfigKeyDTO[] {
+  if (config === undefined) return current;
+  if (!freezeKeys) {
+    return config.map((entry) => ({
+      key: entry.key,
+      description: entry.description,
+      secret: entry.secret,
+    }));
+  }
+  const byKey = new Map(config.map((entry) => [entry.key, entry]));
+  return current.map((row) => {
+    const patch = byKey.get(row.key);
+    if (!patch) return row;
+    return { ...row, description: patch.description };
+  });
+}
+
+export function applyRegisterDraft(
+  current: RegisterFormSnapshot,
+  draft: RegisterDraft,
+  mode: { freezeName: boolean; freezeKeys: boolean },
+): RegisterFormSnapshot {
+  return {
+    name: mode.freezeName || draft.name === undefined ? current.name : draft.name,
+    description:
+      draft.description === undefined ? current.description : draft.description,
+    consumptionInstructions:
+      draft.consumptionInstructions === undefined
+        ? current.consumptionInstructions
+        : draft.consumptionInstructions,
+    keys: applyKeys(current.keys, draft.config, mode.freezeKeys),
+    values: current.values,
+    docs:
+      draft.resourceDocs === undefined
+        ? current.docs
+        : urlDocRows(draft.resourceDocs),
+  };
+}

--- a/apps/console/src/features/marketplace/lib/registerDraft.ts
+++ b/apps/console/src/features/marketplace/lib/registerDraft.ts
@@ -105,21 +105,34 @@ export function parseRegisterDraft(input: unknown): RegisterDraft | null {
   return draft;
 }
 
-function urlDocRows(docs: unknown[]): ResourceDocRow[] {
-  const rows: ResourceDocRow[] = [];
-  for (const raw of docs) {
-    const parsed = parseDocEntry(raw);
+function urlDocRow(entry: { type: DocType; url: string }): ResourceDocRow {
+  return {
+    type: entry.type,
+    source: "url",
+    url: entry.url,
+    fileName: "",
+    content: "",
+    path: "",
+  };
+}
+
+/** Upsert URL docs by type; never drop file rows or URL types the draft omitted. */
+function patchUrlDocs(
+  current: ResourceDocRow[],
+  draftDocs: Array<{ type: DocType; url: string }>,
+): ResourceDocRow[] {
+  const files = current.filter((row) => row.source !== "url");
+  const urls = new Map(
+    current
+      .filter((row) => row.source === "url")
+      .map((row) => [row.type, row] as const),
+  );
+  for (const entry of draftDocs) {
+    const parsed = parseDocEntry(entry);
     if (!parsed) continue;
-    rows.push({
-      type: parsed.type,
-      source: "url",
-      url: parsed.url,
-      fileName: "",
-      content: "",
-      path: "",
-    });
+    urls.set(parsed.type, urlDocRow(parsed));
   }
-  return rows;
+  return [...files, ...urls.values()];
 }
 
 function applyKeys(
@@ -161,6 +174,6 @@ export function applyRegisterDraft(
     docs:
       draft.resourceDocs === undefined
         ? current.docs
-        : urlDocRows(draft.resourceDocs),
+        : patchUrlDocs(current.docs, draft.resourceDocs),
   };
 }

--- a/apps/console/src/mocks/handlers/agent-chat.ts
+++ b/apps/console/src/mocks/handlers/agent-chat.ts
@@ -34,7 +34,7 @@
 
 import { http, HttpResponse } from "msw";
 import { ANSWER_PREFIX, ANSWERS_PREFIX } from "@aep/agent-stream";
-import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
+import { registerChatFrames } from "./registerChatFrames";
 import {
   MAX_ATTACHMENT_FILES,
   MAX_ATTACHMENT_FILE_BYTES,
@@ -291,29 +291,13 @@ export const agentChatHandlers = [
         { type: "turn-failed", message: "Mock turn failure (instruction contained 'fail')." },
       ]);
     }
-    if (instruction.trim().startsWith(REGISTER_EXTERNAL_RESOURCE_COMMAND)) {
-      const input = {
-        name: "stripe",
-        description: "Payments API",
-        consumptionInstructions: "Use the secret key as Bearer.",
-        config: [{ key: "API_KEY", description: "Secret API key", secret: true }],
-        resourceDocs: [{ type: "openapi", url: "https://example.com/stripe/openapi.yaml" }],
-      };
-      return sse([
-        {
-          type: "text-delta",
-          delta:
-            "I'll register this as a Registered External resource. If anything is unclear I'll ask — I won't invent a schema or put secret values in the draft.",
-        },
-        { type: "tool-input-start", id: `draft-${turnId}`, toolName: "draftExternalResource" },
-        {
-          type: "tool-call",
-          toolCallId: `draft-${turnId}`,
-          toolName: "draftExternalResource",
-          input,
-        },
-        { type: "turn-committed", noChanges: true },
-      ]);
+    const registerFrames = registerChatFrames(
+      instruction,
+      String(params.projectName),
+      turnId,
+    );
+    if (registerFrames) {
+      return sse(registerFrames);
     }
     // Grilling scenarios (ADR-0012 / #270) — keyed on the /start flow command
     // or a typed trigger, never on a mere mention of "grill" in an edit

--- a/apps/console/src/mocks/handlers/agent-chat.ts
+++ b/apps/console/src/mocks/handlers/agent-chat.ts
@@ -292,11 +292,25 @@ export const agentChatHandlers = [
       ]);
     }
     if (instruction.trim().startsWith(REGISTER_EXTERNAL_RESOURCE_COMMAND)) {
+      const input = {
+        name: "stripe",
+        description: "Payments API",
+        consumptionInstructions: "Use the secret key as Bearer.",
+        config: [{ key: "API_KEY", description: "Secret API key", secret: true }],
+        resourceDocs: [{ type: "openapi", url: "https://example.com/stripe/openapi.yaml" }],
+      };
       return sse([
         {
           type: "text-delta",
           delta:
             "I'll register this as a Registered External resource. If anything is unclear I'll ask — I won't invent a schema or put secret values in the draft.",
+        },
+        { type: "tool-input-start", id: `draft-${turnId}`, toolName: "draftExternalResource" },
+        {
+          type: "tool-call",
+          toolCallId: `draft-${turnId}`,
+          toolName: "draftExternalResource",
+          input,
         },
         { type: "turn-committed", noChanges: true },
       ]);

--- a/apps/console/src/mocks/handlers/agent-chat.ts
+++ b/apps/console/src/mocks/handlers/agent-chat.ts
@@ -34,6 +34,7 @@
 
 import { http, HttpResponse } from "msw";
 import { ANSWER_PREFIX, ANSWERS_PREFIX } from "@aep/agent-stream";
+import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
 import {
   MAX_ATTACHMENT_FILES,
   MAX_ATTACHMENT_FILE_BYTES,
@@ -288,6 +289,16 @@ export const agentChatHandlers = [
       return sse([
         { type: "text-delta", delta: "Let me try that…" },
         { type: "turn-failed", message: "Mock turn failure (instruction contained 'fail')." },
+      ]);
+    }
+    if (instruction.trim().startsWith(REGISTER_EXTERNAL_RESOURCE_COMMAND)) {
+      return sse([
+        {
+          type: "text-delta",
+          delta:
+            "I'll register this as a Registered External resource. If anything is unclear I'll ask — I won't invent a schema or put secret values in the draft.",
+        },
+        { type: "turn-committed", noChanges: true },
       ]);
     }
     // Grilling scenarios (ADR-0012 / #270) — keyed on the /start flow command

--- a/apps/console/src/mocks/handlers/registerChatFrames.test.ts
+++ b/apps/console/src/mocks/handlers/registerChatFrames.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
+import { describe, expect, it, vi } from "vitest";
+import { MARKETPLACE_CHAT_PROJECT } from "../../features/marketplace/constants";
+
+// Same literals as @aep/agent-stream. Vitest cannot load that barrel here
+// (dist pulls @aep/excalidraw-dsl, which has no dist in this worktree).
+const ANSWER_PREFIX = 'Answer to "';
+vi.mock("@aep/agent-stream", () => ({
+  ANSWER_PREFIX: 'Answer to "',
+  ANSWERS_PREFIX: "Answers:",
+}));
+
+import { registerChatFrames } from "./registerChatFrames";
+
+function framesJson(frames: unknown[] | null): string {
+  return JSON.stringify(frames);
+}
+
+describe("registerChatFrames", () => {
+  it("asks a question and omits draftExternalResource for an unsure register instruction", () => {
+    const frames = registerChatFrames(`${REGISTER_EXTERNAL_RESOURCE_COMMAND} an API`);
+    const json = framesJson(frames);
+    expect(json).toMatch(/ask_questions?/);
+    expect(json).not.toContain("draftExternalResource");
+    expect(json).not.toContain("envValues");
+  });
+
+  it("emits a Stripe-like draft without envValues for a sure register instruction", () => {
+    const frames = registerChatFrames(
+      `${REGISTER_EXTERNAL_RESOURCE_COMMAND} Register Stripe`,
+    );
+    const json = framesJson(frames);
+    expect(json).toContain("draftExternalResource");
+    expect(json).not.toContain("envValues");
+  });
+
+  it("emits the sure draft on a marketplace answer turn", () => {
+    const frames = registerChatFrames(
+      `${ANSWER_PREFIX}What should this resource be called?": stripe`,
+      MARKETPLACE_CHAT_PROJECT,
+    );
+    const json = framesJson(frames);
+    expect(json).toContain("draftExternalResource");
+    expect(json).not.toContain("envValues");
+  });
+
+  it("does not emit a register draft on a real-project answer turn", () => {
+    const frames = registerChatFrames(
+      `${ANSWER_PREFIX}Who is the primary user of this app?": Individual consumers`,
+      "todo-app",
+    );
+    expect(frames).toBeNull();
+  });
+});

--- a/apps/console/src/mocks/handlers/registerChatFrames.ts
+++ b/apps/console/src/mocks/handlers/registerChatFrames.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ANSWER_PREFIX, ANSWERS_PREFIX } from "@aep/agent-stream";
+import { REGISTER_EXTERNAL_RESOURCE_COMMAND } from "@aep/contracts/commands";
+import { MARKETPLACE_CHAT_PROJECT } from "../../features/marketplace/constants";
+
+const UNSURE_REMAINDER = "an API";
+
+/** Stripe-like sure draft. Never includes env values or secret bytes. */
+const SURE_DRAFT_INPUT = {
+  name: "stripe",
+  description: "Payments API",
+  consumptionInstructions: "Use the secret key as Bearer.",
+  config: [{ key: "API_KEY", description: "Secret API key", secret: true }],
+  resourceDocs: [{ type: "openapi", url: "https://example.com/stripe/openapi.yaml" }],
+};
+
+/** Same shape as the grill `ask_question` payload in agent-chat.ts. */
+const UNSURE_QUESTION = {
+  question: "What should this Registered External resource be called?",
+  detail:
+    "A vague 'an API' is not enough to draft a schema — the name is the resource identity, so I'm asking it first.",
+  options: [
+    {
+      label: "stripe",
+      description:
+        "A payments API. Consumption uses a secret key as Bearer; the value stays on the form, not in chat.",
+      recommended: true,
+    },
+    {
+      label: "Something else",
+      description: "Type the resource name in the text field below.",
+      freeText: true,
+    },
+  ],
+  multiSelect: false,
+};
+
+function isAnswer(instruction: string): boolean {
+  return instruction.startsWith(ANSWER_PREFIX) || instruction.startsWith(ANSWERS_PREFIX);
+}
+
+function sureDraftFrames(turnId: string): unknown[] {
+  return [
+    {
+      type: "text-delta",
+      delta:
+        "I'll register this as a Registered External resource. If anything is unclear I'll ask — I won't invent a schema or put secret values in the draft.",
+    },
+    { type: "tool-input-start", id: `draft-${turnId}`, toolName: "draftExternalResource" },
+    {
+      type: "tool-call",
+      toolCallId: `draft-${turnId}`,
+      toolName: "draftExternalResource",
+      input: SURE_DRAFT_INPUT,
+    },
+    { type: "turn-committed", noChanges: true },
+  ];
+}
+
+function unsureQuestionFrames(turnId: string): unknown[] {
+  return [
+    {
+      type: "text-delta",
+      delta:
+        "That is too vague to draft a Registered External resource — I need to ask first. I will not invent a schema or put secret values in the draft.",
+    },
+    { type: "tool-call", toolCallId: `q-${turnId}`, toolName: "ask_question", input: UNSURE_QUESTION },
+    {
+      type: "tool-result",
+      toolName: "ask_question",
+      toolCallId: `q-${turnId}`,
+      input: UNSURE_QUESTION,
+      output: { status: "awaiting_user_response", question: UNSURE_QUESTION.question },
+    },
+    { type: "turn-committed", noChanges: true },
+  ];
+}
+
+/**
+ * Scripted Marketplace register stream. Returns null when this turn is not
+ * a register-command or a marketplace answer (real-project answers stay on
+ * the /start grill path).
+ */
+export function registerChatFrames(
+  instruction: string,
+  projectName?: string,
+  turnId = "mock-turn",
+): unknown[] | null {
+  const trimmed = instruction.trim();
+  if (trimmed.startsWith(REGISTER_EXTERNAL_RESOURCE_COMMAND)) {
+    const remainder = trimmed.slice(REGISTER_EXTERNAL_RESOURCE_COMMAND.length).trim();
+    if (remainder === UNSURE_REMAINDER) {
+      return unsureQuestionFrames(turnId);
+    }
+    return sureDraftFrames(turnId);
+  }
+  if (projectName === MARKETPLACE_CHAT_PROJECT && isAnswer(instruction)) {
+    return sureDraftFrames(turnId);
+  }
+  return null;
+}

--- a/packages/contracts/commands/index.ts
+++ b/packages/contracts/commands/index.ts
@@ -62,6 +62,9 @@ export const START_COMMAND = "/start";
 /** The design CTA's command. */
 export const DESIGN_COMMAND = "/design";
 
+/** Marketplace register flow. Same family as `/start` / `/design`. */
+export const REGISTER_EXTERNAL_RESOURCE_COMMAND = "/register-external-resource";
+
 /**
  * Parse `/start [idea]`. Returns the inline idea (`""` when the command was
  * bare), or null when the line is not the command at all.

--- a/playground/test/slash-command.test.ts
+++ b/playground/test/slash-command.test.ts
@@ -110,3 +110,10 @@ test("prose that merely mentions /start is not the command", () => {
   assert.equal(parseStartCommand("where do I /start with the design?"), null);
   assert.equal(parseStartCommand("/started"), null);
 });
+
+test("/register-external-resource is a flow command", () => {
+  assert.deepEqual(parseFlowCommand("/register-external-resource Register Stripe"), {
+    skill: "register-external-resource",
+    text: "Register Stripe",
+  });
+});

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -371,16 +371,10 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 		}
 		return res.Key, nil
 	}
-	// skillsRepoForTurns ensures the org's _skills repo exists (seeding the
-	// embedded builtin/flow skills on first touch) and hands back its row —
-	// the SkillsRef source for genai + task-plan turns. A closure at the
-	// composition root so neither feature grows a skills edge.
-	skillsRepoForTurns := func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error) {
-		if err := skillSvc.EnsureProvisioned(ctx, orgID); err != nil {
-			return nil, err
-		}
-		return repoService.GetRepo(ctx, orgID, spec.SkillsRepoSentinelProjectID)
-	}
+	// SkillsRef source for genai + task-plan turns. Reconcile (not only
+	// EnsureProvisioned) so a platform skill shipped after first provision
+	// lands in org _skills before the turn snapshot; loadSkill reads that dest.
+	skillsRepoForTurns := spec.SkillsRepoForTurns(skillSvc, repoService)
 	turnRepo := spec.NewTurnRepository(db, in.RateStamper)
 	turnBroker := spec.NewTurnBroker()
 	genaiDeps := spec.ServiceDeps{

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -371,9 +371,8 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 		}
 		return res.Key, nil
 	}
-	// SkillsRef source for genai + task-plan turns. Reconcile (not only
-	// EnsureProvisioned) so a platform skill shipped after first provision
-	// lands in org _skills before the turn snapshot; loadSkill reads that dest.
+	// SkillsRef source for genai + task-plan turns. Reconcile so platform
+	// skills shipped after first provision land before Head/Ensure.
 	skillsRepoForTurns := spec.SkillsRepoForTurns(skillSvc, repoService)
 	turnRepo := spec.NewTurnRepository(db, in.RateStamper)
 	turnBroker := spec.NewTurnBroker()

--- a/services/aep-api/internal/delivery/task/ports.go
+++ b/services/aep-api/internal/delivery/task/ports.go
@@ -107,10 +107,9 @@ type GitReader interface {
 	Resolver() secrets.Resolver
 }
 
-// SkillsRepoResolver ensures the org's _skills repo is provisioned (the
-// task-planning flow skill is seeded there) and returns its row — the source
-// of the plan turn's SkillsRef snapshot. Wired at the composition root from
-// the skills feature so task holds no skills edge.
+// SkillsRepoResolver returns the org _skills git row used as the plan
+// turn's SkillsRef snapshot source. Production wires the same reconcile
+// resolver as genai turns so the library is not first-touch-only.
 type SkillsRepoResolver func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error)
 
 // ExecutionReader is the read side of the executions rows (the platform-owned

--- a/services/aep-api/internal/spec/files/handler.go
+++ b/services/aep-api/internal/spec/files/handler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/platform/apierr"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 	"github.com/wso2/aep/aep-api/internal/platform/tenant"
 	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
 	"github.com/wso2/aep/aep-api/internal/spec"
@@ -216,6 +217,8 @@ func mapFilesError(err error) error {
 		// us on every attempt. That is a concurrent-write conflict, not a
 		// server fault — surface it as a retryable 409, never a 500.
 		return apierr.Conflict("the repository changed during the write; retry")
+	case errors.Is(err, gitfs.ErrDiskAdmission):
+		return apierr.ServiceUnavailable("workspace disk is full — try again in a few minutes, or contact your platform admin")
 	default:
 		return apierr.Internal("internal error")
 	}

--- a/services/aep-api/internal/spec/files/handler_test.go
+++ b/services/aep-api/internal/spec/files/handler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/platform/apierr"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
 )
 
@@ -40,6 +41,20 @@ func TestMapFilesError_CASExhaustionMapsTo409(t *testing.T) {
 	if ae.Status != http.StatusConflict || ae.Code != apierr.CodeConflict {
 		t.Fatalf("status/code = %d/%s, want 409/%s (CAS exhaustion is a retryable conflict)",
 			ae.Status, ae.Code, apierr.CodeConflict)
+	}
+}
+
+func TestMapFilesError_DiskAdmissionMapsTo503(t *testing.T) {
+	err := mapFilesError(fmt.Errorf("ensure: %w (usage=92%%)", gitfs.ErrDiskAdmission))
+	var ae *apierr.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("mapped error %T is not an *apierr.Error", err)
+	}
+	if ae.Status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (disk admission is not a 500)", ae.Status)
+	}
+	if ae.Message == "internal error" {
+		t.Fatalf("message = %q, want a disk-admission sentence the console can show", ae.Message)
 	}
 }
 

--- a/services/aep-api/internal/spec/genai_component_test.go
+++ b/services/aep-api/internal/spec/genai_component_test.go
@@ -430,8 +430,10 @@ func (m *memTurnRepo) row(t *testing.T, id string) spec.AgentTurn {
 
 type stubRepoResolver struct{ rec *sourcecontrol.GitRepository }
 
-func (s stubRepoResolver) GetRepo(_ context.Context, _, _ string) (*sourcecontrol.GitRepository, error) {
-	if s.rec == nil {
+func (s stubRepoResolver) GetRepo(_ context.Context, _, projectID string) (*sourcecontrol.GitRepository, error) {
+	// Match on project id so a synthetic Marketplace id does not silently
+	// receive the fixture repo (that harness lie hid the live 404).
+	if s.rec == nil || projectID != s.rec.ProjectID {
 		return nil, sourcecontrol.ErrRepoNotFound
 	}
 	return s.rec, nil
@@ -478,6 +480,7 @@ type rigConfig struct {
 	mcpBaseURL    string
 	recorder      spec.TurnActivityRecorder
 	conversations spec.ConversationRepository
+	repos         spec.RepoResolver
 }
 
 // withConversations wires the #430 thread store so the resolve/rotate endpoints
@@ -485,6 +488,12 @@ type rigConfig struct {
 // fence, keeping the pre-#430 tests' arbitrary conversation uuids valid).
 func withConversations(repo spec.ConversationRepository) rigOption {
 	return func(c *rigConfig) { c.conversations = repo }
+}
+
+// withRepos swaps the project-repo resolver (e.g. a counting stub that 404s
+// the synthetic Marketplace id while still serving testProj).
+func withRepos(r spec.RepoResolver) rigOption {
+	return func(c *rigConfig) { c.repos = r }
 }
 
 // withRecorder wires an activity recorder so a committed turn's spec_updated
@@ -573,8 +582,12 @@ func newGenaiRig(t *testing.T, seed map[string]string, opts ...rigOption) *genai
 	if cfg.skillsRepo != nil {
 		skillsRepo = cfg.skillsRepo
 	}
+	repos := spec.RepoResolver(stubRepoResolver{rec: rec})
+	if cfg.repos != nil {
+		repos = cfg.repos
+	}
 	svc := spec.NewService(spec.ServiceDeps{
-		Repos:         stubRepoResolver{rec: rec},
+		Repos:         repos,
 		Git:           sourcecontrol.NewGitOpsService(stubResolver{}, fx.Engine),
 		Keys:          func(context.Context, string) (string, error) { return rig.key, nil },
 		Client:        client,

--- a/services/aep-api/internal/spec/genai_component_test.go
+++ b/services/aep-api/internal/spec/genai_component_test.go
@@ -481,6 +481,7 @@ type rigConfig struct {
 	recorder      spec.TurnActivityRecorder
 	conversations spec.ConversationRepository
 	repos         spec.RepoResolver
+	snapshots     sourcecontrol.SnapshotProvider
 }
 
 // withConversations wires the #430 thread store so the resolve/rotate endpoints
@@ -494,6 +495,12 @@ func withConversations(repo spec.ConversationRepository) rigOption {
 // the synthetic Marketplace id while still serving testProj).
 func withRepos(r spec.RepoResolver) rigOption {
 	return func(c *rigConfig) { c.repos = r }
+}
+
+// withSnapshots swaps the snapshot engine (e.g. Ensure returns disk admission
+// so StartTurn can be asserted as 503, not opaque 500).
+func withSnapshots(p sourcecontrol.SnapshotProvider) rigOption {
+	return func(c *rigConfig) { c.snapshots = p }
 }
 
 // withRecorder wires an activity recorder so a committed turn's spec_updated
@@ -586,6 +593,10 @@ func newGenaiRig(t *testing.T, seed map[string]string, opts ...rigOption) *genai
 	if cfg.repos != nil {
 		repos = cfg.repos
 	}
+	snapshots := sourcecontrol.SnapshotProvider(fx.Engine)
+	if cfg.snapshots != nil {
+		snapshots = cfg.snapshots
+	}
 	svc := spec.NewService(spec.ServiceDeps{
 		Repos:         repos,
 		Git:           sourcecontrol.NewGitOpsService(stubResolver{}, fx.Engine),
@@ -593,7 +604,7 @@ func newGenaiRig(t *testing.T, seed map[string]string, opts ...rigOption) *genai
 		Client:        client,
 		Turns:         turns,
 		Broker:        broker,
-		Snapshots:     fx.Engine,
+		Snapshots:     snapshots,
 		SkillsRepo:    skillsRepo,
 		Conversations: cfg.conversations,
 		MCPTokens:     cfg.mcpTokens,

--- a/services/aep-api/internal/spec/genai_conversations.go
+++ b/services/aep-api/internal/spec/genai_conversations.go
@@ -45,9 +45,12 @@ func (s *Service) ListConversations(ctx context.Context, orgID, projectID string
 	if s.conversations == nil {
 		return nil, ErrConversationsUnavailable
 	}
-	// The repo must exist — same tenant fence as every other genai read.
-	if _, err := s.resolveRepo(ctx, orgID, projectID); err != nil {
-		return nil, err
+	// Real projects still require a git repo row. The Marketplace register
+	// chat project is synthetic — no git_repositories row — so skip that fence.
+	if !isMarketplaceRegisterProject(projectID) {
+		if _, err := s.resolveRepo(ctx, orgID, projectID); err != nil {
+			return nil, err
+		}
 	}
 	row, err := s.conversations.ResolveCurrent(ctx, orgID, projectID, useCaseGeneral, displayIdentityFrom(ctx))
 	if err != nil {
@@ -64,8 +67,10 @@ func (s *Service) RotateConversation(ctx context.Context, orgID, projectID strin
 	if s.conversations == nil {
 		return nil, ErrConversationsUnavailable
 	}
-	if _, err := s.resolveRepo(ctx, orgID, projectID); err != nil {
-		return nil, err
+	if !isMarketplaceRegisterProject(projectID) {
+		if _, err := s.resolveRepo(ctx, orgID, projectID); err != nil {
+			return nil, err
+		}
 	}
 	row, err := s.conversations.Rotate(ctx, orgID, projectID, useCaseGeneral, displayIdentityFrom(ctx))
 	if err != nil {

--- a/services/aep-api/internal/spec/genai_disk_admission_test.go
+++ b/services/aep-api/internal/spec/genai_disk_admission_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+// refusingSnapshots is the live disk-admission shape: Ensure wraps
+// gitfs.ErrDiskAdmission the same way StartTurn does (`ensure repo snapshot: %w`).
+type refusingSnapshots struct{}
+
+func (refusingSnapshots) Ensure(context.Context, sourcecontrol.RepoRef, string) error {
+	return fmt.Errorf("ensure repo snapshot: %w (usage=92%%)", gitfs.ErrDiskAdmission)
+}
+
+// TestDiskAdmission_StartTurnIs503Not500 is the HTTP pin the mapper unit tests
+// do not give: snapshots.Ensure refuses → StartTurn is 503 with a sentence,
+// not opaque 500 "internal error", and agents are never dispatched.
+func TestDiskAdmission_StartTurnIs503Not500(t *testing.T) {
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withSnapshots(refusingSnapshots{}),
+	)
+
+	rec := r.post(t, convUUID, "requirements-chat", "x")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("disk-admission POST: code %d, want 503 (%s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"internal error"`) {
+		t.Errorf("503 body must not be opaque internal error, got %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "workspace disk is full") {
+		t.Errorf("503 body must carry the disk-admission sentence, got %s", rec.Body.String())
+	}
+	if r.fake.turns(t) != 0 {
+		t.Error("agents dispatched despite disk admission")
+	}
+	if rec := r.h.AsOrg(testOrg).Get(turnPath("active")); rec.Code != http.StatusNoContent {
+		t.Errorf("no turn row should exist: active = %d, want 204", rec.Code)
+	}
+}
+
+// TestMarketplaceRegister_StartTurnDiskAdmissionIs503 is the live incident
+// path: synthetic register chat dual-Ensure refused at ≥90%.
+func TestMarketplaceRegister_StartTurnDiskAdmissionIs503(t *testing.T) {
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withConversations(&memConversationRepo{}),
+		withSnapshots(refusingSnapshots{}),
+	)
+	current := listMarketplaceConversations(t, r)[0].ConversationID
+	payload, _ := json.Marshal(map[string]any{
+		"instruction": "/register-external-resource Register a payment gateway",
+		"collab":      true,
+	})
+	rec := r.h.AsOrg(testOrg).Post(marketplaceTurnsPath(current), string(payload))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("marketplace disk-admission POST: code %d, want 503 (%s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"internal error"`) {
+		t.Errorf("503 body must not be opaque internal error, got %s", rec.Body.String())
+	}
+	if r.fake.turns(t) != 0 {
+		t.Error("agents dispatched despite marketplace disk admission")
+	}
+}

--- a/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
+++ b/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec_test
+
+// Component coverage for the synthetic Marketplace register chat project:
+// GetRepo 404s for __marketplace_register__ (and the usual testProj still
+// resolves when a fixture row is present), while list / rotate / StartTurn /
+// rehydrate succeed without minting a git_repositories row.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/clients/agentsvc"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+	"github.com/wso2/aep/aep-api/internal/spec"
+)
+
+func marketplaceConversationsPath() string {
+	return "/api/v1/projects/" + spec.MarketplaceRegisterProjectID + "/agents/conversations"
+}
+
+func marketplaceTurnsPath(uuid string) string {
+	return "/api/v1/projects/" + spec.MarketplaceRegisterProjectID + "/agents/" + uuid + "/messages"
+}
+
+func marketplaceConvPath(uuid string) string {
+	return "/api/v1/projects/" + spec.MarketplaceRegisterProjectID + "/agents/" + uuid + "/messages"
+}
+
+func marketplaceTurnPath(turnID string) string {
+	return "/api/v1/projects/" + spec.MarketplaceRegisterProjectID + "/turns/" + turnID
+}
+
+// countingRepoResolver records GetRepo project ids while delegating to an
+// inner stub (404 for the synthetic id; optional fixture for testProj).
+type countingRepoResolver struct {
+	inner stubRepoResolver
+	mu    sync.Mutex
+	calls []string
+}
+
+func (c *countingRepoResolver) GetRepo(ctx context.Context, orgID, projectID string) (*sourcecontrol.GitRepository, error) {
+	c.mu.Lock()
+	c.calls = append(c.calls, projectID)
+	c.mu.Unlock()
+	return c.inner.GetRepo(ctx, orgID, projectID)
+}
+
+func (c *countingRepoResolver) calledFor(projectID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, id := range c.calls {
+		if id == projectID {
+			n++
+		}
+	}
+	return n
+}
+
+func listMarketplaceConversations(t *testing.T, r *genaiRig) []conversationViewBody {
+	t.Helper()
+	rec := r.h.AsOrg(testOrg).Get(marketplaceConversationsPath())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET marketplace conversations: code %d (%s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Conversations []conversationViewBody `json:"conversations"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("list body: %v (%s)", err, rec.Body.String())
+	}
+	return out.Conversations
+}
+
+func TestMarketplaceRegister_ConversationsListAndRotateWithoutRepo(t *testing.T) {
+	// inner.rec is a testProj fixture only — GetRepo for the synthetic id 404s.
+	counter := &countingRepoResolver{inner: stubRepoResolver{rec: &sourcecontrol.GitRepository{
+		OrgID: testOrg, ProjectID: testProj, Status: "ready",
+	}}}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withConversations(&memConversationRepo{}),
+		withRepos(counter),
+	)
+
+	first := listMarketplaceConversations(t, r)
+	if len(first) != 1 || first[0].ConversationID == "" || !first[0].Current {
+		t.Fatalf("first list = %+v, want one current thread", first)
+	}
+	again := listMarketplaceConversations(t, r)
+	if again[0].ConversationID != first[0].ConversationID {
+		t.Fatalf("list minted a second thread: %q then %q", first[0].ConversationID, again[0].ConversationID)
+	}
+	if n := counter.calledFor(spec.MarketplaceRegisterProjectID); n != 0 {
+		t.Fatalf("GetRepo called %d time(s) for synthetic id — must not be a hard dependency", n)
+	}
+
+	rrec := r.h.AsOrg(testOrg).Post(marketplaceConversationsPath(), "")
+	if rrec.Code != http.StatusCreated {
+		t.Fatalf("POST rotate: code %d (%s)", rrec.Code, rrec.Body.String())
+	}
+	var rotated conversationViewBody
+	if err := json.Unmarshal(rrec.Body.Bytes(), &rotated); err != nil || rotated.ConversationID == "" {
+		t.Fatalf("rotate body = %s (err %v)", rrec.Body.String(), err)
+	}
+	if rotated.ConversationID == first[0].ConversationID {
+		t.Fatal("rotate returned the demoted thread")
+	}
+	if got := listMarketplaceConversations(t, r)[0].ConversationID; got != rotated.ConversationID {
+		t.Fatalf("list after rotate = %q, want %q", got, rotated.ConversationID)
+	}
+	if n := counter.calledFor(spec.MarketplaceRegisterProjectID); n != 0 {
+		t.Fatalf("GetRepo called for synthetic id during rotate/list (%d)", n)
+	}
+}
+
+func TestMarketplaceRegister_StartTurnWithoutProjectRepo(t *testing.T) {
+	counter := &countingRepoResolver{inner: stubRepoResolver{rec: &sourcecontrol.GitRepository{
+		OrgID: testOrg, ProjectID: testProj, Status: "ready",
+	}}}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withConversations(&memConversationRepo{}),
+		withRepos(counter),
+	)
+
+	current := listMarketplaceConversations(t, r)[0].ConversationID
+
+	m := manifestPart(map[string]string{}, nil)
+	r.fake.manifest = &m
+
+	payload, _ := json.Marshal(map[string]any{
+		"instruction": "/register-external-resource Register a payment gateway",
+	})
+	rec := r.h.AsOrg(testOrg).Post(marketplaceTurnsPath(current), string(payload))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("StartTurn: code %d, want 202 (%s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || out.TurnID == "" {
+		t.Fatalf("202 body = %s (err %v)", rec.Body.String(), err)
+	}
+
+	var st spec.TurnStatus
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		grec := r.h.AsOrg(testOrg).Get(marketplaceTurnPath(out.TurnID))
+		if grec.Code != http.StatusOK {
+			t.Fatalf("GET turn: code %d (%s)", grec.Code, grec.Body.String())
+		}
+		if err := json.Unmarshal(grec.Body.Bytes(), &st); err != nil {
+			t.Fatalf("status body: %v (%s)", err, grec.Body.String())
+		}
+		if st.Status != "running" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if st.Status != "completed" {
+		t.Fatalf("turn status = %q (%s), want completed", st.Status, st.Message)
+	}
+	if n := counter.calledFor(spec.MarketplaceRegisterProjectID); n != 0 {
+		t.Fatalf("GetRepo called %d time(s) for synthetic id during StartTurn", n)
+	}
+
+	sent := r.fake.sentTurn(t, 0)
+	wantConv := agentsvc.ConversationID(testOrg, spec.MarketplaceRegisterProjectID, "general", current)
+	if sent.req.Workspace.ConversationID != wantConv {
+		t.Errorf("namespaced conversation = %q, want %q", sent.req.Workspace.ConversationID, wantConv)
+	}
+	if sent.req.Workspace.RepoSlug != "marketplace-register" {
+		t.Errorf("repoSlug = %q, want marketplace-register", sent.req.Workspace.RepoSlug)
+	}
+	if sent.req.Workspace.Ref == "" || sent.req.Workspace.Ref != sent.req.Workspace.SkillsRef {
+		t.Errorf("ref=%q skillsRef=%q, want both equal to the skills SHA",
+			sent.req.Workspace.Ref, sent.req.Workspace.SkillsRef)
+	}
+	if sent.req.Workspace.SkillsRef != r.skillsOrigin.HeadSHA(t) {
+		t.Errorf("skillsRef = %s, want skills head %s", sent.req.Workspace.SkillsRef, r.skillsOrigin.HeadSHA(t))
+	}
+
+	// Empty-thread rehydrate on the synthetic id (agents store 404).
+	r.fake.mu.Lock()
+	r.fake.convStatus = http.StatusNotFound
+	r.fake.mu.Unlock()
+	hrec := r.h.AsOrg(testOrg).Get(marketplaceConvPath(current))
+	if hrec.Code != http.StatusOK {
+		t.Fatalf("rehydrate: code %d, want 200 (%s)", hrec.Code, hrec.Body.String())
+	}
+}
+
+func TestMarketplaceRegister_RealProjectStill404WhenRepoMissing(t *testing.T) {
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withConversations(&memConversationRepo{}),
+		withRepos(stubRepoResolver{}), // every GetRepo misses
+	)
+	rec := r.h.AsOrg(testOrg).Get(conversationsPath())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("testProj with no repo: code %d, want 404 (%s)", rec.Code, rec.Body.String())
+	}
+}

--- a/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
+++ b/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
@@ -143,8 +143,16 @@ func TestMarketplaceRegister_StartTurnWithoutProjectRepo(t *testing.T) {
 	)
 
 	current := listMarketplaceConversations(t, r)[0].ConversationID
+	skillsSHA := r.skillsOrigin.HeadSHA(t)
 
-	m := manifestPart(map[string]string{}, nil)
+	// Non-empty edit frames: on the fold path these would mutate (or fail
+	// against) the dual skills snapshot. roomMode must relay-only — same pin
+	// as TestCollabTurn_RoomScopedDispatchNoCommit.
+	r.fake.parts = []string{
+		textPart("drafting the external resource"),
+		editFilePart("requirements/requirements.md", "# Reqs\n", "# Requirements\n"),
+	}
+	m := manifestPart(map[string]string{"requirements/requirements.md": "# Requirements\n"}, nil)
 	r.fake.manifest = &m
 
 	payload, _ := json.Marshal(map[string]any{
@@ -176,8 +184,14 @@ func TestMarketplaceRegister_StartTurnWithoutProjectRepo(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if st.Status != "completed" {
-		t.Fatalf("turn status = %q (%s), want completed", st.Status, st.Message)
+	if st.Status != "completed" || !st.NoChanges {
+		t.Fatalf("terminal = %+v, want completed no-changes (relay-only)", st)
+	}
+	if st.CommitSHA != skillsSHA {
+		t.Errorf("commitSha = %s, want skills pin %s", st.CommitSHA, skillsSHA)
+	}
+	if r.skillsOrigin.HeadSHA(t) != skillsSHA {
+		t.Error("synthetic turn must not Mutate — skills origin tip moved")
 	}
 	if n := counter.calledFor(spec.MarketplaceRegisterProjectID); n != 0 {
 		t.Fatalf("GetRepo called %d time(s) for synthetic id during StartTurn", n)
@@ -195,8 +209,8 @@ func TestMarketplaceRegister_StartTurnWithoutProjectRepo(t *testing.T) {
 		t.Errorf("ref=%q skillsRef=%q, want both equal to the skills SHA",
 			sent.req.Workspace.Ref, sent.req.Workspace.SkillsRef)
 	}
-	if sent.req.Workspace.SkillsRef != r.skillsOrigin.HeadSHA(t) {
-		t.Errorf("skillsRef = %s, want skills head %s", sent.req.Workspace.SkillsRef, r.skillsOrigin.HeadSHA(t))
+	if sent.req.Workspace.SkillsRef != skillsSHA {
+		t.Errorf("skillsRef = %s, want skills head %s", sent.req.Workspace.SkillsRef, skillsSHA)
 	}
 
 	// Empty-thread rehydrate on the synthetic id (agents store 404).

--- a/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
+++ b/services/aep-api/internal/spec/genai_marketplace_register_component_test.go
@@ -223,6 +223,65 @@ func TestMarketplaceRegister_StartTurnWithoutProjectRepo(t *testing.T) {
 	}
 }
 
+// Console AgentChatPanel always POSTs collab:true. The synthetic id has no
+// spec room (no repo; room name fails DNS-label). StartTurn must drop Collab
+// so agents never join spec-<org>-__marketplace_register__.
+func TestMarketplaceRegister_StartTurnIgnoresCollab(t *testing.T) {
+	counter := &countingRepoResolver{inner: stubRepoResolver{rec: &sourcecontrol.GitRepository{
+		OrgID: testOrg, ProjectID: testProj, Status: "ready",
+	}}}
+	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
+		withConversations(&memConversationRepo{}),
+		withRepos(counter),
+	)
+	current := listMarketplaceConversations(t, r)[0].ConversationID
+	r.fake.parts = []string{textPart("drafting the external resource")}
+	m := manifestPart(nil, nil)
+	r.fake.manifest = &m
+
+	payload, _ := json.Marshal(map[string]any{
+		"instruction": "/register-external-resource i want to connect to github",
+		"collab":      true,
+	})
+	rec := r.h.AsOrg(testOrg).Post(marketplaceTurnsPath(current), string(payload))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("StartTurn: code %d, want 202 (%s)", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || out.TurnID == "" {
+		t.Fatalf("202 body = %s (err %v)", rec.Body.String(), err)
+	}
+
+	var st spec.TurnStatus
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		grec := r.h.AsOrg(testOrg).Get(marketplaceTurnPath(out.TurnID))
+		if grec.Code != http.StatusOK {
+			t.Fatalf("GET turn: code %d (%s)", grec.Code, grec.Body.String())
+		}
+		if err := json.Unmarshal(grec.Body.Bytes(), &st); err != nil {
+			t.Fatalf("status body: %v (%s)", err, grec.Body.String())
+		}
+		if st.Status != "running" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if st.Status != "completed" || !st.NoChanges {
+		t.Fatalf("terminal = %+v, want completed no-changes (relay-only)", st)
+	}
+	if n := counter.calledFor(spec.MarketplaceRegisterProjectID); n != 0 {
+		t.Fatalf("GetRepo called %d time(s) for synthetic id during collab StartTurn", n)
+	}
+
+	sent := r.fake.sentTurn(t, 0)
+	if sent.req.Collab != nil {
+		t.Fatalf("synthetic register dispatch carried collab room %q — agents must not join a spec room", sent.req.Collab.RoomID)
+	}
+}
+
 func TestMarketplaceRegister_RealProjectStill404WhenRepoMissing(t *testing.T) {
 	r := newGenaiRig(t, map[string]string{"specs/requirements/prd.md": "# Reqs\n"},
 		withConversations(&memConversationRepo{}),

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -117,17 +117,16 @@ type GitReader interface {
 // pre-202 (no platform fallback). Wired from AnthropicCredentialService.
 type AnthropicKeyResolver func(ctx context.Context, orgID string) (string, error)
 
-// SkillsRepoResolver ensures the org's _skills repo is provisioned (seeded
-// with the embedded flow skills) and returns its row — the source of the
-// turn's SkillsRef snapshot. Wired at the composition root from the skills
-// feature so genai holds no skills edge.
+// SkillsRepoResolver returns the org _skills git row used as a turn's
+// SkillsRef snapshot source. Production wires SkillsRepoForTurns so the
+// library is reconciled (not only first-touch provisioned). Genai holds no
+// skills edge.
 type SkillsRepoResolver func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error)
 
-// SkillsRepoForTurns is the production SkillsRepoResolver: Reconcile so a
-// platform skill shipped after first provision (register-external-resource)
-// lands in org _skills before Head/Ensure. EnsureProvisioned alone is
-// first-touch only and leaves loadSkill on a stale snapshot.
-func SkillsRepoForTurns(skills *SkillService, repos sourcecontrol.RepoService) SkillsRepoResolver {
+// SkillsRepoForTurns is the production SkillsRepoResolver: reconcile the org
+// _skills library so platform skills shipped after first provision land,
+// then return the row. EnsureProvisioned alone is first-touch seed.
+func SkillsRepoForTurns(skills *SkillService, repos RepoResolver) SkillsRepoResolver {
 	return func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error) {
 		if _, err := skills.Reconcile(ctx, orgID); err != nil {
 			return nil, fmt.Errorf("%w: reconcile: %w", ErrSkillsRepoUnavailable, err)

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -318,8 +318,10 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	// bearer NOW (D20 — the runner has no request context). Access is
 	// request-scoped: the collab server's oracle validates this token exactly
 	// like a browser join; no token → the turn cannot join, fail pre-202.
+	// The synthetic Marketplace register project has no spec room (no git
+	// repo; the id is not a DNS label) — ignore collab:true from the panel.
 	collabRoomID, collabToken := "", ""
-	if in.Collab {
+	if in.Collab && !isMarketplaceRegisterProject(projectID) {
 		collabToken = auth.GetAuthToken(ctx)
 		if collabToken == "" {
 			return "", ErrCollabNoToken

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -120,8 +120,21 @@ type AnthropicKeyResolver func(ctx context.Context, orgID string) (string, error
 // SkillsRepoResolver ensures the org's _skills repo is provisioned (seeded
 // with the embedded flow skills) and returns its row — the source of the
 // turn's SkillsRef snapshot. Wired at the composition root from the skills
-// feature (EnsureProvisioned + GetRepo) so genai holds no skills edge.
+// feature so genai holds no skills edge.
 type SkillsRepoResolver func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error)
+
+// SkillsRepoForTurns is the production SkillsRepoResolver: Reconcile so a
+// platform skill shipped after first provision (register-external-resource)
+// lands in org _skills before Head/Ensure. EnsureProvisioned alone is
+// first-touch only and leaves loadSkill on a stale snapshot.
+func SkillsRepoForTurns(skills *SkillService, repos sourcecontrol.RepoService) SkillsRepoResolver {
+	return func(ctx context.Context, orgID string) (*sourcecontrol.GitRepository, error) {
+		if _, err := skills.Reconcile(ctx, orgID); err != nil {
+			return nil, fmt.Errorf("%w: reconcile: %w", ErrSkillsRepoUnavailable, err)
+		}
+		return repos.GetRepo(ctx, orgID, SkillsRepoSentinelProjectID)
+	}
+}
 
 // ---- input / views ----------------------------------------------------------
 

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -330,39 +330,22 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	ws := s.git.Workspace()
 
 	// Workspace + skills snapshots. Real projects resolve their git row; the
-	// synthetic Marketplace register project has none — we dual-materialize
-	// the org _skills commit at the agents project snapshot path instead
-	// (controller ruling: no GitHub / git_repositories row for that id).
+	// synthetic Marketplace register project has none — we rewrite a skills
+	// RepoRef onto the agents project snapshot path instead (controller
+	// ruling: no GitHub / git_repositories row for that id). Skills resolve +
+	// dual Ensure are shared below so error/Ensure changes cannot drift.
 	var (
 		ref              sourcecontrol.RepoRef
 		baseRef          string
-		skillsRef        string
 		nsConversationID string
+		skillsCred       secrets.Credential
 	)
 	if isMarketplaceRegisterProject(projectID) {
 		cred, err := s.git.Resolver().Resolve(ctx, orgID)
 		if err != nil {
 			return "", fmt.Errorf("resolve credential: %w", err)
 		}
-		skillsRow, err := s.skillsRepo(ctx, orgID)
-		if err != nil {
-			return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
-		}
-		skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, cred)
-		skillsRef, err = ws.Head(ctx, skillsRepoRef, "")
-		if err != nil {
-			return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
-		}
-		ref = skillsRepoRef
-		ref.ProjectID = MarketplaceRegisterProjectID
-		ref.RepoSlug = marketplaceRegisterRepoSlug
-		baseRef = skillsRef
-		if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
-			return "", fmt.Errorf("ensure repo snapshot: %w", err)
-		}
-		if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
-			return "", fmt.Errorf("ensure skills snapshot: %w", err)
-		}
+		skillsCred = cred
 		nsConversationID = agentsvc.ConversationID(orgID, projectID, useCaseGeneral, in.ConversationID)
 	} else {
 		repo, err := s.resolveRepo(ctx, orgID, projectID)
@@ -377,22 +360,30 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 		if err != nil {
 			return "", fmt.Errorf("resolve base ref: %w", err)
 		}
-		skillsRow, err := s.skillsRepo(ctx, orgID)
-		if err != nil {
-			return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
-		}
-		skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, ref.Cred)
-		skillsRef, err = ws.Head(ctx, skillsRepoRef, "")
-		if err != nil {
-			return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
-		}
-		if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
-			return "", fmt.Errorf("ensure repo snapshot: %w", err)
-		}
-		if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
-			return "", fmt.Errorf("ensure skills snapshot: %w", err)
-		}
+		skillsCred = ref.Cred
 		nsConversationID = namespacedID(repo, useCaseGeneral, in.ConversationID)
+	}
+
+	skillsRow, err := s.skillsRepo(ctx, orgID)
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
+	}
+	skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, skillsCred)
+	skillsRef, err := ws.Head(ctx, skillsRepoRef, "")
+	if err != nil {
+		return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
+	}
+	if isMarketplaceRegisterProject(projectID) {
+		ref = skillsRepoRef
+		ref.ProjectID = MarketplaceRegisterProjectID
+		ref.RepoSlug = marketplaceRegisterRepoSlug
+		baseRef = skillsRef
+	}
+	if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
+		return "", fmt.Errorf("ensure repo snapshot: %w", err)
+	}
+	if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
+		return "", fmt.Errorf("ensure skills snapshot: %w", err)
 	}
 
 	// Flow recognition (#373): `/<skill>` commands arrive VERBATIM and the

--- a/services/aep-api/internal/spec/genai_service.go
+++ b/services/aep-api/internal/spec/genai_service.go
@@ -309,15 +309,6 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	if strings.TrimSpace(in.Instruction) == "" {
 		return "", ErrEmptyInstruction
 	}
-	repo, err := s.resolveRepo(ctx, orgID, projectID)
-	if err != nil {
-		return "", err
-	}
-	ref, err := sourcecontrol.ResolveWorkspaceRef(ctx, s.git.Resolver(), orgID, repo)
-	if err != nil {
-		return "", fmt.Errorf("resolve workspace ref: %w", err)
-	}
-
 	key, err := s.resolveKey(ctx, orgID)
 	if err != nil {
 		return "", err
@@ -337,9 +328,71 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	}
 
 	ws := s.git.Workspace()
-	baseRef, err := ws.Head(ctx, ref, "")
-	if err != nil {
-		return "", fmt.Errorf("resolve base ref: %w", err)
+
+	// Workspace + skills snapshots. Real projects resolve their git row; the
+	// synthetic Marketplace register project has none — we dual-materialize
+	// the org _skills commit at the agents project snapshot path instead
+	// (controller ruling: no GitHub / git_repositories row for that id).
+	var (
+		ref              sourcecontrol.RepoRef
+		baseRef          string
+		skillsRef        string
+		nsConversationID string
+	)
+	if isMarketplaceRegisterProject(projectID) {
+		cred, err := s.git.Resolver().Resolve(ctx, orgID)
+		if err != nil {
+			return "", fmt.Errorf("resolve credential: %w", err)
+		}
+		skillsRow, err := s.skillsRepo(ctx, orgID)
+		if err != nil {
+			return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
+		}
+		skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, cred)
+		skillsRef, err = ws.Head(ctx, skillsRepoRef, "")
+		if err != nil {
+			return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
+		}
+		ref = skillsRepoRef
+		ref.ProjectID = MarketplaceRegisterProjectID
+		ref.RepoSlug = marketplaceRegisterRepoSlug
+		baseRef = skillsRef
+		if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
+			return "", fmt.Errorf("ensure repo snapshot: %w", err)
+		}
+		if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
+			return "", fmt.Errorf("ensure skills snapshot: %w", err)
+		}
+		nsConversationID = agentsvc.ConversationID(orgID, projectID, useCaseGeneral, in.ConversationID)
+	} else {
+		repo, err := s.resolveRepo(ctx, orgID, projectID)
+		if err != nil {
+			return "", err
+		}
+		ref, err = sourcecontrol.ResolveWorkspaceRef(ctx, s.git.Resolver(), orgID, repo)
+		if err != nil {
+			return "", fmt.Errorf("resolve workspace ref: %w", err)
+		}
+		baseRef, err = ws.Head(ctx, ref, "")
+		if err != nil {
+			return "", fmt.Errorf("resolve base ref: %w", err)
+		}
+		skillsRow, err := s.skillsRepo(ctx, orgID)
+		if err != nil {
+			return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
+		}
+		skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, ref.Cred)
+		skillsRef, err = ws.Head(ctx, skillsRepoRef, "")
+		if err != nil {
+			return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
+		}
+		if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
+			return "", fmt.Errorf("ensure repo snapshot: %w", err)
+		}
+		if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
+			return "", fmt.Errorf("ensure skills snapshot: %w", err)
+		}
+		nsConversationID = namespacedID(repo, useCaseGeneral, in.ConversationID)
 	}
 
 	// Flow recognition (#373): `/<skill>` commands arrive VERBATIM and the
@@ -357,26 +410,6 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 	// Only `/start` is rewritten, and only to append an idea the server just
 	// resolved for the same turn, so the line still describes what was sent.
 	summary := startTurnSummary(in.Instruction, turnSpec)
-
-	// Skills resolve failures are typed: both arms mean the org's _skills repo
-	// is unusable right now (row missing/unprovisionable, or the backing repo
-	// gone/unreachable — e.g. deleted externally under a lingering row). The
-	// edge maps this to a logged 503 rather than the old opaque 500.
-	skillsRow, err := s.skillsRepo(ctx, orgID)
-	if err != nil {
-		return "", fmt.Errorf("%w: resolve repo row: %w", ErrSkillsRepoUnavailable, err)
-	}
-	skillsRepoRef := sourcecontrol.WorkspaceRefFor(orgID, skillsRow, ref.Cred)
-	skillsRef, err := ws.Head(ctx, skillsRepoRef, "")
-	if err != nil {
-		return "", fmt.Errorf("%w: resolve head: %w", ErrSkillsRepoUnavailable, err)
-	}
-	if err := s.snapshots.Ensure(ctx, ref, baseRef); err != nil {
-		return "", fmt.Errorf("ensure repo snapshot: %w", err)
-	}
-	if err := s.snapshots.Ensure(ctx, skillsRepoRef, skillsRef); err != nil {
-		return "", fmt.Errorf("ensure skills snapshot: %w", err)
-	}
 
 	// D18 guard: one active turn per project, any use case.
 	// The display record rides the row itself: a client attaching to this turn
@@ -410,7 +443,7 @@ func (s *Service) StartTurn(ctx context.Context, orgID, projectID string, in Tur
 		projectID:        projectID,
 		flow:             flow,
 		conversationID:   in.ConversationID,
-		nsConversationID: namespacedID(repo, useCaseGeneral, in.ConversationID),
+		nsConversationID: nsConversationID,
 		turn:             turnSpec,
 		target:           in.Target,
 		summary:          summary,
@@ -481,14 +514,21 @@ func (s *Service) Rehydrate(ctx context.Context, orgID, projectID, conversationI
 	if !validConversationID(conversationID) {
 		return nil, ErrInvalidConversationID
 	}
-	repo, err := s.resolveRepo(ctx, orgID, projectID)
-	if err != nil {
-		return nil, err
+	var convID string
+	if isMarketplaceRegisterProject(projectID) {
+		// Synthetic register chat has no git_repositories row — build the
+		// agents tenancy id from the JWT org + path project id directly.
+		convID = agentsvc.ConversationID(orgID, projectID, useCaseGeneral, conversationID)
+	} else {
+		repo, err := s.resolveRepo(ctx, orgID, projectID)
+		if err != nil {
+			return nil, err
+		}
+		// Rehydrate is chat-only (single-turn generate flows never rehydrate). The
+		// console omits "useCase", so its turns are namespaced under useCaseGeneral;
+		// reconstruct the id under the same use case the write path stored it with.
+		convID = namespacedID(repo, useCaseGeneral, conversationID)
 	}
-	// Rehydrate is chat-only (single-turn generate flows never rehydrate). The
-	// console omits "useCase", so its turns are namespaced under useCaseGeneral;
-	// reconstruct the id under the same use case the write path stored it with.
-	convID := namespacedID(repo, useCaseGeneral, conversationID)
 	raw, err := s.client.GetConversation(ctx, convID, orgID)
 	if err != nil {
 		var ue *agentsvc.UpstreamError

--- a/services/aep-api/internal/spec/genaiturns/handler.go
+++ b/services/aep-api/internal/spec/genaiturns/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/agentsvc"
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/platform/apierr"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 	"github.com/wso2/aep/aep-api/internal/platform/tenant"
 	"github.com/wso2/aep/aep-api/internal/spec"
 )
@@ -406,6 +407,12 @@ func mapGenAITurnError(ctx context.Context, err error) error {
 		// skills-repo arm above.
 		slog.ErrorContext(ctx, "genai turn: conversation store not configured", "error", err)
 		return apierr.ServiceUnavailable(spec.ErrConversationsUnavailable.Error())
+	case errors.Is(err, gitfs.ErrDiskAdmission):
+		// New snapshot dests are refused at ≥90% workspace usage. Operator
+		// recovery (reap / prune), not a client bug — 503 with a sentence
+		// the console can show, cause in the logs. Same posture as skills.
+		slog.ErrorContext(ctx, "genai turn: workspace disk admission refused", "error", err)
+		return apierr.ServiceUnavailable("workspace disk is full — try again in a few minutes, or contact your platform admin")
 	default:
 		return genaiInternalError(ctx, "genai turn", err)
 	}

--- a/services/aep-api/internal/spec/genaiturns/handler_test.go
+++ b/services/aep-api/internal/spec/genaiturns/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/wso2/aep/aep-api/internal/platform/apierr"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 	"github.com/wso2/aep/aep-api/internal/spec"
 )
 
@@ -54,6 +55,8 @@ func TestMapGenAITurnError_Table(t *testing.T) {
 		{"buffer truncated", spec.ErrTurnBufferTruncated, 409},
 		{"skills repo unavailable", fmt.Errorf("%w: resolve head: boom", spec.ErrSkillsRepoUnavailable), 503},
 		{"wrapped skills unavailable", fmt.Errorf("start turn: %w", spec.ErrSkillsRepoUnavailable), 503},
+		{"disk admission", fmt.Errorf("ensure repo snapshot: %w", gitfs.ErrDiskAdmission), 503},
+		{"wrapped disk admission", fmt.Errorf("start turn: %w", gitfs.ErrDiskAdmission), 503},
 		{"unmapped default", errors.New("some unexpected failure"), 500},
 	}
 	for _, tc := range cases {
@@ -143,6 +146,25 @@ func TestGenAISkillsUnavailable_LogsCause(t *testing.T) {
 		t.Fatalf("skills-unavailable status = %d, want 503", got)
 	}
 	if !strings.Contains(buf.String(), "git ref not found") {
+		t.Errorf("503 log did not carry the cause; log = %q", buf.String())
+	}
+}
+
+func TestGenAIDiskAdmission_Is503NotInternalError(t *testing.T) {
+	buf := captureGenAILogs(t)
+	err := fmt.Errorf("ensure repo snapshot: %w (usage=92%%)", gitfs.ErrDiskAdmission)
+	mapped := mapGenAITurnError(context.Background(), err)
+	var ae *apierr.Error
+	if !errors.As(mapped, &ae) {
+		t.Fatalf("expected an *apierr.Error, got %T (%v)", mapped, mapped)
+	}
+	if ae.Status != 503 {
+		t.Fatalf("disk-admission status = %d, want 503", ae.Status)
+	}
+	if ae.Message == "internal error" {
+		t.Fatalf("message = %q, want a sentence the console can show", ae.Message)
+	}
+	if !strings.Contains(buf.String(), "disk admission") && !strings.Contains(buf.String(), "usage=92") {
 		t.Errorf("503 log did not carry the cause; log = %q", buf.String())
 	}
 }

--- a/services/aep-api/internal/spec/marketplace_register.go
+++ b/services/aep-api/internal/spec/marketplace_register.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+// MarketplaceRegisterProjectID is the synthetic project key Marketplace
+// register chat uses with today's project-chat APIs. It must match the console
+// constant MARKETPLACE_CHAT_PROJECT — there is no git_repositories row for it.
+const MarketplaceRegisterProjectID = "__marketplace_register__"
+
+// marketplaceRegisterRepoSlug is the agents WorkspaceRef.repoSlug for the
+// dual skills snapshot mounted at the synthetic project path. It must match
+// agents REPO_SLUG_RE (leading [a-z0-9], not underscore).
+const marketplaceRegisterRepoSlug = "marketplace-register"
+
+func isMarketplaceRegisterProject(projectID string) bool {
+	return projectID == MarketplaceRegisterProjectID
+}

--- a/services/aep-api/internal/spec/skills_repo_for_turns_test.go
+++ b/services/aep-api/internal/spec/skills_repo_for_turns_test.go
@@ -43,9 +43,10 @@ func archPlusRegisterLibrary() fstest.MapFS {
 // TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill is the live
 // register-chat miss: org _skills was first-provisioned before
 // register-external-resource shipped. EnsureProvisioned is a no-op on an
-// existing repo, so loadSkill (repos/<org>/_skills/org-skills/snapshots/<sha>/)
-// never sees the skill. The turn resolver must Reconcile, then Ensure, so
-// both the skills dest and the marketplace-register dual dest list it.
+// existing repo, so the SkillsRef snapshot never sees the skill. The turn
+// resolver must Reconcile; StartTurn then Ensures. Both the loadSkill dest
+// (_skills/org-skills) and the marketplace-register dual dest must list the
+// new skill, and skills already in the library (architecture) must remain.
 func TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -76,6 +77,7 @@ func TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill(t *testing.T) {
 	}
 
 	wantRel := filepath.Join("skills", "register-external-resource", "SKILL.md")
+	stillRel := filepath.Join("skills", "architecture", "SKILL.md")
 	for _, ref := range []sourcecontrol.RepoRef{skillsRef, marketRef} {
 		dir, err := gitfs.SnapshotDir(host.engine.Root(), ref, sha)
 		if err != nil {
@@ -87,6 +89,13 @@ func TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill(t *testing.T) {
 		}
 		if !strings.Contains(string(body), "name: register-external-resource") {
 			t.Errorf("snapshot %s: SKILL.md = %q, want name register-external-resource", dir, body)
+		}
+		arch, err := os.ReadFile(filepath.Join(dir, stillRel))
+		if err != nil {
+			t.Fatalf("existing platform skill missing from %s: %v", dir, err)
+		}
+		if !strings.Contains(string(arch), "name: architecture") {
+			t.Errorf("snapshot %s: architecture clobbered: %q", dir, arch)
 		}
 	}
 }

--- a/services/aep-api/internal/spec/skills_repo_for_turns_test.go
+++ b/services/aep-api/internal/spec/skills_repo_for_turns_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
+	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
+)
+
+func archOnlyLibrary() fstest.MapFS {
+	return fstest.MapFS{
+		"architecture/SKILL.md": &fstest.MapFile{Data: []byte("---\nname: architecture\ndescription: d\nmetadata:\n  aep:\n    kind: platform\n---\nbody\n")},
+	}
+}
+
+func archPlusRegisterLibrary() fstest.MapFS {
+	lib := archOnlyLibrary()
+	lib["register-external-resource/SKILL.md"] = &fstest.MapFile{Data: []byte("---\nname: register-external-resource\ndescription: Use when registering a Registered External resource from Marketplace chat.\nmetadata:\n  aep:\n    kind: platform\n    audience: [design]\n---\n# Register\n")}
+	return lib
+}
+
+// TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill is the live
+// register-chat miss: org _skills was first-provisioned before
+// register-external-resource shipped. EnsureProvisioned is a no-op on an
+// existing repo, so loadSkill (repos/<org>/_skills/org-skills/snapshots/<sha>/)
+// never sees the skill. The turn resolver must Reconcile, then Ensure, so
+// both the skills dest and the marketplace-register dual dest list it.
+func TestSkillsRepoForTurns_SnapshotIncludesNewPlatformSkill(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, host := newTestStoreWithLibrary(t, archOnlyLibrary())
+	if err := svc.EnsureProvisioned(ctx, "org1"); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	svc.SwapLibrary(archPlusRegisterLibrary())
+
+	row, err := SkillsRepoForTurns(svc, host)(ctx, "org1")
+	if err != nil {
+		t.Fatalf("SkillsRepoForTurns: %v", err)
+	}
+	git := sourcecontrol.NewGitOpsService(fakeResolver{}, host.engine)
+	skillsRef := sourcecontrol.WorkspaceRefFor("org1", row, fakeCred{})
+	sha, err := git.Workspace().Head(ctx, skillsRef, "")
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if err := host.engine.Ensure(ctx, skillsRef, sha); err != nil {
+		t.Fatalf("Ensure skills: %v", err)
+	}
+	marketRef := skillsRef
+	marketRef.ProjectID = MarketplaceRegisterProjectID
+	marketRef.RepoSlug = marketplaceRegisterRepoSlug
+	if err := host.engine.Ensure(ctx, marketRef, sha); err != nil {
+		t.Fatalf("Ensure marketplace-register: %v", err)
+	}
+
+	wantRel := filepath.Join("skills", "register-external-resource", "SKILL.md")
+	for _, ref := range []sourcecontrol.RepoRef{skillsRef, marketRef} {
+		dir, err := gitfs.SnapshotDir(host.engine.Root(), ref, sha)
+		if err != nil {
+			t.Fatalf("SnapshotDir: %v", err)
+		}
+		body, err := os.ReadFile(filepath.Join(dir, wantRel))
+		if err != nil {
+			t.Fatalf("loadSkill path %s missing %s: %v", dir, wantRel, err)
+		}
+		if !strings.Contains(string(body), "name: register-external-resource") {
+			t.Errorf("snapshot %s: SKILL.md = %q, want name register-external-resource", dir, body)
+		}
+	}
+}

--- a/services/aep-api/internal/spec/turn_runner.go
+++ b/services/aep-api/internal/spec/turn_runner.go
@@ -350,11 +350,11 @@ func (s *Service) executeTurn(ctx context.Context, job turnJob) TurnTerminal {
 		}
 	}()
 
-	// Room-scoped turn (#86 phase 4): the doc is the write surface — the fold
-	// would run against the SNAPSHOT while the agents-side bundle started from
-	// the DOC, so parity is undefined by construction. Relay frames only;
-	// nothing folds, nothing commits, no manifest gate.
-	roomMode := job.collabRoomID != ""
+	// Relay-only turns: collab roomMode (#86 phase 4) — doc is the write
+	// surface — and Marketplace register chat, whose project snapshot is a
+	// dual materialization of org-skills (folding would commit into skills).
+	// Relay frames only; nothing folds, nothing commits, no manifest gate.
+	roomMode := job.collabRoomID != "" || isMarketplaceRegisterProject(job.projectID)
 
 	fold := agentfold.New(s.turnBaseReader(job.repoRef, job.baseRef))
 	var manifest *agentfold.Manifest

--- a/skills/register-external-resource/SKILL.md
+++ b/skills/register-external-resource/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: register-external-resource
+description: Use when registering a Registered External resource from Marketplace chat (`/register-external-resource`).
+metadata:
+  aep:
+    kind: platform
+    audience: [design]
+---
+
+# Register External resource
+
+This creates a **Registered External resource** — an org-level integration
+projects can consume, with config keys whose values are filled per environment
+on the form, never in chat.
+
+The instruction's trailing text is the user's idea, in their words. It is a
+brief, not a schema.
+
+## When unsure, ask — never invent a schema
+
+If the idea does not pin a name, what the resource is, how consumers should
+call it, or which config keys exist, stop and ask with `ask_question` /
+`ask_questions`. Do **not** invent a schema to look finished.
+
+`grilling` owns the question mechanics. Ask only questions whose answers change
+the draft.
+
+## When sure (or after answers), draft
+
+Call `draftExternalResource` with:
+
+- **name** — the resource identity
+- **description** — what the resource is
+- **consumption instructions** — how a consuming project should use it;
+  distinct from description, never a restatement of it
+- **config keys** — each with `key`, `description`, and `secret`
+- **resource-docs** — optional, URL-only
+
+## Secrets stay off this channel
+
+**Never** put env values or secret bytes in the draft, in questions, or in
+narration. Environment values are form-only.
+
+## Edit
+
+On edit, **never** change `name`. Identity is frozen; everything else in the
+draft may still be refined.

--- a/skills/register-external-resource/SKILL.md
+++ b/skills/register-external-resource/SKILL.md
@@ -43,5 +43,6 @@ narration. Environment values are form-only.
 
 ## Edit
 
-On edit, **never** change `name`. Identity is frozen; everything else in the
-draft may still be refined.
+On edit, **never** change `name` or config key identities. You may refine
+description, consumption instructions, existing key descriptions, and URL
+resource-docs. Do not add or rename keys.


### PR DESCRIPTION
## Why

Marketplace **Resources** is the org catalog of third-party APIs and SaaS systems (Stripe, SendGrid, an internal HTTP API, and so on). Earlier PRs in this stack already let someone **register** one of those by hand: a short idea page, then a form for name, description, how to consume it, config keys, per-environment values, and docs.

That form is still a lot to fill from a one-line idea. This PR adds the **agent chat** on that form so the idea can become a draft — without ever putting API keys or other secrets through the agent.

## What a user sees

1. On **Resources**, they click **Register** and type an idea (for example “Stripe payments”).
2. **Start** opens the register form with **agent chat already open** on the side. They do not type a slash command; the view starts the agent with `/register-external-resource` plus their idea.
3. If the idea is enough, the agent fills the non-secret fields (name, description, consumption instructions, config-key names/descriptions, documentation URLs).
4. If the idea is too vague, the agent **asks questions in that chat** and **leaves the form empty** until it has answers. Then it fills the same non-secret fields.
5. They can keep chatting to tweak those fields (for example change the description, or add an OpenAPI URL). Chat never overwrites a documentation **file** they already attached; it only adds or updates URL docs.
6. They type **environment values and secrets themselves**. Chat, questions, and the draft tool never write those fields.
7. Chat can be closed and reopened. **Submit still works with chat closed** — same hand-filled form as before.
8. **Edit** also opens the form with chat. The agent cannot rename the resource or add/rename config keys (consumers already depend on that identity).

This is chat on the register/edit form only. It is not a new chat product, and it is not chat on every console page.

## What this PR does not change

- How submit creates or updates the org record (that is already in the parent stack).
- Project-level “connection values” dialogs.
- Wiring a project to consume a registered resource without re-entering secrets (later work).

## For reviewers

- Reuses the existing **project chat** HTTP/SSE APIs. The register view uses a synthetic project name so org-level register does not need a new chat API.
- New platform skill: `skills/register-external-resource/` (ask when unsure; never put env values or secrets in the draft).
- Console applies a `draftExternalResource` tool payload to the form. That seam is mocked in MSW until the agents service grows a real tool.
- Stack: this PR targets `marketplace/07-docs` ([#622](https://github.com/wso2/labs-agentic-engineer/pull/622)). Merge with `gh stack merge 624 --yes`, not `gh pr merge`.

## Follow-ups on this PR (live e2e)

Live register chat on `:8090` first returned opaque **500** (`ErrDiskAdmission`), then **502** collab join on `spec-default-__marketplace_register__`. After those, StartTurn **202** / `flow=register-external-resource` but agents `loadSkill` returned **unknown skills: register-external-resource** — org `_skills` was first-provisioned before the skill shipped; turns only called `EnsureProvisioned`.

On origin (`f2c9ec82`):

- `195042c3` — `ErrDiskAdmission` → **503** workspace-disk sentence (genai + files).
- `85bab70f` — register chat right-hand dock, full height of `AppShell.Main`.
- `041b79a0` — `StartTurn` ignores `collab: true` for `__marketplace_register__`.
- `680c0126` — HTTP pin: stub `snapshots.Ensure` → StartTurn **503**.
- `05802275` — turn `SkillsRepoResolver` **Reconcile**s org `_skills` before Head/Ensure so `register-external-resource` is in `repos/<org>/_skills/org-skills/snapshots/<skillsRef>/` (the dest `loadSkill` reads).
- `f2c9ec82` — resolver comments/port match Reconcile; test also pins architecture still in that snapshot.

Rebuild **aep-api** from this tip (09 after rebase onto `f2c9ec82`). Do **not** rebuild from dirty primary `main`. MemoryValuePlane wipe → 09 `_dev` rehydrate. Disk must stay under 90%.

Verifying agent handoff: `/tmp/aep-marketplace-05-register-skill-e2e-handoff.md`

## Test plan

- [x] Opening create with a prompt sends `/register-external-resource` plus that prompt once
- [x] Vague idea → questions, form stays empty until a draft; a specific idea fills immediately
- [x] A later chat turn that only patches description/instructions leaves typed env values unchanged
- [x] A later URL-docs draft keeps existing file rows
- [x] `pnpm --filter @aep/console test` — 1199 passed
- [x] `pnpm --filter @aep/console typecheck`
- [x] Playground recognises `/register-external-resource` as a flow command (same family as `/start`)
- [x] `go test ./internal/spec/genaiturns/ ./internal/spec/files/` — disk admission maps to 503
- [x] `go test -run 'TestDiskAdmission_|TestMarketplaceRegister_|TestCollabTurn_RoomScoped|TestSkillsRepoForTurns_' ./internal/spec/`
- [ ] Live `:8090` StartTurn **202**, `loadSkill` succeeds, **draft fills non-secret fields**, secrets stay empty
