### PR TITLE
feat(platform): a SPA's /api reaches a protected sibling through the gateway, and a sibling's wiring comes from the design

### DIFF
--- a/docs/decisions/ADR-0013-derived-wiring-lives-in-the-design.md
+++ b/docs/decisions/ADR-0013-derived-wiring-lives-in-the-design.md
@@ -24,17 +24,21 @@ for information it already had at design time.
 Split the block by what is DERIVED from what is RESOLVED, and give each the
 channel its nature allows.
 
-**Derived — stamped into `design.json`.** Every `platform-resource` and `external`
-dependency carries a platform-stamped `wiring: {ref, envBindings}` object,
-shape-identical to one `dependencies.resources[]` entry so the agent copies rather
-than transforms it. It is derived in the design-save pass (the pre-tag step on
-`POST /build`), committed to the design the agent reads as its spec, and captured
-in the version tag. There is no ordering, no audience, and no idempotency marker
-left to get wrong.
+**Derived — stamped into `design.json`.** Every `platform-resource`, `external`
+and `component` dependency carries a platform-stamped `wiring` object,
+shape-identical to the entry it belongs in so the agent copies rather than
+transforms it: `{ref, envBindings}` for one `dependencies.resources[]` entry, and
+`{endpoint}` for one `dependencies.endpoints[]` entry. A **sibling**'s endpoint
+qualifies for the same reason a resource's ref does — scoped provider name, the
+sibling's own endpoint name, `project` visibility and one `address` binding are
+all pure functions of the design. It is derived in the design-save pass (the
+pre-tag step on `POST /build`), committed to the design the agent reads as its
+spec, and captured in the version tag. There is no ordering, no audience, and no
+idempotency marker left to get wrong.
 
-**Resolved — pushed at cycle dispatch.** The `endpoints:` half genuinely needs
-live resolution (a cross-project provider may not have published; a sibling's
-endpoint name comes from a `workload.yaml` nobody has written yet), so it stays a
+**Resolved — pushed at cycle dispatch.** What is left on the `endpoints:` half is
+an `org-service`, which genuinely needs live resolution because its provider
+belongs to another project and may not have published yet, so it stays a
 comment — but triggered at dispatch, not at gate resolution. Dispatch is provably
 correct rather than lucky: the dispatch predicate already requires that no gate is
 open in the milestone, so everything resolvable has resolved, and the working set
@@ -57,10 +61,11 @@ Three properties make this hold:
 - **Absence is loud.** A declared dependency with no `wiring` is a platform fault
   the agent reports and stops on — never a licence to substitute its own database,
   cache or IDP. Independently, the merged-PR fan-out compares each component's
-  declared refs against the `workload.yaml` it shipped and mints a fix issue on a
-  mismatch, because the silence was a separate defect from the delivery bug: a
-  component that quietly substituted its own persistence BUILDS, so nothing else
-  would ever notice.
+  declared refs AND endpoint targets against the `workload.yaml` it shipped and
+  mints a fix issue on a mismatch, because the silence was a separate defect from
+  the delivery bug: a component that quietly substituted its own persistence
+  BUILDS, and one that named a sibling by its unscoped name builds, deploys and
+  serves, so nothing else would ever notice.
 
 ## Consequences
 

--- a/services/aep-api/.env.example
+++ b/services/aep-api/.env.example
@@ -87,3 +87,12 @@ TEMPORAL_TASKQUEUE=aep-devflow
 # provider (NewOSSOptions). Empty = secrets delivery off. Never set in cloud.
 OPENBAO_ADDR=http://host.docker.internal:8200
 OPENBAO_TOKEN=root
+
+# host:port of the API Platform gateway runtime — the hop that terminates
+# end-user auth for a managed API. Published to a consumer of a PROTECTED
+# sibling as <DEP>_GATEWAY_URL so a SPA's nginx proxies the browser's /api
+# through it instead of straight at the project Service. Empty uses the
+# platform default (projects.DefaultAPIGatewayHost), which mirrors the
+# api-configuration ClusterTrait's Backend host. Set only for a data plane
+# that names its gateway differently.
+#API_GATEWAY_HOST=

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -1174,6 +1174,14 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// The deployment service's two config inputs, wired here because both are
 	// built after it.
 	deploymentService.SetConfigSources(configService, runtimeConfigSvc)
+	// The address a consumer reaches a protected sibling's managed API on. Config
+	// carries only an override; the default lives beside the context-path builder
+	// it has to agree with.
+	if host := cfg.APIGatewayHost; host != "" {
+		deploymentService.SetAPIGatewayHost(host)
+	} else {
+		deploymentService.SetAPIGatewayHost(projects.DefaultAPIGatewayHost)
+	}
 	configService.SetConverger(deploymentService)
 	// The cross-project access grant is the only deploy observer left. The two
 	// that rode beside it — the env-config.js re-emit and the api-configuration

