### PR TITLE
fix: stop counting coding-agent ReleaseBindings as project deployments

### DIFF
--- a/services/aep-api/internal/clients/openchoreo/component_chain_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_chain_client.go
@@ -159,6 +159,14 @@ func (c *componentClient) EnsureReleaseBinding(ctx context.Context, orgName, pro
 		ComponentName: componentName,
 		Environment:   environment,
 		ReleaseName:   releaseName,
+		// MARKED as internal. This verb only ever writes an ephemeral
+		// coding-agent binding, and that binding wraps a batch/v1 Job for which
+		// OpenChoreo registers no health check — its Ready condition reads True
+		// over a Job that is still running or has already failed. The marker is
+		// what keeps ListProjectReleaseBindings from folding it into the
+		// project's deploy status and reporting a project as live before a single
+		// user component has been deployed.
+		Labels: internalMarkerLabels(),
 	})
 	created, err := c.createReleaseBinding(ctx, orgName, bindingName, body)
 	if err != nil {
@@ -303,10 +311,15 @@ func releaseBindingBody(projectName string, in ReleaseBindingDesired) ocgen.Rele
 		}{ComponentName: scoped, ProjectName: projectName},
 	}
 	applyDesiredToBinding(spec, in)
-	return ocgen.ReleaseBinding{
-		Metadata: ocgen.ObjectMeta{Name: ReleaseBindingName(projectName, in.ComponentName, in.Environment)},
-		Spec:     spec,
+	meta := ocgen.ObjectMeta{Name: ReleaseBindingName(projectName, in.ComponentName, in.Environment)}
+	if len(in.Labels) > 0 {
+		labels := make(map[string]string, len(in.Labels))
+		for k, v := range in.Labels {
+			labels[k] = v
+		}
+		meta.Labels = &labels
 	}
+	return ocgen.ReleaseBinding{Metadata: meta, Spec: spec}
 }
 
 // applyDesiredToBinding overlays the owned fields onto a binding spec. It is

