### PR TITLE
fix(collab,console): a room that cannot be seeded is refused, not opened empty

### DIFF
--- a/apps/console/design/decisions/ADR-0020-console-reads-never-create-doc-nodes.md
+++ b/apps/console/design/decisions/ADR-0020-console-reads-never-create-doc-nodes.md
@@ -14,16 +14,6 @@
 - **Reads of the collab document are non-creating.** `getFileFragment` returns a
   fragment only when `doc.share.has(path)`, matching `getFileText`. No render
   path may bring a node into existence as a side effect of looking at it.
-- **One narrow exception, and it is the caller's assertion, not the getter's
-  guess:** `getFileFragment(path, { create: true })` materialises the fragment
-  for a path **git already holds**. It exists because presence cannot answer for
-  an *empty* file — an empty or whitespace-only markdown file seeds to a
-  zero-length fragment, which generates no update and so never replicates its
-  key to a joining client, leaving `share.has` false for a document the room
-  genuinely owns. Without the exception such a file would open read-only forever
-  and nobody could type its first character. The flag is passed only from the
-  committed file list the Files API returned — never from `docPaths`, which
-  would let a phantom vouch for itself.
 - **A path enters a room from exactly two sources:** the server's seed from git
   (`onLoadDocument`), and peers over sync — agents writing spec files, or
   another client that already holds them. The console authors *edits to nodes
@@ -45,8 +35,20 @@
   requirements entry that suppressed both the empty state and the failed-kickoff
   banner.
 - The rule is checkable in review: a `getXmlFragment` call in console code is a
-  defect unless it is guarded by `share.has` or by a committed-file list that
-  proves git holds the path.
+  defect unless it is guarded by `share.has`. There is no exception to carve
+  out and no flag to pass, which is the point — an exception is a rule every
+  future call site has to remember.
 - Agents keep full authority to introduce files mid-session; nothing about the
   live agent-authoring flow changes, because those nodes arrive over sync with
   their share entry already present.
+- **`share.has` is only trustworthy because an empty document is one empty
+  paragraph.** Parsing `""` used to yield zero blocks, and a fragment with no
+  children generates no Yjs update — so its key never replicated and a file the
+  room really was seeded with read as absent here. Emptying a document is a
+  supported action (the committer writes an emptied fragment back as an empty
+  file, since a top-level fragment cannot be deleted from a Y.Doc), so this was
+  reachable by clearing a document and reopening it after the room unloaded:
+  permanently read-only, with no way to type the first character back.
+  `markdownToFragment` now normalizes the empty document to the shape the
+  editor itself holds, which is what lets this ADR stay a rule with no
+  exceptions.

--- a/apps/console/design/decisions/ADR-0020-console-reads-never-create-doc-nodes.md
+++ b/apps/console/design/decisions/ADR-0020-console-reads-never-create-doc-nodes.md
@@ -1,0 +1,52 @@
+# ADR-0020: The console never creates document nodes — agents do
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Context:** grilled on #586 (a failed room seed rendering a blank PRD). The
+  console's two collab reads were asymmetric: `getFileText` reads through
+  `filesMap(doc).get(path)` and returns `null` for a path the room lacks, while
+  `getFileFragment` called `Y.Doc.getXmlFragment(path)`, which **creates** a
+  fragment for any path asked for. A read that writes made "does the room hold
+  this file?" unanswerable, because asking made the answer yes.
+
+## Decision
+
+- **Reads of the collab document are non-creating.** `getFileFragment` returns a
+  fragment only when `doc.share.has(path)`, matching `getFileText`. No render
+  path may bring a node into existence as a side effect of looking at it.
+- **One narrow exception, and it is the caller's assertion, not the getter's
+  guess:** `getFileFragment(path, { create: true })` materialises the fragment
+  for a path **git already holds**. It exists because presence cannot answer for
+  an *empty* file — an empty or whitespace-only markdown file seeds to a
+  zero-length fragment, which generates no update and so never replicates its
+  key to a joining client, leaving `share.has` false for a document the room
+  genuinely owns. Without the exception such a file would open read-only forever
+  and nobody could type its first character. The flag is passed only from the
+  committed file list the Files API returned — never from `docPaths`, which
+  would let a phantom vouch for itself.
+- **A path enters a room from exactly two sources:** the server's seed from git
+  (`onLoadDocument`), and peers over sync — agents writing spec files, or
+  another client that already holds them. The console authors *edits to nodes
+  that exist*; it never authors their existence.
+- **Therefore `docPaths` is a fact about the room**, not about what the console
+  has looked at, and `usesCollab` means what it says: the room really holds this
+  file, so the live editor owns it and the committed-git fallback stands down.
+- Should the console ever need to create a spec file, it is an **explicit user
+  action** that says so — never a getter.
+
+## Consequences
+
+- The committed-git fallback becomes reachable again. It was suppressed for any
+  path the console had merely rendered, which is what let an unseeded room paint
+  a blank document over a PRD that exists in git.
+- The file list stops gaining phantom entries. `listDocPaths` reads
+  `doc.share.keys()`, so a console-created fragment appeared as a real file —
+  on a project with no `prd.md` yet, reading the PRD for the rail conjured a
+  requirements entry that suppressed both the empty state and the failed-kickoff
+  banner.
+- The rule is checkable in review: a `getXmlFragment` call in console code is a
+  defect unless it is guarded by `share.has` or by a committed-file list that
+  proves git holds the path.
+- Agents keep full authority to introduce files mid-session; nothing about the
+  live agent-authoring flow changes, because those nodes arrive over sync with
+  their share entry already present.

--- a/apps/console/src/features/spec/api/labels.ts
+++ b/apps/console/src/features/spec/api/labels.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { PRD_PATH } from "./mapping";
+
+const DESIGN_ROOT = "specs/design/design.md";
+const SECURITY = "specs/design/security.md";
+const OPENAPI_RE = /\/openapi\.ya?ml$/;
+const COMPONENT_DESIGN_RE = /^specs\/design\/components\/[^/]+\/design\.json$/;
+const VALIDATION_CRITERIA_RE = /^specs\/validation\/validation-criteria\.json$/;
+
+function basename(path: string): string {
+  return path.split("/").at(-1) ?? path;
+}
+
+/**
+ * A document's NAME, never its filename (#575).
+ *
+ * The user is reading a document tree, not a repository — `prd.md` and
+ * `security.md` are storage details that leaked into the one surface they read
+ * throughout the journey. The repo paths deliberately do not change; this is
+ * the mapping, and the lexicon holds the same table in words.
+ *
+ * A file with no entry here falls back to its filename, which keeps an
+ * agent-invented document readable rather than blank. Feature files land there
+ * on purpose: their filename IS the feature's name, so the fallback is already
+ * the right answer.
+ */
+const TITLES: Record<string, string> = {
+  [PRD_PATH]: "Product requirements",
+  [DESIGN_ROOT]: "Design overview",
+  [SECURITY]: "Security",
+};
+
+export function fileLabel(path: string): string {
+  if (Object.hasOwn(TITLES, path)) return TITLES[path] as string;
+  if (OPENAPI_RE.test(path)) return "API";
+  if (COMPONENT_DESIGN_RE.test(path)) return "Design overview";
+  if (VALIDATION_CRITERIA_RE.test(path)) return "Acceptance criteria";
+  // A document nothing above names — a feature file most of the time, where
+  // the filename IS the feature's name once the extension is off it. Keeping
+  // `.md` would leave the one surface the user reads throughout still showing
+  // them a file.
+  return basename(path).replace(/\.md$/, "");
+}
+

--- a/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
+++ b/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
@@ -27,8 +27,10 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type * as Y from "yjs";
+import * as Y from "yjs";
 import { useCollabSpec } from "./useCollabSpec";
