### PR TITLE
A project awaiting the agent's questions no longer looks dead in the spec view

### DIFF
--- a/apps/console/src/features/agent-chat/api/conversations.ts
+++ b/apps/console/src/features/agent-chat/api/conversations.ts
@@ -60,7 +60,17 @@ export async function rotateConversation(projectName: string): Promise<string> {
   return data.conversationId;
 }
 
-/** Query key for the resolved current-thread id (react-query). */
+/** Query keys for the thread (react-query). */
 export const conversationKeys = {
   current: (projectName: string) => ["agent-conversation", projectName] as const,
+  /**
+   * The thread's server-side history. ONE cache entry shared by every surface
+   * that rehydrates the log (#606) — the chat panel, the spec workspace and the
+   * overview's spec card — so three mounted readers cost one request, not three.
+   *
+   * Keyed on the conversation id as well as the project: a rotation must not
+   * serve the demoted thread's messages under the new thread's key.
+   */
+  messages: (projectName: string, conversationId: string) =>
+    ["agent-conversation", projectName, "messages", conversationId] as const,
 };

--- a/apps/console/src/features/agent-chat/chatStore.ts
+++ b/apps/console/src/features/agent-chat/chatStore.ts
@@ -525,3 +525,70 @@ export function registerDeterministicFlush(key: string): () => void {
 export function hasDeterministicFlush(key: string): boolean {
   return (deterministicFlushKeys.get(key) ?? 0) > 0;
 }
+
+// --- Log-write guards (#606) ---------------------------------------------
+//
+// Rehydrating the log from server truth used to belong to `useAgentChat`, so
+// the two conditions that must block a REPLACE lived there as component refs.
+// #606 gives the log THREE writers — the chat panel, the spec workspace and
+// the overview's spec card — because a member arriving without the panel
+// otherwise has no log at all, and every surface that reads one then reads an
+// empty conversation.
+//
+// The guards move here because they describe the LOG, not any one hook: any
+// writer must be able to ask "is it safe to replace this right now", and the
+// answer cannot live inside one of them.
+//
+// Both are per chatKey, and both are FAIL-CLOSED — an unknown key is safe to
+// replace, a marked key is not:
+//
+// - ATTACHED: a turn stream is being folded into this log. A replace would
+//   wash out the streamed partials the fold has appended so far, and (worse)
+//   the streaming question prefix `useRoomQuestion` is mirroring into the room.
+// - SENDING: a local send is mid-dispatch. Its optimistic user row has no turn
+//   id yet and the server has no record of it, so it survives neither the
+//   replace nor the `localOnly` filter that keeps error/failed rows — the
+//   user's own message would vanish between typing and dispatch.
+//
+// Ref-counted rather than boolean, for the same reason `registerDeterministicFlush`
+// is: a remount can overlap two registrations for one key, and the first
+// cleanup must not clear the second's claim.
+
+const attachedFolds = new Map<string, number>();
+const inFlightSends = new Map<string, number>();
+
+function claim(counts: Map<string, number>, key: string): () => void {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) return; // idempotent: cleanup may run twice (StrictMode)
+    released = true;
+    const remaining = (counts.get(key) ?? 1) - 1;
+    if (remaining <= 0) counts.delete(key);
+    else counts.set(key, remaining);
+  };
+}
+
+/** Mark a turn stream as being folded into `key`'s log. Call the returned
+ *  function when the fold ends, however it ends. */
+export function claimStreamFold(key: string): () => void {
+  return claim(attachedFolds, key);
+}
+
+/** Mark a local send as mid-dispatch for `key`. Call the returned function
+ *  once the dispatch resolves, successfully or not. */
+export function claimSendInFlight(key: string): () => void {
+  return claim(inFlightSends, key);
+}
+
+/**
+ * May a caller REPLACE `key`'s log with server truth right now?
+ *
+ * False while a fold or a send owns it. A blocked rehydrate is DROPPED, never
+ * queued: the surfaces that rehydrate all re-ask on their own triggers (mount,
+ * refocus, the agent peer leaving the room), and the fold that blocked this one
+ * is itself appending fresher content than the replace would have written.
+ */
+export function canReplaceLog(key: string): boolean {
+  return !attachedFolds.has(key) && !inFlightSends.has(key);
+}