--- a/services/aep-api/internal/clients/openchoreo/component_chain_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_chain_client_test.go
@@ -270,6 +270,12 @@ func TestEnsureReleaseBinding_Create(t *testing.T) {
 	if spec["environment"] != chainTestEnv {
 		t.Errorf("unexpected environment: %v", spec["environment"])
 	}
+	// MARKED internal, or the project-status poll folds this agent Job's binding
+	// into the project's deploy status and reports it live.
+	labels, _ := meta["labels"].(map[string]any)
+	if labels[string(LabelKeyAepInternal)] != LabelValueAepInternal {
+		t.Errorf("binding not marked internal: labels=%v", labels)
+	}
 }
 
 func TestEnsureReleaseBinding_ConflictIsSuccess(t *testing.T) {

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -370,6 +370,15 @@ func isInternalComponent(annotations, labels map[string]string) bool {
 	return labels[annotationInternal] == "true"
 }
 
+// internalMarkerLabels is the label set that marks an object as the platform's
+// own ephemeral scaffolding rather than one of the user's components. One
+// spelling for the pair, because the writer (EnsureReleaseBinding) and the
+// reader (ListProjectReleaseBindings) have to agree on it or a marked object is
+// counted as a deployment anyway.
+func internalMarkerLabels() map[string]string {
+	return map[string]string{string(LabelKeyAepInternal): LabelValueAepInternal}
+}
+
 func (c *componentClient) ListComponents(ctx context.Context, orgName, projectName string, limit int, cursor string) (*gen.ComponentList, error) {
 	params := &ocgen.ListComponentsParams{}
 	sel := ocgen.LabelSelectorParam(fmt.Sprintf("%s=%s", string(LabelKeyProject), projectName))
@@ -982,7 +991,23 @@ func (c *componentClient) ListDeployments(ctx context.Context, orgName, projectN
 }
 
 // ListProjectReleaseBindings lists the org's ReleaseBindings and keeps the
-// project's, following pagination — the status poll's single OC call.
+// project's USER-COMPONENT ones, following pagination — the status poll's single
+// OC call.
+//
+// Internally marked bindings are skipped, the same exclusion ListComponents
+// makes: every coding-agent cycle creates a real dev-environment binding owned
+// by the user's project, and because that binding wraps a batch/v1 Job (which
+// OpenChoreo registers no health check for) it reports Ready=True regardless of
+// the Job's state. Folded into the deploy stage those bindings reported a
+// project as "deployed" before anything had been deployed — and the project's
+// first run could never report "none" at all, since one finished cycle is
+// enough to leave a permanently-Ready binding behind.
+//
+// The predicate is client-side rather than a labelSelector on the request: this
+// loop already filters by project here, so one more test is free, and the 5s
+// status poll must not depend on openchoreo-api honouring a selector on
+// releasebindings. Bindings created before the marker existed carry no label and
+// are still returned; they age out with the retention pass.
 func (c *componentClient) ListProjectReleaseBindings(ctx context.Context, orgName, projectName string) ([]ReleaseBindingSummary, error) {
 	var out []ReleaseBindingSummary
 	params := &ocgen.ListReleaseBindingsParams{}
@@ -1000,6 +1025,16 @@ func (c *componentClient) ListProjectReleaseBindings(ctx context.Context, orgNam
 		}
 		for _, rb := range resp.JSON200.Items {
 			if rb.Spec == nil || rb.Spec.Owner.ProjectName != projectName {
+				continue
+			}
+			// The same predicate the Component read uses — it tests the marker,
+			// not a kind, and reusing it is what keeps the two exclusions from
+			// drifting onto different spellings of "internal".
+			var lbls map[string]string
+			if rb.Metadata.Labels != nil {
+				lbls = *rb.Metadata.Labels
+			}
+			if isInternalComponent(nil, lbls) {
 				continue
 			}
 			out = append(out, releaseBindingSummary(rb))

--- a/services/aep-api/internal/clients/openchoreo/component_client_project_bindings_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client_project_bindings_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// bindingListPayload is one OC ReleaseBindingList page. A document rather than
+// the typed model for the same reason componentListPayload is: the fixture's
+// POINT is metadata.labels, which ReleaseBindingSummary drops.
+func bindingListPayload(items ...map[string]any) map[string]any {
+	return map[string]any{"items": items, "pagination": map[string]any{}}
+}
+
+// readyBinding is a binding whose Ready condition is True — the only state that
+// folds to "deployed", and the state an agent Job's binding sits in
+// unconditionally.
+func readyBinding(project, component string, labels map[string]any) map[string]any {
+	meta := map[string]any{"name": ReleaseBindingName(project, component, DevEnvironmentName)}
+	if labels != nil {
+		meta["labels"] = labels
+	}
+	return map[string]any{
+		"metadata": meta,
+		"spec": map[string]any{
+			"environment": DevEnvironmentName,
+			"owner": map[string]any{
+				"projectName":   project,
+				"componentName": ScopedComponentName(project, component),
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":               "Ready",
+					"status":             "True",
+					"reason":             "ResourcesReady",
+					"lastTransitionTime": "2026-08-01T10:00:00Z",
+				},
+			},
+		},
+	}
+}
+
+func serveBindings(t *testing.T, payload map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/releasebindings") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		writeJSON(t, w, http.StatusOK, payload)
+	}))
+}
+
+// A coding-agent binding is owned by the USER'S project and lives in the dev
+// environment, so project ownership alone cannot tell it apart from a real
+// deployment. It also reports Ready=True whatever its Job is doing, because
+// OpenChoreo registers no health check for batch/v1 Job. Counting it reported a
+// project "deployed" before a single component had been deployed.
+func TestListProjectReleaseBindings_ExcludesMarkedAgentBindings(t *testing.T) {
+	const project = "widgets"
+	srv := serveBindings(t, bindingListPayload(
+		readyBinding(project, "order-service", nil),
+		readyBinding(project, "ca-run-7", map[string]any{
+			string(LabelKeyAepInternal): LabelValueAepInternal,
+			string(LabelKeyAepCycle):    "cyc-7",
+		}),
+		readyBinding("other-project", "billing", nil),
+	))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListProjectReleaseBindings(context.Background(), "org", project)
+	if err != nil {
+		t.Fatalf("ListProjectReleaseBindings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 binding, got %d: %+v", len(got), got)
+	}
+	if got[0].ComponentName != "order-service" {
+		t.Errorf("unexpected component: %q", got[0].ComponentName)
+	}
+	if got[0].ReadyStatus != "True" {
+		t.Errorf("user binding lost its Ready condition: %q", got[0].ReadyStatus)
+	}
+}
+
+// The honest "nothing deployed" state has to be REACHABLE. Before the marker,
+// one finished coding cycle left a permanently-Ready binding behind and the
+// deploy stage could never report `none` again for the life of the project.
+func TestListProjectReleaseBindings_AgentOnlyProjectIsEmpty(t *testing.T) {
+	const project = "widgets"
+	srv := serveBindings(t, bindingListPayload(
+		readyBinding(project, "ca-run-1", map[string]any{
+			string(LabelKeyAepInternal): LabelValueAepInternal,
+		}),
+	))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListProjectReleaseBindings(context.Background(), "org", project)
+	if err != nil {
+		t.Fatalf("ListProjectReleaseBindings: %v", err)
+	}
+	// Empty is what deployStageStatus folds to deployNone — "Nothing deployed".
+	if len(got) != 0 {
+		t.Fatalf("want no bindings, got %d: %+v", len(got), got)
+	}
+}
+
+// Bindings created before the marker existed carry no label, so they are still
+// counted. Deliberate, not an oversight: they age out with the retention pass,
+// and the alternative (matching the agent's run-name convention) would infer
+// identity from a naming scheme. Pinned so the limitation is a decision on
+// record rather than a surprise in the field.
+func TestListProjectReleaseBindings_UnmarkedAgentBindingStillCounts(t *testing.T) {
+	const project = "widgets"
+	srv := serveBindings(t, bindingListPayload(
+		readyBinding(project, "ca-run-legacy", nil),
+	))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListProjectReleaseBindings(context.Background(), "org", project)
+	if err != nil {
+		t.Fatalf("ListProjectReleaseBindings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want the unmarked binding returned, got %d: %+v", len(got), got)
+	}
+}
+
+// A marker on a binding whose value is not "true" is not a marker.
+func TestListProjectReleaseBindings_NonTrueMarkerDoesNotFilter(t *testing.T) {
+	const project = "widgets"
+	srv := serveBindings(t, bindingListPayload(
+		readyBinding(project, "order-service", map[string]any{
+			string(LabelKeyAepInternal): "false",
+		}),
+	))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListProjectReleaseBindings(context.Background(), "org", project)
+	if err != nil {
+		t.Fatalf("ListProjectReleaseBindings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 binding, got %d: %+v", len(got), got)
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/component_types.go
+++ b/services/aep-api/internal/clients/openchoreo/component_types.go
@@ -202,6 +202,12 @@ type ReleaseBindingDesired struct {
 	// Non-nil-but-empty is meaningful: it clears the field.
 	Env   []WorkflowEnvVarRef
 	Files []WorkflowFileVar
+	// Labels, when non-empty, are written to metadata.labels at CREATE only —
+	// nil means unmanaged, the same rule the fields above follow. It exists for
+	// the internal marker: a binding is the one link in the ephemeral
+	// coding-agent chain that carried no marker, which left the project-status
+	// read counting agent Jobs as the project's deployments.
+	Labels map[string]string
 }
 
 // ReleaseBindingState values for ReleaseBindingDesired.State.

--- a/services/aep-api/internal/clients/openchoreo/constants.go
+++ b/services/aep-api/internal/clients/openchoreo/constants.go
@@ -50,9 +50,12 @@ const (
 	LabelKeyComponentType LabelKeys = "openchoreo.dev/component-type"
 	LabelKeyProjectName   LabelKeys = "openchoreo.dev/project-name"
 
-	// Markers on ephemeral coding-agent Components (and their Workloads).
-	// ListComponents filters on LabelKeyAepInternal; retention / cancel /
-	// watchers key on the rest.
+	// Markers on ephemeral coding-agent Components, and on their Workloads and
+	// ReleaseBindings. ListComponents and ListProjectReleaseBindings both filter
+	// on LabelKeyAepInternal — a binding MUST carry it, because it wraps a
+	// batch/v1 Job whose Ready condition OpenChoreo reports as True regardless of
+	// the Job's state, and an unmarked one is counted as one of the project's
+	// deployments. Retention / cancel / watchers key on the rest.
 	LabelKeyAepInternal  LabelKeys = "aep.wso2.com/internal"
 	LabelKeyAepMilestone LabelKeys = "aep.wso2.com/milestone"
 	LabelKeyAepCycle     LabelKeys = "aep.wso2.com/cycle"

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -96,6 +96,13 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
 - **Deploy is DRIVEN, never inferred.** Components carry `autoDeploy: false`, so nothing promotes a release
   except a call to `Deploy`. That is what lets the run supervisor place validation after a version is
   genuinely serving — see [ADR-0017](../../../../docs/decisions/ADR-0017-the-platform-owns-deploy.md).
+- **The deploy stage counts USER components only.** Every coding-agent cycle creates a real
+  dev-environment ReleaseBinding owned by the user's project, and that binding wraps a `batch/v1 Job`
+  for which OpenChoreo registers no health check — it reports `Ready=True` over a Job that is still
+  running or has already failed. So the marked (`aep.wso2.com/internal`) ones are excluded in
+  `ListProjectReleaseBindings`, exactly as `ListComponents` excludes the matching Components. Without
+  that, one finished cycle was enough to report a project "deployed" before anything was deployed, and
+  `none` became unreachable for the rest of the project's life.
 - **A converge never re-pins.** `Converge` re-asserts wiring at whatever release is already serving; a user
   editing env vars must not be able to move which release is live. It also skips components with no binding
   yet — writing one with no release pinned produces an object OpenChoreo cannot render. The deploy stage's
@@ -119,10 +126,10 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
   body for a non-service component; build-logs 503s when the observability client is unwired.
 - **The Stage aggregate is one cheap poll (5s active / 30s idle), strict-join.** get-project-status runs
   four sources concurrently — spec from a fetch-free local-mirror snapshot, build from the newest
-  `milestone_runs` row (a version's delivery IS its run), deploy from the project's `development` release
-  bindings, and the newest `agent_turns` row — with no GitHub API, Temporal query, or origin fetch. Any
-  source failure fails the whole read (the console keeps last-good); the one carve-out: a deploy tag
-  missing from the local mirror degrades to a 0 denominator, not a 500.
+  `milestone_runs` row (a version's delivery IS its run), deploy from the project's `development`
+  USER-COMPONENT release bindings, and the newest `agent_turns` row — with no GitHub API, Temporal
+  query, or origin fetch. Any source failure fails the whole read (the console keeps last-good); the
+  one carve-out: a deploy tag missing from the local mirror degrades to a 0 denominator, not a 500.
 - **`spec.agent` is the one spec field git cannot answer.** exists/version/dirty all read committed truth,
   and a turn writes nothing until it lands — so through the whole kickoff (#562), the busiest moment in a
   project's life, git says the project is untouched. The newest turn row says otherwise, and folds to three


### PR DESCRIPTION
Fixes #608

## The bug

The Overview's Deploy tile read **"live in dev"** and the Deployments page showed a green **"Deployed"** chip while a build was still finishing, before the deploy stage had promoted anything. Both labels corrected themselves to "Deploying" once the rollout actually started.

This is not a console derivation artifact — the API genuinely returned `deploy.status: "deployed"` for that window. It also reproduced on a project's **first run, with nothing ever deployed**, which is what ruled out a stale-condition race and pointed at the real cause.

## Root cause

Every coding-agent cycle is dispatched as a real OpenChoreo chain — Component → Workload → Release → **ReleaseBinding** — and that binding lives in the `dev` environment **owned by the user's project** (`delivery/codingagent/oc_dispatcher.go:147-170`).

It wraps a `batch/v1 Job`, and OpenChoreo registers no health check for Jobs, so its `Ready` condition reads `True` regardless of what the Job is doing. The `codingagent` package knows this and says so three times — `watcher.go:23-26`:

> It NEVER reads the ReleaseBinding's Ready condition. OpenChoreo registers no health check for `batch/v1 Job`, so a binding reports "completed successfully" over a Job that is still running or has already failed.

`codingagent` refuses to trust it. The project-status path trusted it, because of a filter asymmetry:

| Read | Filter |
|---|---|
| `ListComponents` | project label selector **+ `isInternalComponent`** → agent components excluded |
| `ListProjectReleaseBindings` | `Owner.ProjectName` → **nothing else** |

So `deployStageStatus` (`projects/status_stages.go:585-602`) saw a non-empty set of all-`Ready` dev bindings and folded it to `deployed`. Worse: one finished cycle leaves a permanently-Ready binding behind, so `none` — the honest "Nothing deployed" state — became **unreachable for the rest of the project's life**.

This is also the defect behind the "2 of 0 components ready" oddity the console already carries a note about (#401): `components.ready` counted agent bindings while `total` came from the design.

## The fix

The marker vocabulary already existed and was already stamped on the agent's Component and Workload — but a binding could not carry it: `EnsureReleaseBinding` accepted no labels and `releaseBindingBody` wrote only `metadata.name`.

- **`ReleaseBindingDesired` gains `Labels`**, following the struct's existing nil-means-unmanaged rule, so the user deploy path is untouched.
- **`EnsureReleaseBinding` stamps the internal marker.** No signature change: it has exactly one production caller and is documented create-only for ephemeral agent components, so the marker belongs to the verb rather than to a new parameter. `OCJobSurface`, the `ComponentClient` interface and the generated moq all stand unchanged.
- **`ListProjectReleaseBindings` skips marked bindings**, reusing `isInternalComponent` so the two exclusions cannot drift onto different spellings of "internal".

The predicate is client-side rather than a `labelSelector` on the request: the loop already filters by project there, so one more test is free, and the 5s status poll must not depend on openchoreo-api honouring a selector on releasebindings.

## Proof

`ListProjectReleaseBindings` had **no** client test before this. Five tests added, and I verified each half genuinely fails without the fix rather than passing vacuously.

Reverting the filter reproduces the defect verbatim:

```
--- FAIL: TestListProjectReleaseBindings_ExcludesMarkedAgentBindings
    want 1 binding, got 2: [{ComponentName:order-service ... ReadyStatus:True ReadyReason:ResourcesReady}
                            {ComponentName:ca-run-7      ... ReadyStatus:True ReadyReason:ResourcesReady}]
--- FAIL: TestListProjectReleaseBindings_AgentOnlyProjectIsEmpty
    want no bindings, got 1: [{ComponentName:ca-run-1 ... ReadyStatus:True}]
```

Reverting the marker stamp:

```
--- FAIL: TestEnsureReleaseBinding_Create
    binding not marked internal: labels=map[]
```

Gates, all run locally:

| Gate | Result |
|---|---|
| `go test ./...` (whole service) | **exit 0**, 0 failures |
| `go build ./...` | pass |
| `go vet` | pass |
| `gofmt` | clean on all touched files |
| `make deadcode-check` | `OK — no dead functions` |
| `golangci-lint` (changed packages) | `0 issues` |

**Still outstanding:** the cluster capture. Reviewer or I should confirm on a **fresh** project that `GET /projects/{name}/status` holds `deploy.status: "none"` through the agent and build phases and then goes `none → deploying → deployed`, and that `kubectl get releasebindings -A --show-labels` shows `aep.wso2.com/internal=true` on new agent bindings only. Fresh matters — see the limitation below.

## Known limitation, deliberate

Bindings created before this change carry no label and are **still counted**. They age out with the retention pass (LRU, cap 10 — `retention.go:39`). The alternative was inferring identity from the agent's run-name convention, which is worse. Pinned by `TestListProjectReleaseBindings_UnmarkedAgentBindingStillCounts` so the limitation is on record rather than a surprise in the field.

Practical effect: **existing projects keep showing the old label until their stale agent bindings prune.** Verify on a fresh project.

## Docs

- `clients/openchoreo/constants.go` — the marker comment scoped them to "Components (and their Workloads)"; now covers ReleaseBindings and says why a binding *must* carry one.
- `projects/README.md` — new invariant ("The deploy stage counts USER components only"), and the Stage-aggregate invariant now reads "USER-COMPONENT release bindings".

## Out of scope — worth separate issues

Three adjacent defects surfaced during the diagnosis and are deliberately **not** touched here:

1. **`ReleaseBindingSummary` is version-blind** — it drops `releaseName`, `observedGeneration` and `lastSpecUpdateTime`, all of which the CR exposes. So a re-pinned binding's stale `Ready=True` still reads as deployed. Needs a prior release to trigger, so it is not #608, but it means the run loop's first poll after a pin can go green before the new rollout starts — a correctness risk, not a label one.
2. **`Deployment.status` uses `latestConditionReason`** (`helpers.go:66-72`) — last array entry's `Reason`, ignoring condition type and `True`/`False`, which the sibling projection explicitly warns against.
3. **The console asserts "live in dev" / "Active" from validation state alone** (`pipeline.ts:144-152`, `projectChip.ts:69-73`), keeping a non-empty `version` against the contract.

The run supervisor was never affected by #608: it reads per-component via `GetReleaseBindingStatus`, so agent bindings never entered its verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
