### PR TITLE
fix: say what the validation criteria are, and stop saying E2E

### DIFF
--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -649,6 +649,51 @@ The chat panel is the spine and **never collapses itself**; only the user closes
 pointing at a form that already owns the screen, and its composer stays live during a form — the
 agent is waiting on the user, not working, and the user may want to talk instead of fill.
 
+## The criteria pane
+
+The read-only pane behind the Validation section's document. A reader meets it
+cold: the rail carries no explanation, a design turn mints the file as its last
+step with no announcement, and the only sentence in the product that said what
+criteria were for lived in the **Validations** empty state, on another page most
+readers never reach.
+
+| | |
+|---|---|
+| Description, under the heading | *Each criterion represents one thing your software must do, based on your requirements. After every deployment they are checked against the running software, and the results appear under Validations. To change one, ask the agent.* |
+| Checked by a test | **`AUTO`**, tooltip *Validated automatically by the agent.* |
+| Checked by a person | **`MANUAL`**, tooltip *Requires manual validation.* |
+
+**`AUTO`, never `E2E`.** The stored value stays `e2e` — the validation runner,
+the report generator and the per-criterion spec path all key on it — so the badge
+carries a **display name** instead, the same split the run-state chips already
+draw. `E2E` was never a copy decision: it was agent-authored JSON rendered
+verbatim, which is how an unexpanded acronym reached the screen past naming rule
+4. The rule now has a place to bite, because the word is finally a string
+somebody wrote.
+
+**Every badge earns a tooltip, and only the two real methods get one.** A third
+value exists in older documents; it renders bare rather than being given an
+invented explanation.
+
+**"Ask the agent", not an edit control.** There is no way to edit a criterion
+here, by design: they are written from the requirements alone and never from the
+design, so they judge the work rather than describe it. The chat panel is on
+screen throughout, so this points at something the reader can use rather than
+narrating a procedure (rule 3).
+
+**The description belongs to the spec view, not to Validations.** Both surfaces
+render the same pane, and Validations suppresses it — a reader there came for run
+results, so a sentence promising that results appear under Validations is
+redundant on the page holding them.
+
+**Unsettled: `deployment` or `build`.** This description says criteria are checked
+*after every deployment*; the **Validations** empty state says *"After a build,
+your software is checked against the acceptance criteria in your spec"*. Both name
+the same event. *Deployment* is the more accurate word, since validation runs
+against the deployed system and needs its resolved endpoints, but that empty state
+was out of scope when this pane was written. Whoever settles it changes both and
+deletes this note.
+
 ## What a change invalidates
 
 **Numbered decisions, precise where the link was recorded, coarse where it was not.**

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1638,3 +1638,64 @@ describe("SpecView keeps the chat log fed without the chat panel (#606)", () => 
     expect(mockResyncConversation).not.toHaveBeenCalled();
   });
 });