--- a/apps/console/src/features/agent-chat/useAgentChat.ts
+++ b/apps/console/src/features/agent-chat/useAgentChat.ts
@@ -27,6 +27,8 @@ import {
   ensureUserMessage,
   getMessages,
   replaceMessages,
+  claimSendInFlight,
+  claimStreamFold,
   settleUserMessage,
   setTurnStatus,
   subscribe,
@@ -36,7 +38,6 @@ import {
 import {
   ConversationRotatedError,
   getActiveTurn,
-  getConversationMessages,
   startCollabTurn,
   type TurnStatus,
 } from "./api/turns.js";
@@ -46,7 +47,10 @@ import {
   rotateConversation,
 } from "./api/conversations.js";
 import { attachAndFoldTurn } from "./runTurn.js";
-import { projectableHistory } from "./history.js";
+import {
+  applyConversationHistory,
+  fetchConversationHistory,
+} from "./useConversationLog.js";
 import { useCurrentAuthor } from "./currentUser.js";
 
 // The panel's behavior hook (#130), on the SHARED project thread (#430): the
@@ -173,6 +177,12 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
   const abortRef = useRef<AbortController | null>(null);
   // Mirrors the attachment state for the poll/refocus triggers: a rehydrate
   // REPLACE must never run mid-fold, or it would clobber streamed partials.
+  //
+  // Since #606 the log has other writers (the spec workspace, the overview's
+  // spec card), so both guards are ALSO published to the store — see
+  // `markAttached` / `markSending` below. The refs stay because this hook reads
+  // them synchronously for its own concurrency control ("am I already
+  // attached"), which is a different question from "may anyone replace the log".
   const attachedRef = useRef(false);
   // A local send whose dispatch has not answered yet. `attachedRef` cannot
   // cover this window: the turn row exists server-side the moment StartTurn
@@ -184,6 +194,45 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
   const pendingStartRef = useRef(false);
   const author = useCurrentAuthor();
   const queryClient = useQueryClient();
+
+  // The ONLY writers of the two guards above, so the local ref and the store
+  // claim it publishes cannot drift apart. Both are idempotent: setting a guard
+  // that is already set keeps the single outstanding claim.
+  const foldClaimRef = useRef<(() => void) | null>(null);
+  const sendClaimRef = useRef<(() => void) | null>(null);
+  const markAttached = useCallback(
+    (on: boolean) => {
+      attachedRef.current = on;
+      if (on) foldClaimRef.current ??= claimStreamFold(chatKey);
+      else {
+        foldClaimRef.current?.();
+        foldClaimRef.current = null;
+      }
+    },
+    [chatKey],
+  );
+  const markSending = useCallback(
+    (on: boolean) => {
+      pendingStartRef.current = on;
+      if (on) sendClaimRef.current ??= claimSendInFlight(chatKey);
+      else {
+        sendClaimRef.current?.();
+        sendClaimRef.current = null;
+      }
+    },
+    [chatKey],
+  );
+  // A chatKey change (rotation, project switch) strands any claim held under
+  // the old key — release it rather than leaving that log permanently unreplaceable.
+  useEffect(
+    () => () => {
+      foldClaimRef.current?.();
+      foldClaimRef.current = null;
+      sendClaimRef.current?.();
+      sendClaimRef.current = null;
+    },
+    [chatKey],
+  );
 
   // The project's current thread id (#430) — server-resolved, shared by every
   // member. staleTime Infinity: the id only moves on rotation, and rotation
@@ -242,12 +291,16 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
       // the user's own message, and `settleUserMessage` would then no-op onto
       // an id that no longer exists.
       if (attachedRef.current || pendingStartRef.current) return;
-      const history = await getConversationMessages(projectName, conversationId);
-      if (ac.signal.aborted || attachedRef.current || history === null) return;
-      const localOnly = getMessages(chatKey).filter(
-        (m) => m.role === "error" || (m.role === "user" && m.status === "failed"),
+      // Through the SHARED cache entry (#606), not a bare fetch: the spec
+      // workspace and the overview's spec card observe the same key, so this
+      // read serves them too instead of racing a second identical request.
+      const history = await fetchConversationHistory(
+        queryClient,
+        projectName,
+        conversationId,
       );
-      replaceMessages(chatKey, [...projectableHistory(history), ...localOnly]);
+      if (ac.signal.aborted) return;
+      applyConversationHistory(chatKey, history);
     };
 
     // Attach to a running turn (ours or a teammate's, or the platform's own
@@ -255,7 +308,7 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
     const attach = async (active: TurnStatus) => {
       if (attachedRef.current) return;
       const turnId = active.turnId;
-      attachedRef.current = true;
+      markAttached(true);
       setIsSending(true);
       setActiveTurnId(turnId);
       dropTurnOutput(chatKey, turnId); // replay-from-0 re-adds it all
@@ -271,7 +324,7 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
       } catch {
         // surfaced by the fold's error handling; the view just settles
       } finally {
-        attachedRef.current = false;
+        markAttached(false);
         if (!ac.signal.aborted) {
           setIsSending(false);
           setActiveTurnId(undefined);
@@ -371,20 +424,20 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
       ac.abort();
       if (pollTimer !== undefined) clearTimeout(pollTimer);
       document.removeEventListener("visibilitychange", onVisible);
-      attachedRef.current = false;
-      pendingStartRef.current = false;
+      markAttached(false);
+      markSending(false);
       setHistoryReady(false);
       setIsSending(false);
       setActiveTurnId(undefined);
     };
-  }, [chatKey, org, projectName, conversationId, onTurnCommitted, queryClient]);
+  }, [chatKey, org, projectName, conversationId, onTurnCommitted, queryClient, markAttached, markSending]);
 
   const send = useCallback(
     async (instruction: string, files: File[] = []): Promise<boolean> => {
       const text = instruction.trim();
       if (!text || isSending || !conversationId) return false;
       setIsSending(true);
-      pendingStartRef.current = true;
+      markSending(true);
       // Names only, and only when there are any: a message without attachments
       // must persist exactly the row shape it did before this feature.
       const attachments = files.length > 0 ? files.map((f) => f.name) : undefined;
@@ -409,7 +462,7 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
       } catch (err) {
         // The row the user is already looking at becomes the failed one —
         // adding a second copy beside it would read as two sends.
-        pendingStartRef.current = false;
+        markSending(false);
         settleUserMessage(chatKey, messageId, { failed: true });
         addMessage(chatKey, {
           role: "error",
@@ -447,12 +500,12 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
         // concurrently with that sequence — so `attach` can already own this
         // turn. Folding it a second time would replay the whole stream on top
         // of itself after `dropTurnOutput`.
-        pendingStartRef.current = false;
+        markSending(false);
         if (attachedRef.current) {
           setIsSending(false);
           return;
         }
-        attachedRef.current = true;
+        markAttached(true);
         try {
           await attachAndFoldTurn(chatKey, projectName, turnId, signal, onTurnCommitted);
         } catch {
@@ -464,7 +517,7 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
             });
           }
         } finally {
-          attachedRef.current = false;
+          markAttached(false);
           if (!signal.aborted) {
             setIsSending(false);
             setActiveTurnId(undefined);
@@ -473,7 +526,7 @@ export function useAgentChat(org: string, projectName: string): AgentChat {
       })();
       return true;
     },
-    [chatKey, projectName, conversationId, isSending, author, onTurnCommitted, queryClient],
+    [chatKey, projectName, conversationId, isSending, author, onTurnCommitted, queryClient, markAttached, markSending],
   );
 
   // Rotation (D4): a PROJECT-WIDE act — the demoted thread stops being current

