### PR TITLE
fix(console): submitted answers count as agent work before the turn exists

### DIFF
--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -413,6 +413,16 @@ Requirements — nothing downstream can be written before that document exists, 
 a member's interview answers (plain prose, no flow) is the very one that writes it (#629). The
 moment anything exists, the silence above resumes.
 
+**"In flight" starts at the submit, not at the server.** `spec.agent` cannot see a turn before its
+row exists, and submitted interview answers take the dispatch round-trip — seconds — to become one;
+in that gap every signal above read idle and the empty workspace offered Retry against the very
+interview it could not see ([#635](https://github.com/wso2/labs-agentic-engineer/issues/635)). The
+browser that submitted holds the missing evidence — a seeded message waiting, a dispatch awaiting
+its turn id, a stream being folded — and that chain counts as agent work until the status catches
+up. It is claim-scoped, not timed: a refused send releases its claim and Retry surfaces at once. A
+teammate's browser holds no claim for a send made elsewhere and waits on the status, as it always
+did.
+
 **The counts read the LIVE document, not the committed one.** Deleting an `*assumed*` flag clears
 the alert as you delete it; the committed copy is a collab flush behind, and on the agent's own
 edits that lag was long enough to look broken.

--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -419,7 +419,10 @@ in that gap every signal above read idle and the empty workspace offered Retry a
 interview it could not see ([#635](https://github.com/wso2/labs-agentic-engineer/issues/635)). The
 browser that submitted holds the missing evidence — a seeded message waiting, a dispatch awaiting
 its turn id, a stream being folded — and that chain counts as agent work until the status catches
-up. It is claim-scoped, not timed: a refused send releases its claim and Retry surfaces at once. A
+up. It is claim-scoped, not timed — a refused send releases its claim and Retry surfaces at once —
+with one backstop: a seeded message whose consumer never opens (the one stage with no failure path
+of its own) lapses from the signal after a generous TTL, so an outage cannot pin a working state
+that hides Retry. A
 teammate's browser holds no claim for a send made elsewhere and waits on the status, as it always
 did.
 

--- a/apps/console/src/features/agent-chat/chatStore.test.ts
+++ b/apps/console/src/features/agent-chat/chatStore.test.ts
@@ -51,6 +51,10 @@ import {
   subscribeTurnEnd,
   upsertToolMessage,
   clearFailedSends,
+  claimSendInFlight,
+  claimStreamFold,
+  hasLocalTurnActivity,
+  subscribeLocalTurnActivity,
 } from "./chatStore";
 
 let n = 0;
@@ -442,5 +446,64 @@ describe("clearFailedSends", () => {
     clearFailedSends(KEY);
     // Same array identity: a needless persist would remount the whole log.
     expect(getMessages(KEY)).toBe(before);
+  });
+});
+
+// #635: the chain a submitted send rides from form to turn — seed waiting,
+// dispatch in flight, stream being folded. Any stage live means this browser
+// holds evidence of a turn the status endpoint may not report yet.
+describe("local turn activity", () => {
+  it("is live through each stage of a send, and collapses when the last releases", () => {
+    const key = freshKey();
+    expect(hasLocalTurnActivity(key)).toBe(false);
+
+    setPendingSeed(key, "answers");
+    expect(hasLocalTurnActivity(key)).toBe(true);
+
+    // Consumption hands over to the send claim with no dead stage between.
+    const releaseSend = claimSendInFlight(key);
+    consumePendingSeed(key);
+    expect(hasLocalTurnActivity(key)).toBe(true);
+
+    const releaseFold = claimStreamFold(key);
+    releaseSend();
+    expect(hasLocalTurnActivity(key)).toBe(true);
+
+    releaseFold();
+    expect(hasLocalTurnActivity(key)).toBe(false);
+  });
+
+  it("collapses when a send dies before a turn exists", () => {
+    const key = freshKey();
+    const release = claimSendInFlight(key);
+    expect(hasLocalTurnActivity(key)).toBe(true);
+    release();
+    expect(hasLocalTurnActivity(key)).toBe(false);
+  });
+
+  it("notifies on every edge: seed set/consumed, claim taken/released", () => {
+    const key = freshKey();
+    let fired = 0;
+    const unsubscribe = subscribeLocalTurnActivity(key, () => {
+      fired += 1;
+    });
+    setPendingSeed(key, "answers");
+    consumePendingSeed(key);
+    const release = claimSendInFlight(key);
+    release();
+    expect(fired).toBe(4);
+
+    unsubscribe();
+    setPendingSeed(key, "again");
+    expect(fired).toBe(4);
+    consumePendingSeed(key);
+  });
+
+  it("keeps distinct keys apart", () => {
+    const key1 = freshKey();
+    const key2 = freshKey();
+    const release = claimSendInFlight(key1);
+    expect(hasLocalTurnActivity(key2)).toBe(false);
+    release();
   });
 });

--- a/apps/console/src/features/agent-chat/chatStore.test.ts
+++ b/apps/console/src/features/agent-chat/chatStore.test.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Node test env: the store only touches localStorage — a Map-backed stub
 // keeps the test out of jsdom.
@@ -55,6 +55,7 @@ import {
   claimStreamFold,
   hasLocalTurnActivity,
   subscribeLocalTurnActivity,
+  SEED_ACTIVITY_TTL_MS,
 } from "./chatStore";
 
 let n = 0;
@@ -505,5 +506,55 @@ describe("local turn activity", () => {
     const release = claimSendInFlight(key1);
     expect(hasLocalTurnActivity(key2)).toBe(false);
     release();
+  });
+
+  // The seed is the one stage with no failure path of its own: its consumer
+  // sits behind gates an outage can hold shut, and an unconsumed seed would
+  // pin a working state that HIDES Retry. So only the seed's contribution
+  // expires — and expiry is an edge subscribers hear about, or the pane
+  // would hold the stale state until an unrelated re-render.
+  describe("seed TTL", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("expires a waiting seed from the signal, and notifies the edge", () => {
+      const key = freshKey();
+      let fired = 0;
+      const unsubscribe = subscribeLocalTurnActivity(key, () => {
+        fired += 1;
+      });
+      setPendingSeed(key, "answers");
+      expect(hasLocalTurnActivity(key)).toBe(true);
+      const firedBeforeExpiry = fired;
+
+      vi.advanceTimersByTime(SEED_ACTIVITY_TTL_MS);
+      expect(hasLocalTurnActivity(key)).toBe(false);
+      expect(fired).toBe(firedBeforeExpiry + 1);
+
+      // The seed itself is untouched by the lapse — still there to consume.
+      expect(peekPendingSeed(key)).toEqual({ message: "answers", guarded: false });
+      unsubscribe();
+      consumePendingSeed(key);
+    });
+
+    it("does not expire the claims — their release paths own their end", () => {
+      const key = freshKey();
+      const release = claimSendInFlight(key);
+      vi.advanceTimersByTime(SEED_ACTIVITY_TTL_MS * 2);
+      expect(hasLocalTurnActivity(key)).toBe(true);
+      release();
+    });
+
+    it("a fresh seed restarts the clock", () => {
+      const key = freshKey();
+      setPendingSeed(key, "first");
+      vi.advanceTimersByTime(SEED_ACTIVITY_TTL_MS - 1000);
+      setPendingSeed(key, "second");
+      vi.advanceTimersByTime(2000);
+      expect(hasLocalTurnActivity(key)).toBe(true);
+      vi.advanceTimersByTime(SEED_ACTIVITY_TTL_MS);
+      expect(hasLocalTurnActivity(key)).toBe(false);
+      consumePendingSeed(key);
+    });
   });
 });