+
+// The criteria pane is where a reader meets the acceptance oracle cold: the rail
+// carries no explanation, the design turn mints the file with no announcement, and
+// the only sentence in the product that said what criteria were for lived on the
+// Validations page's empty state. This is the surface that gap was reported
+// against, so the description's presence here is the change's real coverage.
+describe("SpecView validation criteria explanation", () => {
+  const CRITERIA_JSON = JSON.stringify({
+    requirements: [
+      {
+        id: "REQ-001",
+        statement: "Shoppers can search the catalog.",
+        criteria: [
+          { id: "AC-001-a", must: "Search returns matches", method: "e2e" },
+          { id: "AC-001-b", must: "Payment is encrypted", method: "manual" },
+        ],
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    mockUseSpecFiles.mockReturnValue({
+      data: [
+        {
+          path: "specs/validation/validation-criteria.json",
+          sha: "abc",
+          group: "validation",
+        },
+      ],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUseSpecFileContent.mockReturnValue({
+      data: { sha: "abc", content: CRITERIA_JSON },
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("explains what the criteria are, where they come from, and how to change one", () => {
+    render(<SpecView projectName="proj1" />);
+
+    expect(
+      screen.getByText(/Each criterion represents one thing your software must do/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/based on your requirements/)).toBeInTheDocument();
+    expect(screen.getByText(/To change one, ask the agent/)).toBeInTheDocument();
+  });
+
+  it("names the methods without the e2e acronym", () => {
+    render(<SpecView projectName="proj1" />);
+
+    expect(screen.getByText("auto")).toBeInTheDocument();
+    expect(screen.getByText("manual")).toBeInTheDocument();
+    expect(screen.queryByText("e2e")).not.toBeInTheDocument();
+  });
+});

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1053,3 +1053,62 @@ describe("ValidationPage lifecycle", () => {
     expect(screen.queryByText("Passed")).not.toBeInTheDocument();
   });
 });
+
+// The method badge is the reader's only signal for who checks a criterion, and it
+// used to render the wire value verbatim — `E2E`, an acronym the lexicon forbids
+// and nothing in the product expanded. The wire value cannot change (the runner,
+// the report generator and the tests/e2e/specs/<AC-ID>.spec.ts path all key on
+// it), so the display name is the thing under test here.
+describe("ValidationPage criterion method badges", () => {
+  function renderWithCriteria() {
+    mockValidation = "passed";
+    mockRun = run({
+      validation: { verdict: "passed", reportPath: "tests/validation/report.json" },
+      cycles: [validationCycle],
+    });
+    mockCriteria.data = { content: CRITERIA };
+    mockReport.data = { content: REPORT };
+    renderPage(undefined);
+  }
+
+  it("says auto rather than the e2e wire value", () => {
+    renderWithCriteria();
+
+    // Two e2e criteria in the fixture, plus the summary tally's own badge.
+    expect(screen.getAllByText("auto")).toHaveLength(2);
+    expect(screen.queryByText("e2e")).not.toBeInTheDocument();
+    expect(screen.getByText("auto 2")).toBeInTheDocument();
+  });
+
+  it("leaves the manual badge alone", () => {
+    renderWithCriteria();
+
+    expect(screen.getByText("manual")).toBeInTheDocument();
+    expect(screen.getByText("manual 1")).toBeInTheDocument();
+  });
+
+  it("explains each method on hover", async () => {
+    renderWithCriteria();
+
+    fireEvent.mouseOver(screen.getAllByText("auto")[0]!);
+    expect(
+      await screen.findByText("Validated automatically by the agent."),
+    ).toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByText("manual"));
+    expect(
+      await screen.findByText("Requires manual validation."),
+    ).toBeInTheDocument();
+  });
+
+  // The description explaining what criteria ARE belongs to the Spec view, where
+  // a reader meets the document cold. Here they arrived to read run results, so a
+  // sentence telling them results appear under Validations would be redundant on
+  // the page holding them. Gated by `hideDescription`, asserted so the gate cannot
+  // be dropped silently.
+  it("omits the spec view's explanation", () => {
+    renderWithCriteria();
+
+    expect(screen.queryByText(/Each criterion represents/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -612,6 +612,7 @@ export function ValidationPage({
       <ValidationView
         noPadding
         fullWidth
+        hideDescription
         criteria={criteria.data.content}
         {...(report.data ? { report: report.data.content } : {})}
       />

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-import { useMemo } from "react";
-import { Alert, alpha, Box, Chip, Typography } from "@wso2/oxygen-ui";
+import { forwardRef, useMemo, type ComponentPropsWithoutRef } from "react";
+import { Alert, alpha, Box, Chip, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { Check } from "@wso2/oxygen-ui-icons-react";
 import {
   parseValidationCriteria,
@@ -42,6 +42,22 @@ const METHOD_COLOR: Record<string, string> = {
 };
 // Fixed display order for the summary tally; unknown methods sort after these.
 const METHOD_ORDER = ["e2e", "scenario", "manual"];
+// What a method badge SAYS, as against the wire value it is keyed by. `e2e` is
+// the contract shared with the runner, the report generator and the spec-path
+// convention, so it cannot be renamed — but it is an acronym the reader has to
+// expand, which the console lexicon forbids. Same split CRITERION_STATE_LABEL
+// draws for run statuses. A method with no entry here renders verbatim, so
+// `manual` and anything unrecognised are unaffected.
+const METHOD_LABEL: Record<string, string> = {
+  e2e: "auto",
+};
+// One line saying who does the checking, shown on hover. Only the two methods a
+// design turn can author carry one; anything else gets a bare badge rather than
+// an invented explanation.
+const METHOD_TOOLTIP: Record<string, string> = {
+  e2e: "Validated automatically by the agent.",
+  manual: "Requires manual validation.",
+};
 // Requirement ids are structural, so a muted slate keeps them from competing
 // with the colored method badges.
 const REQ_COLOR = "#546e7a";
@@ -72,10 +88,23 @@ const STATE_COLOR: Record<string, ChipColor> = {
   manual: "default",
 };
 
-function SolidBadge({ label, color }: { label: string; color: string }) {
+type SolidBadgeProps = { label: string; color: string } & ComponentPropsWithoutRef<"span">;
+
+// Forwards its ref and any remaining props onto the Box, because Tooltip hands
+// its child both a ref and the hover/focus handlers that open it. The console
+// wraps un-forwarding components in an inline-flex Box instead (see the kind chip
+// in SkillsSection), which works here too — but that comment calls itself out as
+// standing in for a ref the child could not hold, and this badge is local enough
+// to just hold one.
+const SolidBadge = forwardRef<HTMLSpanElement, SolidBadgeProps>(function SolidBadge(
+  { label, color, ...rest },
+  ref,
+) {
   return (
     <Box
       component="span"
+      ref={ref}
+      {...rest}
       sx={(theme) => ({
         display: "inline-flex",
         alignItems: "center",
@@ -96,10 +125,22 @@ function SolidBadge({ label, color }: { label: string; color: string }) {
       {label}
     </Box>
   );
-}
+});
 
-function MethodBadge({ method }: { method: string }) {
-  return <SolidBadge label={method} color={METHOD_COLOR[method] ?? FALLBACK} />;
+// Says who checks a criterion, with a tooltip carrying what the word means —
+// the badge alone cannot, and it is the reader's first encounter with the
+// distinction. `count` is passed only by the summary tally, which shows the same
+// badge with its total appended, so both surfaces stay in step by construction.
+function MethodBadge({ method, count }: { method: string; count?: number }) {
+  const label = METHOD_LABEL[method] ?? method;
+  const badge = (
+    <SolidBadge
+      label={count === undefined ? label : `${label} ${count}`}
+      color={METHOD_COLOR[method] ?? FALLBACK}
+    />
+  );
+  const tooltip = METHOD_TOOLTIP[method];
+  return tooltip ? <Tooltip title={tooltip}>{badge}</Tooltip> : badge;
 }
 
 // The per-criterion run-state chip (only rendered when a report is joined in).
@@ -262,6 +303,7 @@ function ValidationBody({
   statuses,
   noPadding,
   fullWidth,
+  hideDescription,
 }: {
   criteria: ValidationCriteria;
   statuses: ValidationReport | undefined;
@@ -269,6 +311,7 @@ function ValidationBody({
    *  props are defaulted at the boundary rather than forwarded as `undefined`. */
   noPadding: boolean;
   fullWidth: boolean;
+  hideDescription: boolean;
 }) {
   const { requirements } = criteria;
   // Per-method tally for the summary header, kept in a stable order. The
@@ -310,6 +353,18 @@ function ValidationBody({
           Validation Criteria
         </Typography>
 
+        {/* What this document is, where it comes from, and what happens to it.
+            Nothing else in the spec workspace says so, and the reader meets the
+            criteria here before any run has produced a result to learn from. */}
+        {!hideDescription && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, maxWidth: "72ch" }}>
+            Each criterion represents one thing your software must do, based on your
+            requirements. After every deployment they are checked against the running
+            software, and the results appear under Validations. To change one, ask the
+            agent.
+          </Typography>
+        )}
+
         {/* Summary — totals plus a colored tally per verification method */}
         <Box
           sx={{
@@ -326,11 +381,7 @@ function ValidationBody({
             {total} {total === 1 ? "criterion" : "criteria"}
           </Typography>
           {orderedMethods.map((m) => (
-            <SolidBadge
-              key={m}
-              label={`${m} ${methodCounts.get(m) ?? 0}`}
-              color={METHOD_COLOR[m] ?? FALLBACK}
-            />
+            <MethodBadge key={m} method={m} count={methodCounts.get(m) ?? 0} />
           ))}
         </Box>
 
@@ -376,6 +427,15 @@ export interface ValidationViewProps {
    * govern width. Oxygen's own PageContent draws the same line.
    */
   fullWidth?: boolean;
+  /**
+   * Drop the paragraph explaining what the criteria are. Default off, same reason
+   * as the two above: the Spec view is where a reader first meets this document,
+   * with nothing else on the page to say what it is for. The Validations page is
+   * the opposite — the reader arrived there to read run results, and a sentence
+   * telling them results appear under Validations is redundant on the page that
+   * holds them.
+   */
+  hideDescription?: boolean;
 }
 
 export function ValidationView({
@@ -383,6 +443,7 @@ export function ValidationView({
   report,
   noPadding = false,
   fullWidth = false,
+  hideDescription = false,
 }: ValidationViewProps) {
   const parsed = useMemo(() => parseValidationCriteria(criteria), [criteria]);
   // The report is optional and tolerant: a bad report never blocks the oracle —
@@ -419,6 +480,7 @@ export function ValidationView({
         statuses={statuses}
         noPadding={noPadding}
         fullWidth={fullWidth}
+        hideDescription={hideDescription}
       />
     </>
   );


### PR DESCRIPTION
Closes #667.

https://github.com/user-attachments/assets/27a7c13e-96cb-44ac-99e1-049dc7dd8bc9



A reader met the acceptance oracle cold: the rail carries no explanation, a design turn mints the file as its last step with no announcement, and the only sentence in the product saying what criteria were for lived in the Validations empty state, on a page most readers never reach. The method badge was worse — agent-authored JSON rendered verbatim, so `e2e` reached the screen as an unexpanded acronym past the lexicon's naming rule 4. It was never a copy decision, which is how it slipped review.

## What changed

**`packages/ui/validation-view/src/ValidationView.tsx`**

- **`METHOD_LABEL`** maps `e2e → "auto"` for display only. The stored value is untouched: the validation runner, the report generator's `AC_TITLE_RE` join key, the server tally and the committed `tests/e2e/specs/<AC-ID>.spec.ts` path all key on it. This is the same split `CRITERION_STATE_LABEL` (`counts.ts:37-43`) already draws for run statuses.
- **`METHOD_TOOLTIP`** for the two methods a design turn can author. `scenario` and the `"unknown"` parse fallback have no entry, so they render exactly as they do today rather than being given an invented explanation.
- **`SolidBadge` forwards its ref and remaining props**, because `Tooltip` hands its child both a ref and the handlers that open it. The console's existing pattern wraps un-forwarding components in an `inline-flex` Box (`SkillsSection.tsx:341`), which works here too — but that comment calls itself out as standing in for a ref the child could not hold, and this badge is local to the file.
- **`MethodBadge` now serves both surfaces** — the per-criterion row and the summary tally (`AUTO 4`) — so the two cannot drift apart.
- **The description**, gated by a new `hideDescription` prop documented in the same voice as its `noPadding` / `fullWidth` neighbours: the consumer owns the choice, the view does not guess.

**`ValidationPage.tsx`** passes `hideDescription`. Both surfaces mount the same component, and a reader on the Validations page came for run results — a sentence promising that results appear under Validations is redundant on the page holding them.

**`apps/console/design/lexicon.md`** records the copy in a new *The criteria pane* section, as ADR-0019 requires. Placed away from line 45 and the spec-workspace naming table, which are being changed separately.

## The copy

| | |
|---|---|
| Description | *Each criterion represents one thing your software must do, based on your requirements. After every deployment they are checked against the running software, and the results appear under Validations. To change one, ask the agent.* |
| Checked by a test | **`AUTO`**, tooltip *Validated automatically by the agent.* |
| Checked by a person | **`MANUAL`**, tooltip *Requires manual validation.* |

Tooltip styling and placement are the bare library default, which is what ~40 other call sites in the console do; there is no `MuiTooltip` theme override, so the default *is* the house style here.

## Proof

Six new tests, covering both surfaces and the gate between them:

```
✓ ValidationPage criterion method badges > says auto rather than the e2e wire value
✓ ValidationPage criterion method badges > leaves the manual badge alone
✓ ValidationPage criterion method badges > explains each method on hover
✓ ValidationPage criterion method badges > omits the spec view's explanation
✓ SpecView validation criteria explanation > explains what the criteria are, where they come from, and how to change one
✓ SpecView validation criteria explanation > names the methods without the e2e acronym
```

`explains each method on hover` drives a real `mouseOver` and asserts the tooltip text appears, which is also what proves the `forwardRef` change works — the tooltip cannot open without it.

No React test harness was added to `@aep/ui-validation-view`: its `vitest.config.ts` is `environment: "node"` with no jsdom, no testing-library and no react plugin, and standing one up for a single component is disproportionate when the console — its only consumer — already has jsdom component tests via the per-file `// @vitest-environment jsdom` pragma.

**Suites:** `@aep/ui-validation-view` 68/68 pass. `@aep/console` 1478 pass, 1 fail — `useCollabSpec.test.tsx:258`, which fails identically on a stashed clean tree, so it is pre-existing and unrelated. `make typecheck` clean on both packages.

**Manual verification:** run in console mock mode and checked on both surfaces.

```js
localStorage.setItem("aep:mock:settings", "connected");
localStorage.setItem("aep:mock:project", "deployed");
localStorage.setItem("aep:mock:validation", "failed");
```

`/projects/demo-shop/spec` → Validation → the criteria document: description present, badges read `AUTO` / `MANUAL`, both tooltips open on the row badges and on the summary tally. `/projects/demo-shop/validation`: description absent, badges and tooltips present.

## Deliberately untouched

- **The rail's artifact label**, being renamed from `Acceptance criteria` to `Validation criteria` separately. Left alone to avoid a conflict, which also means the pane heading stays as it is.
- **The `scenario` method.** Nothing authors it any more, but four consumers still read it. Out of scope for a copy fix.
- **`deployment` vs `build`.** This description says *after every deployment*; the Validations empty state says *"After a build…"*. Both name the same event, and *deployment* is the more accurate word since validation runs against the deployed system. Settling it means changing that empty state too, so it is recorded as an open note in the lexicon rather than fixed silently. Worth a reviewer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