--- a/apps/console/src/features/agent-chat/useConversationLog.test.tsx
+++ b/apps/console/src/features/agent-chat/useConversationLog.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+// Filling this browser's chat log WITHOUT the chat panel (#606).
+//
+// The behaviors here are the ones that made a project awaiting the agent's
+// questions look dead: the log was filled only by `AgentChatPanel`, so a
+// member arriving on a spec link cold had none, and every surface reading one
+// — the spec workspace's question form, the overview's spec card — read an
+// empty conversation and said nothing had started.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addMessage,
+  chatKeyFor,
+  claimSendInFlight,
+  claimStreamFold,
+  getMessages,
+  replaceMessages,
+} from "./chatStore";
+import { useConversationLog } from "./useConversationLog";
+import { answerableQuestionIds } from "./questionCards";
+
+const ORG = "acme";
+const PROJECT = "proj1";
+const KEY = chatKeyFor(ORG, PROJECT);
+
+const mockFetchCurrent = vi.fn();
+vi.mock("./api/conversations", async (importOriginal) => {
+  const real = await importOriginal<typeof import("./api/conversations")>();
+  return { ...real, fetchCurrentConversationId: (...a: unknown[]) => mockFetchCurrent(...a) };
+});
+
+const mockGetHistory = vi.fn();
+vi.mock("./api/turns", async (importOriginal) => {
+  const real = await importOriginal<typeof import("./api/turns")>();
+  return { ...real, getConversationMessages: (...a: unknown[]) => mockGetHistory(...a) };
+});
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+/** A thread that ended ON a question — the state the whole issue is about. */
+const AWAITING_ANSWERS = [
+  { role: "user", content: "/start a helpdesk" },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: "tc-1",
+        toolName: "ask_questions",
+        input: { questions: [{ question: "Who raises tickets?", options: [{ label: "Staff" }] }] },
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  replaceMessages(KEY, []);
+  mockFetchCurrent.mockResolvedValue("conv-1");
+  mockGetHistory.mockResolvedValue(AWAITING_ANSWERS);
+});
+
+describe("useConversationLog — a log without the chat panel (#606)", () => {
+  it("fills an empty log with the pending question, so the spec view can see it", async () => {
+    // The bug, stated as a test: no chat panel has ever mounted for this
+    // project, so the log is empty and `useRoomQuestion` has nothing to mirror
+    // into the room. Mounting this hook is the whole fix.
+    expect(getMessages(KEY)).toHaveLength(0);
+
+    renderHook(() => useConversationLog(ORG, PROJECT), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      const question = getMessages(KEY).find((m) => m.role === "question");
+      expect(question).toBeDefined();
+    });
+    // And it reads as STILL WAITING — which is what turns the empty state into
+    // the question form rather than "Nothing written yet" plus a Retry.
+    expect(answerableQuestionIds(getMessages(KEY)).size).toBe(1);
+  });
+
+  it("reports historyReady only once the server has been asked", async () => {
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.historyReady).toBe(false);
+    await waitFor(() => expect(result.current.historyReady).toBe(true));
+  });
+
+  it("reports historyReady even when the read FAILED", async () => {
+    // It says "we have asked", not "we know". A guarded seed held forever on a
+    // history the server will not serve would strand the only recovery a
+    // stalled project has.
+    mockGetHistory.mockResolvedValue(null);
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.historyReady).toBe(true));
+  });
+
+  it("keeps painting the local log when the read fails", async () => {
+    mockGetHistory.mockResolvedValue(null);
+    addMessage(KEY, { role: "user", content: "typed locally", status: "completed" });
+
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.historyReady).toBe(true));
+    expect(getMessages(KEY).some((m) => "content" in m && m.content === "typed locally")).toBe(true);
+  });
+
+  it("REPLACES a stale local log with server truth", async () => {
+    addMessage(KEY, { role: "user", content: "stale local fork", status: "completed" });
+
+    renderHook(() => useConversationLog(ORG, PROJECT), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      const contents = getMessages(KEY).map((m) => ("content" in m ? m.content : ""));
+      expect(contents).toContain("/start a helpdesk");
+      expect(contents).not.toContain("stale local fork");
+    });
+  });
+
+  it("keeps a failed send and its error row through the replace", async () => {
+    // They exist nowhere server-side; washing them out destroys the one copy of
+    // a message the user still needs to retry.
+    addMessage(KEY, { role: "user", content: "never reached the server", status: "failed" });
+    addMessage(KEY, { role: "error", content: "Lost the agent's stream" });
+
+    renderHook(() => useConversationLog(ORG, PROJECT), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      const contents = getMessages(KEY).map((m) => ("content" in m ? m.content : ""));
+      expect(contents).toContain("/start a helpdesk");
+      expect(contents).toContain("never reached the server");
+      expect(contents).toContain("Lost the agent's stream");
+    });
+  });
+
+  it("does not replace the log while a turn stream is being folded", async () => {
+    // The guard that makes a second writer safe: a replace mid-fold would wash
+    // out streamed partials — including the streaming question prefix the room
+    // is mirroring.
+    const release = claimStreamFold(KEY);
+    addMessage(KEY, { role: "assistant", content: "…streaming so far", turnId: "t1" });
+
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.historyReady).toBe(true));
+    const contents = getMessages(KEY).map((m) => ("content" in m ? m.content : ""));
+    expect(contents).toContain("…streaming so far");
+    expect(contents).not.toContain("/start a helpdesk");
+    release();
+  });
+
+  it("does not replace the log while a local send is mid-dispatch", async () => {
+    // The optimistic row has no turn id and the server has no record of it, so
+    // it survives neither the replace nor the local-only filter.
+    const release = claimSendInFlight(KEY);
+    addMessage(KEY, { role: "user", content: "just typed", status: "in_flight" });
+
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.historyReady).toBe(true));
+    expect(getMessages(KEY).some((m) => "content" in m && m.content === "just typed")).toBe(true);
+    release();
+  });
+
+  it("re-reads the thread on resync — the caller's own turn-end signal", async () => {
+    const { result } = renderHook(() => useConversationLog(ORG, PROJECT), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(mockGetHistory).toHaveBeenCalledTimes(1));
+
+    // The agent has since answered its own questions and written the document.
+    mockGetHistory.mockResolvedValue([
+      ...AWAITING_ANSWERS,
+      { role: "user", content: "Use your recommended answers" },
+      { role: "assistant", content: "Written." },
+    ]);
+    await act(async () => {
+      result.current.resync();
+    });
+
+    await waitFor(() => {
+      // The question is no longer answerable, so the spec view stops offering a
+      // form over a document that is already written.
+      expect(answerableQuestionIds(getMessages(KEY)).size).toBe(0);
+    });
+  });
+
+  it("supersedes a question the server shows answered, even when the local send says failed", async () => {
+    // The mid-turn navigation case: the browser lost the stream and recorded
+    // the send as failed, but the server did receive it and the turn ran.
+    // `answerableQuestionIds` ignores failed sends on purpose, so only server
+    // truth can close this question — which is why the log must be able to
+    // reach it without the chat panel.
+    addMessage(KEY, { role: "user", content: "Use your recommended answers", status: "failed" });
+    addMessage(KEY, { role: "error", content: "Lost the agent's stream" });
+    mockGetHistory.mockResolvedValue([
+      ...AWAITING_ANSWERS,
+      { role: "user", content: "Use your recommended answers" },
+      { role: "assistant", content: "Written." },
+    ]);
+
+    renderHook(() => useConversationLog(ORG, PROJECT), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(getMessages(KEY).some((m) => m.role === "question")).toBe(true));
+    expect(answerableQuestionIds(getMessages(KEY)).size).toBe(0);
+  });
+
+  it("asks for nothing without a project", async () => {
+    renderHook(() => useConversationLog(ORG, undefined), { wrapper: createWrapper() });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockFetchCurrent).not.toHaveBeenCalled();
+    expect(mockGetHistory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/console/src/features/agent-chat/useConversationLog.ts
+++ b/apps/console/src/features/agent-chat/useConversationLog.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Filling this browser's chat log from server truth (#606).
+//
+// Extracted from `useAgentChat`, where it used to run only while the chat panel
+// was mounted. That made `chatStore` mean "what the panel has seen", and every
+// surface reading it inherited that: a member who opened a spec link without the
+// panel had NO log, so `useRoomQuestion` had nothing to mirror into the room and
+// the workspace showed "Nothing written yet" while the agent stood waiting on
+// three questions. The overview's spec card read "nothing has started" for the
+// same reason.
+//
+// `chatStore` now means "this browser's view of the project conversation", and
+// any surface that needs one fills it. The chat panel still folds live turns —
+// that is its own job and stays there; this is only the rehydrate.
+//
+// It is a REPLACE, not a merge, for the reason it always was (#430 D6): a
+// project-scoped thread must show a teammate's messages, and a merge cannot
+// remove what the server no longer has.
+
+import { useCallback, useEffect } from "react";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import {
+  canReplaceLog,
+  chatKeyFor,
+  getMessages,
+  replaceMessages,
+} from "./chatStore.js";
+import { projectableHistory } from "./history.js";
+import { conversationKeys, fetchCurrentConversationId } from "./api/conversations.js";
+import { getConversationMessages, type ConversationMessage } from "./api/turns.js";
+
+/**
+ * Fetch the thread's history THROUGH the shared cache entry.
+ *
+ * Exported for `useAgentChat`, whose rehydrate is imperative (it runs before an
+ * attach, and on its own poll) rather than observer-driven. Routing it here
+ * rather than calling `getConversationMessages` directly is what makes the
+ * panel and the non-panel surfaces share one in-flight request instead of
+ * racing two.
+ *
+ * `staleTime: 0` because every caller here is a freshness trigger: they ask
+ * precisely when they have reason to believe the answer moved.
+ */
+export function fetchConversationHistory(
+  queryClient: QueryClient,
+  projectName: string,
+  conversationId: string,
+): Promise<ConversationMessage[] | null> {
+  return queryClient.fetchQuery({
+    queryKey: conversationKeys.messages(projectName, conversationId),
+    queryFn: () => getConversationMessages(projectName, conversationId),
+    staleTime: 0,
+  });
+}
+
+/**
+ * Write server history into `chatKey`'s log, keeping the rows the server has
+ * no record of.
+ *
+ * LOCAL-ONLY rows survive: a failed send's user row (the typed text) and its
+ * error row exist nowhere server-side, and washing them out would destroy the
+ * one copy of a message the user still needs to retry. They are cleared by the
+ * next successful send or by a rotation.
+ *
+ * `null` means the read FAILED — keep painting the local cache. "This thread is
+ * empty" never arrives as null (see `getConversationMessages`).
+ */
+export function applyConversationHistory(
+  chatKey: string,
+  history: ConversationMessage[] | null,
+): void {
+  if (history === null) return;
+  if (!canReplaceLog(chatKey)) return;
+  const localOnly = getMessages(chatKey).filter(
+    (m) => m.role === "error" || (m.role === "user" && m.status === "failed"),
+  );
+  replaceMessages(chatKey, [...projectableHistory(history), ...localOnly]);
+}
+
+export interface ConversationLog {
+  /** True once the server has been ASKED — not "the read succeeded". Gates the
+   *  guarded-seed backstop, which needs the exchange to be knowable. */
+  historyReady: boolean;
+  /** Re-read the thread now. For triggers the query cannot see for itself —
+   *  chiefly the agent peer leaving the collab room, i.e. a turn just ended. */
+  resync: () => void;
+}
+
+/**
+ * Keep this browser's log for `(org, projectName)` in step with the server.
+ *
+ * Mount it on any surface that reads the log. Mounting it more than once is
+ * free: the surfaces share one cache entry, so the extra readers cost no extra
+ * request.
+ *
+ * Refreshes on mount and on tab refocus. Callers with a sharper signal call
+ * `resync` — `SpecView` does, when the agent peer leaves the room, which is
+ * turn-end observed without polling.
+ */
+export function useConversationLog(
+  org: string,
+  projectName: string | undefined,
+): ConversationLog {
+  const queryClient = useQueryClient();
+  const chatKey = projectName ? chatKeyFor(org, projectName) : null;
+
+  // Same query as `useAgentChat`'s, so the id resolves once per project however
+  // many surfaces are mounted. `refetchOnWindowFocus: "always"` is the recovery
+  // path when the resolve failed outright: with no id there is nothing to read.
+  const conversation = useQuery({
+    queryKey: conversationKeys.current(projectName ?? ""),
+    queryFn: () => fetchCurrentConversationId(projectName!),
+    enabled: Boolean(projectName),
+    staleTime: Infinity,
+    refetchOnWindowFocus: "always",
+  });
+  const conversationId = conversation.data;
+
+  const history = useQuery({
+    queryKey: conversationKeys.messages(projectName ?? "", conversationId ?? ""),
+    queryFn: () => getConversationMessages(projectName!, conversationId!),
+    enabled: Boolean(projectName && conversationId),
+    // The thread only moves when a turn ends, and every surface that mounts
+    // this has a trigger for that. A time-based staleness would refetch on
+    // every remount of a workspace the user is tabbing around in.
+    staleTime: Infinity,
+    refetchOnWindowFocus: "always",
+  });
+
+  // Apply on every settled read — including a repeat of identical data, which
+  // costs one `replaceMessages` and keeps the rule in one place rather than
+  // splitting "did it change" between here and the store.
+  const data = history.data;
+  useEffect(() => {
+    if (!chatKey || data === undefined) return;
+    applyConversationHistory(chatKey, data);
+  }, [chatKey, data]);
+
+  const resync = useCallback(() => {
+    if (!projectName || !conversationId) return;
+    void queryClient.invalidateQueries({
+      queryKey: conversationKeys.messages(projectName, conversationId),
+    });
+  }, [queryClient, projectName, conversationId]);
+
+  return {
+    // `isFetched` rather than `isSuccess`: a read that FAILED still answers
+    // "we have asked", and holding a guarded seed forever on a history the
+    // server will not serve would strand the only recovery a stalled project
+    // has.
+    historyReady: Boolean(conversationId) && history.isFetched,
+    resync,
+  };
+}

--- a/apps/console/src/features/projects/components/OverviewPipeline.test.tsx
+++ b/apps/console/src/features/projects/components/OverviewPipeline.test.tsx
@@ -53,6 +53,15 @@ vi.mock("../../../auth/SessionContext", () => ({
 }));
 
 const mockNavigate = vi.fn();
+// --- Conversation log (#606): this card reads the local chat log, so it now
+// makes sure one exists. Stubbed here (this file mounts no QueryClientProvider);
+// the hook's own behavior is covered by useConversationLog.test.tsx, and the
+// wiring assertion lives below.
+const mockUseConversationLog = vi.fn();
+vi.mock("../../agent-chat/useConversationLog", () => ({
+  useConversationLog: (...args: unknown[]) => mockUseConversationLog(...args),
+}));
+
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
 }));