--- a/services/aep-api/internal/config/config.go
+++ b/services/aep-api/internal/config/config.go
@@ -115,6 +115,15 @@ type Config struct {
 	// still deploy, just without per-org publishers).
 	ThunderAdmin ThunderAdminConfig
 
+	// APIGatewayHost is host:port of the API Platform gateway runtime — the hop
+	// that terminates authentication for a managed API. Published to a consumer
+	// of a protected sibling as `<DEP>_GATEWAY_URL` so a SPA's nginx can proxy
+	// the browser's /api through it instead of straight at the project Service.
+	// Loaded from API_GATEWAY_HOST. Empty means "use the platform default" —
+	// the constant lives in the projects domain beside the context-path builder
+	// it must agree with, so config carries only the override.
+	APIGatewayHost string
+
 	// Platform IDP defaults seeded into organization_idp_profiles rows
 	// on first access. Loaded from PLATFORM_IDP_ISSUER /
 	// PLATFORM_IDP_JWKS_URL — should match the cluster's Thunder

--- a/services/aep-api/internal/config/config_loader.go
+++ b/services/aep-api/internal/config/config_loader.go
@@ -70,6 +70,7 @@ func Load() (Config, error) {
 			ClientID:     r.readOptionalString("THUNDER_SYSTEM_CLIENT_ID", "aep-system-client"),
 			ClientSecret: r.readOptionalString("THUNDER_SYSTEM_CLIENT_SECRET", "aep-system-client-secret"),
 		},
+		APIGatewayHost: r.readOptionalString("API_GATEWAY_HOST", ""),
 		PlatformIDP: PlatformIDPDefaults{
 			Issuer:  r.readOptionalString("PLATFORM_IDP_ISSUER", "http://thunder.openchoreo.localhost:8080"),
 			JWKSURL: r.readOptionalString("PLATFORM_IDP_JWKS_URL", "http://thunder-service.thunder.svc.cluster.local:8090/oauth2/jwks"),

--- a/services/aep-api/internal/platform/ocname/naming.go
+++ b/services/aep-api/internal/platform/ocname/naming.go
@@ -143,6 +143,25 @@ func ServiceURLEnvName(depName string) string {
 	return EnvVarName(depName, "URL")
 }
 
+// ServiceGatewayURLEnvName is the env var a consumer reads a PROTECTED provider
+// component's gateway address from: "todo-api" → "TODO_API_GATEWAY_URL". It sits
+// beside ServiceURLEnvName because the two name the same provider reached two
+// different ways, and the difference is authentication:
+//
+//   - ServiceURLEnvName is the project Service, reached directly. Nothing
+//     validates a token and nothing injects identity headers.
+//   - This one is the API gateway, which validates the caller's bearer token and
+//     injects X-User-* from its claims. The platform emits it only for a provider
+//     whose design declares `exposesAPI.auth` (spec.ResolveAPISecurityEnabled).
+//
+// A consumer that carries untrusted traffic — a SPA's nginx proxying the
+// browser's /api — must prefer this one. Keyed on the LOGICAL dependency name for
+// the same reason as ServiceURLEnvName: the var the coding agent codes against
+// does not move when OC's scoping rule does.
+func ServiceGatewayURLEnvName(depName string) string {
+	return EnvVarName(depName, "GATEWAY_URL")
+}
+
 // ExternalResourceName is the per-project OC Resource name (== the Workload
 // dependency `ref`) for a project's external OR platform resource. metadata.name
 // is namespace-unique — owner.projectName does NOT scope it — so the project

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -66,8 +66,8 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
 - **The DEPLOY** (`DeploymentService`): cut a component's release from the Workload its build posted, compose
   the whole desired binding, write it once, and report what the cluster says back. Plus `ConvergeWatcher`,
   the sweep that re-asserts deployed bindings for drift no event causes.
-- **The desired-state projection** (`DesiredDeploymentFor`, `api_traits.go`, `alert_rule_trait.go`): design
-  facts → the two objects the platform owns, as pure functions.
+- **The desired-state projection** (`DesiredDeploymentFor`, `api_traits.go`, `alert_rule_trait.go`,
+  `gateway_address.go`): design facts → the two objects the platform owns, as pure functions.
 - **Persistence**: the `component_config` gorm and its entities live in this domain (`repository_config.go`
   over `component_config.go`), single write-authority.
 
@@ -82,6 +82,17 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
   without its config does not degrade — it fails the whole binding render. The two halves land at different
   times (the shape pre-build, since a ComponentRelease freezes it; the config at deploy, since it needs a
   release to bind) and that split is forced by OpenChoreo, not chosen.
+- **A protected sibling is addressed through the gateway** (`gateway_address.go`). OpenChoreo resolves a
+  `component`-kind dependency to the provider's project Service — right for a trusted service-to-service
+  caller, wrong for a consumer that forwards UNTRUSTED traffic, because a SPA's nginx proxying the browser's
+  `/api` then carries it into the project's trusted lane with nothing authenticating it. So for every
+  dependency whose provider passes `ResolveAPISecurityEnabled`, the projection also publishes
+  `<DEP>_GATEWAY_URL`, and the `react-webapp` proxy prefers it. Two couplings this file must keep:
+  `APIGatewayContextPath` mirrors the `api-configuration` trait's `RestApi.spec.context` template (a
+  mismatched prefix 404s at the gateway, it does not degrade), and the provider's endpoint must list
+  `internal` or the gateway is not admitted by the component's NetworkPolicy (it authenticates, then 503s).
+  The address rides the binding's env field and is overlaid ONLY when that field is already managed —
+  merging into an unmanaged (nil) one would replace the user's whole config with the platform's variable.
 - **Deploy is DRIVEN, never inferred.** Components carry `autoDeploy: false`, so nothing promotes a release
   except a call to `Deploy`. That is what lets the run supervisor place validation after a version is
   genuinely serving — see [ADR-0017](../../../../docs/decisions/ADR-0017-the-platform-owns-deploy.md).

--- a/services/aep-api/internal/projects/deployment_service.go
+++ b/services/aep-api/internal/projects/deployment_service.go
@@ -58,6 +58,10 @@ type DeploymentService struct {
 	// files computes the literal files a component needs mounted
 	// (env-config.js). Optional, same unmanaged-vs-empty rule.
 	files RuntimeFileProvider
+	// gatewayHost is host:port of the API gateway runtime, published to a
+	// consumer of a protected sibling as `<DEP>_GATEWAY_URL`. Empty leaves every
+	// consumer on the direct-Service lane (see gateway_address.go).
+	gatewayHost string
 }
 
 // ComponentEnvVarReader is the user's component config, consumer-side.
@@ -93,6 +97,17 @@ func (s *DeploymentService) SetIDPService(idp OrgPublisher) {
 func (s *DeploymentService) SetConfigSources(envVars ComponentEnvVarReader, files RuntimeFileProvider) {
 	if s != nil {
 		s.envVars, s.files = envVars, files
+	}
+}
+
+// SetAPIGatewayHost wires the address a consumer reaches a protected sibling's
+// managed API on. Empty (the zero value) publishes no gateway address at all,
+// which leaves consumers on the unauthenticated direct-Service lane — so the
+// composition root passes projects.DefaultAPIGatewayHost unless the deployment
+// overrides it.
+func (s *DeploymentService) SetAPIGatewayHost(host string) {
+	if s != nil {
+		s.gatewayHost = host
 	}
 }
 
@@ -238,6 +253,11 @@ func (s *DeploymentService) deployOne(ctx context.Context, orgID, projectID, com
 		Issuers:       issuers,
 		EnvVars:       s.envVarsFor(ctx, orgID, projectID, componentName),
 		Files:         s.filesFor(ctx, orgID, projectID, componentName),
+		// The org IS the OC namespace components are created in, and that
+		// namespace is a segment of every managed API's gateway context path.
+		ComponentNamespace: orgID,
+		GatewayHost:        s.gatewayHost,
+		ProtectedSiblings:  ProtectedSiblingsOf(design, *comp),
 	})
 	if err := s.components.ApplyReleaseBinding(ctx, orgID, projectID, desired.Binding); err != nil {
 		return outcome, fmt.Errorf("apply release binding: %w", permanentIfMissing(err))

--- a/services/aep-api/internal/projects/deployment_spec.go
+++ b/services/aep-api/internal/projects/deployment_spec.go
@@ -77,6 +77,16 @@ type DeploymentInputs struct {
 	// Files are the literal files the runtime-config projection wants mounted
 	// (env-config.js for a web app). Nil means "not managed by this write".
 	Files []openchoreo.WorkflowFileVar
+	// ComponentNamespace is the OC namespace the component's CR lives in — a
+	// segment of every managed API's gateway context path.
+	ComponentNamespace string
+	// GatewayHost is host:port of the API gateway runtime. Empty emits no
+	// gateway address, which leaves a consumer on the direct-Service lane.
+	GatewayHost string
+	// ProtectedSiblings are the component-kind dependencies whose provider sits
+	// behind the gateway. Each becomes a `<DEP>_GATEWAY_URL` env var so the
+	// consumer can choose the authenticated lane (see gateway_address.go).
+	ProtectedSiblings []ProtectedSibling
 }
 
 // DesiredDeploymentFor projects one component's design facts onto the two
@@ -111,6 +121,20 @@ func DesiredDeploymentFor(in DeploymentInputs) DesiredDeployment {
 		}
 	}
 
+	// The gateway address for each protected sibling rides the same env field as
+	// the user's own config, so it is overlaid rather than written separately.
+	//
+	// Only when that field is already MANAGED (non-nil). Nil means the user's env
+	// could not be read on this pass, and replacing it with the platform's two
+	// variables would drop configuration the platform does not own — a
+	// component that loses its env is worse off than one still on the direct
+	// lane, and the next converge re-attempts the overlay anyway.
+	envVars := in.EnvVars
+	if envVars != nil {
+		envVars = mergeEnvVars(envVars,
+			GatewayEnvVars(in.GatewayHost, in.Environment, in.ComponentNamespace, in.ProtectedSiblings))
+	}
+
 	return DesiredDeployment{
 		Traits: traits,
 		Binding: openchoreo.ReleaseBindingDesired{
@@ -122,7 +146,7 @@ func DesiredDeploymentFor(in DeploymentInputs) DesiredDeployment {
 			// traits wants an EMPTY config map, not an untouched one, or a trait
 			// turned off in the design would keep its config forever.
 			TraitEnvironmentConfigs: liveTraitConfigs(configs),
-			Env:                     in.EnvVars,
+			Env:                     envVars,
 			Files:                   in.Files,
 		},
 	}

--- a/services/aep-api/internal/projects/gateway_address.go
+++ b/services/aep-api/internal/projects/gateway_address.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/platform/ocname"
+	"github.com/wso2/aep/aep-api/internal/spec"
+)
+
+// Addressing a PROTECTED sibling API through the gateway.
+//
+// A component-kind dependency resolves, via OpenChoreo, to the provider's
+// project Service — a direct pod-to-pod address with no gateway in front of it.
+// That is correct for a trusted service-to-service caller and WRONG for a
+// consumer that forwards untrusted traffic: a SPA's nginx proxying the browser's
+// `/api` turns the project's trusted lane into an unauthenticated public one, and
+// the backend then receives no injected identity at all (or, worse, whatever the
+// browser chose to send).
+//
+// So for every protected sibling the platform ALSO publishes the gateway
+// address, and the consumer picks the lane. The direct address stays: a genuine
+// backend-to-backend caller may still want it.
+
+// DefaultAPIGatewayHost is the in-cluster host:port of the API Platform gateway
+// runtime — the hop that terminates authentication for a managed API.
+//
+// It MIRRORS the `api-configuration` ClusterTrait's Backend template, which
+// points its static host at the same service. The two must move together: this
+// is the address, that is the routing, and a consumer proxying here relies on
+// both agreeing. Overridable via API_GATEWAY_HOST for a data plane that names its
+// gateway differently.
+//
+// FULLY QUALIFIED on purpose, unlike the trait's `<service>.<namespace>` short
+// form. The consumer here is nginx, and nginx's `resolver` queries the name
+// verbatim — it does NOT apply the search domains in /etc/resolv.conf the way
+// getaddrinfo does. The short name resolves for `wget` inside the very same pod
+// and is NXDOMAIN for nginx, which surfaces as a 502 on every /api call with
+// `could not be resolved (3: Host not found)` in the error log.
+const DefaultAPIGatewayHost = "api-platform-default-gateway-gateway-runtime.openchoreo-data-plane.svc.cluster.local:8080"
+
+// ProtectedSibling is one component-kind dependency whose provider sits behind
+// the API gateway, resolved to everything needed to address it there.
+type ProtectedSibling struct {
+	// DepName is the LOGICAL dependency name from design.json. It keys the env
+	// var, so it must be the name the coding agent codes against.
+	DepName string
+	// ComponentName is the SCOPED OC component name, taken from the dependency's
+	// platform-recomputed endpoint wiring rather than re-derived here.
+	ComponentName string
+	// EndpointName is the provider's workload endpoint name ("http" by default).
+	EndpointName string
+}
+
+// APIGatewayContextPath is the URL prefix the api-configuration trait gives a
+// component's managed API.
+//
+// It MIRRORS the trait's `RestApi.spec.context` template:
+//
+//	/${metadata.environmentName}-${metadata.componentNamespace}-${metadata.componentName}-${parameters.endpointName}
+//
+// and must move with it. This prefix is how the gateway decides which API a
+// request belongs to, so a consumer proxying to the gateway has to preserve it
+// verbatim — drop it and every call 404s at the gateway instead of reaching the
+// service.
+func APIGatewayContextPath(environment, componentNamespace, scopedComponentName, endpointName string) string {
+	if endpointName == "" {
+		endpointName = spec.DefaultEndpointName
+	}
+	return "/" + environment + "-" + componentNamespace + "-" + scopedComponentName + "-" + endpointName
+}
+
+// ProtectedSiblingsOf returns the component-kind dependencies of comp whose
+// provider component declares gateway auth.
+//
+// Resolution reads the dependency's `wiring.endpoint`, which the platform
+// recomputes on every design save and which already carries the scoped component
+// name and endpoint name. A dependency with no endpoint wiring yet is skipped
+// rather than guessed at: the address would be wrong, and a wrong gateway prefix
+// fails every call.
+func ProtectedSiblingsOf(design *spec.DesignFile, comp spec.DesignComponent) []ProtectedSibling {
+	if design == nil {
+		return nil
+	}
+	var out []ProtectedSibling
+	for _, dep := range comp.Dependencies {
+		if dep.Kind != spec.DependencyKindComponent {
+			continue
+		}
+		provider := findDesignComponent(design, dep.Name)
+		if provider == nil || !spec.ResolveAPISecurityEnabled(*provider) {
+			continue
+		}
+		wiring := dep.Wiring
+		if wiring == nil || wiring.Endpoint == nil || wiring.Endpoint.Component == "" {
+			continue
+		}
+		endpoint := wiring.Endpoint.Name
+		if endpoint == "" {
+			endpoint = provider.EndpointName()
+		}
+		out = append(out, ProtectedSibling{
+			DepName:       dep.Name,
+			ComponentName: wiring.Endpoint.Component,
+			EndpointName:  endpoint,
+		})
+	}
+	return out
+}
+
+// GatewayEnvVars projects one `<DEP>_GATEWAY_URL` pod env var per protected
+// sibling. An empty gatewayHost or no siblings yields nothing, which is the
+// correct answer for a component that consumes no protected API.
+func GatewayEnvVars(gatewayHost, environment, componentNamespace string, siblings []ProtectedSibling) []openchoreo.WorkflowEnvVarRef {
+	if gatewayHost == "" || environment == "" || componentNamespace == "" || len(siblings) == 0 {
+		return nil
+	}
+	out := make([]openchoreo.WorkflowEnvVarRef, 0, len(siblings))
+	for _, s := range siblings {
+		if s.DepName == "" || s.ComponentName == "" {
+			continue
+		}
+		out = append(out, openchoreo.WorkflowEnvVarRef{
+			Key:   ocname.ServiceGatewayURLEnvName(s.DepName),
+			Value: "http://" + gatewayHost + APIGatewayContextPath(environment, componentNamespace, s.ComponentName, s.EndpointName),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeEnvVars overlays platform-owned env vars onto the user's, platform
+// winning on a key collision.
+//
+// It is only ever called with a NON-NIL user slice. Nil means "this write does
+// not manage the binding's env" (the config read failed, or no reader is wired),
+// and merging into that would replace the user's whole env with the platform's
+// two variables — silently dropping configuration the platform never owned.
+func mergeEnvVars(user, platform []openchoreo.WorkflowEnvVarRef) []openchoreo.WorkflowEnvVarRef {
+	if len(platform) == 0 {
+		return user
+	}
+	owned := make(map[string]struct{}, len(platform))
+	for _, p := range platform {
+		owned[p.Key] = struct{}{}
+	}
+	out := make([]openchoreo.WorkflowEnvVarRef, 0, len(user)+len(platform))
+	for _, u := range user {
+		if _, taken := owned[u.Key]; taken {
+			continue
+		}
+		out = append(out, u)
+	}
+	return append(out, platform...)
+}

--- a/services/aep-api/internal/projects/gateway_address_test.go
+++ b/services/aep-api/internal/projects/gateway_address_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/spec"
+)
+
+// The gateway address is the one value that decides whether a SPA's browser
+// traffic is authenticated, so its exact shape is pinned here rather than left
+// to a deploy-time surprise: a wrong context prefix does not degrade, it 404s
+// every call at the gateway.
+
+// designFile parses a whole design fixture through the real codec.
+func designFile(t *testing.T, body string) *spec.DesignFile {
+	t.Helper()
+	var d spec.DesignFile
+	if err := json.Unmarshal([]byte(body), &d); err != nil {
+		t.Fatalf("fixture parse: %v", err)
+	}
+	return &d
+}
+
+// TestAPIGatewayContextPath pins the prefix byte-for-byte against the value the
+// api-configuration ClusterTrait renders on a real cluster. This string is the
+// contract between the trait's RestApi `context` and every consumer proxying to
+// the gateway; if the trait template changes, this test is what should fail.
+func TestAPIGatewayContextPath(t *testing.T) {
+	t.Parallel()
+
+	got := APIGatewayContextPath("development", "default", "track-each-hire41-onboarding-api", "http")
+	const want = "/development-default-track-each-hire41-onboarding-api-http"
+	if got != want {
+		t.Fatalf("context path\n got %q\nwant %q", got, want)
+	}
+
+	// An endpoint the design left unnamed defaults to "http", the same default
+	// the workload and the trait both fall back to.
+	if got := APIGatewayContextPath("development", "default", "proj-api", ""); got != "/development-default-proj-api-http" {
+		t.Fatalf("default endpoint name: got %q", got)
+	}
+}
+
+// TestDefaultAPIGatewayHostIsFullyQualified guards a failure that only shows up
+// in a cluster. The consumer of this address is nginx, whose `resolver` queries
+// the name verbatim and does NOT apply /etc/resolv.conf search domains — so the
+// `<service>.<namespace>` short form the api-configuration trait uses resolves
+// for getaddrinfo inside the very same pod and is NXDOMAIN for nginx. The
+// symptom is a 502 on every /api call, which reads like the API being down.
+func TestDefaultAPIGatewayHostIsFullyQualified(t *testing.T) {
+	t.Parallel()
+
+	host, _, found := strings.Cut(DefaultAPIGatewayHost, ":")
+	if !found {
+		t.Fatalf("default gateway host must carry a port: %q", DefaultAPIGatewayHost)
+	}
+	if !strings.HasSuffix(host, ".svc.cluster.local") {
+		t.Fatalf("default gateway host must be fully qualified for nginx's resolver, got %q", host)
+	}
+}
+
+func TestProtectedSiblingsOf(t *testing.T) {
+	t.Parallel()
+
+	// A SPA depending on one protected service, one unprotected service, and a
+	// platform resource — only the protected sibling may be addressed via the
+	// gateway.
+	design := designFile(t, `{"components":[
+      {"name":"web","type":"web-application","dependencies":[
+        {"kind":"component","name":"api","wiring":{"endpoint":{"component":"proj-api","name":"http","visibility":"project","envBindings":{"address":"API_URL"}}}},
+        {"kind":"component","name":"open","wiring":{"endpoint":{"component":"proj-open","name":"http","visibility":"project","envBindings":{"address":"OPEN_URL"}}}},
+        {"kind":"platform-resource","name":"user-auth","resourceType":"thunder-app"}
+      ]},
+      {"name":"api","type":"service","dependencies":[],"exposesAPI":{"auth":"end-user-required"}},
+      {"name":"open","type":"service","dependencies":[]}
+    ]}`)
+
+	webapp := findDesignComponent(design, "web")
+	if webapp == nil {
+		t.Fatal("fixture: no web component")
+	}
+	got := ProtectedSiblingsOf(design, *webapp)
+	if len(got) != 1 {
+		t.Fatalf("want exactly the protected sibling, got %+v", got)
+	}
+	if got[0].DepName != "api" || got[0].ComponentName != "proj-api" || got[0].EndpointName != "http" {
+		t.Fatalf("resolved sibling wrong: %+v", got[0])
+	}
+}
+
+// TestProtectedSiblingsOfSkipsUnwiredDependency covers the ordering window: a
+// dependency whose endpoint wiring has not been stamped yet cannot be addressed,
+// and guessing the scoped name would produce a prefix that 404s. Skipping leaves
+// the consumer on the direct lane until the next converge.
+func TestProtectedSiblingsOfSkipsUnwiredDependency(t *testing.T) {
+	t.Parallel()
+
+	design := designFile(t, `{"components":[
+      {"name":"web","type":"web-application","dependencies":[{"kind":"component","name":"api"}]},
+      {"name":"api","type":"service","dependencies":[],"exposesAPI":{"auth":"end-user-required"}}
+    ]}`)
+	webapp := findDesignComponent(design, "web")
+	if got := ProtectedSiblingsOf(design, *webapp); got != nil {
+		t.Fatalf("unwired dependency must not be addressed, got %+v", got)
+	}
+}
+
+func TestGatewayEnvVars(t *testing.T) {
+	t.Parallel()
+
+	sibs := []ProtectedSibling{{DepName: "onboarding-api", ComponentName: "track-each-hire41-onboarding-api", EndpointName: "http"}}
+	got := GatewayEnvVars(DefaultAPIGatewayHost, "development", "default", sibs)
+	if len(got) != 1 {
+		t.Fatalf("want one env var, got %+v", got)
+	}
+	if got[0].Key != "ONBOARDING_API_GATEWAY_URL" {
+		t.Fatalf("env key: got %q", got[0].Key)
+	}
+	const wantVal = "http://" + DefaultAPIGatewayHost + "/development-default-track-each-hire41-onboarding-api-http"
+	if got[0].Value != wantVal {
+		t.Fatalf("env value\n got %q\nwant %q", got[0].Value, wantVal)
+	}
+
+	// Every missing input independently yields nothing rather than a malformed
+	// address: a half-formed gateway URL would send the SPA somewhere that 404s,
+	// which is harder to diagnose than staying on the direct lane.
+	for _, c := range []struct {
+		name          string
+		host, env, ns string
+		sibs          []ProtectedSibling
+	}{
+		{"no host", "", "development", "default", sibs},
+		{"no environment", DefaultAPIGatewayHost, "", "default", sibs},
+		{"no namespace", DefaultAPIGatewayHost, "development", "", sibs},
+		{"no siblings", DefaultAPIGatewayHost, "development", "default", nil},
+		{"sibling missing component", DefaultAPIGatewayHost, "development", "default", []ProtectedSibling{{DepName: "x"}}},
+	} {
+		if got := GatewayEnvVars(c.host, c.env, c.ns, c.sibs); got != nil {
+			t.Errorf("%s: want nil, got %+v", c.name, got)
+		}
+	}
+}
+
+func TestMergeEnvVars(t *testing.T) {
+	t.Parallel()
+
+	user := []openchoreo.WorkflowEnvVarRef{
+		{Key: "FEATURE_FLAG", Value: "on"},
+		{Key: "ONBOARDING_API_GATEWAY_URL", Value: "http://stale"},
+	}
+	platform := []openchoreo.WorkflowEnvVarRef{{Key: "ONBOARDING_API_GATEWAY_URL", Value: "http://fresh"}}
+
+	got := mergeEnvVars(user, platform)
+	if len(got) != 2 {
+		t.Fatalf("want the user var plus one platform var, got %+v", got)
+	}
+	if got[0].Key != "FEATURE_FLAG" {
+		t.Fatalf("user var must survive: %+v", got)
+	}
+	// The platform owns this key. A stale user-set value cannot shadow the
+	// address the platform just computed.
+	if got[1].Value != "http://fresh" {
+		t.Fatalf("platform must win the collision: %+v", got[1])
+	}
+
+	// Nothing to overlay leaves the slice identical.
+	if got := mergeEnvVars(user, nil); len(got) != 2 || got[1].Value != "http://stale" {
+		t.Fatalf("empty platform overlay must be a no-op, got %+v", got)
+	}
+}
+
+// TestDesiredDeploymentForGatewayEnv is the rule that protects a user's config:
+// the gateway address rides the env field, and that field is only touched when
+// this write already manages it.
+func TestDesiredDeploymentForGatewayEnv(t *testing.T) {
+	t.Parallel()
+
+	sibs := []ProtectedSibling{{DepName: "api", ComponentName: "proj-api", EndpointName: "http"}}
+	base := DeploymentInputs{
+		Component:          designComponent(t, `{"name":"web","type":"web-application","dependencies":[]}`),
+		ComponentName:      "web",
+		Environment:        "development",
+		ComponentNamespace: "default",
+		GatewayHost:        DefaultAPIGatewayHost,
+		ProtectedSiblings:  sibs,
+	}
+
+	// Unmanaged (nil) env stays nil. Overlaying here would replace the user's
+	// whole env with one platform variable.
+	if got := DesiredDeploymentFor(base).Binding.Env; got != nil {
+		t.Fatalf("unmanaged env must stay unmanaged, got %+v", got)
+	}
+
+	// Managed-but-empty is the ordinary case for a component with no user config,
+	// and it does receive the address.
+	in := base
+	in.EnvVars = []openchoreo.WorkflowEnvVarRef{}
+	got := DesiredDeploymentFor(in).Binding.Env
+	if len(got) != 1 || got[0].Key != "API_GATEWAY_URL" {
+		t.Fatalf("managed env must receive the gateway address, got %+v", got)
+	}
+
+	// No protected sibling means no address, and the user's env is untouched.
+	in2 := base
+	in2.ProtectedSiblings = nil
+	in2.EnvVars = []openchoreo.WorkflowEnvVarRef{{Key: "FEATURE_FLAG", Value: "on"}}
+	got2 := DesiredDeploymentFor(in2).Binding.Env
+	if len(got2) != 1 || got2[0].Key != "FEATURE_FLAG" {
+		t.Fatalf("no sibling must leave env alone, got %+v", got2)
+	}
+}

--- a/skills/aep/SKILL.md
+++ b/skills/aep/SKILL.md
@@ -185,7 +185,8 @@ For **each** issue in the ordered set:
    plus the `openapi.yaml` of every component it consumes. The issue says what to
    build; the contract fixes the shape.
    Read its comments too (`gh issue view <number> --comments`): a
-   "Platform-resolved dependencies" comment carries dependency wiring you need.
+   "Platform-resolved dependencies" comment carries an `org-service`'s
+   coordinates.
 2. **Make the change it asks for**, holding to
    `references/component-contract.md` and the stack skills of every component it
    touches.
@@ -354,18 +355,22 @@ is guessable. Both failure modes are silent: an env var you renamed arrives empt
 a `visibility` you omitted leaves a dependent's config unwritten, and nothing
 errors until deploy.
 
-One thing that file cannot give you is a provider's live coordinates. That is
-below.
+One thing that file cannot give you is an `org-service`'s live coordinates. That
+is below.
 
 ### The `endpoints:` half
 
-The platform resolves live addresses and posts them as a **"Platform-resolved
-dependencies"** comment on the open issues of your working set, so it may land
-on a **sibling** issue rather than the one for the component it describes. Read
-the comments on the issues you are working and copy every `## Component <name>`
-block into **that named component's** `workload.yaml` — invent, rename and omit
-nothing. Two blocks for the same component: the **latest** is the complete
-answer.
+A **sibling** (`kind: component`) is already resolved in your own tree: its entry
+is the `wiring.endpoint` object on that dependency in `design.json`, copied
+verbatim. That holds whether or not the comment below exists.
+
+An **`org-service`** belongs to another project, so only the platform can resolve
+it. It posts what it resolved as a **"Platform-resolved dependencies"** comment
+on the open issues of your working set, so it may land on a **sibling** issue
+rather than the one for the component it describes. Read the comments on the
+issues you are working and copy every `## Component <name>` block into **that
+named component's** `workload.yaml` — invent, rename and omit nothing. Two blocks
+for the same component: the **latest** is the complete answer.
 
 ### Finding an `org-service` contract
 

--- a/skills/aep/overlays/local.md
+++ b/skills/aep/overlays/local.md
@@ -62,7 +62,8 @@ runtime relationship, not a build order — it never holds an issue back.
 
 <!-- replace-text -->
    Read its comments too (`gh issue view <number> --comments`): a
-   "Platform-resolved dependencies" comment carries dependency wiring you need.
+   "Platform-resolved dependencies" comment carries an `org-service`'s
+   coordinates.
 <!-- with -->
 <!-- /replace-text -->
 

--- a/skills/aep/references/workload-and-wiring.md
+++ b/skills/aep/references/workload-and-wiring.md
@@ -112,16 +112,31 @@ project → `visibility: namespace` plus `project:` (and the provider must alrea
 list `namespace` / be org-published). That "not `external`" is the SPA's
 **dependency** entry only — not the service's own `endpoints[].visibility`.
 
-The SPA browser calls `/api` on its own host; nginx in the SPA pod reverse-proxies
-to the project Service URL injected as `<DEP_NAME>_URL`. That pod env var is not
-a `window._env_` key.
+The SPA browser calls `/api` on its own host; nginx in the SPA pod
+reverse-proxies to the sibling. For a sibling whose design declares
+`exposesAPI.auth` the platform also injects `<DEP_NAME>_GATEWAY_URL` — the
+auth-terminating address — and the proxy prefers it over the direct
+`<DEP_NAME>_URL` (`react-webapp` owns that rule). Both are pod env vars, never
+`window._env_` keys.
 
 **Provider endpoint visibility:** a service a sibling SPA calls lists
-`visibility: [project, external]` — `project` for the nginx hop, `external` so
-the API remains curl-able on the public gateway. Write both YAML list items.
-A single-item `project` list is wrong even when the SPA uses `/api`, and
-`design.json` `exposure: intranet` does not drop `external`. The SPA must not
-fetch that public URL. Org-published services still add `namespace` as below.
+`visibility: [project, internal, external]`. Each item earns its place:
+
+- `internal` — **required for a protected service.** It is the only value that
+  admits the API gateway to the component's NetworkPolicy. Without it the
+  gateway authenticates the caller and then cannot reach the upstream, so every
+  call through the SPA's `/api` proxy returns `503`.
+- `project` — the same-namespace lane, for a trusted service-to-service caller.
+- `external` — so the API remains curl-able on the public gateway.
+
+Write all three YAML list items. A single-item `project` list is wrong even when
+the SPA uses `/api`, and `design.json` `exposure: intranet` does not drop
+`external`. The SPA must not fetch that public URL — its nginx proxies to the
+gateway's IN-CLUSTER address (`react-webapp`). Org-published services still add
+`namespace` as below.
+
+`namespace` is NOT a substitute for `internal`: it widens pod-to-pod reach to
+sibling projects and grants the gateway nothing.
 
 **Org-published services.** If the component's `design.json` sets
 `exposesAPI.orgPublished: true`, components in OTHER projects consume it — also

--- a/skills/aep/references/workload-and-wiring.md
+++ b/skills/aep/references/workload-and-wiring.md
@@ -6,8 +6,8 @@ dependency's *contract* is, and how code reads its injected values, is in
 
 Everything here derives from what `specs/` already fixed, so it reads the same
 for a component's first line and for a change to one that shipped weeks ago. The
-one half that is **not** derivable — a provider's live coordinates — stays in the
-skill body under **Dependencies and `workload.yaml`**.
+one kind that is **not** derivable — an `org-service`, which belongs to another
+project — stays in the skill body under **Dependencies and `workload.yaml`**.
 
 Most of what goes wrong here is silent: an env var you renamed arrives empty, a
 `visibility` you omitted leaves a dependent's config unwritten, and nothing fails
@@ -22,21 +22,38 @@ consumes. Its `kind` decides where the wiring comes from and what you write:
 |---|---|---|
 | `platform-resource` | its `wiring` object | one `resources:` entry |
 | `external` | its `wiring` object — **only when it declares `config` keys** | one `resources:` entry (none when it declares no keys) |
-| `component` | not derivable from `specs/` — the skill body | one `endpoints:` entry, `visibility: project` |
+| `component` | its `wiring` object | one `endpoints:` entry |
 | `org-service` | not derivable from `specs/` — the skill body | one `endpoints:` entry, plus `project:` and `visibility: namespace` |
 
-`component` and `org-service` need no `wiring` object: their env var is always
-`<DEP_NAME>_URL`. What does need resolving is the provider's *coordinates* — its
-`project`, the platform's name for it, and an endpoint name that comes from a
-`workload.yaml` nobody may have written yet.
+Three of the four kinds carry a `wiring` object the platform derived and
+committed into `design.json`. Its **shape** tells you which half of
+`dependencies:` the entry belongs in:
+
+| `wiring` holds | The entry goes in |
+|---|---|
+| an `endpoint` object | `dependencies.endpoints[]` |
+| `ref` + `envBindings` | `dependencies.resources[]` |
+
+`org-service` is the one kind with no `wiring` object, because its provider
+belongs to another project: its `project`, the platform's name for it and its
+endpoint name are resolved live and reach you by the channel the skill body
+names.
 
 **A `platform-resource` with no `wiring` is broken input, not a licence to
 substitute your own store** — say so in one line and stop the run.
 
-**Copy a `wiring` object verbatim** — `ref` and every `envBindings` pair,
-unchanged. **Those env-var names are the keys the platform populates at
-runtime**: an output arrives under that name and no other. Never rename one,
-never invent one.
+**Copy a `wiring` object verbatim** — every field and every `envBindings` pair,
+unchanged. It is already byte-identical to the entry that belongs there.
+
+**Those env-var names are the keys the platform populates at runtime**: an output
+arrives under that name and no other. Never rename one, never invent one.
+
+**A `wiring.endpoint`'s `component` carries the project as a prefix** —
+`<project>-<component>`. It deliberately does not match the name the rest of the
+tree calls that component: this prefixed one is what OpenChoreo resolves a
+connection by. Write the `wiring` value. Any other spelling parses, builds,
+deploys and serves with the address env var silently absent, and the only symptom
+is a project that reports "deploying" for ever.
 
 **Every component writes its `resources:` entries, a `web-application`
 included** — a web app reads the values from `window._env_` rather than pod env
@@ -73,9 +90,11 @@ endpoints:
       - external
 
 dependencies:                    # what you resolved above — omit a half you have none of
-  endpoints:                     # component / org-service
-    - project: <provider-project> # cross-project only; absent = same project
-      component: <provider-component> # the platform's name — never "correct" it
+  endpoints:                     # component: `wiring.endpoint`, verbatim
+                                 # org-service: resolved live (skill body)
+    - project: <provider-project> # org-service only; absent = same project
+      component: <provider-component> # `<project>-<component>` — the platform's
+                                  # own name for it, project-prefixed
       name: <provider-endpoint>   # e.g. http
       visibility: namespace       # or project (same-project)
       envBindings:

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -25,8 +25,7 @@ gateway and will disagree with it.
 or any token endpoint on any backend. The IDP owns token issuance — see
 `thunder-authentication`.
 
-**Identity arrives in headers**, set by the gateway from the validated token, so
-a client cannot spoof them:
+**Identity arrives in headers**, set by the gateway from the validated token:
 
 | Header | Claim | Presence |
 |---|---|---|
@@ -41,7 +40,23 @@ Two rules are this skill's, because they are the gateway's contract:
 
 - **`X-User-Id` missing on a protected request → 401.** The gateway always sets
   it when it lets a request through, so its absence means the request did not
-  come through the gateway.
+  come through the gateway — a deployment fault, not an anonymous caller. Declare
+  the header OPTIONAL in your framework and resolve it in one helper, so your
+  service picks that status: a framework-level "required header" rejection
+  answers 400 before your resolver runs, which makes this rule unreachable.
+
+- **Only the gateway may assert identity.** A proxy in front of your service that
+  forwards untrusted traffic (a SPA's nginx) must clear inbound `X-User-*`, and
+  must itself proxy THROUGH the gateway — `react-webapp` ships an asset that does
+  both. A caller reaching your service on a lane with no gateway on it can set
+  those headers freely.
+
+- **A claim the token does not carry is not asserted.** The gateway writes a
+  header only when its claim is present; when it is absent the client's own value
+  for that header is forwarded. `groups` is the one that matters: a token issued
+  without it (a `client_credentials` token, or a user in no groups) leaves
+  `X-User-Groups` caller-controlled. Treat a role decision as trustworthy only
+  for a caller whose token actually carries the claim.
 - **An authenticated caller who has no role → 403, never 401.** A 401 tells the
   SPA its token expired, so it restarts sign-in and loops forever. The role
   resolution itself is in `thunder-authentication`.

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -56,7 +56,9 @@ Two rules are this skill's, because they are the gateway's contract:
   for that header is forwarded. `groups` is the one that matters: a token issued
   without it (a `client_credentials` token, or a user in no groups) leaves
   `X-User-Groups` caller-controlled. Treat a role decision as trustworthy only
-  for a caller whose token actually carries the claim.
+  for a caller whose token actually carries the claim. A service that owns its
+  own people records sidesteps this: its role comes from the record it stored,
+  keyed on `X-User-Id`, which no caller can set (`thunder-authentication`).
 - **An authenticated caller who has no role → 403, never 401.** A 401 tells the
   SPA its token expired, so it restarts sign-in and loops forever. The role
   resolution itself is in `thunder-authentication`.

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -280,9 +280,12 @@ component contract. Consumer connection to the sibling: `visibility: project`,
 `configurations.env` arrives as a `window._env_` entry.
 
 **Done when:** this app's dependency on the sibling is `visibility: project`
-(never `external`). The sibling *service's* own endpoint lists both
-`project` and `external` — that file is the Go (or other backend) skill's
-to write; do not strip `external` from it because this SPA uses `/api`.
+(never `external`). The sibling *service's* own endpoint lists all three of
+`project`, `internal` and `external` — `internal` is what admits the gateway to
+the service's NetworkPolicy, and without it every `/api` call answers `503`.
+That file is the Go (or other backend) skill's to write: leave all three in
+place rather than stripping `external` because this SPA uses `/api`
+(`workload-and-wiring` covers what each item earns).
 
 ## Pitfalls
 

--- a/skills/react-webapp/SKILL.md
+++ b/skills/react-webapp/SKILL.md
@@ -71,8 +71,9 @@ is `undefined` at module load. Use these exact spellings:
 
 There is **no** `API_BASE_URL` and **no** `<UPSTREAM>_URL` in `window._env_` for
 a sibling service. The sibling lives at **same-origin** `/api` (extra siblings:
-`/api/<component-name>/`). OpenChoreo still injects `<DEP>_URL` as a **pod**
-env var; only the nginx drop-in reads it.
+`/api/<component-name>/`). Its addresses — `<DEP>_GATEWAY_URL` and `<DEP>_URL` —
+are **pod** env vars, never browser keys; only the nginx drop-in reads them (see
+**Same-origin API proxy** below).
 
 **Throw on a missing key, never default it.** No `?? ""`, no `|| ''`, for keys
 this table says are set. A silent fallback hides a missing OIDC issuer. Do not
@@ -84,12 +85,30 @@ stock Vite default is correct: **do NOT set `base`**. Asset URLs, any react-rout
 `/callback`). Services ARE path-routed, under `/<project>-<component>-http` on a
 shared gateway — copying that prefix into `base` 404s every asset.
 
-**Same-origin API proxy.** Nginx reverse-proxies `location /api/` to the primary
-sibling's project Service URL. Copy the assets in Layout; do not hand-write a
-different `proxy_pass`, do not add `/oidc/` (token endpoint stays cross-origin;
-`thunder-authentication`), do not copy `apps/console/docker-entrypoint.sh`.
-Keep the official `nginx:alpine` `ENTRYPOINT`. The only extra file is
-`/docker-entrypoint.d/15-aep-api-proxy.sh`.
+**Same-origin API proxy, through the gateway.** Nginx reverse-proxies
+`location /api/` to the primary sibling. Two pod env vars address that sibling and
+they are NOT interchangeable:
+
+| Pod env var | Reaches | Auth |
+|---|---|---|
+| `<DEP>_GATEWAY_URL` | the API gateway. Set by the platform for a sibling whose design declares `exposesAPI.auth`. Carries a **context path prefix**. | validates the bearer token, injects `X-User-*` from its claims |
+| `<DEP>_URL` | the project Service, directly | none — nothing validates a token, nothing injects identity |
+
+The asset **prefers `<DEP>_GATEWAY_URL`** and falls back to `<DEP>_URL`. That
+order is the whole point: browser traffic is untrusted, and this proxy is the one
+hop that would otherwise carry it into the project's trusted lane with no
+authentication in between. Two rules follow, and the asset already obeys both —
+which is why you copy it rather than write it:
+
+- **Preserve the context prefix.** The gateway routes on it; a rewrite that
+  strips it 404s every call.
+- **Clear inbound `X-User-*`.** Identity is the gateway's to assert. A browser
+  that sets those headers itself must not be believed.
+
+Copy the assets in Layout; do not hand-write a different `proxy_pass`, do not add
+`/oidc/` (token endpoint stays cross-origin; `thunder-authentication`), do not
+copy `apps/console/docker-entrypoint.sh`. Keep the official `nginx:alpine`
+`ENTRYPOINT`. The only extra file is `/docker-entrypoint.d/15-aep-api-proxy.sh`.
 
 **Auth.** If the component declares an auth `platform-resource` dependency, add
 `src/auth.ts` and attach `Authorization: Bearer <token>` to every API call —
@@ -149,12 +168,17 @@ cp "$AEP_SKILLS_DIR/react-webapp/assets/15-aep-api-proxy.sh" nginx/15-aep-api-pr
 If `$AEP_SKILLS_DIR` is unset, copy from `assets/` next to this skill's `SKILL.md`
 (the BFF mirrors that directory to `.claude/skills/react-webapp/`).
 
-Then in `nginx/15-aep-api-proxy.sh` only: change `API_URL="${TODO_API_URL:-}"` so
-`TODO_API_URL` is the UPPER_SNAKE `_URL` of the **primary** component-kind
-dependency (`todo-api` → `TODO_API_URL`). Do not invent a second name.
+Then in `nginx/15-aep-api-proxy.sh` only: rename **both** variables so they name
+the **primary** component-kind dependency in UPPER_SNAKE —
+`API_URL="${TODO_API_GATEWAY_URL:-}"` and the fallback `"${TODO_API_URL:-}"`
+(`todo-api` → `TODO_API_GATEWAY_URL` / `TODO_API_URL`). Rename both or the
+fallback silently wins and the app runs unauthenticated. Do not invent a second
+name, and do not delete the fallback — an unprotected sibling has no gateway
+address.
 
-**Done when:** `nginx/default.conf` contains `location /api/` and
-`proxy_pass http://$api_backend`; the drop-in script's `API_URL=` line uses that
+**Done when:** `nginx/default.conf` contains `location /api/`,
+`proxy_pass http://$api_backend` and the `__API_CONTEXT__` rewrite; the drop-in
+script's two `API_URL=` lines use that
 primary `<DEP>_URL`; there is no `/oidc/` location.
 
 Extra component-kind siblings: add one `location /api/<component-name>/` block
@@ -267,6 +291,9 @@ to write; do not strip `external` from it because this SPA uses `/api`.
 | SPA throws on load: `window._env_ not set` | `/env-config.js` failed to load — path wrong, 404, or the `<script>` was `defer`/`async` | Make the tag synchronous in `<head>`, BEFORE the bundle's `<script type="module">`. |
 | `nginx: [emerg] host not found in upstream "…"` at pod start | Literal `proxy_pass http://hostname` (startup DNS) or leftover `/oidc/` block | Use the asset conf (`proxy_pass http://$api_backend`) and the drop-in; delete `/oidc/`. |
 | Browser CORS error calling the sibling API | `baseUrl` is the public gateway URL or `window._env_.API_BASE_URL` | `baseUrl: "/api"`. |
-| `/api` 502, SPA otherwise fine | API pod down, or drop-in left `TODO_API_URL` when the dep is named something else | Align `API_URL="${…}"` with `envBindings.address`; 502 while the API is down is expected. |
+| `/api` 502, SPA otherwise fine | API pod down, or drop-in left `TODO_API_URL` when the dep is named something else | Align both `API_URL="${…}"` lines with the dependency name; 502 while the API is down is expected. |
+| `/api` 400 `no header value found for 'x-user-id'` | The proxy took the direct-Service lane, so nothing injected identity | Check the pod log line `aep-api-proxy: /api -> … [lane]`. `direct Service` means `<DEP>_GATEWAY_URL` was unset: the provider's design has no `exposesAPI.auth`, or the drop-in names the wrong variable. |
+| `/api` 404 from the gateway | The rewrite dropped the context prefix | `nginx/default.conf` must rewrite to `__API_CONTEXT__/$1`, not `/$1`. |
+| `/api` 503 through the gateway | The gateway authenticated but cannot reach the service | The provider endpoint needs `internal` in its `workload.yaml` visibility (`workload-and-wiring`). |
 | Types in `src/generated/*` don't match the live service | Upstream `openapi.yaml` changed since last generation | Re-run the `openapi-typescript` command and commit the diff. |
 | Docker build succeeds but ships stale/hand-written shapes, or fails `ENOENT ../specs/...` | `src/generated/` wasn't committed — the per-component build context is this app's folder alone | Generate and commit `src/generated/` before PR. |

--- a/skills/react-webapp/assets/15-aep-api-proxy.sh
+++ b/skills/react-webapp/assets/15-aep-api-proxy.sh
@@ -29,13 +29,41 @@ if [ -z "$DNS_RESOLVERS" ]; then
 fi
 sed -i "s|__DNS_RESOLVERS__|${DNS_RESOLVERS}|g" "$CONF"
 
-# Primary sibling address. After copy, the coding agent sets this to the
-# UPPER_SNAKE `_URL` of the primary component-kind dependency
-# (todo-api → TODO_API_URL). OpenChoreo injects it on the pod.
-API_URL="${TODO_API_URL:-}"
-API_BACKEND="$(echo "${API_URL}" | sed 's|^https\{0,1\}://||' | sed 's|/.*||')"
-if [ -z "$API_BACKEND" ]; then
-    echo "aep-api-proxy: primary *_URL unset; /api will 502 until OpenChoreo injects it"
-    API_BACKEND="127.0.0.1:9"
+# Primary sibling address. After copy, the coding agent renames BOTH variables
+# below to the UPPER_SNAKE of the primary component-kind dependency
+# (todo-api → TODO_API_GATEWAY_URL / TODO_API_URL). OpenChoreo and the platform
+# inject them on the pod.
+#
+# Two lanes exist and they are NOT interchangeable:
+#
+#   <DEP>_GATEWAY_URL  the API gateway. It validates the caller's bearer token
+#                      and injects the X-User-* identity headers the backend
+#                      authorizes on. Set by the platform for any sibling whose
+#                      design declares `exposesAPI.auth`. Carries a context
+#                      path prefix.
+#   <DEP>_URL          the project Service, reached directly. Nothing validates
+#                      a token and nothing injects identity.
+#
+# Always prefer the gateway when the platform offers it. Browser traffic is
+# untrusted, and this proxy is the one hop that would otherwise carry it into
+# the project's trusted lane with no authentication in between.
+API_URL="${TODO_API_GATEWAY_URL:-}"
+API_LANE="gateway (token validated, identity injected)"
+if [ -z "$API_URL" ]; then
+    API_URL="${TODO_API_URL:-}"
+    API_LANE="direct Service (NO token validation)"
 fi
+
+# Split the injected address into host:port and the context path prefix.
+API_BACKEND="$(echo "${API_URL}" | sed -e 's|^https\{0,1\}://||' -e 's|/.*$||')"
+API_CONTEXT="$(echo "${API_URL}" | sed -e 's|^https\{0,1\}://[^/]*||' -e 's|/$||')"
+
+if [ -z "$API_BACKEND" ]; then
+    echo "aep-api-proxy: no sibling API address injected; /api will 502 until one is"
+    API_BACKEND="127.0.0.1:9"
+    API_CONTEXT=""
+fi
+
+echo "aep-api-proxy: /api -> ${API_BACKEND}${API_CONTEXT}  [${API_LANE}]"
 sed -i "s|__API_BACKEND__|${API_BACKEND}|g" "$CONF"
+sed -i "s|__API_CONTEXT__|${API_CONTEXT}|g" "$CONF"

--- a/skills/react-webapp/assets/nginx-default.conf
+++ b/skills/react-webapp/assets/nginx-default.conf
@@ -10,11 +10,27 @@ server {
 
     location /api/ {
         set $api_backend __API_BACKEND__;
-        rewrite ^/api/(.*) /$1 break;
+
+        # The context prefix MUST survive the rewrite. When /api is proxied to
+        # the API gateway, the gateway routes on that prefix and dropping it
+        # 404s every call. Empty for a direct-Service backend, which reduces
+        # this to the plain `/$1` strip.
+        rewrite ^/api/(.*) __API_CONTEXT__/$1 break;
+
         proxy_pass http://$api_backend;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $api_backend;
         proxy_set_header Connection "";
+
+        # Identity is the gateway's to assert, never the browser's. Clearing
+        # these means a client cannot pre-set an identity header and have the
+        # backend — which is required to trust them — believe it. Setting a
+        # proxy header to "" drops it from the upstream request.
+        proxy_set_header X-User-Id "";
+        proxy_set_header X-User-Name "";
+        proxy_set_header X-User-Groups "";
+        proxy_set_header X-User-Ou "";
+
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/skills/security-design/SKILL.md
+++ b/skills/security-design/SKILL.md
@@ -18,7 +18,8 @@ requirements like everything else.
 ## Sections, in order
 
 1. **Roles → permissions** — a matrix: role × component × allowed actions and
-   screens. Roles come from the PRD's Actors section — define no role the PRD
+   screens, plus **how a person comes to hold the role** (the cold start,
+   below). Roles come from the PRD's Actors section — define no role the PRD
    has no actor for, and give every actor a row. Cite stories per row.
 2. **Authentication (Thunder)** — the design-altitude Thunder facts: the
    shared `thunder-app` dependency NAME (the same name on the SPA and every
@@ -28,7 +29,8 @@ requirements like everything else.
    The `thunder-authentication` skill owns the build-time mechanics; this
    section owns the design decisions it consumes.
 3. **Role resolution** — how each service maps a token to a role: the claim
-   or lookup used, and what an unmapped caller gets (deny by default).
+   or lookup used, and what a caller holding no role yet reaches (the cold
+   start, below), with every privileged action still denied by default.
 
 ## Rules
 
@@ -37,5 +39,14 @@ requirements like everything else.
 - Public, unauthenticated surfaces are declared here too ("no sign-in:
   <component> — serves stories …"), so absence of auth is a decision, not an
   omission.
+- **Answer the cold start.** Where a role lives in a record this system stores
+  rather than in a token claim, the matrix says how the first such record
+  appears. Default: a first sign-in creates the person's record as the PRD's
+  least-privileged actor, so a fresh deployment is usable by whoever signs in,
+  and every role above that is granted by someone who already holds one — the
+  matrix names who. Say so explicitly where a system needs a different origin:
+  an admin admits people, an import loads them, the first user becomes the
+  admin. A matrix whose every role is granted by somebody else describes a
+  system nobody can enter.
 - Keep it at design altitude: which role may do what, never how a middleware
   implements it.

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -182,10 +182,11 @@ What follows is what that identity *means*.
 `X-User-Id` is an **opaque IdP subject** — not a record key in any other service,
 so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
-- **Role** (what may they do) comes from `X-User-Groups` — the SAME groups claim
-  the SPA reads from `user.profile.groups`. An authenticated caller with no
-  recognized role is a **403, never a 401**: a 401 tells the SPA its token
-  expired, so it restarts sign-in and loops forever.
+- **Role** (what may they do) comes from ONE authority, and which one depends on
+  whether the org publishes a directory: `X-User-Groups` when it does, the
+  service's own people record when it does not (**Implementation** below). Either
+  way, an authenticated caller with no role is a **403, never a 401**: a 401 tells
+  the SPA its token expired, so it restarts sign-in and loops forever.
 - **Directory attributes** (which unit is theirs, their own id in the directory)
   come from the caller's **directory record**, resolved by `X-User-Name` — the
   username, which the directory keys on. A group name is a role, not an identity,
@@ -196,18 +197,25 @@ so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
 ## Implementation
 
-Resolve the role from `X-User-Groups`, never by looking `X-User-Id` up anywhere.
-**403**, never 401, when no group maps. One resolver, called by every protected
-handler:
+**One authority decides a caller's role, and the design picks which.** A published
+directory owns roles through `X-User-Groups`; with none published, the service
+owns them in its own people records. The two are alternatives, never a fallback
+chain — a resolver that tries one and falls through to the other grants whatever
+the weaker source says.
 
-- **Parsing `X-User-Groups`.** It arrives as a JSON array (e.g.
-  `["Compliance Admin"]`); accept a comma-separated string as a fallback. Match
-  each group case-insensitively against the spec's role names — a substring
-  match on the keyword (`admin`, `auditor`) survives the org renaming its
-  groups, an equality check does not.
-- **No recognized group → no role → 403.** Return the empty/absent case
-  explicitly rather than defaulting to the least-privileged real role; a
-  default role is a silent authorization grant.
+One resolver, called by every protected handler, whichever authority it reads.
+**403**, never 401, when it yields no role: return the empty/absent case
+explicitly rather than defaulting to the least-privileged real role, which is a
+silent authorization grant.
+
+### A directory is published — the role is in `X-User-Groups`
+
+Resolve from the header, never by looking `X-User-Id` up anywhere. It arrives as
+a JSON array (e.g. `["Compliance Admin"]`) — the SAME groups claim the SPA reads
+from `user.profile.groups`; accept a comma-separated string as a fallback. Match
+each group case-insensitively against the spec's role names: a substring match on
+the keyword (`admin`, `auditor`) survives the org renaming its groups, an
+equality check does not.
 
 When roles scope by the caller's own directory attributes — their unit, their own
 id — resolve the caller's **directory record** by `X-User-Name` and filter on
@@ -218,14 +226,23 @@ that record's fields:
   of the resolved record — never on `X-User-Id` (opaque) and never on a group
   name.
 
-**With no directory published, the service owns its people records.** Key them
-on `X-User-Id` — the one case where that is right, because the service stored
-the subject itself rather than matching it against ids another system minted —
-and fill display fields from `X-User-Name`. `security-design`'s cold start says
-which role a first-time caller holds; create that record on first sign-in, so a
-new user reaches the app's base experience rather than a 403 nobody can clear.
-A roster in config is a demo fixture, not the mechanism: it goes stale the
-moment somebody new signs in.
+### No directory is published — the service owns its people records
+
+Key them on `X-User-Id` — the one case where that is right, because the service
+stored the subject itself rather than matching it against ids another system
+minted — and fill display fields from `X-User-Name`.
+
+**The stored record's role IS the role**, resolved by `X-User-Id`. Read
+`X-User-Groups` for nothing on this path: no directory published those groups, so
+they carry no authority here, and a token issued without a `groups` claim leaves
+that header caller-controlled (`api-management`) — reading a role out of it lets
+a caller name their own.
+
+**A caller with no record yet gets one, at the cold-start role.**
+`security-design`'s cold start says which role a first-time caller holds; create
+that record on first sign-in, so a new user reaches the app's base experience
+rather than a 403 nobody can clear. A roster in config is a demo fixture, not the
+mechanism: it goes stale the moment somebody new signs in.
 
 Express this in your stack's own idiom — where the resolver lives, its
 signature, and how a handler returns 403 — following the conventions that skill
@@ -239,10 +256,10 @@ hardcode a roster.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403**; never key a directory lookup on `X-User-Id`. |
+| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Return **403**. Resolve the role from the service's one authority — `X-User-Groups` with a directory, the stored people record without one — and never key a *directory* lookup on `X-User-Id`. |
 | A role-scoped caller signs in but sees no rows | Scope derived the attribute from a group NAME (empty for a generic role group), or matched `X-User-Id` (an opaque subject) against a stored directory id (never equal) | Resolve the caller's directory record via `X-User-Name`, read the attribute from it, filter on that. |
 | Every user shows no role / `groups` is empty | Roles read from the access token or a hand-decoded JWT | SPA: `user.profile.groups`. API: `X-User-Groups`. |
-| Every signed-in user gets 403 and the app is unusable from a fresh deploy | The service requires a people record it has no way to create | Create the caller's record on first sign-in at the least-privileged role — `security-design` owns which role that is. |
+| Every signed-in user gets 403 and the app is unusable from a fresh deploy | The service requires a people record it has no way to create, or it creates one and then still resolves the role from `X-User-Groups` | Create the caller's record on first sign-in at the cold-start role, and resolve the role FROM that record — `security-design` owns which role that is. |
 | Sign-in loops at the right path, or the user is sent to login on every visit / new tab | No persistent `WebStorageStateStore` (the in-memory default loses the PKCE verifier across the redirect), session in `sessionStorage`, or the load path calls `signIn()` on a merely-expired token | `WebStorageStateStore({ store: localStorage })` + `automaticSilentRenew`; renew via `signinSilent()` and only `signIn()` when there is no session. |
 | After login, "invalid redirect URI" | `redirect_uri` doesn't match the `<origin>/callback` the platform registered | Compute `window.location.origin + '/callback'`. |
 | Logout button does nothing | `signOut()` calls only `signoutRedirect()`, which rejects (no `end_session_endpoint`), and the handler swallows it | Wrap it in the try/catch fallback to `removeUser()` + reload. |

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -218,6 +218,15 @@ that record's fields:
   of the resolved record — never on `X-User-Id` (opaque) and never on a group
   name.
 
+**With no directory published, the service owns its people records.** Key them
+on `X-User-Id` — the one case where that is right, because the service stored
+the subject itself rather than matching it against ids another system minted —
+and fill display fields from `X-User-Name`. `security-design`'s cold start says
+which role a first-time caller holds; create that record on first sign-in, so a
+new user reaches the app's base experience rather than a 403 nobody can clear.
+A roster in config is a demo fixture, not the mechanism: it goes stale the
+moment somebody new signs in.
+
 Express this in your stack's own idiom — where the resolver lives, its
 signature, and how a handler returns 403 — following the conventions that skill
 already sets. The directory's real endpoint, its username field, and the
@@ -233,6 +242,7 @@ hardcode a roster.
 | Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Resolve role from `X-User-Groups`; return **403**; never key a directory lookup on `X-User-Id`. |
 | A role-scoped caller signs in but sees no rows | Scope derived the attribute from a group NAME (empty for a generic role group), or matched `X-User-Id` (an opaque subject) against a stored directory id (never equal) | Resolve the caller's directory record via `X-User-Name`, read the attribute from it, filter on that. |
 | Every user shows no role / `groups` is empty | Roles read from the access token or a hand-decoded JWT | SPA: `user.profile.groups`. API: `X-User-Groups`. |
+| Every signed-in user gets 403 and the app is unusable from a fresh deploy | The service requires a people record it has no way to create | Create the caller's record on first sign-in at the least-privileged role — `security-design` owns which role that is. |
 | Sign-in loops at the right path, or the user is sent to login on every visit / new tab | No persistent `WebStorageStateStore` (the in-memory default loses the PKCE verifier across the redirect), session in `sessionStorage`, or the load path calls `signIn()` on a merely-expired token | `WebStorageStateStore({ store: localStorage })` + `automaticSilentRenew`; renew via `signinSilent()` and only `signIn()` when there is no session. |
 | After login, "invalid redirect URI" | `redirect_uri` doesn't match the `<origin>/callback` the platform registered | Compute `window.location.origin + '/callback'`. |
 | Logout button does nothing | `signOut()` calls only `signoutRedirect()`, which rejects (no `end_session_endpoint`), and the handler swallows it | Wrap it in the try/catch fallback to `removeUser()` + reload. |


### PR DESCRIPTION
> **Deployed and verified on the local plane.** The org skill library is served byte-identical to this branch's content (md5-matched on all 9 changed skill files), pending skill updates `count: 0`, and `EXPENSE_API_GATEWAY_URL` is injected on live SPA pods with the correct FQDN and context path. #633 is folded in here — this branch is the whole change.

## What this fixes

A generated app's SPA sends the user's bearer token to its sibling API. Nothing was checking it.

The `react-webapp` nginx proxy sent the browser's `/api` straight to the provider's **project Service**. Neither gateway was in that path, so no component validated the token and no component injected the `X-User-*` identity headers the backend authorizes on.

Two consequences, both measured on a live project before the fix:

```
# The app, from a real browser with a real signed-in session
fetch('/api/new-hires', { headers: { Authorization: 'Bearer ' + token } })
  → 400  "no header value found for 'x-user-id'"

# The same endpoint, no token at all, identity headers invented by the caller
curl <webapp>/api/new-hires -H 'X-User-Id: anything' -H 'X-User-Groups: ["Administrators"]'
  → 200  {"count":0,"next":null,"previous":null,"data":[]}
```

The second one is the serious one: anything that could resolve the web app's public hostname held the application's highest-privilege role, with no token.

## Old flow

```mermaid
flowchart LR
    B["Browser<br/>untrusted"] -->|"/api/... + Bearer"| N["SPA pod<br/>nginx"]
    N -.->|"proxy_pass DEP_URL<br/><b>no auth, no identity</b>"| S["service :9090"]
    B -->|"public URL"| K["ingress<br/>kgateway"]
    K --> G["API gateway<br/>jwt-auth"]
    G -->|"X-User-* injected"| S
    style N fill:#fde2dd,stroke:#b4402e
    style G fill:#e2efe4,stroke:#3d7a4e
```

Two ways in, one enforcing and one not — and the SPA used the one that did not. The `Authorization` header the SPA attached was forwarded to the service and read by nobody.

## New flow

```mermaid
flowchart LR
    B["Browser<br/>untrusted"] -->|"/api/... + Bearer"| N["SPA pod<br/>nginx<br/><i>clears X-User-*</i>"]
    N -->|"DEP_GATEWAY_URL<br/>+ context prefix"| G["API gateway<br/>jwt-auth<br/>injects X-User-*"]
    B -->|"public URL"| K["ingress<br/>kgateway"]
    K --> G
    G --> S["service :9090"]
    style N fill:#e2efe4,stroke:#3d7a4e
    style G fill:#e2efe4,stroke:#3d7a4e
```

Both routes converge on the one hop that terminates authentication. The SPA stays **same-origin** on `/api`, so there is no CORS surface and no SPA code change.

## Design

**Authentication is a property of the service, not of the route.** For every dependency whose provider passes `ResolveAPISecurityEnabled`, the platform now publishes a second address, `<DEP>_GATEWAY_URL`, and the proxy prefers it. That same predicate already decides whether the `api-configuration` trait is attached, so the address and the token check are driven by **one boolean** and cannot disagree — you can never get an address pointing at a gateway that is not validating, or validation with no address published.

Nothing inspects the generated code. The decision chain is entirely declared design facts:

| Step | Input | Where |
|---|---|---|
| 1 | Service declares a dependency on a resource type carrying `aep.wso2.com/role: end-user-auth` | `design.json` |
| 2 | Platform stamps `exposesAPI.auth: end-user-required` | `deriveEndUserAuth`, at build pre-tag |
| 3 | Consumer of that provider gets `<DEP>_GATEWAY_URL` | `ProtectedSiblingsOf` + `GatewayEnvVars` (new) |
| 4 | Proxy tests whether the variable is set | `15-aep-api-proxy.sh` |

Two couplings the new file carries deliberately, both documented at the code:

- `APIGatewayContextPath` **mirrors** the `api-configuration` trait's `RestApi.spec.context` template. A mismatched prefix does not degrade, it `404`s at the gateway.
- The provider endpoint must list `internal`, or the gateway is not admitted by the component's NetworkPolicy — it authenticates, then `503`s. `namespace` is **not** a substitute: it widens pod-to-pod reach and grants the gateway nothing.

The address rides the binding's env field and is overlaid **only when that field is already managed**. Merging into an unmanaged (`nil`) one would replace the user's whole config with the platform's single variable.

### One bug only a cluster could find

`DefaultAPIGatewayHost` is fully qualified, unlike the trait's `<service>.<namespace>` short form. nginx's `resolver` queries the name verbatim and does **not** apply the search domains in `/etc/resolv.conf`. The short name resolves for `getaddrinfo` inside the very same pod and is `NXDOMAIN` for nginx — a `502` on every `/api` call that reads like the API being down. `TestDefaultAPIGatewayHostIsFullyQualified` guards it.

## Skills

`react-webapp` gains the two-lane contract (prefer the gateway address, preserve its context prefix, clear inbound `X-User-*`, keep the direct-address fallback for an unprotected sibling), and three new pitfall rows keyed to the observable symptom (`400`, `404`, `503`).

`workload-and-wiring` explains why `internal` is required and why `namespace` does not substitute.

`api-management` **loses a false claim**. It said identity headers are set by the gateway "so a client cannot spoof them", which was untrue under the topology `react-webapp` prescribed. Measurement replaced it with the real rule: the gateway writes a header only when its claim is present, so a token issued without `groups` — a `client_credentials` token, or a user in no groups — leaves `X-User-Groups` caller-controlled, **through the front door**. Proven side by side:

| Header sent by client | User token (has `groups`) | client_credentials token (no `groups`) |
|---|---|---|
| `X-User-Id: SPOOF` | overwritten → real `sub` | overwritten → real `sub` |
| `X-User-Groups: ["SpoofedAdmins"]` | overwritten → `["Administrators"]` | **passed through unchanged** |

## Second commit: the cold start

A separate generated app (expenses) denied every signed-in caller. Its `security.md` reasoned correctly to a locked door — no directory service is published, so own the record locally; deny by default; no implicit role — and never asked where the first record comes from. No endpoint creates one, no screen creates one, and the PRD recorded `Open Questions: None outstanding.`

The old wording **permitted** this: section 3 asked what an unmapped caller gets and accepted "deny by default", which a system nobody can enter satisfies exactly.

- `security-design`: the roles matrix gains a column, **`how a person comes to hold the role`**, which every actor row must fill; and a rule names the default — a first sign-in creates the person's record as the PRD's least-privileged actor. Deny-by-default keeps its real scope: privileged actions, not the front door.
- `thunder-authentication`: gains the branch it was missing (no directory published → the service owns its people records). Keying on `X-User-Id` is called out as *the one case where that is right*, because six lines above sits "never on `X-User-Id` (opaque)" — correct for a directory join, wrong here. Left implicit, an agent meets a flat contradiction and picks one at random.

## Third commit: a sibling's wiring comes from the design (was #633)

Folded in here rather than reviewed separately, since it is the same class of defect and the same files.

`employees-submit-expense131` shipped `component: expense-api` in its `expense-webapp/workload.yaml`. OpenChoreo resolves an endpoint dependency by the **scoped** name, so it matched no binding: the release rendered, the pod ran, the app served, and the only symptom was a ReleaseBinding parked at `Ready=False / ConnectionsPending` with the project reporting "deploying" for ever. The conformance check minted a fix issue, which cost a whole coding cycle to change one string.

The correct value was already in the agent's own tree, committed by the platform before it ran:

```jsonc
// specs/design/components/expense-webapp/design.json
"wiring": { "endpoint": { "component": "employees-submit-expense131-expense-api", … } }
```

`183e67a8` (2026-08-01) moved sibling endpoint wiring off the live endpoint catalog and into `design.json`, because the catalog only lists components that have already **deployed** — so on a first delivery it answers nothing. The agent-facing docs never moved with it:

| Where | Said | Actually |
|---|---|---|
| `workload-and-wiring.md` kind table | `component` → *"not derivable from `specs/`"* | derived and stamped since 2026-08-01 |
| `SKILL.md` → *The `endpoints:` half* | read the "Platform-resolved dependencies" comment | that comment carries `org-service` only |
| `ADR-0013` | *"a sibling's endpoint name comes from a `workload.yaml` nobody has written yet"* | written one day before `183e67a8` superseded it |

So the agent read the table, looked for a comment, found none — no such comment exists on any issue in that repo, I checked all of them — and fell back to the only name it had seen. The template's `# never "correct" it` never fired, because the agent had already been told the value was not in `specs/`.

Fixed by moving the docs to where the data is: the kind table routes `component` to its `wiring` object; a shape table maps the two `wiring` variants onto the two halves of `dependencies:`; the project prefix is stated as the platform's own name; the skill body resolves a sibling from `design.json` and keeps the comment for `org-service` alone, with *"that holds whether or not the comment below exists"* closing the hole the agent fell into. `ADR-0013` is restated at its current state.

## Fourth commit: review fixes

Three findings from review, two valid:

- **The cold-start commit contradicted the rule beside it.** `thunder-authentication` opened with *"resolve the role from `X-User-Groups`, never by looking `X-User-Id` up anywhere; 403 when no group maps"*, and then told a directory-less service to create a people record at the cold-start role. A service obeying both writes the record, still resolves from groups, finds nothing, and 403s — the record never read, the fresh deploy as unusable as before. Split into the two authorities it always had, stated as alternatives rather than a fallback chain: directory → `X-User-Groups`; no directory → **the stored record's role IS the role**, resolved by `X-User-Id`.
- That second path also removes real exposure. The gateway overwrites an identity header only when its claim is **present**, so a token without `groups` leaves `X-User-Groups` carrying whatever the caller sent. A role read from a record the service stored, keyed on the subject, cannot be told its own answer. Since no generated app has a published directory today, this covers all of them, and `api-management` names it beside the warning.
- **`react-webapp`'s completion rule required only `project` and `external`** for a protected sibling, written before `internal` became load-bearing — so it certified a config that 503s until the agent reaches the pitfall table. All three items are in the criterion now.

The third finding — the gateway's conditional header write — is real but is `jwt-auth` `claimMappings` in the OpenChoreo trait, not reachable from a skill. It stays listed below.

## Proof of real execution

Verified twice. First on an existing project by hand, then on **`todo-web`, created from a prompt in this session and generated, built and deployed by the platform with nothing hand-patched**.

The generated web app's own boot log names the route it took:

```
aep-api-proxy: /api -> api-platform-default-gateway-gateway-runtime.openchoreo-data-plane.svc.cluster.local:8080
                       /development-default-todo-web-todo-api-http  [gateway (token validated, identity injected)]
```

The coding agent, reading the updated skills, wrote the required visibility unprompted:

```yaml
# todo-api/workload.yaml — generated, not edited
endpoints:
  - name: http
    visibility: [project, internal, external]
```

| Check | Before | After |
|---|---|---|
| SPA root (must stay public) | 200 | 200 |
| `/api` no token | 400 | **401** |
| `/api` + spoofed `X-User-*`, no token | **200 + data** | **401** |
| `/api` + real Bearer | 400 | **200** |
| HR-admin-only endpoint + real Bearer | — | **200** |
| Sign in → create → reload | — | persisted |

End-to-end identity, checked in the database rather than the UI:

```
todo_items.owner_id = 01a03727-4e04-73da-86dc-a85d8d160e85
```

That is byte-for-byte the `sub` claim in the signed-in user's Thunder access token. Thunder → SPA → same-origin `/api` → nginx → API gateway → `X-User-Id` → Ballerina → Postgres.

## Gates

`go build` · `go vet` · `gofmt` · affected package tests · `make deadcode-check` · `make license-check` — all green.

Re-verified on `upstream/main` at `22a84cfd` with all four commits merged: 6 Go packages `ok` / 0 failures, `runners/remote-worker` **398/398** (these render `skills/aep/SKILL.md` through `overlays/local.md`, and `skill_overlay` throws on a stale anchor, so the overlay edit is proven rather than assumed), `license-check` exit 0.

7 new tests in `gateway_address_test.go`, including the context path pinned byte-for-byte against the value the trait renders on a real cluster, and the `nil`-env no-clobber rule.

## Deliberately not in this PR

- **The direct-Service lane still exists.** `podSelector: {}` is rendered unconditionally, so no visibility value removes it. Closing it means making that rule conditional on `ResolveAPISecurityEnabled` in the controller that renders the NetworkPolicy, and moving genuine service-to-service callers onto the gateway too.
- **`X-User-Groups` remains spoofable for a token without a `groups` claim.** That is a gateway policy fix (always write the mapped header), independent of routing.
- **No gate proves a generated app is usable by a first-time user.** Both defects this PR addresses were found by a human opening the app. One universal validation criterion would catch the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvanuzxvZmpfvnh2Pbr2wD

