### PR TITLE
docs(skills): a sibling's wiring comes from the design, not from a comment

### DIFF
--- a/docs/decisions/ADR-0013-derived-wiring-lives-in-the-design.md
+++ b/docs/decisions/ADR-0013-derived-wiring-lives-in-the-design.md
@@ -24,17 +24,21 @@ for information it already had at design time.
 Split the block by what is DERIVED from what is RESOLVED, and give each the
 channel its nature allows.
 
-**Derived — stamped into `design.json`.** Every `platform-resource` and `external`
-dependency carries a platform-stamped `wiring: {ref, envBindings}` object,
-shape-identical to one `dependencies.resources[]` entry so the agent copies rather
-than transforms it. It is derived in the design-save pass (the pre-tag step on
-`POST /build`), committed to the design the agent reads as its spec, and captured
-in the version tag. There is no ordering, no audience, and no idempotency marker
-left to get wrong.
+**Derived — stamped into `design.json`.** Every `platform-resource`, `external`
+and `component` dependency carries a platform-stamped `wiring` object,
+shape-identical to the entry it belongs in so the agent copies rather than
+transforms it: `{ref, envBindings}` for one `dependencies.resources[]` entry, and
+`{endpoint}` for one `dependencies.endpoints[]` entry. A **sibling**'s endpoint
+qualifies for the same reason a resource's ref does — scoped provider name, the
+sibling's own endpoint name, `project` visibility and one `address` binding are
+all pure functions of the design. It is derived in the design-save pass (the
+pre-tag step on `POST /build`), committed to the design the agent reads as its
+spec, and captured in the version tag. There is no ordering, no audience, and no
+idempotency marker left to get wrong.
 
-**Resolved — pushed at cycle dispatch.** The `endpoints:` half genuinely needs
-live resolution (a cross-project provider may not have published; a sibling's
-endpoint name comes from a `workload.yaml` nobody has written yet), so it stays a
+**Resolved — pushed at cycle dispatch.** What is left on the `endpoints:` half is
+an `org-service`, which genuinely needs live resolution because its provider
+belongs to another project and may not have published yet, so it stays a
 comment — but triggered at dispatch, not at gate resolution. Dispatch is provably
 correct rather than lucky: the dispatch predicate already requires that no gate is
 open in the milestone, so everything resolvable has resolved, and the working set
@@ -57,10 +61,11 @@ Three properties make this hold:
 - **Absence is loud.** A declared dependency with no `wiring` is a platform fault
   the agent reports and stops on — never a licence to substitute its own database,
   cache or IDP. Independently, the merged-PR fan-out compares each component's
-  declared refs against the `workload.yaml` it shipped and mints a fix issue on a
-  mismatch, because the silence was a separate defect from the delivery bug: a
-  component that quietly substituted its own persistence BUILDS, so nothing else
-  would ever notice.
+  declared refs AND endpoint targets against the `workload.yaml` it shipped and
+  mints a fix issue on a mismatch, because the silence was a separate defect from
+  the delivery bug: a component that quietly substituted its own persistence
+  BUILDS, and one that named a sibling by its unscoped name builds, deploys and
+  serves, so nothing else would ever notice.
 
 ## Consequences
 

--- a/skills/aep/SKILL.md
+++ b/skills/aep/SKILL.md
@@ -185,7 +185,8 @@ For **each** issue in the ordered set:
    plus the `openapi.yaml` of every component it consumes. The issue says what to
    build; the contract fixes the shape.
    Read its comments too (`gh issue view <number> --comments`): a
-   "Platform-resolved dependencies" comment carries dependency wiring you need.
+   "Platform-resolved dependencies" comment carries an `org-service`'s
+   coordinates.
 2. **Make the change it asks for**, holding to
    `references/component-contract.md` and the stack skills of every component it
    touches.
@@ -354,18 +355,22 @@ is guessable. Both failure modes are silent: an env var you renamed arrives empt
 a `visibility` you omitted leaves a dependent's config unwritten, and nothing
 errors until deploy.
 
-One thing that file cannot give you is a provider's live coordinates. That is
-below.
+One thing that file cannot give you is an `org-service`'s live coordinates. That
+is below.
 
 ### The `endpoints:` half
 
-The platform resolves live addresses and posts them as a **"Platform-resolved
-dependencies"** comment on the open issues of your working set, so it may land
-on a **sibling** issue rather than the one for the component it describes. Read
-the comments on the issues you are working and copy every `## Component <name>`
-block into **that named component's** `workload.yaml` — invent, rename and omit
-nothing. Two blocks for the same component: the **latest** is the complete
-answer.
+A **sibling** (`kind: component`) is already resolved in your own tree: its entry
+is the `wiring.endpoint` object on that dependency in `design.json`, copied
+verbatim. That holds whether or not the comment below exists.
+
+An **`org-service`** belongs to another project, so only the platform can resolve
+it. It posts what it resolved as a **"Platform-resolved dependencies"** comment
+on the open issues of your working set, so it may land on a **sibling** issue
+rather than the one for the component it describes. Read the comments on the
+issues you are working and copy every `## Component <name>` block into **that
+named component's** `workload.yaml` — invent, rename and omit nothing. Two blocks
+for the same component: the **latest** is the complete answer.
 
 ### Finding an `org-service` contract
 