@@ -158,5 +167,17 @@ describe("OverviewPipeline — the spec card", () => {
 
     expect(screen.getByText("v2")).toBeInTheDocument();
     expect(screen.getByText("The agent has questions for you.")).toBeInTheDocument();
+  });
+});
+
+// The card reads the local chat log to say "the agent is waiting on you", so it
+// must make sure a log EXISTS (#606). Without this a teammate opening the
+// overview in a fresh browser read "nothing has started" over a thread holding
+// someone else's unanswered question — and the Generate-spec CTA it offers
+// would have answered that question with the agent's own defaults.
+describe("OverviewPipeline keeps the chat log fed (#606)", () => {
+  it("mounts the conversation log for this org and project", () => {
+    renderPipeline();
+    expect(mockUseConversationLog).toHaveBeenCalledWith(ORG, PROJECT);
   });
 });

--- a/apps/console/src/features/projects/components/OverviewPipeline.tsx
+++ b/apps/console/src/features/projects/components/OverviewPipeline.tsx
@@ -37,6 +37,7 @@ import { useNavigate } from "@tanstack/react-router";
 import type { components } from "../../../generated/aep-api";
 import { useSession } from "../../../auth/SessionContext";
 import { useAgentEngaged } from "../../agent-chat/useAgentEngaged";