--- a/apps/console/src/features/agent-chat/chatStore.ts
+++ b/apps/console/src/features/agent-chat/chatStore.ts
@@ -559,6 +559,7 @@ const inFlightSends = new Map<string, number>();
 
 function claim(counts: Map<string, number>, key: string): () => void {
   counts.set(key, (counts.get(key) ?? 0) + 1);
+  notifyLocalTurnActivity(key);
   let released = false;
   return () => {
     if (released) return; // idempotent: cleanup may run twice (StrictMode)
@@ -566,6 +567,7 @@ function claim(counts: Map<string, number>, key: string): () => void {
     const remaining = (counts.get(key) ?? 1) - 1;
     if (remaining <= 0) counts.delete(key);
     else counts.set(key, remaining);
+    notifyLocalTurnActivity(key);
   };
 }
 
@@ -591,4 +593,54 @@ export function claimSendInFlight(key: string): () => void {
  */
 export function canReplaceLog(key: string): boolean {
   return !attachedFolds.has(key) && !inFlightSends.has(key);
+}
+
+// --- Local turn activity (#635) -------------------------------------------
+//
+// `spec.agent` lags a send by the dispatch round-trip: interview answers leave
+// through the seed slot the instant the question form submits, but the turn
+// carrying them has no `agent_turns` row until StartTurn answers — seconds
+// later, longer under load. In that window the status endpoint reads idle, the
+// question form is gone, and an empty project has no files, so every signal
+// the spec workspace checks said "nothing running" and it offered Retry
+// against an interview mid-flight — #629's hazard surviving as a race.
+//
+// This browser knows better. The seed slot, the send claim and the fold claim
+// chain without a gap from form-submit to the turn's terminal frame (`send()`
+// releases the send claim and takes the fold claim in one synchronous
+// continuation), and every failure path releases its claim — a refused
+// dispatch, a severed stream, a chatKey rotation. So "any of the three is
+// live" is precisely "this browser holds evidence of a turn the status
+// endpoint may not report yet", and it needs no expiry timer: the signal
+// collapses the moment a send is refused or a turn dies, letting Retry
+// surface honestly.
+//
+// Browser-local by nature: a teammate's browser holds no claim for a send
+// made here. Their pane recovers through the status poll as it always did —
+// this only closes the gap for the member who just submitted.
+
+const localTurnActivityListeners = new Map<string, Set<() => void>>();
+
+function notifyLocalTurnActivity(key: string): void {
+  for (const fn of localTurnActivityListeners.get(key) ?? []) fn();
+}
+
+/** True while THIS browser holds live evidence of a turn for `key`: a seed
+ *  waiting to send, a dispatch awaiting its turn id, or a stream being
+ *  folded. */
+export function hasLocalTurnActivity(key: string): boolean {
+  return pendingSeeds.has(key) || inFlightSends.has(key) || attachedFolds.has(key);
+}
+
+/** Fires on every edge of `hasLocalTurnActivity`: seed set or consumed, claim
+ *  taken or released. */
+export function subscribeLocalTurnActivity(key: string, fn: () => void): () => void {
+  const unsubscribeSeed = subscribeSeed(key, fn);
+  const set = localTurnActivityListeners.get(key) ?? new Set();
+  set.add(fn);
+  localTurnActivityListeners.set(key, set);
+  return () => {
+    unsubscribeSeed();
+    set.delete(fn);
+  };
 }

--- a/apps/console/src/features/agent-chat/chatStore.ts
+++ b/apps/console/src/features/agent-chat/chatStore.ts
@@ -433,6 +433,7 @@ const seedListeners = new Map<string, Set<() => void>>();
  */
 export function setPendingSeed(key: string, message: string, guarded = false): void {
   pendingSeeds.set(key, { message, guarded });
+  stampSeedForActivity(key);
   for (const fn of seedListeners.get(key) ?? []) fn();
 }
 
@@ -451,6 +452,7 @@ export function consumePendingSeed(key: string): PendingSeed | null {
   const seed = pendingSeeds.get(key);
   if (seed === undefined) return null;
   pendingSeeds.delete(key);
+  clearSeedActivity(key);
   for (const fn of seedListeners.get(key) ?? []) fn();
   return seed;
 }
@@ -592,7 +594,14 @@ export function claimSendInFlight(key: string): () => void {
  * is itself appending fresher content than the replace would have written.
  */
 export function canReplaceLog(key: string): boolean {
-  return !attachedFolds.has(key) && !inFlightSends.has(key);
+  return !hasLiveClaims(key);
+}
+
+/** A dispatch or fold this browser currently owns for `key` — the shared base
+ *  of `canReplaceLog` and `hasLocalTurnActivity`, so a future claim map cannot
+ *  be added to one reading and silently missed by the other. */
+function hasLiveClaims(key: string): boolean {
+  return inFlightSends.has(key) || attachedFolds.has(key);
 }
 
 // --- Local turn activity (#635) -------------------------------------------
@@ -611,9 +620,15 @@ export function canReplaceLog(key: string): boolean {
 // continuation), and every failure path releases its claim — a refused
 // dispatch, a severed stream, a chatKey rotation. So "any of the three is
 // live" is precisely "this browser holds evidence of a turn the status
-// endpoint may not report yet", and it needs no expiry timer: the signal
+// endpoint may not report yet". The CLAIMS need no expiry timer — the signal
 // collapses the moment a send is refused or a turn dies, letting Retry
-// surface honestly.
+// surface honestly. The SEED is the one stage with no failure path of its
+// own: its sole consumer sits behind gates (the conversation id resolving,
+// the history rehydrate landing) that an outage can hold shut indefinitely,
+// and a seed nobody consumes would otherwise pin a working state that HIDES
+// Retry — strictly worse than the gap being closed. So only the seed's
+// contribution expires, on a TTL generous against a slow panel mount; the
+// seed itself stays consumable, exactly as before.
 //
 // Browser-local by nature: a teammate's browser holds no claim for a send
 // made here. Their pane recovers through the status poll as it always did —
@@ -625,11 +640,43 @@ function notifyLocalTurnActivity(key: string): void {
   for (const fn of localTurnActivityListeners.get(key) ?? []) fn();
 }
 
+/** How long a WAITING seed counts as turn activity. Normal consumption is
+ *  near-immediate (the panel is mounted, or mounts on the seed's own signal),
+ *  so this bounds only the pathological stall where the consumer's gates
+ *  never open. */
+export const SEED_ACTIVITY_TTL_MS = 30_000;
+
+const seedActivitySetAt = new Map<string, number>();
+const seedActivityTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function stampSeedForActivity(key: string): void {
+  seedActivitySetAt.set(key, Date.now());
+  clearTimeout(seedActivityTimers.get(key));
+  // The expiry is an EDGE subscribers must hear about — without the wake-up
+  // call, a pane holding "working" on this seed would keep it until some
+  // unrelated re-render happened to re-read the snapshot.
+  seedActivityTimers.set(
+    key,
+    setTimeout(() => {
+      seedActivityTimers.delete(key);
+      notifyLocalTurnActivity(key);
+    }, SEED_ACTIVITY_TTL_MS),
+  );
+}
+
+function clearSeedActivity(key: string): void {
+  seedActivitySetAt.delete(key);
+  clearTimeout(seedActivityTimers.get(key));
+  seedActivityTimers.delete(key);
+}
+
 /** True while THIS browser holds live evidence of a turn for `key`: a seed
- *  waiting to send, a dispatch awaiting its turn id, or a stream being
- *  folded. */
+ *  waiting to send (within its TTL), a dispatch awaiting its turn id, or a
+ *  stream being folded. */
 export function hasLocalTurnActivity(key: string): boolean {
-  return pendingSeeds.has(key) || inFlightSends.has(key) || attachedFolds.has(key);
+  const setAt = pendingSeeds.has(key) ? seedActivitySetAt.get(key) : undefined;
+  const seedLive = setAt !== undefined && Date.now() - setAt < SEED_ACTIVITY_TTL_MS;
+  return seedLive || hasLiveClaims(key);
 }
 
 /** Fires on every edge of `hasLocalTurnActivity`: seed set or consumed, claim

--- a/apps/console/src/features/agent-chat/useLocalTurnActivity.ts
+++ b/apps/console/src/features/agent-chat/useLocalTurnActivity.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import { chatKeyFor, hasLocalTurnActivity, subscribeLocalTurnActivity } from "./chatStore.js";
+
+/**
+ * True while THIS browser holds live evidence of a turn for the project — a
+ * seeded message waiting to send, a dispatch awaiting its turn id, or a
+ * stream being folded (#635). Covers the window where `spec.agent` still
+ * reads idle because the turn's row does not exist server-side yet, which is
+ * exactly when a surface deciding "is anything running" from status alone
+ * would wrongly offer Retry against work in flight.
+ */
+export function useLocalTurnActivity(
+  org: string,
+  projectName: string | undefined,
+): boolean {
+  const chatKey = projectName ? chatKeyFor(org, projectName) : null;
+  return useSyncExternalStore(
+    useCallback(
+      (fn: () => void) => (chatKey ? subscribeLocalTurnActivity(chatKey, fn) : () => {}),
+      [chatKey],
+    ),
+    () => (chatKey ? hasLocalTurnActivity(chatKey) : false),
+  );
+}

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -439,6 +439,40 @@ describe("SpecView while the kickoff is still writing", () => {
     ).not.toBeInTheDocument();
   });
 
+  // #635 (review): `spec.agent` keeps reading "failed" until the retry's own
+  // turn has a row, so unguarded the banner sat through the retry's dispatch
+  // offering a SECOND Retry against the send it already fired — while the rail
+  // beside it pulsed working. The click's own seed is the evidence that flips
+  // the pane; if the send dies, the claim releases and the banner returns.
+  it("drops the failure banner the moment Retry is clicked", () => {
+    mockSpecAgent = "failed";
+    empty();
+    render(<SpecView projectName="proj1" />);
+    expect(
+      screen.getByText("The agent couldn't write your requirements"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      screen.queryByText("The agent couldn't write your requirements"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Agent is working on the requirements document"),
+    ).toBeInTheDocument();
+
+    // The send died before a turn existed: the seed's consumption with no
+    // claim taken collapses the evidence, and the banner returns.
+    act(() => {
+      consumePendingSeed(chatKeyFor("acme", "proj1"));
+    });
+    expect(
+      screen.getByText("The agent couldn't write your requirements"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
   // The dead end this closed (#562 review): a dispatch that never reached the
   // turn guard — no Anthropic key, an unreachable skills repo — or an abandoned
   // reference upload the create held the kickoff for. There is no turn row, so

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -25,9 +25,12 @@ import type { components } from "../../../generated/aep-api";
 import { START_COMMAND } from "@aep/contracts/commands";
 import {
   chatKeyFor,
+  claimSendInFlight,
+  claimStreamFold,
   consumePendingSeed,
   notifyTurnEnd,
   replaceMessages,
+  setPendingSeed,
 } from "../../agent-chat/chatStore";
 import { SpecView } from "./SpecView";
 
@@ -502,6 +505,74 @@ describe("SpecView while the kickoff is still writing", () => {
     expect(screen.getByText("Agent is working")).toBeInTheDocument();
     expect(screen.queryByText("Nothing written yet")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+  });
+
+  // #635: the status field cannot see a turn before its row exists. Submitted
+  // interview answers leave through the seed slot the instant the form goes,
+  // but for the dispatch round-trip `spec.agent` still reads idle — and every
+  // other running-work signal is gone too, so the pane fell through to
+  // "Nothing written yet" plus a Retry whose /start would supersede the very
+  // interview it cannot see. The browser that submitted holds the evidence:
+  // seed waiting, dispatch in flight, stream being folded — each stage counts
+  // as agent work until the status catches up.
+  it("keeps the working state while this browser's send is still dispatching", () => {
+    mockSpecAgent = "";
+    mockSpecFlow = "";
+    empty();
+    act(() => setPendingSeed(chatKeyFor("acme", "proj1"), "my interview answers"));
+    render(<SpecView projectName="proj1" />);
+
+    expect(
+      screen.getByText("Agent is working on the requirements document"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Nothing written yet")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+
+    // The seed's consumption hands over to the send claim with no gap — the
+    // pane must not flash Retry between the stages.
+    let releaseSend: () => void;
+    act(() => {
+      releaseSend = claimSendInFlight(chatKeyFor("acme", "proj1"));
+      consumePendingSeed(chatKeyFor("acme", "proj1"));
+    });
+    expect(
+      screen.getByText("Agent is working on the requirements document"),
+    ).toBeInTheDocument();
+
+    // Dispatch answered: the fold claim takes over in the same continuation.
+    let releaseFold: () => void;
+    act(() => {
+      releaseFold = claimStreamFold(chatKeyFor("acme", "proj1"));
+      releaseSend();
+    });
+    expect(
+      screen.getByText("Agent is working on the requirements document"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+
+    act(() => releaseFold());
+  });
+
+  // The signal collapses with the claims: a refused dispatch releases its
+  // claim (and the seed is already consumed), so the pane returns to the
+  // truthful empty state rather than spinning on evidence that died.
+  it("surfaces Retry again once a send dies without a turn", () => {
+    mockSpecAgent = "";
+    mockSpecFlow = "";
+    empty();
+    let release: () => void;
+    act(() => {
+      release = claimSendInFlight(chatKeyFor("acme", "proj1"));
+    });
+    render(<SpecView projectName="proj1" />);
+    expect(
+      screen.getByText("Agent is working on the requirements document"),
+    ).toBeInTheDocument();
+
+    act(() => release());
+
+    expect(screen.getByText("Nothing written yet")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
   // An empty workspace offers NOTHING (#562 retest). It used to carry a Start

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -68,6 +68,7 @@ import {
 } from "../lib/railSections";
 import { chatKeyFor, setPendingSeed, subscribeTurnEnd } from "../../agent-chat/chatStore";
 import { useConversationLog } from "../../agent-chat/useConversationLog";
+import { useLocalTurnActivity } from "../../agent-chat/useLocalTurnActivity";
 import { EmptyState } from "../../../components/EmptyState";
 import { ProblemsDialog } from "./ProblemsDialog";
 import { CommittedFileView } from "./CommittedFileView";
@@ -531,13 +532,21 @@ export function SpecView({ projectName }: { projectName: string }) {
     () => prdUnsettled(livePrd ?? prdContent.data?.content),
     [livePrd, prdContent.data],
   );
+  // The status field cannot see a turn before its row exists (#635): submitted
+  // interview answers travel through the chat's seed slot and take the dispatch
+  // round-trip — seconds — to become a turn `spec.agent` reports. This browser
+  // holds that evidence locally (seed waiting, dispatch in flight, stream being
+  // folded), so a send counts as agent work from the moment it leaves the form;
+  // otherwise the pane meets the gap with "Nothing written yet" plus a Retry
+  // whose `/start` would supersede the interview it cannot see.
+  const localTurnActivity = useLocalTurnActivity(orgHandle ?? "default", projectName);
   const railSections = useMemo(
     () =>
       buildRailSections({
         hasRequirements: hasRequirementsFiles,
         hasDesign: files.some((f) => f.group === "designs"),
         hasValidation: files.some((f) => f.group === "validation"),
-        agentWorking: deriving,
+        agentWorking: deriving || localTurnActivity,
         agentFlow: status.data?.spec.agentFlow ?? "",
         designOutdated: status.data?.spec.designOutdated ?? false,
         assumptions: unsettled.assumptions,
@@ -547,6 +556,7 @@ export function SpecView({ projectName }: { projectName: string }) {
       files,
       hasRequirementsFiles,
       deriving,
+      localTurnActivity,
       status.data?.spec.agentFlow,
       status.data?.spec.designOutdated,
       unsettled,

--- a/apps/console/src/features/spec/components/SpecView.tsx
+++ b/apps/console/src/features/spec/components/SpecView.tsx
@@ -487,7 +487,20 @@ export function SpecView({ projectName }: { projectName: string }) {
   // requirements, so its CTA needs them first) all share it, so they cannot
   // drift into contradicting each other about the same files.
   const hasRequirementsFiles = files.some((f) => f.group === "requirements");
-  const failed = specAgent === "failed" && !hasRequirementsFiles;
+  // The status field cannot see a turn before its row exists (#635): submitted
+  // interview answers travel through the chat's seed slot and take the dispatch
+  // round-trip — seconds — to become a turn `spec.agent` reports. This browser
+  // holds that evidence locally (seed waiting, dispatch in flight, stream being
+  // folded), so a send counts as agent work from the moment it leaves the form;
+  // otherwise the pane meets the gap with "Nothing written yet" plus a Retry
+  // whose `/start` would supersede the interview it cannot see.
+  const localTurnActivity = useLocalTurnActivity(orgHandle ?? "default", projectName);
+  // `failed` yields to that same evidence: `spec.agent` keeps reading "failed"
+  // until the retry's own turn has a row, so unguarded the banner would sit
+  // through the retry's dispatch offering a SECOND Retry against the send it
+  // already fired — while the rail beside it pulses working. If the send dies,
+  // its claim releases (or the seed's TTL lapses) and the banner returns.
+  const failed = specAgent === "failed" && !hasRequirementsFiles && !localTurnActivity;
   // Retrying is a SEND, so it goes where every other send goes: the chat's
   // one-shot seed slot, GUARDED — the panel re-decides after it has rehydrated,
   // which is the first moment "is the agent mid-exchange" is knowable here.
@@ -532,14 +545,6 @@ export function SpecView({ projectName }: { projectName: string }) {
     () => prdUnsettled(livePrd ?? prdContent.data?.content),
     [livePrd, prdContent.data],
   );
-  // The status field cannot see a turn before its row exists (#635): submitted
-  // interview answers travel through the chat's seed slot and take the dispatch
-  // round-trip — seconds — to become a turn `spec.agent` reports. This browser
-  // holds that evidence locally (seed waiting, dispatch in flight, stream being
-  // folded), so a send counts as agent work from the moment it leaves the form;
-  // otherwise the pane meets the gap with "Nothing written yet" plus a Retry
-  // whose `/start` would supersede the interview it cannot see.
-  const localTurnActivity = useLocalTurnActivity(orgHandle ?? "default", projectName);
   const railSections = useMemo(
     () =>
       buildRailSections({


### PR DESCRIPTION
Fixes #635.

## The gap

`spec.agent` cannot see a turn before its row exists. Submitted interview answers leave through the chat's seed slot the instant the question form goes, but the turn carrying them takes the dispatch round-trip — ~3.5s on a warm local stack, longer under load — to become something the status endpoint reports. In that window the form is gone, the status reads idle, and an empty project has no files, so the spec workspace met the gap with **"Nothing written yet" + Retry**, whose `/start` would supersede the very interview it cannot see (#629's hazard surviving as a race; #634 fixed attribution of a *reported* flowless turn, and was observed doing so — it cannot attribute a turn the backend has not admitted exists yet).

## The fix

The browser that submitted holds the evidence the server cannot give yet. The pending seed, the send claim (`claimSendInFlight`) and the fold claim (`claimStreamFold`) chain without a gap from form-submit to the turn's terminal frame — `send()` releases the send claim and takes the fold claim in one synchronous continuation — and every failure path releases its claim. `hasLocalTurnActivity` surfaces that chain; SpecView feeds it into the rail's `agentWorking` input beside the status signal, so the rail and the pane hold the working state together and collapse to the truthful empty state the moment a send dies.

The claims need no expiry timer. The **seed** is the one stage with no failure path of its own — its sole consumer sits behind gates (conversation id resolving, history rehydrate) an outage can hold shut — so only the seed's contribution lapses, on a 30s TTL, with the expiry notified as the edge it is. The seed itself stays consumable, exactly as before.

## Proof of real execution (local stack, `deployments-console` rebuilt at each step)

**Before** (project `expense-repro-tworounds`, backend `/status` polled at 1s beside 2s UI samples):

| Time | Backend `spec.agent` | Spec page |
|---|---|---|
| 19:09:22.2 | `""` | answers submitted — **"Nothing written yet" + Retry** for ~4s |
| 19:09:25.7 | `working` | recovers to "Agent is working on the requirements document" |

The window reopened on every round of a two-round interview while the project had no files.

**After** (projects `expense-repro-guard`, `expense-final-proof`): 1s sampling from the submit instant across both interview rounds shows an unbroken "Agent is working on the requirements document" from submit to the document's arrival — zero Retry samples in ~150 checks.

## Review triage

`/code-review` ran on the branch; addressed here:
- the unconsumed-seed permanent-working state (now the seed TTL above),
- `canReplaceLog` / `hasLocalTurnActivity` sharing one `hasLiveClaims` base so a future claim map cannot join one reading and miss the other.

Noted, deliberately not in this fix:
- **Closing the chat panel mid-dispatch** releases the send claim (the panel's unmount cleanup guards log-replace correctness), degrading that rare interleaving to the pre-fix flash — not worse than today.
- **The Overview spec card** still derives from status alone and can disagree with SpecView for the same few seconds; adopting the signal there is a follow-up.
- **Status poll cadence** (`statusIsMoving`) takes no local-activity input; an invalidate-on-send would tighten non-empty-project surfaces.
- A plain chat message on an empty project now shows the requirements-working state a few seconds earlier than the identical state #634 already shows once the server reports the flowless turn — same attribution decision, same rationale.

## Tests

- `chatStore`: the stage chain stays live end-to-end, collapses when a send dies, notifies on every edge, seed TTL expiry (+ claims exempt), key isolation.
- `SpecView`: working state held through seed→send→fold handoffs with status idle; Retry returns when a send dies without a turn.
- Full console suite: 1169 passed. `tsc`, eslint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpXLxZ5x5PNYZrJ5Gmf5cG