--- a/skills/aep/overlays/local.md
+++ b/skills/aep/overlays/local.md
@@ -62,7 +62,8 @@ runtime relationship, not a build order — it never holds an issue back.
 
 <!-- replace-text -->
    Read its comments too (`gh issue view <number> --comments`): a
-   "Platform-resolved dependencies" comment carries dependency wiring you need.
+   "Platform-resolved dependencies" comment carries an `org-service`'s
+   coordinates.
 <!-- with -->
 <!-- /replace-text -->
 

--- a/skills/aep/references/workload-and-wiring.md
+++ b/skills/aep/references/workload-and-wiring.md
@@ -6,8 +6,8 @@ dependency's *contract* is, and how code reads its injected values, is in
 
 Everything here derives from what `specs/` already fixed, so it reads the same
 for a component's first line and for a change to one that shipped weeks ago. The
-one half that is **not** derivable — a provider's live coordinates — stays in the
-skill body under **Dependencies and `workload.yaml`**.
+one kind that is **not** derivable — an `org-service`, which belongs to another
+project — stays in the skill body under **Dependencies and `workload.yaml`**.
 
 Most of what goes wrong here is silent: an env var you renamed arrives empty, a
 `visibility` you omitted leaves a dependent's config unwritten, and nothing fails
@@ -22,21 +22,38 @@ consumes. Its `kind` decides where the wiring comes from and what you write:
 |---|---|---|
 | `platform-resource` | its `wiring` object | one `resources:` entry |
 | `external` | its `wiring` object — **only when it declares `config` keys** | one `resources:` entry (none when it declares no keys) |
-| `component` | not derivable from `specs/` — the skill body | one `endpoints:` entry, `visibility: project` |
+| `component` | its `wiring` object | one `endpoints:` entry |
 | `org-service` | not derivable from `specs/` — the skill body | one `endpoints:` entry, plus `project:` and `visibility: namespace` |
 
-`component` and `org-service` need no `wiring` object: their env var is always
-`<DEP_NAME>_URL`. What does need resolving is the provider's *coordinates* — its
-`project`, the platform's name for it, and an endpoint name that comes from a
-`workload.yaml` nobody may have written yet.
+Three of the four kinds carry a `wiring` object the platform derived and
+committed into `design.json`. Its **shape** tells you which half of
+`dependencies:` the entry belongs in:
+
+| `wiring` holds | The entry goes in |
+|---|---|
+| an `endpoint` object | `dependencies.endpoints[]` |
+| `ref` + `envBindings` | `dependencies.resources[]` |
+
+`org-service` is the one kind with no `wiring` object, because its provider
+belongs to another project: its `project`, the platform's name for it and its
+endpoint name are resolved live and reach you by the channel the skill body
+names.
 
 **A `platform-resource` with no `wiring` is broken input, not a licence to
 substitute your own store** — say so in one line and stop the run.
 
-**Copy a `wiring` object verbatim** — `ref` and every `envBindings` pair,
-unchanged. **Those env-var names are the keys the platform populates at
-runtime**: an output arrives under that name and no other. Never rename one,
-never invent one.
+**Copy a `wiring` object verbatim** — every field and every `envBindings` pair,
+unchanged. It is already byte-identical to the entry that belongs there.
+
+**Those env-var names are the keys the platform populates at runtime**: an output
+arrives under that name and no other. Never rename one, never invent one.
+
+**A `wiring.endpoint`'s `component` carries the project as a prefix** —
+`<project>-<component>`. It deliberately does not match the name the rest of the
+tree calls that component: this prefixed one is what OpenChoreo resolves a
+connection by. Write the `wiring` value. Any other spelling parses, builds,
+deploys and serves with the address env var silently absent, and the only symptom
+is a project that reports "deploying" for ever.
 
 **Every component writes its `resources:` entries, a `web-application`
 included** — a web app reads the values from `window._env_` rather than pod env
@@ -73,9 +90,11 @@ endpoints:
       - external
 
 dependencies:                    # what you resolved above — omit a half you have none of
-  endpoints:                     # component / org-service
-    - project: <provider-project> # cross-project only; absent = same project
-      component: <provider-component> # the platform's name — never "correct" it
+  endpoints:                     # component: `wiring.endpoint`, verbatim
+                                 # org-service: resolved live (skill body)
+    - project: <provider-project> # org-service only; absent = same project
+      component: <provider-component> # `<project>-<component>` — the platform's
+                                  # own name for it, project-prefixed
       name: <provider-endpoint>   # e.g. http
       visibility: namespace       # or project (same-project)
       envBindings:


### PR DESCRIPTION
## The problem

`employees-submit-expense131` shipped this in `expense-webapp/workload.yaml`:

```yaml
dependencies:
  endpoints:
    - component: expense-api          # ← the friendly name
```

OpenChoreo resolves an endpoint dependency by the **scoped** name, so this matched no
binding. The release rendered, the pod ran, the app served — and the only symptom was a
ReleaseBinding parked at `Ready=False / ConnectionsPending`, with the project reporting
"deploying" for ever. The wiring-conformance check caught it and minted
[issue #6](https://github.com/asdlc-repos/employees-submit-expense131/issues/6), which
cost a **whole coding cycle** (#6 → #7 → PR #8) to change one string.

The correct value was already in the agent's own tree, byte-exact, committed by the
platform before the agent ever ran:

```jsonc
// specs/design/components/expense-webapp/design.json
"wiring": { "endpoint": { "component": "employees-submit-expense131-expense-api", … } }
```

## Root cause: doc drift against a fix that already landed

`183e67a8` (2026-08-01) moved a `component` dependency's endpoint wiring off the live
endpoint catalog and into `design.json` — precisely because the catalog only lists
components that have already **deployed**, so on a first delivery it answers nothing.
Its own commit message names this exact failure.

The agent-facing docs were never moved with it:

| Where | Said | Actually |
|---|---|---|
| `workload-and-wiring.md` kind table | `component` → *"not derivable from `specs/` — the skill body"* | derived, and stamped into `design.json` since 2026-08-01 |
| `SKILL.md` → *The `endpoints:` half* | read the **"Platform-resolved dependencies"** comment | that comment carries `org-service` only |
| `ADR-0013` | *"a sibling's endpoint name comes from a `workload.yaml` nobody has written yet"* | written one day before `183e67a8` superseded it |

So the agent read the table, went looking for a comment, found none — **no
"Platform-resolved dependencies" comment exists on any issue in that repo**, I checked
all of them — and fell back to the only name it had ever seen.

The instruction that was supposed to save it (`# the platform's name — never "correct"
it`, in the template) never fired, because the agent had already been told the value
was not in `specs/`.

## The change

Move the docs to where the data is.

**`references/workload-and-wiring.md`**

- The kind table routes `component` to *its `wiring` object*, like the other two derived
  kinds.
- A new shape table maps the two `wiring` variants onto the two halves of
  `dependencies:` — an `endpoint` object → `endpoints[]`, `ref` + `envBindings` →
  `resources[]` — so *which half* is read off the data rather than off the kind.
- Copy-verbatim now covers both variants, and the project prefix is stated as the
  platform's own name for the component, with the silent failure spelled out:

  > **A `wiring.endpoint`'s `component` carries the project as a prefix** —
  > `<project>-<component>`. It deliberately does not match the name the rest of the
  > tree calls that component […] Any other spelling parses, builds, deploys and serves
  > with the address env var silently absent.

**`SKILL.md`** — the `endpoints:` half resolves a sibling from `design.json`, and keeps
the comment for `org-service` alone. It closes the hole the agent actually fell into:

> A **sibling** (`kind: component`) is already resolved in your own tree […] **That
> holds whether or not the comment below exists.**

**`ADR-0013`** — restated at its current state: `component` sits on the derived side,
and the conformance net checks endpoint targets as well as refs.

**`overlays/local.md`** — the anchor moves in lockstep.

## Gates

- `runners/remote-worker` — **398/398 pass**, on this branch's base. These render
  `SKILL.md` through `local.md`, and `skill_overlay` throws on a stale anchor
  (`replace-text matched 0 times`), so the overlay edit is proven, not assumed.
- `make license-check` — exit 0.

## Not in this PR

The structural fix. `dependencies:` in `workload.yaml` is **100% platform-derived** —
`ScopedComponentName`, the sibling's own endpoint name, `visibility: project`,
`ServiceURLEnvName`. Asking a model to transcribe a value the platform calculated is a
variance source that no wording removes, and the friendly name is the natural thing to
write, so the wording is fighting the grain.

`checkWiringConformance` already holds, at the same moment and in the same process, the
shipped file, the declared truth, and the exact missing values — and it writes an
*issue*. It could write the *file*: reconcile `dependencies:` from `design.json`, commit,
then build off that commit. No PR, no cycle, no model. The precedent exists —
`DerivePlatformResourceFactsAtHead` already commits to `main` outside a PR at the same
pre-tag step.

That is a separate change. This one stops the bleeding for the next project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvanuzxvZmpfvnh2Pbr2wD