+import { useConversationLog } from "../../agent-chat/useConversationLog";
 import {
   buildStageView,
   CHIP_COLOR,
@@ -197,6 +198,12 @@ export function OverviewPipeline({
   // a completed turn to "", and a turn that ends ON a question is exactly that.
   // The local chat log is the only thing that knows.
   const org = useSession().orgHandle ?? "default";
+  // ...so this card must make sure the log EXISTS (#606). It used to be filled
+  // only while the chat panel was mounted, which is why a teammate opening the
+  // overview in a fresh browser read "nothing has started" over a thread holding
+  // someone else's unanswered question. One shared cache entry with the panel
+  // and the spec workspace, so mounting it here costs no extra request.
+  useConversationLog(org, projectName);
   const engaged = useAgentEngaged(org, projectName);
   const spec = specStageView(status, engaged);
   const build = buildStageView(status);

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -115,6 +115,22 @@ vi.mock("../collab/useTurnEndFlush", () => ({
   useTurnEndFlush: (...args: unknown[]) => mockUseTurnEndFlush(...args),
 }));
 
+// --- Conversation log (#606): filling this browser's chat log from server
+// truth without the chat panel. Its own behavior is covered by
+// useConversationLog.test.tsx — here it's a stub for the same reason
+// useTurnEndFlush is (no QueryClientProvider in this file), and so SpecView's
+// own wiring can be asserted: the (org, projectName) it mounts the hook with,
+// and that it calls `resync` when the agent peer leaves the room.
+const mockResyncConversation = vi.fn();
+const mockUseConversationLog = vi.fn();
+mockUseConversationLog.mockReturnValue({
+  historyReady: true,
+  resync: mockResyncConversation,
+});
+vi.mock("../../agent-chat/useConversationLog", () => ({
+  useConversationLog: (...args: unknown[]) => mockUseConversationLog(...args),
+}));
+
 // --- "Resolve in chat" (#252 Task 9 seam, Task 5's plumbing): its own
 // behavior is covered by useResolveDependencyViaChat.test.ts — here it's a
 // stub so SpecView's own wiring (which componentName/dep it's called with)
@@ -1238,5 +1254,50 @@ describe("SpecView warns before designing against unsettled requirements", () =>
       expect(screen.queryByRole("button", { name: "Generate anyway" })).toBeNull(),
     );
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// A project whose agent is WAITING on answers must not look dead here (#606).
+// The question form is the room's, but the fact that a question is pending
+// reaches the room through this browser's chat log — which used to be filled
+// only while AgentChatPanel was mounted. These pin the two halves of removing
+// the panel from that path: the workspace mounts the log itself, and it
+// re-reads the thread when the agent peer leaves the room (turn-end observed,
+// not polled).
+describe("SpecView keeps the chat log fed without the chat panel (#606)", () => {
+  it("mounts the conversation log for this org and project", () => {
+    render(<SpecView projectName="proj1" />);
+    // The SAME org expression the chatKey above uses (`orgHandle ?? "default"`,
+    // matching AppLayout/AgentChatPanel) — this harness signs in under "acme",
+    // so the log it fills is `aep.chat.v1.acme.proj1`, the very key
+    // useTurnEndFlush is wired with. Mounting it under a different org fills a
+    // log nothing reads.
+    expect(mockUseConversationLog).toHaveBeenCalledWith("acme", "proj1");
+  });
+
+  it("re-reads the thread when the agent peer leaves the room", () => {
+    // The agent joins the room while it works and leaves when the turn ends, so
+    // its departure is the moment the thread gained a question — or the answer
+    // to one. Nothing else can tell us with the panel closed.
+    mockCollab = {
+      ...soloCollab(),
+      status: "connected",
+      peers: [{ clientId: 1, name: "Agent", color: "#000000", kind: "agent" }],
+    };
+    const { rerender } = render(<SpecView projectName="proj1" />);
+    expect(mockResyncConversation).not.toHaveBeenCalled();
+
+    mockCollab = { ...soloCollab(), status: "connected", peers: [], version: 1 };
+    rerender(<SpecView projectName="proj1" />);
+
+    expect(mockResyncConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-read on mount into an already-idle project", () => {
+    // Falling edge only. The query's own mount read covers arrival; firing here
+    // as well would spend a second request on every visit to a quiet project.
+    mockCollab = { ...soloCollab(), status: "connected", peers: [] };
+    render(<SpecView projectName="proj1" />);
+    expect(mockResyncConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -67,6 +67,7 @@ import {
   type SectionReason,
 } from "../lib/railSections";
 import { chatKeyFor, setPendingSeed, subscribeTurnEnd } from "../../agent-chat/chatStore";
+import { useConversationLog } from "../../agent-chat/useConversationLog";
 import { EmptyState } from "../../../components/EmptyState";
 import { ProblemsDialog } from "./ProblemsDialog";
 import { CommittedFileView } from "./CommittedFileView";
@@ -594,6 +595,38 @@ export function SpecView({ projectName }: { projectName: string }) {
   // renders them with kind:"agent"). Building a half-written design is wrong,
   // so Build is disabled — with a tooltip — while one is working (#162).
   const agentBusy = collab.peers.some((p) => p.kind === "agent");
+
+  // Keep this browser's chat log fed WITHOUT the chat panel (#606).
+  //
+  // The question form is the room's, but the fact that a question is pending
+  // reaches the room via `useRoomQuestion`, which reads the chat log — and the
+  // log used to be filled only while `AgentChatPanel` was mounted. So a member
+  // opening a spec link cold had no log, nothing mirrored, and this workspace
+  // showed "Nothing written yet" plus a Retry while the agent stood waiting on
+  // their answers. Mounting the log here removes the panel from that path.
+  //
+  // Same "default" org fallback as the chatKey above, not the room's "acme".
+  const { resync: resyncConversation } = useConversationLog(
+    orgHandle ?? "default",
+    projectName,
+  );
+  // Turn-end, observed rather than polled. The agent joins the room as a peer
+  // while it works and leaves when the turn ends, so its DEPARTURE is the exact
+  // moment the thread gained something — a question, or the answer to one.
+  // `subscribeTurnEnd` cannot serve this: it fires from the panel's fold, which
+  // is precisely what is absent here. Edge-triggered off a ref rather than a
+  // state flag: this must fire on the falling edge only, never on mount into an
+  // already-idle project, where the query's own mount read has it covered.
+  const agentWasInRoom = useRef(false);
+  useEffect(() => {
+    if (agentBusy) {
+      agentWasInRoom.current = true;
+      return;
+    }
+    if (!agentWasInRoom.current) return;
+    agentWasInRoom.current = false;
+    resyncConversation();
+  }, [agentBusy, resyncConversation]);
   // A standing question form owns the turn: the agent's turn ended ON the
   // question, so `agentBusy` is false while the work is very much unfinished.
   // Since the interview is uncapped (#578) the PRD now exists from the first


### PR DESCRIPTION
Fixes #606.

## The bug

A project whose agent is **waiting on your answers** looks dead in the spec workspace: *"Nothing
written yet"* plus a Retry, while the agent's questions sit unanswered on the server. Opening the
agent chat panel fixes it instantly.

The question form lives in the collab room, and the only thing that ever put a question there was
`useRoomQuestion`, reading **this browser's chat log** — which `AgentChatPanel` alone filled. No
panel → no log → no mirror → the empty state. The overview's spec card reads the same log and said
*"nothing has started"* for the same reason.

## Who it hits, precisely

`chatStore` is localStorage-backed (`aep.chat.v1.<org>.<project>`, capped at 200 messages), and
`AppLayout.tsx:147` opens the panel once on arrival from project creation. So:

| who | log present? | before this PR |
|---|---|---|
| the creator, in the browser they created it in | yes | fine, including after a reload |
| **a teammate on a shared link** | no | **empty page + Retry** |
| the creator on a second device / private window | no | **empty page + Retry** |
| after clearing site data, or past the 200-message cap | no | **empty page + Retry** |

The creator never sees it. The teammate following a shared link — the audience #606 names — always
does.

## The fix

Take the rehydrate out of the panel. `chatStore` stops meaning "what the panel has seen" and starts
meaning "this browser's view of the project conversation".

```
before:  record --[ chat panel only ]--> chatStore --[ useRoomQuestion ]--> room --> form
after:   record --[ panel OR SpecView OR overview ]--> chatStore --> room --> form
```

`useConversationLog` owns the read, behind ONE shared React Query entry
(`conversationKeys.messages`), so three mounted readers cost one request. Nothing downstream
changes: `useRoomQuestion`, `answerableQuestionIds`, the superseded/orphan rules and the `#270`
streaming path are untouched.

**The guards move.** Three writers means a REPLACE could land mid-fold and wash out streamed
partials, or drop an optimistic row the server has no record of yet. `useAgentChat` guarded that
with two private refs; they become ref-counted claims on `chatStore` (`claimStreamFold`,
`claimSendInFlight`, `canReplaceLog`), beside the log they protect — they describe the log, not the
hook. `useAgentChat` keeps the refs for its own concurrency control and sets both through one pair
of helpers, so the two cannot drift.

**Freshness off the panel** is mount, tab refocus, and **the agent peer leaving the room**. The
agent joins the room as a peer while it works (`services/agents/src/collab/room-peer.ts:106`), so
its departure is turn-end observed rather than polled — no traffic on an idle project. Edge-
triggered, so it never fires on mount into an already-idle project. The existing `notifyTurnEnd`
cannot serve this: it only fires from the panel's own fold, which is exactly what is absent.

**Retry disappears on its own.** `awaitingAnswers` is already `Boolean(roomQuestion && roomDoc)`, so
with the question known the form renders and the empty state is never reached.

## A third fault, found while verifying, also fixed

Clicked "Use recommended answers", then navigated away ~4s later. The turn finished server-side —
wrote `specs/requirements/prd.md`, committer landed `cdcd9178`. The browser recorded the send as
`failed` because it lost the stream:

```
0: user/completed  "/start …"
1: question         (the card)
2: user/FAILED     "Use your recommended answers…"   ← the server DID receive this
3: error           "Lost the agent's stream…"
```

`answerableQuestionIds` ignores failed sends on purpose — *"a failed send supersedes nothing — the
agent never saw it"*. Here it had. With the panel closed nothing corrected the belief, so the spec
view re-opened an **already-answered question form over a committed PRD**. Only server truth can
supersede that, and now it reaches the log without the panel. Pinned by a test.

The mid-turn navigation was induced; closing a tab mid-turn is not.

## Proof of real execution

Local stack, **signed-out browser profile with zero stored chat logs**
(`Object.keys(localStorage).filter(k => k.startsWith('aep.chat.v1.')).length === 0`), agent chat
panel **never opened** (header button still reads "Toggle agent chat"):

| surface | before | after |
|---|---|---|
| `lending-t2` → `/spec` | "Nothing written yet" + Retry, stable 40s+ | the three questions, form rendered |
| `employees-submit-expense890` → overview | "nothing has started" + Generate spec | **"The agent has questions for you."** + Open spec |

Both projects' conversations end on an unanswered `ask_questions` in `conversations.messages`, and
neither test created a turn (`agent_turns` count stayed at 1 throughout).

Also measured, and the reason **Retry's timing is NOT in this PR**: on a fresh kickoff the spec view
shows the working spinner while the turn runs and only offers Retry ~6s *after* it ends. That is a
different defect with a different cause — see #629.

## Tests

- `useConversationLog.test.tsx` — 11 new: fills an empty log with the pending question and leaves it
  answerable; `historyReady` semantics including a failed read; REPLACE vs. the retained
  failed/error rows; both write guards; `resync`; and the failed-send-that-actually-landed case
  above.
- `SpecView.test.tsx` — mounts the hook under the same org as the chatKey; resyncs on the agent
  peer's departure; does **not** resync on mount into an idle project.
- `OverviewPipeline.test.tsx` — mounts the hook.

Gates: 1078 console tests pass, `make lint`, `make typecheck`, `make license-check`,
`make deadcode-ts-check` all clean.

## Follow-ups, deliberately not here

- **#629** — Retry is offered while an agent is writing. A turn with no flow token (the one carrying
  a member's interview answers) maps to no rail section, so `nothingToShow` stays true mid-write.
- **#630** — the platform, not a browser, writes questions into the room. Removes the client from
  this path entirely and makes a streaming question reach every member.

## Docs

No doc change: this restores the behaviour `history.ts` already documents as its reason for
existing ("without which an awaiting-human conversation would rehydrate in a fresh browser with the
pending question invisible and unanswerable"). The new seam is explained where it lives, in
`useConversationLog.ts` and the `chatStore` guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f175Nx8qzsnRmaXUvi4Bg