+
+const PRD_PATH = "specs/requirements/prd.md";
 
 interface FakeConfig {
   document: Y.Doc;
@@ -167,7 +169,7 @@ describe("useCollabSpec — rejoin from scratch after a post-sync drop", () => {
 // provider would present the same token and be rejected again. The server
 // closes the socket right after rejecting, so the rejection and the close
 // arrive in either order — both must end offline and stay there.
-describe("useCollabSpec — an authentication failure is terminal", () => {
+describe("useCollabSpec — a REJECTION is terminal, an outage is not", () => {
   beforeEach(() => {
     instances.length = 0;
     vi.useFakeTimers();
@@ -198,6 +200,126 @@ describe("useCollabSpec — an authentication failure is terminal", () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });
 
+    expect(instances).toHaveLength(1);
+    expect(result.current.status).toBe("offline");
+  });
+});
+
+// ADR-0020: the console reads the room, agents author it. `getXmlFragment`
+// creates a fragment for any path it is asked for, so a read used to make its
+// own answer true — which is what let an unseeded room paint a blank document
+// over a PRD that exists in git, and what conjured phantom files into the rail.
+describe("useCollabSpec — reading a document never creates one", () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  it("returns null for a path the room does not hold, and leaves the doc alone", () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    const doc = instances[0]!.document;
+
+    expect(result.current.getFileFragment(PRD_PATH)).toBeNull();
+    expect(doc.share.has(PRD_PATH)).toBe(false);
+    // The file list unions this with git; a path invented by a read would show
+    // up in the rail as a real document that opens onto nothing.
+    expect(result.current.docPaths).not.toContain(PRD_PATH);
+  });
+
+  it("returns the fragment once the room really holds the path", () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    const doc = instances[0]!.document;
+    // How an agent's file arrives: over sync, with its share entry present.
+    act(() => {
+      doc.getXmlFragment(PRD_PATH).insert(0, [new Y.XmlText("hello")]);
+    });
+
+    expect(result.current.getFileFragment(PRD_PATH)).not.toBeNull();
+    expect(result.current.docPaths).toContain(PRD_PATH);
+  });
+
+  // The one file "does the room hold it?" cannot answer. An empty (or
+  // whitespace-only) markdown file seeds to a zero-length fragment, which
+  // generates no update and so never replicates its key to a joining client —
+  // `share.has` is false for a file the room genuinely owns. Gating the editor
+  // on presence alone would leave an empty committed document permanently
+  // read-only, with no way to type the first character into it.
+  it("opens a committed file the room holds but never replicated", () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+    const doc = instances[0]!.document;
+    expect(doc.share.has(PRD_PATH)).toBe(false);
+
+    expect(result.current.getFileFragment(PRD_PATH, { create: true })).not.toBeNull();
+  });
+
+  // ...and `create` stays the caller's assertion that GIT has the path, not a
+  // way around ADR-0020: the default is still never-create.
+  it("still refuses to create when the caller does not vouch for the path", () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onSynced());
+
+    expect(result.current.getFileFragment(PRD_PATH, { create: false })).toBeNull();
+    expect(instances[0]!.document.share.has(PRD_PATH)).toBe(false);
+  });
+});
+
+// #586. The collab server reaches its oracle, and reads the spec bundle, over
+// the same `aep-api` that restarts on every deploy — and BOTH of those failures
+// arrive here, because Hocuspocus runs the load hook inside the same try/catch
+// as authentication and answers either with a permission-denied frame. Latching
+// on those left the spec view offline until the page was reloaded, and the
+// frame leaves the socket OPEN, so nothing below this retries on its own.
+describe("useCollabSpec — an unreachable upstream retries instead of latching", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("rebuilds after a refusal that never synced", async () => {
+    const { result } = renderCollab();
+    act(() =>
+      instances[0]!.onAuthenticationFailed({ reason: "upstream-unavailable" }),
+    );
+    expect(result.current.status).toBe("offline");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(2);
+  });
+
+  it("backs off rather than retrying once a second while it keeps failing", async () => {
+    // The room never syncs here, so the "has this session held long enough to
+    // be healthy?" reset has no sync to measure from — it must not read a
+    // never-synced room as healthy and flatten the ladder.
+    renderCollab();
+    const refuse = async (waitMs: number) => {
+      const room = instances[instances.length - 1]!;
+      act(() => room.onAuthenticationFailed({ reason: "upstream-unavailable" }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(waitMs);
+      });
+    };
+    await refuse(1_000);
+    expect(instances).toHaveLength(2);
+    // Second failure is due at 2s, not 1s.
+    await refuse(1_000);
+    expect(instances).toHaveLength(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(3);
+  });
+
+  it("still latches when the bearer itself was refused", async () => {
+    const { result } = renderCollab();
+    act(() => instances[0]!.onAuthenticationFailed({ reason: "Forbidden" }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
     expect(instances).toHaveLength(1);
     expect(result.current.status).toBe("offline");
   });

--- a/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
+++ b/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
@@ -314,6 +314,40 @@ describe("useCollabSpec — an unreachable upstream retries instead of latching"
     expect(instances).toHaveLength(3);
   });
 
+  // The same flattening, reached from the other side: a session that DID hold
+  // long enough to count as healthy earns the next attempt a fast retry — but
+  // only that one. The timestamp belongs to a provider being thrown away, so
+  // leaving it set makes every refused replacement look like it just came off a
+  // healthy session, and the ladder never climbs.
+  it("spends a healthy session's fast-retry credit only once", async () => {
+    renderCollab();
+    act(() => instances[0]!.onSynced());
+    // Hold the room well past the reset window, then lose the upstream.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    const refuse = async (waitMs: number) => {
+      const room = instances[instances.length - 1]!;
+      act(() => room.onAuthenticationFailed({ reason: "upstream-unavailable" }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(waitMs);
+      });
+    };
+
+    // The credit: this one retries fast.
+    await refuse(1_000);
+    expect(instances).toHaveLength(2);
+    // The next refusal must climb the ladder, not reset it. Nothing has synced
+    // since, so 1s is not enough.
+    await refuse(1_000);
+    expect(instances).toHaveLength(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(instances).toHaveLength(3);
+  });
+
   it("still latches when the bearer itself was refused", async () => {
     const { result } = renderCollab();
     act(() => instances[0]!.onAuthenticationFailed({ reason: "Forbidden" }));

--- a/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
+++ b/apps/console/src/features/spec/collab/useCollabSpec.test.tsx
@@ -28,6 +28,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
+import { markdownToFragment } from "@aep/collab-doc";
 import { useCollabSpec } from "./useCollabSpec";
 
 const PRD_PATH = "specs/requirements/prd.md";
@@ -239,29 +240,25 @@ describe("useCollabSpec — reading a document never creates one", () => {
     expect(result.current.docPaths).toContain(PRD_PATH);
   });
 
-  // The one file "does the room hold it?" cannot answer. An empty (or
-  // whitespace-only) markdown file seeds to a zero-length fragment, which
-  // generates no update and so never replicates its key to a joining client —
-  // `share.has` is false for a file the room genuinely owns. Gating the editor
-  // on presence alone would leave an empty committed document permanently
-  // read-only, with no way to type the first character into it.
-  it("opens a committed file the room holds but never replicated", () => {
+  // An EMPTY document still opens for editing. `share.has` can only be trusted
+  // as "the room holds this file" because an empty markdown document seeds as
+  // one empty paragraph (`markdownToFragment`) rather than zero blocks — a
+  // fragment with no children generates no update, so its key would never
+  // replicate and the file would read as absent, leaving it permanently
+  // read-only. Emptying a document is a supported action, so this is reachable
+  // by clearing one and reopening it.
+  it("opens an empty document the room holds", () => {
     const { result } = renderCollab();
     act(() => instances[0]!.onSynced());
     const doc = instances[0]!.document;
-    expect(doc.share.has(PRD_PATH)).toBe(false);
+    // How an emptied file arrives over sync: present, with no text in it.
+    act(() => {
+      markdownToFragment("", doc.getXmlFragment(PRD_PATH));
+    });
+    expect(doc.getXmlFragment(PRD_PATH).length).toBe(1);
 
-    expect(result.current.getFileFragment(PRD_PATH, { create: true })).not.toBeNull();
-  });
-
-  // ...and `create` stays the caller's assertion that GIT has the path, not a
-  // way around ADR-0020: the default is still never-create.
-  it("still refuses to create when the caller does not vouch for the path", () => {
-    const { result } = renderCollab();
-    act(() => instances[0]!.onSynced());
-
-    expect(result.current.getFileFragment(PRD_PATH, { create: false })).toBeNull();
-    expect(instances[0]!.document.share.has(PRD_PATH)).toBe(false);
+    expect(result.current.getFileFragment(PRD_PATH)).not.toBeNull();
+    expect(result.current.docPaths).toContain(PRD_PATH);
   });
 });
 

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -220,6 +220,21 @@ export function useCollabSpec(
       const held =
         syncedAtRef.current > 0 &&
         Date.now() - syncedAtRef.current >= REBUILD_RESET_MS;
+      // Spend that credit ONCE. The healthy session earns the next attempt a
+      // fast retry, not every attempt: `syncedAtRef` belongs to a provider that
+      // is being thrown away, and leaving it set means each replacement room —
+      // none of which ever syncs, because the server is refusing them — still
+      // reads as "just came off a healthy session" and restarts the ladder. The
+      // result is the same once-a-second hammer the ladder exists to prevent,
+      // reached from the other side. The next successful sync sets it again.
+      // Spend that credit ONCE. The healthy session earns the next attempt a
+      // fast retry, not every attempt: `syncedAtRef` belongs to a provider that
+      // is being thrown away, and leaving it set means each replacement room —
+      // none of which ever syncs, because the server is refusing them — still
+      // reads as "just came off a healthy session" and restarts the ladder. The
+      // result is the same once-a-second hammer the ladder exists to prevent,
+      // reached from the other side. The next successful sync sets it again.
+      syncedAtRef.current = 0;
       const attempt = held ? 0 : rebuildAttemptsRef.current;
       rebuildAttemptsRef.current = attempt + 1;
       rebuildTimerRef.current = setTimeout(

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -38,6 +38,14 @@ import {
 // pushes `{type:"token"}` over the stateless channel (D6) so long sessions
 // keep flushing after the initial handshake token expires.
 
+/**
+ * The reason the collab server tags an auth failure with when its own upstream
+ * was unreachable, rather than when the bearer was refused. Duplicated from
+ * `services/collab/src/server.ts` rather than shared, matching how the
+ * stateless message types are already spelled on both sides of this socket.
+ */
+const UPSTREAM_UNAVAILABLE = "upstream-unavailable";
+
 export interface CollabPeer {
   clientId: number;
   name: string;
@@ -52,8 +60,17 @@ export interface CollabSpec {
   peers: CollabPeer[];
   /** Y.Text for a non-md path, once synced; null → REST-content fallback. */
   getFileText: (path: string) => Y.Text | null;
-  /** Y.XmlFragment for an md path, once synced (#86 phase 6 doc model). */
-  getFileFragment: (path: string) => Y.XmlFragment | null;
+  /**
+   * Y.XmlFragment for an md path, once synced (#86 phase 6 doc model).
+   *
+   * Never creates the fragment (ADR-0020) unless `create` says the caller has
+   * already established that git holds the path — the one case where absence
+   * means "empty file", not "no such document".
+   */
+  getFileFragment: (
+    path: string,
+    opts?: { create?: boolean },
+  ) => Y.XmlFragment | null;
   /** Live file paths in the doc (Y.Map entries + md fragments) — the source
    *  for the reactive spec list; empty until connected. */
   docPaths: string[];
@@ -175,8 +192,15 @@ export function useCollabSpec(
     // present the same token and be rejected again, so `authFailed` latches for
     // the life of this provider.
     let authFailed = false;
-    const scheduleRebuild = () => {
-      if (authFailed || !syncedRef.current || rebuildTimerRef.current) return;
+    // `requireSynced: false` is for the one drop that never synced and never
+    // will on its own: a room the server REFUSED (#586, an unseedable room or
+    // an unreachable oracle). That arrives as a permission-denied frame, which
+    // leaves the socket open — so the websocket's own reconnect never fires and
+    // nothing retries unless this does. The doc is empty in that case, so the
+    // doubling this ladder normally guards against cannot happen.
+    const scheduleRebuild = ({ requireSynced = true } = {}) => {
+      if (authFailed || rebuildTimerRef.current) return;
+      if (requireSynced && !syncedRef.current) return;
       syncedRef.current = false;
       // Silence the OLD provider's own retry first. Its websocket re-arms a
       // reconnect from `onClose` on the same 1s delay as ours, so a socket that
@@ -187,10 +211,16 @@ export function useCollabSpec(
       provider.disconnect();
       // Back off while drops keep coming, and start over once a session has
       // held long enough to count as healthy.
-      const attempt =
-        Date.now() - syncedAtRef.current >= REBUILD_RESET_MS
-          ? 0
-          : rebuildAttemptsRef.current;
+      // `syncedAtRef` is 0 until a session actually syncs, so "has it held long
+      // enough to count as healthy?" must ask whether it EVER synced first —
+      // otherwise a room that never synced (a server that refuses it, #586)
+      // reads as infinitely healthy, resets the ladder on every attempt, and
+      // retries once a second forever against the service that is already
+      // struggling.
+      const held =
+        syncedAtRef.current > 0 &&
+        Date.now() - syncedAtRef.current >= REBUILD_RESET_MS;
+      const attempt = held ? 0 : rebuildAttemptsRef.current;
       rebuildAttemptsRef.current = attempt + 1;
       rebuildTimerRef.current = setTimeout(
         () => {
@@ -222,7 +252,19 @@ export function useCollabSpec(
       // the rejection and the close in either order, so this both latches the
       // flag and cancels a bump the close already queued. The room stays
       // offline until something else remounts the hook.
-      onAuthenticationFailed: () => {
+      //
+      // Terminal for a VERDICT only (#586). The collab server reaches its
+      // oracle over the same `aep-api` that goes down on every deploy, and it
+      // used to report an unreachable oracle through this same channel — so a
+      // 503 during a redeploy latched the room offline for the life of the
+      // page, when retrying was the whole answer. Those now arrive tagged, and
+      // the provider's own reconnect is left to do its job.
+      onAuthenticationFailed: ({ reason }) => {
+        if (reason === UPSTREAM_UNAVAILABLE) {
+          setStatus("offline");
+          scheduleRebuild({ requireSynced: false });
+          return;
+        }
         authFailed = true;
         if (rebuildTimerRef.current) {
           clearTimeout(rebuildTimerRef.current);
@@ -368,10 +410,27 @@ export function useCollabSpec(
         status === "connected"
           ? (docRef.current?.getMap<Y.Text>("files").get(path) ?? null)
           : null,
-      getFileFragment: (path: string) =>
-        status === "connected"
-          ? (docRef.current?.getXmlFragment(path) ?? null)
-          : null,
+      // A READ MUST NOT CREATE (ADR-0020). `Y.Doc.getXmlFragment` registers a
+      // fragment for any path it is asked for, which made "does the room hold
+      // this file?" unanswerable — asking made the answer yes. That is what
+      // let an unseeded room paint a blank document over a PRD that exists in
+      // git (#586), because `usesCollab` saw a fragment and stood the
+      // committed-git fallback down; and it is what conjured phantom entries
+      // into `docPaths`, which the file list unions into the rail.
+      //
+      // `create` is for the one caller that already KNOWS the file exists,
+      // because git says so. An empty (or whitespace-only) markdown file seeds
+      // to a zero-length fragment, which generates no update and so never
+      // replicates its key to a joining client — `share.has` is false for a
+      // file the room genuinely owns. Without this the editor could never be
+      // opened on it and nobody could type the first character. Materialising
+      // it is not inventing a document: git already has the path.
+      getFileFragment: (path: string, { create = false } = {}) => {
+        const doc = docRef.current;
+        if (status !== "connected" || !doc) return null;
+        if (!create && !doc.share.has(path)) return null;
+        return doc.getXmlFragment(path);
+      },
       docPaths:
         status === "connected" && docRef.current
           ? listDocPaths(docRef.current)

--- a/apps/console/src/features/spec/collab/useCollabSpec.ts
+++ b/apps/console/src/features/spec/collab/useCollabSpec.ts
@@ -60,17 +60,9 @@ export interface CollabSpec {
   peers: CollabPeer[];
   /** Y.Text for a non-md path, once synced; null → REST-content fallback. */
   getFileText: (path: string) => Y.Text | null;
-  /**
-   * Y.XmlFragment for an md path, once synced (#86 phase 6 doc model).
-   *
-   * Never creates the fragment (ADR-0020) unless `create` says the caller has
-   * already established that git holds the path — the one case where absence
-   * means "empty file", not "no such document".
-   */
-  getFileFragment: (
-    path: string,
-    opts?: { create?: boolean },
-  ) => Y.XmlFragment | null;
+  /** Y.XmlFragment for an md path, once synced (#86 phase 6 doc model).
+   *  Never creates the fragment — a read is not authorship (ADR-0020). */
+  getFileFragment: (path: string) => Y.XmlFragment | null;
   /** Live file paths in the doc (Y.Map entries + md fragments) — the source
    *  for the reactive spec list; empty until connected. */
   docPaths: string[];
@@ -433,17 +425,13 @@ export function useCollabSpec(
       // committed-git fallback down; and it is what conjured phantom entries
       // into `docPaths`, which the file list unions into the rail.
       //
-      // `create` is for the one caller that already KNOWS the file exists,
-      // because git says so. An empty (or whitespace-only) markdown file seeds
-      // to a zero-length fragment, which generates no update and so never
-      // replicates its key to a joining client — `share.has` is false for a
-      // file the room genuinely owns. Without this the editor could never be
-      // opened on it and nobody could type the first character. Materialising
-      // it is not inventing a document: git already has the path.
-      getFileFragment: (path: string, { create = false } = {}) => {
+      // `share.has` can be trusted as "the room holds this file" because an
+      // empty markdown document seeds as one empty paragraph rather than zero
+      // blocks (`markdownToFragment`) — without that, an emptied file would
+      // generate no update, never replicate its key, and read as absent here.
+      getFileFragment: (path: string) => {
         const doc = docRef.current;
-        if (status !== "connected" || !doc) return null;
-        if (!create && !doc.share.has(path)) return null;
+        if (status !== "connected" || !doc?.share.has(path)) return null;
         return doc.getXmlFragment(path);
       },
       docPaths:

--- a/apps/console/src/features/spec/components/CommittedFileView.tsx
+++ b/apps/console/src/features/spec/components/CommittedFileView.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Alert, Box, Button, CircularProgress, TextField } from "@wso2/oxygen-ui";
+import { MarkdownView } from "../../../components/MarkdownView";
+import { EmptyState } from "../../../components/EmptyState";
+import { fileLabel } from "../api/labels";
+
+/**
+ * A document as GIT has it — the view the spec workspace falls back to whenever
+ * the live room is not the source (#586).
+ *
+ * It exists because the fallback used to be dishonest in both directions. A
+ * room that failed to seed rendered a blank, editable pane over a document that
+ * exists in git; and when the committed copy DID render, it rendered into a
+ * `TextField` whose keystrokes went nowhere ("edits aren't saved yet"). Both
+ * offered to take work that nothing could commit.
+ *
+ * So: read-only, always. Markdown is rendered rather than shown as source,
+ * because the user is reading a document, not a file. When the room is offline
+ * the pane says so and says what it is showing instead — the banner names the
+ * user's situation, never the service that failed (lexicon naming rule 6), and
+ * names the recovery, because the provider really is reconnecting.
+ */
+export function CommittedFileView({
+  path,
+  content,
+  errorMessage,
+  onRetry,
+  offline,
+}: {
+  path: string;
+  /** The committed bytes, or null while they are loading / failed to load. */
+  content: string | null;
+  /** Set when the committed read failed — the pane has nothing to show. */
+  errorMessage?: string | undefined;
+  onRetry: () => void;
+  /** The room is unreachable, as opposed to simply not holding this file. */
+  offline: boolean;
+}) {
+  if (content !== null) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2, height: "100%" }}>
+        {offline && (
+          <Alert severity="warning">
+            Live editing is unavailable. Showing the last committed version.
+            Reconnecting…
+          </Alert>
+        )}
+        {path.endsWith(".md") ? (
+          <MarkdownView>{content}</MarkdownView>
+        ) : (
+          <TextField
+            fullWidth
+            multiline
+            minRows={20}
+            value={content}
+            aria-label={`${fileLabel(path)}, read only`}
+            slotProps={{
+              input: {
+                readOnly: true,
+                sx: { fontFamily: "monospace", fontSize: "0.875rem" },
+              },
+            }}
+          />
+        )}
+      </Box>
+    );
+  }
+
+  // Nothing to show. Same shape as the pane's other whole-view states (the
+  // empty workspace, the agent mid-turn) rather than a bar pinned above an
+  // empty document — and it carries the message and the one Retry, the way a
+  // failed repository clone does.
+  if (errorMessage !== undefined) {
+    return (
+      <EmptyState
+        title={`${fileLabel(path)} couldn't be loaded`}
+        description={errorMessage}
+        action={
+          <Button variant="contained" onClick={onRetry}>
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <CircularProgress aria-label={`Loading ${fileLabel(path)}`} />
+    </Box>
+  );
+}

--- a/apps/console/src/features/spec/components/SpecFileList.tsx
+++ b/apps/console/src/features/spec/components/SpecFileList.tsx
@@ -43,6 +43,7 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { WorkingPulse } from "../../agent-chat/components/WorkingIndicator";
 import { PRD_PATH, type SpecFileEntry } from "../api/mapping";
+import { fileLabel } from "../api/labels";
 import {
   mostSignificant,
   reasonCount,
@@ -55,47 +56,6 @@ import {
   selectionKey,
   type SpecSelection,
 } from "../api/designTree";
-
-function basename(path: string): string {
-  return path.split("/").at(-1) ?? path;
-}
-
-const OPENAPI_RE = /\/openapi\.ya?ml$/;
-const COMPONENT_DESIGN_RE = /^specs\/design\/components\/[^/]+\/design\.json$/;
-const VALIDATION_CRITERIA_RE = /^specs\/validation\/validation-criteria\.json$/;
-const DESIGN_ROOT = "specs/design/design.md";
-const SECURITY = "specs/design/security.md";
-
-/**
- * A document's NAME, never its filename (#575).
- *
- * The user is reading a document tree, not a repository — `prd.md` and
- * `security.md` are storage details that leaked into the one surface they read
- * throughout the journey. The repo paths deliberately do not change; this is
- * the mapping, and the lexicon holds the same table in words.
- *
- * A file with no entry here falls back to its filename, which keeps an
- * agent-invented document readable rather than blank. Feature files land there
- * on purpose: their filename IS the feature's name, so the fallback is already
- * the right answer.
- */
-const TITLES: Record<string, string> = {
-  [PRD_PATH]: "Product requirements",
-  [DESIGN_ROOT]: "Design overview",
-  [SECURITY]: "Security",
-};
-
-function fileLabel(path: string): string {
-  if (Object.hasOwn(TITLES, path)) return TITLES[path] as string;
-  if (OPENAPI_RE.test(path)) return "API";
-  if (COMPONENT_DESIGN_RE.test(path)) return "Design overview";
-  if (VALIDATION_CRITERIA_RE.test(path)) return "Acceptance criteria";
-  // A document nothing above names — a feature file most of the time, where
-  // the filename IS the feature's name once the extension is off it. Keeping
-  // `.md` would leave the one surface the user reads throughout still showing
-  // them a file.
-  return basename(path).replace(/\.md$/, "");
-}
 
 function fileSel(path: string): SpecSelection {
   return { kind: "file", path };

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1005,14 +1005,68 @@ describe("SpecView header metadata (soft version chips)", () => {
     mockFlush.mockResolvedValue(undefined);
   });
 
+  // #586. Whenever the room is not the source for a document, git is — and it
+  // is READ-ONLY there, because nothing in that state can commit. The pane used
+  // to offer an editable box whose keystrokes went nowhere, or (when the room
+  // had failed to seed) a blank editor over a document that exists in git.
+  it("shows the committed document read-only, and says live editing is unavailable", () => {
+    mockUseSpecFileContent.mockReturnValue({
+      data: { sha: "abc", content: "# Product requirements\n\nThe committed text." },
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    render(<SpecView projectName="proj1" />);
+
+    expect(screen.getByText("The committed text.")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Live editing is unavailable/),
+    ).toBeInTheDocument();
+    // Nothing offers to take an edit: the committed markdown is rendered, not
+    // dropped into a textbox.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("names the document and offers one Retry when there is nothing to show", () => {
+    const refetch = vi.fn();
+    mockUseSpecFiles.mockReturnValue({
+      data: [{ path: "specs/requirements/prd.md", sha: "abc", group: "requirements" }],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUseSpecFileContent.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+      error: new Error("Failed to read spec files (500)"),
+      refetch,
+    });
+    render(<SpecView projectName="proj1" />);
+
+    // The document's NAME, never its path (the lexicon's mapping holds only
+    // while the user never sees one).
+    expect(
+      screen.getByText("Product requirements couldn't be loaded"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Failed to read spec files (500)")).toBeInTheDocument();
+    expect(screen.queryByText(/specs\/requirements/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
   it("renders session/version info as soft status chips (not buttons) and drops 'Approved'", () => {
     render(<SpecView projectName="proj1" />);
 
     // Version + session state render as soft status chips beside the title
     // (consistent with the builds/deployments headers): "v1 · published"
-    // (tags.latest) and "solo session" (offline collab).
+    // (tags.latest) and "offline" (no room). The chip says `offline`, not
+    // `solo session` — the lexicon retired the latter for reading like a focus
+    // feature rather than a degraded state.
     expect(screen.getByText("v1 · published")).toBeInTheDocument();
-    expect(screen.getByText("solo session")).toBeInTheDocument();
+    expect(screen.getByText("offline")).toBeInTheDocument();
 
     // The old "Approved" status chip is gone entirely (specStatus is
     // "approved" in this test's project-status mock).

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -207,14 +207,6 @@ export function SpecView({ projectName }: { projectName: string }) {
   // on every render (`collab.docPaths` is derived, not memoized), so the editor
   // compares it BY VALUE rather than by identity — see `knownPaths` there.
   const specPaths = useMemo(() => files.map((f) => f.path), [files]);
-  // Paths GIT holds, as distinct from `files` (which unions in the room's own
-  // doc paths). Only this set may materialise a fragment — see
-  // `getFileFragment`'s `create`. Using `files` here would re-open the door
-  // ADR-0020 closed, since a phantom doc path would vouch for itself.
-  const committedPaths = useMemo(
-    () => new Set((spec.data ?? []).map((f) => f.path)),
-    [spec.data],
-  );
   // A live design turn is signalled by `?generate=design` (the Generate-design
   // CTA) and, more durably, by an agent peer streaming design.cell into the
   // room. In either case the Architecture (cell-diagram) tab is where the user
@@ -425,9 +417,7 @@ export function SpecView({ projectName }: { projectName: string }) {
   const selectedIsMd = selectedFile?.path.endsWith(".md") ?? false;
   const fragment =
     selectedFile && selectedIsMd && !isOpenApiFile
-      ? collab.getFileFragment(selectedFile.path, {
-          create: committedPaths.has(selectedFile.path),
-        })
+      ? collab.getFileFragment(selectedFile.path)
       : null;
   const ytext =
     selectedFile && !selectedIsMd && !isStructuredFile
@@ -523,9 +513,7 @@ export function SpecView({ projectName }: { projectName: string }) {
   // until the server next wrote, and on the agent's own edits that lag was long
   // enough to look broken. Falls back to the committed content when the room is
   // offline, which is the only time it is the freshest thing available.
-  const prdFragment = collab.getFileFragment(PRD_PATH, {
-    create: committedPaths.has(PRD_PATH),
-  });
+  const prdFragment = collab.getFileFragment(PRD_PATH);
   const prdVersion = useYFragmentVersion(prdFragment);
   const livePrd = useMemo(() => {
     // The fragment is mutated IN PLACE, so its identity never changes and only

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -33,7 +33,6 @@ import {
   IconButton,
   PageContent,
   Stack,
-  TextField,
   Tooltip,
   Typography,
   useAppShell,
@@ -70,6 +69,7 @@ import {
 import { chatKeyFor, setPendingSeed, subscribeTurnEnd } from "../../agent-chat/chatStore";
 import { EmptyState } from "../../../components/EmptyState";
 import { ProblemsDialog } from "./ProblemsDialog";
+import { CommittedFileView } from "./CommittedFileView";
 import { useResolveDependencyViaChat } from "../../agent-chat/useResolveDependencyViaChat";
 import type { DependencyResolutionIntent } from "../../projects/lib/dependencyResolutionMessage.js";
 import { useDesignCellChangeCount } from "../collab/useDesignCellChange";
@@ -207,6 +207,14 @@ export function SpecView({ projectName }: { projectName: string }) {
   // on every render (`collab.docPaths` is derived, not memoized), so the editor
   // compares it BY VALUE rather than by identity — see `knownPaths` there.
   const specPaths = useMemo(() => files.map((f) => f.path), [files]);
+  // Paths GIT holds, as distinct from `files` (which unions in the room's own
+  // doc paths). Only this set may materialise a fragment — see
+  // `getFileFragment`'s `create`. Using `files` here would re-open the door
+  // ADR-0020 closed, since a phantom doc path would vouch for itself.
+  const committedPaths = useMemo(
+    () => new Set((spec.data ?? []).map((f) => f.path)),
+    [spec.data],
+  );
   // A live design turn is signalled by `?generate=design` (the Generate-design
   // CTA) and, more durably, by an agent peer streaming design.cell into the
   // room. In either case the Architecture (cell-diagram) tab is where the user
@@ -417,7 +425,9 @@ export function SpecView({ projectName }: { projectName: string }) {
   const selectedIsMd = selectedFile?.path.endsWith(".md") ?? false;
   const fragment =
     selectedFile && selectedIsMd && !isOpenApiFile
-      ? collab.getFileFragment(selectedFile.path)
+      ? collab.getFileFragment(selectedFile.path, {
+          create: committedPaths.has(selectedFile.path),
+        })
       : null;
   const ytext =
     selectedFile && !selectedIsMd && !isStructuredFile
@@ -513,7 +523,9 @@ export function SpecView({ projectName }: { projectName: string }) {
   // until the server next wrote, and on the agent's own edits that lag was long
   // enough to look broken. Falls back to the committed content when the room is
   // offline, which is the only time it is the freshest thing available.
-  const prdFragment = collab.getFileFragment(PRD_PATH);
+  const prdFragment = collab.getFileFragment(PRD_PATH, {
+    create: committedPaths.has(PRD_PATH),
+  });
   const prdVersion = useYFragmentVersion(prdFragment);
   const livePrd = useMemo(() => {
     // The fragment is mutated IN PLACE, so its identity never changes and only
@@ -787,10 +799,13 @@ export function SpecView({ projectName }: { projectName: string }) {
                   dot
                 />
               )}
+              {/* `offline`, not `solo session` — the lexicon retired the latter
+                  (it reads like a focus feature), and the tooltip names the
+                  user's situation rather than which service is down. */}
               {isOffline && (
-                <Tooltip title="Collaboration server unreachable — editing solo; edits aren't shared or saved.">
+                <Tooltip title="Live editing is unavailable — showing the last committed version. Reconnecting…">
                   <Box sx={{ display: "inline-flex" }}>
-                    <StatusChip label="solo session" tone="neutral" appearance="soft" />
+                    <StatusChip label="offline" tone="neutral" appearance="soft" />
                   </Box>
                 </Tooltip>
               )}
@@ -1231,48 +1246,24 @@ export function SpecView({ projectName }: { projectName: string }) {
                     path={selectedFile.path}
                     isLocalTransaction={collab.isLocalTransaction}
                   />
-                ) : content.data ? (
-                  <TextField
-                    key={`${selectedFile.path}:${content.data.sha}`}
-                    fullWidth
-                    multiline
-                    minRows={20}
-                    defaultValue={content.data.content}
-                    aria-label={`Content of ${selectedFile.path}`}
-                    helperText={`${selectedFile.path} — edits aren't saved yet; editing lands with the file editors.`}
-                    slotProps={{
-                      input: {
-                        sx: { fontFamily: "monospace", fontSize: "0.875rem" },
-                      },
-                    }}
-                  />
-                ) : content.isError ? (
-                  <Alert
-                    severity="error"
-                    action={
-                      <Button onClick={() => void content.refetch()}>
-                        Retry
-                      </Button>
-                    }
-                  >
-                    Failed to load {selectedFile.path}
-                    {content.error instanceof Error && content.error.message
-                      ? `: ${content.error.message}`
-                      : ""}
-                  </Alert>
                 ) : (
-                  <Box
-                    sx={{
-                      height: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <CircularProgress
-                      aria-label={`Loading ${selectedFile.path}`}
-                    />
-                  </Box>
+                  /* The room is not the source for this file — it is
+                     unreachable, or it genuinely does not hold the path. Git
+                     is, and it is read-only there (#586). */
+                  <CommittedFileView
+                    key={`${selectedFile.path}:committed`}
+                    path={selectedFile.path}
+                    content={content.data?.content ?? null}
+                    errorMessage={
+                      content.isError
+                        ? content.error instanceof Error && content.error.message
+                          ? content.error.message
+                          : "The workspace could not be reached."
+                        : undefined
+                    }
+                    onRetry={() => void content.refetch()}
+                    offline={isOffline}
+                  />
                 )
               ) : failed ? null : /* The alert above owns this case: it names the
                    failure and carries the one Retry. A body beneath it would

--- a/packages/collab-doc/src/markdown.ts
+++ b/packages/collab-doc/src/markdown.ts
@@ -50,12 +50,41 @@ export function isMarkdownPath(path: string): boolean {
   return path.endsWith(".md");
 }
 
+/**
+ * An EMPTY document is one empty paragraph, not zero blocks.
+ *
+ * That is what the editor itself holds for a document with nothing in it, and
+ * `fragmentToMarkdown` serializes it back to "" — so the two agree and no
+ * spurious write is produced. Parsing "" gives zero blocks instead, and the
+ * difference is not cosmetic: a fragment with no children generates NO Yjs
+ * update, so its share key never replicates to a joining client. `doc.share`
+ * then answers "no such document" for a file the room was seeded with and git
+ * really holds, which left an emptied markdown file permanently uneditable —
+ * and emptying one is a supported action (the committer writes an emptied
+ * fragment back as an empty file, since a top-level fragment cannot be deleted
+ * from a Y.Doc).
+ *
+ * Normalizing here rather than at the call sites keeps every producer of a
+ * fragment — the seed, and an agent writing a file — on the same shape.
+ */
+function withEmptyDocAsParagraph(json: Record<string, unknown>): Record<string, unknown> {
+  const content = json.content;
+  if (Array.isArray(content) && content.length > 0) return json;
+  return { ...json, content: [{ type: "paragraph" }] };
+}
+
 /** Parse markdown into an (empty) Y.XmlFragment. */
 export function markdownToFragment(
   markdown: string,
   fragment: Y.XmlFragment,
 ): void {
-  prosemirrorJSONToYXmlFragment(schema, manager.parse(markdown), fragment);
+  prosemirrorJSONToYXmlFragment(
+    schema,
+    withEmptyDocAsParagraph(
+      manager.parse(markdown) as unknown as Record<string, unknown>,
+    ),
+    fragment,
+  );
 }
 
 /** Serialize a fragment back to markdown (committer + agent-read seam). */

--- a/packages/collab-doc/test/empty-document.test.ts
+++ b/packages/collab-doc/test/empty-document.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * AN EMPTY DOCUMENT IS ONE EMPTY PARAGRAPH, NOT ZERO BLOCKS.
+ *
+ * Emptying a markdown document is a supported action — a top-level fragment
+ * cannot be deleted from a Y.Doc, so the committer writes an emptied one back
+ * to git as an empty FILE. Parsing that file back to zero blocks made the
+ * round trip lossy in a way that only showed up on the next reader: a fragment
+ * with no children generates no Yjs update, so its share key never replicates,
+ * and a joining client cannot tell the room's own seeded file from a file that
+ * does not exist. With reads gated on `share.has` (ADR-0020) that left the
+ * document permanently read-only — nobody could type the first character back.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as Y from "yjs";
+import { fragmentToMarkdown, markdownToFragment } from "../src/index.js";
+
+const PATH = "specs/design/security.md";
+
+/** What a second client actually receives, rather than what the writer holds. */
+function replicated(build: (doc: Y.Doc) => void): Y.Doc {
+  const source = new Y.Doc();
+  build(source);
+  const joiner = new Y.Doc();
+  Y.applyUpdate(joiner, Y.encodeStateAsUpdate(source));
+  return joiner;
+}
+
+test("an emptied document still reaches a joining client", () => {
+  for (const content of ["", "\n", "   "]) {
+    const joiner = replicated((doc) =>
+      markdownToFragment(content, doc.getXmlFragment(PATH)),
+    );
+    assert.equal(
+      joiner.share.has(PATH),
+      true,
+      `an empty document (${JSON.stringify(content)}) never replicated its key`,
+    );
+  }
+});
+
+// The half that makes the fix safe: the shape is the EDITOR's empty document,
+// so it serializes back to an empty file. Were it anything else, every empty
+// file in git would take a spurious write on the first load after this shipped.
+test("an empty document still serializes back to an empty file", () => {
+  for (const content of ["", "\n", "   "]) {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment(PATH);
+    markdownToFragment(content, fragment);
+    assert.equal(fragment.length, 1, "expected exactly one empty block");
+    assert.equal(fragmentToMarkdown(fragment), "");
+  }
+});
+
+test("a document with content is untouched by the normalization", () => {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment(PATH);
+  markdownToFragment("# Security\n\nNotes.", fragment);
+  assert.equal(fragmentToMarkdown(fragment), "# Security\n\nNotes.");
+});

--- a/services/agents/src/collab/room-peer.ts
+++ b/services/agents/src/collab/room-peer.ts
@@ -43,6 +43,14 @@ import {
 /** Transaction origin for every doc write this peer makes. */
 export const AGENT_ORIGIN = "aep-agent";
 
+/**
+ * The reason the collab server tags a refusal with when ITS upstream was
+ * unreachable, rather than when the bearer was refused. Duplicated from
+ * `services/collab/src/server.ts` — the console spells it out on its side of
+ * this socket too, the same way the stateless message types are.
+ */
+const UPSTREAM_UNAVAILABLE = "upstream-unavailable";
+
 const SYNC_TIMEOUT_MS = 10_000;
 
 export interface RoomPeer {
@@ -101,15 +109,38 @@ export async function joinRoom(input: JoinRoomInput): Promise<RoomPeer> {
   try {
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
-        reject(new Error(`collab: room ${input.roomId} did not sync within ${SYNC_TIMEOUT_MS}ms`));
+        // A room the server REFUSES does not land here — that arrives
+        // immediately as `authenticationFailed` below, because a rejected load
+        // is answered with a permission-denied frame rather than a closed
+        // socket. This branch is the genuinely slow or silent room: a seed
+        // still running, or a socket that never came up at all.
+        reject(
+          new Error(
+            `collab: room ${input.roomId} could not be loaded — no sync within ${SYNC_TIMEOUT_MS}ms`,
+          ),
+        );
       }, SYNC_TIMEOUT_MS);
       provider.on("synced", () => {
         clearTimeout(timer);
         resolve();
       });
-      provider.on("authenticationFailed", () => {
+      // A refused room and a refused bearer arrive through the SAME event
+      // (#586): the collab server answers an unseedable room with a
+      // permission-denied frame too, tagging it so the two can be told apart.
+      // Both are terminal for this turn — an agent has no committed copy to
+      // fall back on the way the console does, and writing into a room that
+      // was never seeded is what corrupted the spec in the first place — but
+      // they must not be REPORTED alike, or an `aep-api` restart shows up in
+      // the turn log as a credentials problem.
+      provider.on("authenticationFailed", ({ reason }: { reason?: string }) => {
         clearTimeout(timer);
-        reject(new Error(`collab: room ${input.roomId} rejected the forwarded bearer`));
+        reject(
+          new Error(
+            reason === UPSTREAM_UNAVAILABLE
+              ? `collab: room ${input.roomId} is unavailable — the collab server could not reach its upstream (${reason})`
+              : `collab: room ${input.roomId} rejected the forwarded bearer`,
+          ),
+        );
       });
       provider.attach();
     });

--- a/services/collab/AGENTS.md
+++ b/services/collab/AGENTS.md
@@ -31,6 +31,44 @@ parameter names the project for that read.
 
 Never enable dev mode or the mock BFF in a cluster.
 
+## Room lifecycle
+
+**A room exists only if it was seeded.** If the spec read fails — or the oracle
+never resolved a project — the load is REFUSED rather than opening an empty
+document ([#586](https://github.com/wso2/labs-agentic-engineer/issues/586)). An
+unseeded room looks healthy and is not: its committer baseline is empty, so
+every path writes with `baseSha: ""` (the Files API reads that as *must not
+exist*) and every flush 409s for as long as the room lives — which is as long as
+any client stays connected. Clients see an empty document with nothing to
+distinguish it from an empty project, and an agent turn joins it, syncs, and is
+told the project has no files.
+
+Refusing costs nothing a retry does not recover: `onLoadDocument` runs per room
+LOAD, so the room reloads and reseeds from git on the next attempt.
+
+**Transient failures are tagged.** Hocuspocus runs the load hook inside the same
+try/catch as authentication, so a refused room reaches the client as a
+permission-denied frame — indistinguishable, by default, from a rejected bearer,
+which clients are right to stop retrying. Anything that is not a verdict the
+oracle actually made (5xx, a refused connection, a DNS failure mid-redeploy) is
+therefore thrown with `reason: "upstream-unavailable"`, which Hocuspocus
+forwards verbatim and the console reads to decide whether to retry or give up.
+Keep that string in step with `useCollabSpec.ts` and `room-peer.ts`, which spell
+it on their own side, as the stateless message types already are.
+
+The split runs on STATUS, both for the oracle (`BffAccessDeniedError`) and for
+the spec read (`BffReadError`) — which is why both carry one. A permanent answer
+is a verdict and must NOT be tagged: a 404 for a project whose repo row is
+missing would otherwise have every open tab reconnect forever against a room
+that can never be seeded. The retryable 4xx (408, 425, 429) go the other way — a
+BFF shedding load is the same outage wearing a different code.
+
+A refused load clears the room's committer **baseline**, never the room state
+itself. That state is shared by every connection that authenticated into the
+room, and evicting it takes another tab's token with it — a room with no token
+skips its flush, so that tab's edits would be discarded in silence at exactly
+the moment several tabs are reconnecting together.
+
 ## Persistence + ops (shipped)
 
 - **Committer**: quiet-period flush (`COLLAB_COMMIT_DEBOUNCE_MS`, default 60s)

--- a/services/collab/package.json
+++ b/services/collab/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test \"src/**/!(seed-recovery).test.ts\" && tsx --test --test-force-exit src/seed-recovery.test.ts",
     "dev": "tsx watch src/main.ts",
     "start": "tsx src/main.ts"
   },

--- a/services/collab/src/bff.ts
+++ b/services/collab/src/bff.ts
@@ -104,9 +104,32 @@ export interface BffClient {
 }
 
 export class BffAccessDeniedError extends Error {
+  /** Retained so the caller can tell a verdict (4xx) from an outage (5xx). */
+  readonly status: number;
+
   constructor(status: number) {
     super(`BFF denied collab access (${status})`);
     this.name = "BffAccessDeniedError";
+    this.status = status;
+  }
+}
+
+/**
+ * A spec read that the BFF refused or could not serve.
+ *
+ * Carries the status for the same reason `BffAccessDeniedError` does: the seed
+ * path has to tell a permanent answer (a 404 for a project whose repo row is
+ * missing) from a transient one (a 502 mid-redeploy). Tagging the permanent
+ * case as transient would have the console retry a room forever that the
+ * server will never be able to seed.
+ */
+export class BffReadError extends Error {
+  readonly status: number;
+
+  constructor(projectName: string, status: number) {
+    super(`Failed to read spec files for ${projectName} (${status})`);
+    this.name = "BffReadError";
+    this.status = status;
   }
 }
 
@@ -147,11 +170,7 @@ export function createBffClient(
         `${base}/projects/${project}/files/bundle?prefix=${encodeURIComponent(SPECS_PREFIX)}`,
         { headers: { Authorization: `Bearer ${token}` } },
       );
-      if (!res.ok) {
-        throw new Error(
-          `Failed to read spec files for ${projectName} (${res.status})`,
-        );
-      }
+      if (!res.ok) throw new BffReadError(projectName, res.status);
       const body = (await res.json()) as {
         files?: SpecFile[] | null;
       };

--- a/services/collab/src/seed-recovery.test.ts
+++ b/services/collab/src/seed-recovery.test.ts
@@ -190,9 +190,12 @@ test("a room whose spec read failed is refused, and the next attempt recovers it
     const refusedAtSeed = await attemptJoin(port);
     assert.equal(refusedAtSeed.synced, false, "an unseeded room must not sync");
     assert.equal(refusedAtSeed.refusedWith, "upstream-unavailable");
+    // Ask the share map, not `getXmlFragment` — that getter CREATES the key it
+    // is asked about (ADR-0020), so inspecting the doc that way would plant the
+    // very node this line is claiming is absent.
     assert.equal(
-      refusedAtSeed.doc.getXmlFragment(PRD_PATH).length,
-      0,
+      refusedAtSeed.doc.share.has(PRD_PATH),
+      false,
       "the refused client holds nothing to render",
     );
     await leave(refusedAtSeed);

--- a/services/collab/src/seed-recovery.test.ts
+++ b/services/collab/src/seed-recovery.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A room the server could not seed must not open (#586).
+ *
+ * Observed as a blank PRD on a project whose requirements are 4993 bytes in
+ * git, after an `aep-api` restart while `aep-collab` stayed up. The seed threw,
+ * the failure was swallowed, and the room opened empty — permanently, because a
+ * room stays loaded while any client is connected. The console could not tell
+ * that room from an empty project, so it suppressed the committed-git fallback;
+ * an agent turn joined it, synced perfectly, and was told the project had no
+ * files; and every flush 409ed, because a baseline that was never populated
+ * writes with `baseSha: ""`, which the Files API reads as "must not exist".
+ *
+ * These run the REAL server against a REAL provider: the claim is about what a
+ * client experiences when a load fails, which neither side can demonstrate on
+ * its own.
+ *
+ * WHY THIS FILE ALONE RUNS WITH `--test-force-exit`: a connection Hocuspocus
+ * REFUSES is never registered against a document, so `Server.destroy()` —
+ * which closes documents' connections — does not reach it, and the process
+ * stops draining its loop even though no active referenced handle is left.
+ * That is a teardown gap in the library, reachable only from a test that
+ * makes the server refuse; nothing in the service's own lifetime depends on
+ * it. The flag is scoped to this file by `package.json` rather than applied
+ * package-wide, so every OTHER suite keeps its leak detection — that is what
+ * would catch a real `Server.destroy()` or stray-timer regression in the
+ * service's own code.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import * as Y from "yjs";
+import { HocuspocusProvider, HocuspocusProviderWebsocket } from "@hocuspocus/provider";
+import WebSocket from "ws";
+import { fragmentToMarkdown } from "@aep/collab-doc";
+import { createCollabServer } from "./server.js";
+import { dropRoomState, roomState } from "./rooms.js";
+import type { ApplyWrite, BffClient } from "./bff.js";
+import type { CollabConfig } from "./env.js";
+
+const ROOM = "spec-acme-shop";
+const PRD_PATH = "specs/requirements/prd.md";
+const PRD = "# PRD\n\nA paragraph of body text.\n";
+const PRD_SHA = "s1";
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function config(port: number): CollabConfig {
+  return {
+    port,
+    aepApiBase: "http://bff.test/api/v1",
+    devMode: false,
+    mockBff: false,
+    mockBffPort: 0,
+    commitDebounceMs: 60_000,
+    commitMaxDebounceMs: 300_000,
+  };
+}
+
+/**
+ * An `aep-api` with two independently failing halves — the two windows a
+ * restart opens. `oracleDown` is the likelier one (the validate call is first
+ * and cheap); `readDown` is the narrower one the bug was reported from, where
+ * the oracle answers and the spec bundle read does not.
+ */
+interface Upstream {
+  oracleDown: boolean;
+  readDown: boolean;
+}
+
+function flakyBff(up: Upstream, applied: ApplyWrite[]): BffClient {
+  return {
+    validateAccess: async () => {
+      if (up.oracleDown) throw new Error("oracle unavailable (503)");
+      return { name: "Jo", email: "jo@example.com", projectName: "shop" };
+    },
+    fetchSpecFiles: async () => {
+      if (up.readDown) throw new Error("Failed to read spec files for shop (500)");
+      return [{ path: PRD_PATH, content: PRD, sha: PRD_SHA }];
+    },
+    applyFiles: async (_t, _p, batch) => {
+      applied.push(...batch.writes);
+      return { commitSha: "c1", files: [] };
+    },
+  };
+}
+
+interface Attempt {
+  provider: HocuspocusProvider;
+  socket: HocuspocusProviderWebsocket;
+  doc: Y.Doc;
+  synced: boolean;
+  refusedWith: string | null;
+}
+
+/**
+ * One join attempt with a FRESH doc, resolving on whichever comes first: a
+ * sync, or the server's refusal. A fresh doc per attempt is what the console
+ * does when it rebuilds — the refused doc never synced, so it carries nothing.
+ */
+async function attemptJoin(port: number): Promise<Attempt> {
+  const doc = new Y.Doc();
+  const socket = new HocuspocusProviderWebsocket({
+    url: `ws://127.0.0.1:${port}`,
+    WebSocketPolyfill: WebSocket,
+  });
+  const provider = new HocuspocusProvider({
+    websocketProvider: socket,
+    name: ROOM,
+    document: doc,
+    token: "jwt",
+  });
+  const attempt: Attempt = { provider, socket, doc, synced: false, refusedWith: null };
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("neither synced nor refused")), 10_000);
+    provider.on("synced", () => {
+      clearTimeout(timer);
+      attempt.synced = true;
+      resolve();
+    });
+    provider.on("authenticationFailed", ({ reason }: { reason: string }) => {
+      clearTimeout(timer);
+      attempt.refusedWith = reason;
+      resolve();
+    });
+    provider.attach();
+  });
+  return attempt;
+}
+
+async function leave(attempt: Attempt) {
+  attempt.provider.destroy();
+  attempt.socket.destroy();
+  // Let the server observe the close and run its unload (and final flush).
+  await new Promise((r) => setTimeout(r, 400));
+}
+
+test("a room whose spec read failed is refused, and the next attempt recovers it", async () => {
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const up: Upstream = { oracleDown: true, readDown: true };
+  const applied: ApplyWrite[] = [];
+  const server = createCollabServer(config(port), { bff: flakyBff(up, applied) });
+  await server.listen(port);
+
+  try {
+    // aep-api is down: the oracle itself fails first, which is the likelier of
+    // the two windows during a restart.
+    const refusedAtAuth = await attemptJoin(port);
+    assert.equal(refusedAtAuth.synced, false, "an unseedable room must not sync");
+    assert.equal(
+      refusedAtAuth.refusedWith,
+      "upstream-unavailable",
+      "an outage must not read to the client as a rejected bearer",
+    );
+    await leave(refusedAtAuth);
+
+    // The narrower window the bug was reported from: the oracle answers, the
+    // spec read does not. Same refusal, same tag — a room that cannot be
+    // seeded is refused however the seed failed.
+    up.oracleDown = false;
+    const refusedAtSeed = await attemptJoin(port);
+    assert.equal(refusedAtSeed.synced, false, "an unseeded room must not sync");
+    assert.equal(refusedAtSeed.refusedWith, "upstream-unavailable");
+    assert.equal(
+      refusedAtSeed.doc.getXmlFragment(PRD_PATH).length,
+      0,
+      "the refused client holds nothing to render",
+    );
+    await leave(refusedAtSeed);
+
+    // Recovery: aep-api is back, and a fresh attempt seeds from git.
+    up.readDown = false;
+    const recovered = await attemptJoin(port);
+    assert.equal(recovered.synced, true, "the room must open once the read works");
+    assert.equal(
+      fragmentToMarkdown(recovered.doc.getXmlFragment(PRD_PATH)).trim(),
+      PRD.trim(),
+      "the recovered room holds the committed document",
+    );
+
+    // The wedge itself: a baseline that was never populated writes with
+    // baseSha "" — "must not exist" — and 409s against the real file forever.
+    recovered.doc.getXmlFragment(PRD_PATH).insert(0, [new Y.XmlText("edited ")]);
+    await leave(recovered);
+    const write = applied.find((w) => w.path === PRD_PATH);
+    assert.ok(write, "the recovered room must be able to commit");
+    assert.equal(
+      write.baseSha,
+      PRD_SHA,
+      "a recovered room commits against the sha it was seeded from",
+    );
+  } finally {
+    await server.destroy();
+  }
+});
+
+test("refusing a room leaves no stale baseline behind", async () => {
+  // Hocuspocus registers a document only AFTER its load resolves, so the unload
+  // path — and the afterUnloadDocument hook that normally drops this — never
+  // runs for a load that threw. A baseline left here would hand the NEXT load
+  // entries it did not seed, and the flush would commit against those shas.
+  dropRoomState(ROOM);
+  const port = await freePort();
+  const server = createCollabServer(config(port), {
+    bff: flakyBff({ oracleDown: false, readDown: true }, []),
+  });
+  await server.listen(port);
+  try {
+    const refused = await attemptJoin(port);
+    assert.equal(refused.synced, false);
+    await leave(refused);
+    assert.equal(
+      roomState(ROOM)?.baseline.size ?? 0,
+      0,
+      "a refused room kept a baseline the next load would commit against",
+    );
+  } finally {
+    await server.destroy();
+  }
+});

--- a/services/collab/src/server.test.ts
+++ b/services/collab/src/server.test.ts
@@ -22,13 +22,14 @@ import { createServer } from "node:net";
 import * as Y from "yjs";
 import type { CollabConfig } from "./env.js";
 import type { BffClient } from "./bff.js";
-import { BffAccessDeniedError } from "./bff.js";
+import { BffAccessDeniedError, BffReadError } from "./bff.js";
 import {
   buildAuthenticateHook,
   buildLoadDocumentHook,
   buildStatelessHook,
   createCollabServer,
   requestFreshToken,
+  UPSTREAM_UNAVAILABLE,
   type CollabContext,
 } from "./server.js";
 import { filesMap } from "./seed.js";
@@ -146,6 +147,112 @@ test("auth propagates oracle denial", async () => {
   );
 });
 
+// A 403 is a verdict about this bearer, and the console is right to stop
+// retrying it. A 503 is not (#586): `aep-api` restarts on every deploy, and
+// every non-ok status used to arrive as the same BffAccessDeniedError — so a
+// redeploy left the spec view offline until the page was reloaded. The reason
+// is what the console reads to tell the two apart.
+test("an unreachable oracle is tagged transient, not a denial", async () => {
+  for (const failure of [
+    new BffAccessDeniedError(503),
+    new TypeError("fetch failed"),
+  ]) {
+    const auth = buildAuthenticateHook(prodConfig, {
+      bff: fakeBff({
+        validateAccess: async () => {
+          throw failure;
+        },
+      }),
+    });
+    const err = await auth({ token: "t", documentName: ROOM }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    assert.equal(
+      (err as { reason?: string }).reason,
+      UPSTREAM_UNAVAILABLE,
+      `${String(failure)} should not read as a verdict`,
+    );
+  }
+});
+
+// The retryable 4xx are the same outage wearing a different status. A BFF
+// shedding load answers 429, and latching the console offline on that would
+// reintroduce #586 through the one door the 5xx test does not cover.
+test("a rate-limited or timing-out oracle is transient, not a verdict", async () => {
+  for (const status of [408, 425, 429]) {
+    const auth = buildAuthenticateHook(prodConfig, {
+      bff: fakeBff({
+        validateAccess: async () => {
+          throw new BffAccessDeniedError(status);
+        },
+      }),
+    });
+    const err = await auth({ token: "t", documentName: ROOM }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    assert.equal(
+      (err as { reason?: string }).reason,
+      UPSTREAM_UNAVAILABLE,
+      `${status} should keep the client retrying`,
+    );
+  }
+});
+
+// The seed read needs the same split the oracle got. A 404 for a project whose
+// repo row is missing is permanent: tagging it transient would have every open
+// tab reconnect forever against a room that can never be seeded.
+test("a permanently-unreadable spec is a verdict, a failing one is not", async () => {
+  for (const [failure, expected] of [
+    [new BffReadError("shop", 404), undefined],
+    [new BffReadError("shop", 502), UPSTREAM_UNAVAILABLE],
+    [new BffReadError("shop", 429), UPSTREAM_UNAVAILABLE],
+    [new TypeError("fetch failed"), UPSTREAM_UNAVAILABLE],
+  ] as const) {
+    const load = buildLoadDocumentHook(prodConfig, {
+      bff: fakeBff({
+        fetchSpecFiles: async () => {
+          throw failure;
+        },
+      }),
+    });
+    ensureRoomState(ROOM, "shop");
+    const err = await load({
+      document: new Y.Doc() as Document,
+      documentName: ROOM,
+      context: {
+        user: { name: "Jo", email: "j", kind: "user" },
+        token: "t",
+        projectName: "shop",
+      },
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    assert.equal(
+      (err as { reason?: string }).reason,
+      expected,
+      `${String(failure)} was classified wrongly`,
+    );
+  }
+});
+
+test("a denial carries no transient reason", async () => {
+  const auth = buildAuthenticateHook(prodConfig, {
+    bff: fakeBff({
+      validateAccess: async () => {
+        throw new BffAccessDeniedError(403);
+      },
+    }),
+  });
+  const err = await auth({ token: "t", documentName: ROOM }).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.equal((err as { reason?: string }).reason, undefined);
+});
+
 test("auth rejects a missing token outside dev mode", async () => {
   const auth = buildAuthenticateHook(prodConfig, { bff: fakeBff() });
   await assert.rejects(
@@ -259,25 +366,56 @@ test("load never seeds reference documents into the room", async () => {
   );
 });
 
-test("load opens an unseeded doc when the files fetch fails (room must survive)", async () => {
+// A ROOM EXISTS ONLY IF IT WAS SEEDED (#586). This used to assert the
+// opposite — that a failed read still opened a live room, on the reasoning that
+// an unseeded doc beat a dead connection. It did not: the baseline stayed
+// empty, so every write preconditioned on baseSha "" ("must not exist") and
+// 409ed against the real file for as long as the room lived, while the console
+// painted the empty room over a document that exists in git.
+test("a failed files fetch rejects the load rather than opening an empty room", async () => {
   const load = buildLoadDocumentHook(prodConfig, {
     bff: fakeBff({
       fetchSpecFiles: async () => {
-        throw new Error("files fetch exploded (404)");
+        throw new Error("files fetch exploded (500)");
       },
     }),
   });
+  // Stand in for a second tab that authenticated into this room while this
+  // load was in flight: its token and its stale baseline entry are both
+  // already on the shared state.
+  const state = ensureRoomState(ROOM, "shop");
+  state.lastToken = "held-by-another-tab";
+  state.baseline.set("specs/requirements/prd.md", { content: "stale", sha: "s0" });
   const doc = new Y.Doc() as Document;
-  await load({
-    document: doc,
-    documentName: "spec-acme-shop",
-    context: {
-      user: { name: "Jo", email: "j", kind: "user" },
-      token: "t",
-      projectName: "shop",
-    },
-  });
-  assert.equal(filesMap(doc).size, 0);
+  await assert.rejects(
+    load({
+      document: doc,
+      documentName: ROOM,
+      context: {
+        user: { name: "Jo", email: "j", kind: "user" },
+        token: "t",
+        projectName: "shop",
+      },
+    }),
+    /files fetch exploded \(500\)/,
+  );
+  // The BASELINE is what must not survive: a seed that threw partway leaves
+  // entries the next successful seed would not overwrite, and a stale baseline
+  // is what makes a flush commit against the wrong sha.
+  assert.equal(
+    roomState(ROOM)!.baseline.size,
+    0,
+    "a failed seed left a baseline behind for the next load to commit against",
+  );
+  // The state itself belongs to every connection that authenticated into the
+  // room, not to this load. Evicting it would take another tab's token with
+  // it, and a room with no token skips its flush entirely — that tab's edits
+  // would be dropped in silence, which is worse than the wedge being fixed.
+  assert.equal(
+    roomState(ROOM)!.lastToken,
+    "held-by-another-tab",
+    "a failed load evicted state another connection owns",
+  );
 });
 
 test("GET /healthz returns 200 ok", async () => {
@@ -290,15 +428,46 @@ test("GET /healthz returns 200 ok", async () => {
   await server.destroy();
 });
 
-test("load opens an empty doc when the oracle gave no project (pre-phase-2 BFF)", async () => {
+// The same wedge through a different door: a room with no project can never
+// commit either, because the committer needs the project the oracle failed to
+// resolve. It opened empty as a pre-phase-2 BFF allowance; nothing in the field
+// is that old, and one branch left returning an unseeded room would keep the
+// class alive while the fix claims it closed.
+test("no project from the oracle rejects the load too", async () => {
   const load = buildLoadDocumentHook(prodConfig, { bff: fakeBff() });
+  ensureRoomState(ROOM, "shop");
   const doc = new Y.Doc() as Document;
-  await load({
+  await assert.rejects(
+    load({
+      document: doc,
+      documentName: ROOM,
+      context: { user: { name: "Jo", email: "j", kind: "user" }, token: "t", projectName: null },
+    }),
+    /missing bff\/token\/project/,
+  );
+});
+
+// ...and it is a VERDICT, not an outage. A room the oracle resolved without a
+// project will keep resolving without one, so tagging it transient would have
+// every open tab reconnect every 30s for the life of the page against a room
+// that can never open.
+test("a room with no project is refused permanently, not tagged transient", async () => {
+  const load = buildLoadDocumentHook(prodConfig, { bff: fakeBff() });
+  ensureRoomState(ROOM, "shop");
+  const doc = new Y.Doc() as Document;
+  const err = await load({
     document: doc,
-    documentName: "spec-acme-shop",
+    documentName: ROOM,
     context: { user: { name: "Jo", email: "j", kind: "user" }, token: "t", projectName: null },
-  });
-  assert.equal(filesMap(doc).size, 0);
+  }).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.equal(
+    (err as { reason?: string }).reason,
+    undefined,
+    "a permanent condition must not invite an endless retry",
+  );
 });
 
 test("stateless token updates connection context and lastToken", async () => {

--- a/services/collab/src/server.ts
+++ b/services/collab/src/server.ts
@@ -27,7 +27,12 @@ import type {
   onStoreDocumentPayload,
 } from "@hocuspocus/server";
 import type { CollabConfig } from "./env.js";
-import type { BffClient } from "./bff.js";
+import {
+  BffAccessDeniedError,
+  BffReadError,
+  type BffClient,
+  type CollabIdentity,
+} from "./bff.js";
 import { isSpecRoom } from "./room.js";
 import { isReferenceDocPath, seedDocument } from "./seed.js";
 import { devSeedFiles } from "./fixtures.js";
@@ -137,6 +142,67 @@ function surfaceFlushError(
   }
 }
 
+// A rejected bearer and an unreachable oracle both surface here as a thrown
+// error, and Hocuspocus answers either one with the same permission-denied
+// frame — which the console latches on, correctly, because a bearer that was
+// rejected will be rejected again. An `aep-api` that is merely restarting is
+// NOT that (#586): every non-ok status became BffAccessDeniedError, so a 503
+// during a deploy left the spec view offline until the page was reloaded.
+//
+// So the reason is classified before it leaves. Hocuspocus forwards
+// `error.reason` verbatim into the frame and the provider re-emits it as
+// `onAuthenticationFailed({ reason })`, which is where the console decides
+// whether to latch. The string is duplicated there rather than shared, the
+// same way the stateless message types already are.
+export const UPSTREAM_UNAVAILABLE = "upstream-unavailable";
+
+/**
+ * An error tagged as "not now" rather than "not you".
+ *
+ * The load hook needs this as much as the auth hook does, which is not
+ * obvious: Hocuspocus runs `onLoadDocument` inside the SAME try/catch as
+ * `onAuthenticate` (it is reached through `setUpNewConnection`), so a refused
+ * room reaches the client as a permission-denied frame — not as a dropped
+ * socket. Untagged, refusing an unseedable room would read to the console as a
+ * rejected bearer and latch the view offline for the life of the page, which is
+ * worse than the wedge it replaces.
+ */
+function unavailable(message: string): Error {
+  return Object.assign(new Error(message), { reason: UPSTREAM_UNAVAILABLE });
+}
+
+/**
+ * True for a status that says "not you" rather than "not now".
+ *
+ * The three retryable 4xx are excluded deliberately. A rate-limited or
+ * timing-out oracle is the SAME outage this fix exists for, reached through a
+ * different status code — latching the console offline on a 429 would
+ * reintroduce #586 the moment the BFF starts shedding load.
+ */
+const RETRYABLE_4XX = new Set([408, 425, 429]);
+
+function isDenial(status: number): boolean {
+  return status < 500 && !RETRYABLE_4XX.has(status);
+}
+
+async function validated(
+  bff: BffClient,
+  token: string,
+  documentName: string,
+): Promise<CollabIdentity> {
+  try {
+    return await bff.validateAccess(token, documentName);
+  } catch (err) {
+    // Anything that is not a decision the oracle actually made — a 5xx, a
+    // refused connection, a DNS failure mid-redeploy — is transient, and the
+    // client should keep retrying rather than treat it as a verdict.
+    if (err instanceof BffAccessDeniedError && isDenial(err.status)) throw err;
+    throw unavailable(
+      `collab oracle unavailable for ${documentName}: ${String(err)}`,
+    );
+  }
+}
+
 export function buildAuthenticateHook(config: CollabConfig, deps: CollabDeps) {
   return async (
     data: Pick<onAuthenticatePayload, "token" | "documentName">,
@@ -160,7 +226,7 @@ export function buildAuthenticateHook(config: CollabConfig, deps: CollabDeps) {
     // room's project-ownership/tenancy check. This service verifies nothing
     // itself (#86: identity stays the BFF's problem). It also resolves the
     // room into a project name for the seed read.
-    const identity = await deps.bff.validateAccess(token, documentName);
+    const identity = await validated(deps.bff, token, documentName);
     // Committer bookkeeping (#133): the session's participants become the
     // commit's Co-authored-by trailers; the latest token backs the forced
     // unload flush (no connection context exists by then).
@@ -199,15 +265,31 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
 
     // Real path: read the spec files as the first joiner (the oracle
     // resolved the room into context.projectName).
+    //
+    // A ROOM EXISTS ONLY IF IT WAS SEEDED (#586). Both failure branches below
+    // therefore reject the load rather than returning an unseeded document.
+    //
+    // This one is NOT tagged transient. `deps.bff` and `context.token` cannot
+    // be missing here at all (the auth hook throws first), and a room the
+    // oracle resolved without a project is a room it will keep resolving
+    // without one — so it is a verdict, and the client should stop asking
+    // rather than reconnect every 30s for the life of the page.
     if (!deps.bff || !context.token || !context.projectName) {
-      deps.log?.(
-        `cannot seed ${documentName}: missing bff/token/project — opening empty`,
-      );
-      return document;
+      throw new Error(`cannot seed ${documentName}: missing bff/token/project`);
     }
-    // A failed seed must not kill the room: access was already authorized
-    // by the oracle, and an unseeded-but-live doc beats a dead connection
-    // (transient BFF errors would otherwise hard-fail every join).
+    // Returning an empty document here is what wedged a project's spec view
+    // (#586): the baseline stays empty, so every path writes with baseSha ""
+    // — which the Files API reads as "must not exist" — and every flush 409s
+    // against the real file for as long as the room lives. Meanwhile the
+    // console could not tell the empty room from an empty project, and an
+    // agent turn joined a room that synced perfectly and reported no files.
+    //
+    // Failing the load costs nothing that a retry does not recover: the
+    // provider reconnects on its own (1s doubling to 30s, unbounded), so the
+    // next attempt reseeds from git once the read works. That IS the retry —
+    // marking the room unseeded would buy a flag with no trigger, because
+    // `onLoadDocument` fires per LOAD and a room stays loaded while any client
+    // is connected.
     try {
       const fetched = await deps.bff.fetchSpecFiles(
         context.token,
@@ -225,9 +307,23 @@ export function buildLoadDocumentHook(config: CollabConfig, deps: CollabDeps) {
       }
       deps.log?.(`seeded ${documentName} (${files.length} files) from BFF`);
     } catch (err) {
+      // Clear the BASELINE, not the room state. A seed that threw partway
+      // leaves entries the next successful seed would not overwrite, so they
+      // have to go — but the state itself belongs to every connection that
+      // authenticated into this room, not to this load. Dropping it wholesale
+      // loses another tab's `lastToken`, and a room with no token skips its
+      // flush (committer.ts) — that tab's edits would be discarded in silence
+      // at exactly the moment several tabs are reconnecting together.
+      roomState(documentName)?.baseline.clear();
       deps.log?.(
-        `seed failed for ${documentName} (${String(err)}) — opening empty`,
+        `seed failed for ${documentName} (${String(err)}) — refusing the room`,
       );
+      // A read the BFF answered permanently — a 404 for a project whose repo
+      // row is missing — is a verdict, not an outage. Tagging it transient
+      // would have every open tab reconnect forever against a room that can
+      // never be seeded.
+      if (err instanceof BffReadError && isDenial(err.status)) throw err;
+      throw unavailable(`could not load ${documentName}: ${String(err)}`);
     }
     return document;
   };


### PR DESCRIPTION
Fixes #586.

An `aep-api` restart mid-session blanks a project's spec view for everyone in it, and keeps it blank until the last client leaves. `onLoadDocument` caught a failed seed, logged it, and returned the empty `Y.Doc` Hocuspocus had handed it. Hocuspocus cached that doc as the room's authoritative state, the console painted an empty pane over a PRD that exists in git, and the committer then flushed the emptiness back with `baseSha: ""` — a precondition that means *must not exist* — so every commit 409'd from then on.

**A room now exists only if it was seeded.** The design was settled decision-by-decision on the issue before any code was written — see the [decisions comment](https://github.com/wso2/labs-agentic-engineer/issues/586#issuecomment-5406148557).

## What changed

**`services/collab`**

- Both branches of `onLoadDocument` — missing prerequisites, and a read that threw — **reject** instead of returning the empty document. Hocuspocus never caches an unseeded doc, so no client is handed one and no committer is left holding an empty baseline.
- The refusal is **tagged `reason: "upstream-unavailable"`**. Hocuspocus runs `setUpNewConnection` inside the same try/catch as `onAuthenticate`, so a throw from `onLoadDocument` reaches the browser as a permission-denied frame on a socket that stays open. Untagged, this would have swapped the wedge for a permanently-latched offline view.
- **A denial and an outage are told apart by status, on both upstream calls.** `BffAccessDeniedError` keeps its status and the spec read gained `BffReadError` so it can do the same. Permanent answers are re-raised unchanged — a 403 from the oracle, a 404 for a project whose repo row is missing — because tagging those transient would have every open tab reconnect forever against a room that can never open. The three retryable 4xx (408, 425, 429) are classified as outages: a BFF shedding load is the same failure wearing a different code.
- **The prerequisites branch is a verdict**, not an outage — a room the oracle resolved without a project will keep resolving without one.
- **A refused load clears the committer baseline, not the room state.** That state is shared by every connection that authenticated into the room; dropping it wholesale takes another tab's `lastToken` with it, and a room with no token skips its flush — those edits would be discarded in silence exactly when several tabs reconnect together.
- `AGENTS.md` gains a **Room lifecycle** section stating the contract, so the next hook author does not re-swallow it.

**`apps/console`**

- `onAuthenticationFailed` branches on the reason: `upstream-unavailable` goes offline and schedules a rebuild; anything else keeps the existing terminal behaviour.
- The rebuild ladder gains `requireSynced: false` — a room refused before it ever synced still has to retry — and the backoff reset is now gated on having actually synced once. `syncedAtRef` starts at `0`, so the "held a healthy session, restart the ladder" test was unconditionally true for a room that had never connected, and a refused room would have hammered the server once a second forever.
- **`getFileFragment` no longer creates document nodes.** `doc.getXmlFragment(path)` conjures the node when absent; on an empty project the rail's own PRD read was enough to invent `specs/requirements/prd.md` and then commit it — a second live defect, with no outage involved. Recorded as **ADR-0020: the console never creates document nodes; agents do** — a rule with no exceptions, which is what the `collab-doc` change below buys.
- New `CommittedFileView`: when the room is unavailable and the committed bytes are in hand, they render **read-only under a warning banner** ("Live editing is unavailable. Showing the last committed version. Reconnecting…") with the header chip reading `offline`. When the bytes are not in hand either, the pane **names the document** it could not load and offers Retry. The previous fallback was an editable `TextField` whose edits went nowhere. No new vocabulary — `offline` is already in the console lexicon (ADR-0019).

**`packages/collab-doc`** — **an empty document is one empty paragraph, not zero blocks.**

Emptying a markdown document is a supported action: a top-level fragment cannot be deleted from a Y.Doc, so the committer deliberately writes an emptied one back to git as an empty *file*. Parsing that file back gave zero blocks — and a fragment with no children generates no Yjs update, so its share key never replicates. A joining client then cannot tell a file the room was seeded with from one that does not exist, and with reads gated on `share.has` that left the document **permanently read-only**: clear a document, leave, come back, and nobody can type the first character again. No outage and no agent required — just the most ordinary editing action there is.

`markdownToFragment` now normalises the empty document to the shape the editor itself holds. Both halves were checked before relying on it: the key replicates, and `fragmentToMarkdown` still serialises it to `""`, so no empty file in git takes a spurious write on the first load after this ships. Re-seeding stays idempotent. It also retires a false anomaly on the server: `needsSeeding` tests `fragment.length === 0`, which an empty document satisfied even straight after being seeded, so every load reported a "seed identity collision" and re-seeded it.

Fixing the representation at the source is what lets ADR-0020 stay exception-free. The alternative — a `create` flag on `getFileFragment` — is a caller obligation meaning *"I promise git has this path"*, and sourcing it from `docPaths` instead of the committed list once would silently reopen the phantom-file hole the ADR exists to close.

**`services/agents`** — the peer keeps its 10s sync timeout (a refused room never reaches that branch: it arrives immediately as a permission-denied frame), and now tells the two refusals apart, so an `aep-api` restart stops showing up in the turn log as a credentials problem. Both stay terminal for the turn — an agent has no committed copy to fall back on, and writing into a never-seeded room is what corrupted the spec.

## Proof of real execution

Driven on the **real local stack** (not mocks), logged in as `admin`/`admin`, on project `employees-submit-expense`.

With the spec view open and live, `docker stop aep-api` + `docker restart aep-collab` forced a re-seed with the API gone:

```
[onAuthenticate] collab oracle unavailable for spec-default-employees-submit-expense: TypeError: fetch failed
```

repeated — the console retrying rather than latching. The pane held the `offline` chip, the banner and the read-only PRD, byte-identical across 18s of captures. Then `docker start aep-api`:

```
[collab] seeded spec-default-employees-submit-expense (11 files) from BFF
```

Chip gone, toolbar back, `contenteditable` true again — **no page reload**. An edit in the recovered room then committed against the correct baseline, with no 409:

```
[collab] committer: spec-default-employees-submit-expense applying writes=[specs/requirements/prd.md] deletes=[]
[collab] committer: spec-default-employees-submit-expense → 90167c32 (1 write(s), 0 delete(s))
```

The test edit was reverted through the same path (`e7bb5c8c`); `git diff 90167c32~1 e7bb5c8c -- specs/requirements/prd.md` is empty, so nothing was left behind in the repo.

`services/collab/src/seed-recovery.test.ts` pins the same claim in CI against a real server and a real provider: refusal at auth and at seed are both tagged transient and never sync, recovery seeds and commits with the correct `baseSha`, and a refused room leaves no stale baseline behind.

## Tests

Every test added for the original defect was verified to **fail against the fix stashed out** — 6 console, 3 collab.

- `make test`, `make lint`, `make license-check`, `make deadcode-ts-check` — all green

Only the e2e file runs with `--test-force-exit`: a refused connection is never registered against a document, so `Server.destroy()`'s `closeConnections()` does not see it and the process stays alive with no active referenced handles. The flag is scoped to that one file rather than the package, so every other suite keeps the leak detection that would catch a real teardown regression in the service's own code.

`/code-review` was run before this PR and surfaced eight findings; all eight are fixed here, each with a test — the status split on the seed read, the retryable 4xx, the permanent prerequisites branch, the shared-room-state race, the empty-committed-file regression, the agents-side reason branch and its stale comment, and the force-exit scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPnoQSuFeDyKcwGbv7m49s
