### PR TITLE
feat: show what a first validation is checking, not just its log

### DIFF
--- a/apps/console/src/features/spec/api/queries.ts
+++ b/apps/console/src/features/spec/api/queries.ts
@@ -21,13 +21,19 @@ import type { components } from "../../../generated/aep-api";
 import { client } from "../../../api/client";
 import { specKeys } from "./keys";
 import { toSpecEntries } from "./mapping";
-import { apiErrorMessage } from "../../../api/errors";
+import { ApiRequestError } from "../../../api/errors";
 
 type FileContent = components["schemas"]["FileContent"];
 type ComponentDependencies = components["schemas"]["ComponentDependencies"];
 
+// ApiRequestError, not Error: it keeps the envelope's `code` alongside the same
+// message every existing caller already reads. The Validation page needs it to tell
+// a file that is genuinely ABSENT (`not_found` — a version whose spec authored no
+// criteria) from a read that merely failed, which decides whether the page explains
+// itself or offers a retry. Branching on the code rather than the message, which the
+// BFF owns and may reword.
 function toError(error: unknown, fallback: string): Error {
-  return new Error(apiErrorMessage(error, fallback));
+  return new ApiRequestError(error, fallback);
 }
 
 /**

--- a/apps/console/src/features/validation/components/PendingTile.tsx
+++ b/apps/console/src/features/validation/components/PendingTile.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Alert, AlertTitle, Typography } from "@wso2/oxygen-ui";
+import { METHOD_LABEL, type CriterionMethodCount } from "@aep/ui-validation-view";
+import { validationView } from "../../projects/lib/pipeline";
+
+// What the run is doing to the criteria listed below it. Said here because the
+// criteria themselves cannot: a reader meeting a page of "Pending" chips has no way
+// to know which of them an agent is about to answer and which are waiting on them.
+const RUNNING = "Auto criteria are being validated end to end against the deployed system.";
+// Only when there ARE manual criteria. The sentence is an instruction, and an
+// instruction to check criteria that do not exist sends the reader looking for a
+// list that is empty.
+const MANUAL = "Please validate the manual criteria yourself.";
+// The oracle was never authored, which is also why this run will settle as skipped.
+// Said in the tile rather than as a note above the log because the tile is then the
+// whole body — there are no criteria to put under it.
+const NO_CRITERIA =
+  "This version has no validation criteria, so there is nothing to check the deployment against.";
+
+/**
+ * The tile over a FIRST validation attempt in flight: what is being checked, by
+ * whom, and how much of it.
+ *
+ * A sibling of VerdictTile rather than a branch inside it. That tile is keyed to
+ * verdicts in its gate, its severity, its sentence and its tally — a run that has
+ * concluded nothing shares only the Alert shell with it, and the two would have
+ * ended up as one component with an escape hatch in every one of those four places.
+ *
+ * The headline comes from the shared mapper (projects/lib/pipeline) exactly as
+ * VerdictTile's does, so the tile and the header chip above it cannot drift.
+ *
+ * `methods` is the oracle's per-method tally, absent while the criteria are still
+ * loading — the counts line is then simply not drawn, rather than the tile waiting
+ * for numbers to explain a run that is already under way.
+ */
+export function PendingTile({
+  methods,
+  noCriteria = false,
+}: {
+  methods?: CriterionMethodCount[];
+  /** The criteria read came back `not_found`: none were ever authored. */
+  noCriteria?: boolean;
+}) {
+  const view = validationView("running");
+  if (!view) return null;
+
+  const manual = methods?.find((m) => m.method === "manual")?.count ?? 0;
+  // "12 auto · 3 manual" — the same words as the badges on the rows below, because
+  // both read METHOD_LABEL.
+  const counts = (methods ?? [])
+    .map(({ method, count }) => `${count} ${METHOD_LABEL[method] ?? method}`)
+    .join(" · ");
+
+  return (
+    // No margins, same as VerdictTile: the page's body container owns the gap below.
+    <Alert severity="info">
+      {/* The shared labels are lowercase for mid-sentence use; a headline leads. */}
+      <AlertTitle>
+        {view.label.charAt(0).toUpperCase() + view.label.slice(1)}
+      </AlertTitle>
+      <Typography variant="body2">
+        {noCriteria ? NO_CRITERIA : manual > 0 ? `${RUNNING} ${MANUAL}` : RUNNING}
+      </Typography>
+      {!noCriteria && counts && (
+        <Typography variant="body2" sx={{ mt: 0.5, fontWeight: 500 }}>
+          {counts}
+        </Typography>
+      )}
+    </Alert>
+  );
+}

--- a/apps/console/src/features/validation/components/PendingTile.tsx
+++ b/apps/console/src/features/validation/components/PendingTile.tsx
@@ -16,18 +16,50 @@
  * under the License.
  */
 
-import { Alert, AlertTitle, Typography } from "@wso2/oxygen-ui";
-import { METHOD_LABEL, type CriterionMethodCount } from "@aep/ui-validation-view";
+import { Alert, AlertTitle, alpha, Box, Typography } from "@wso2/oxygen-ui";
+import {
+  METHOD_COLOR,
+  METHOD_FALLBACK_COLOR,
+  METHOD_LABEL,
+  type CriterionMethodCount,
+} from "@aep/ui-validation-view";
 import { validationView } from "../../projects/lib/pipeline";
 
-// What the run is doing to the criteria listed below it. Said here because the
-// criteria themselves cannot: a reader meeting a page of "Pending" chips has no way
-// to know which of them an agent is about to answer and which are waiting on them.
-const RUNNING = "Auto criteria are being validated end to end against the deployed system.";
-// Only when there ARE manual criteria. The sentence is an instruction, and an
-// instruction to check criteria that do not exist sends the reader looking for a
-// list that is empty.
-const MANUAL = "Please validate the manual criteria yourself.";
+// A method named inside a sentence: the badge's word, set the way the badge sets it
+// — same monospace, same weight, same tracking, same uppercase — so a reader
+// recognises it as the thing marking every row below.
+//
+// What it does NOT take from the badge is the solid fill and the badge's padding. A
+// filled pill mid-sentence stops the line dead; a wash of the same colour carries the
+// identity while the words keep flowing. `text.primary` over an alpha fill rather
+// than the raw colour as text, so it holds in both themes — the idiom StatusChip's
+// soft tones and ValidationView's failure block both use.
+//
+// Word and colour both come from the shared vocabulary (counts.ts), so renaming a
+// method or recolouring it carries the sentence along with the badges.
+function Method({ method }: { method: string }) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        px: 0.5,
+        py: 0.125,
+        borderRadius: 0.75,
+        fontFamily: "monospace",
+        fontSize: "0.6875rem",
+        fontWeight: 700,
+        letterSpacing: "0.06em",
+        textTransform: "uppercase",
+        whiteSpace: "nowrap",
+        bgcolor: alpha(METHOD_COLOR[method] ?? METHOD_FALLBACK_COLOR, 0.16),
+        color: "text.primary",
+      }}
+    >
+      {METHOD_LABEL[method] ?? method}
+    </Box>
+  );
+}
+
 // The oracle was never authored, which is also why this run will settle as skipped.
 // Said in the tile rather than as a note above the log because the tile is then the
 // whole body — there are no criteria to put under it.
@@ -76,7 +108,26 @@ export function PendingTile({
         {view.label.charAt(0).toUpperCase() + view.label.slice(1)}
       </AlertTitle>
       <Typography variant="body2">
-        {noCriteria ? NO_CRITERIA : manual > 0 ? `${RUNNING} ${MANUAL}` : RUNNING}
+        {noCriteria ? (
+          NO_CRITERIA
+        ) : (
+          <>
+            {/* The two method words are the vocabulary of the badges on every row
+                below, so they are marked as terms rather than left as ordinary
+                prose — otherwise nothing connects the sentence to the list. */}
+            <Method method="e2e" /> criteria are being validated end to end
+            against the deployed system.
+            {/* Only when there ARE manual criteria: this half is an instruction, and
+                an instruction to check criteria that do not exist sends the reader
+                looking for an empty list. */}
+            {manual > 0 && (
+              <>
+                {" "}
+                Please validate the <Method method="manual" /> criteria yourself.
+              </>
+            )}
+          </>
+        )}
       </Typography>
       {!noCriteria && counts && (
         <Typography variant="body2" sx={{ mt: 0.5, fontWeight: 500 }}>

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1152,11 +1152,13 @@ describe("ValidationPage first attempt in flight", () => {
     ).toBeInTheDocument();
     // Chip and tile headline both, as with every other state.
     expect(screen.getAllByText("Validating").length).toBe(2);
-    expect(
-      screen.getByText(
-        "Auto criteria are being validated end to end against the deployed system. Please validate the manual criteria yourself.",
-      ),
-    ).toBeInTheDocument();
+    // Read through the tile's own element rather than by text: the two method names
+    // are marked up as terms, so no single text node holds the whole sentence. Their
+    // text is the vocabulary's lowercase label — the uppercase is CSS, exactly as on
+    // the badges.
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "auto criteria are being validated end to end against the deployed system. Please validate the manual criteria yourself.",
+    );
     // Counted off the ORACLE — there is no report to count — and in the same words
     // the badges below use.
     expect(screen.getByText("2 auto · 1 manual")).toBeInTheDocument();
@@ -1210,11 +1212,10 @@ describe("ValidationPage first attempt in flight", () => {
 
     renderPage(undefined);
 
-    expect(
-      screen.getByText(
-        "Auto criteria are being validated end to end against the deployed system.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "auto criteria are being validated end to end against the deployed system.",
+    );
+    expect(screen.getByRole("alert")).not.toHaveTextContent(/Please validate/);
     expect(screen.getByText("1 auto")).toBeInTheDocument();
   });
 

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -113,10 +113,13 @@ const validationCycle = {
   createdAt: "2026-07-10T10:00:00Z",
 };
 
+// `error` is widened because the page BRANCHES on it: the envelope's `not_found`
+// means the oracle was never authored, which reads differently from a read that
+// merely failed.
 const mockCriteria = {
   isPending: false,
   isError: false,
-  error: null,
+  error: null as Error | null,
   refetch: vi.fn(),
   data: undefined as { content: string } | undefined,
 };
@@ -208,6 +211,7 @@ vi.mock("../api/queries", () => ({
 }));
 
 import { ValidationPage } from "./ValidationPage";
+import { ApiRequestError } from "../../../api/errors";
 
 const CRITERIA = JSON.stringify({
   requirements: [
@@ -282,6 +286,7 @@ afterEach(() => {
   mockDeployVersion = "v1";
   mockCriteria.isPending = false;
   mockCriteria.isError = false;
+  mockCriteria.error = null;
   mockCriteria.data = undefined;
   mockReport.isError = false;
   mockReport.data = undefined;
@@ -399,6 +404,9 @@ describe("ValidationPage cancel", () => {
   });
 });
 
+// The feed tests below ask for ?view=logs: a validating run with no verdict opens
+// on its criteria now, so the log — which is what these are about — is the
+// reader's second click rather than the default body.
 describe("ValidationPage across a milestone's runs", () => {
   // The incident run never validates, and settle stamps `skipped` on a succeeded
   // run that never did. Reading the newest run therefore sent a version that had
@@ -448,7 +456,7 @@ describe("ValidationPage across a milestone's runs", () => {
       },
     ];
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(screen.getAllByTestId("run-feed")).toHaveLength(2);
   });
@@ -467,7 +475,7 @@ describe("ValidationPage across a milestone's runs", () => {
       },
     ];
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(screen.getAllByTestId("run-feed")).toHaveLength(1);
   });
@@ -487,7 +495,7 @@ describe("ValidationPage across a milestone's runs", () => {
       },
     ];
 
-    renderPage(undefined);
+    renderPage("logs");
 
     // The whole arrangement in one assertion: presence alone would pass whichever
     // end the newest run were drawn at, which is the bug this replaces.
@@ -518,7 +526,7 @@ describe("ValidationPage across a milestone's runs", () => {
       },
     ];
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(
       screen
@@ -543,7 +551,7 @@ describe("ValidationPage across a milestone's runs", () => {
       },
     ];
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(
       screen
@@ -559,7 +567,7 @@ describe("ValidationPage across a milestone's runs", () => {
     mockValidation = "running";
     mockRun = run({ cycles: [validationCycle] });
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(screen.getByTestId("run-feed")).toHaveAttribute(
       "data-run-number",
@@ -573,7 +581,7 @@ describe("ValidationPage across a milestone's runs", () => {
     mockValidation = "running";
     mockRun = run({ cycles: [validationCycle] });
 
-    renderPage(undefined);
+    renderPage("logs");
 
     expect(screen.getAllByTestId("run-feed")).toHaveLength(1);
     expect(
@@ -595,10 +603,12 @@ describe("ValidationPage lifecycle", () => {
     expect(screen.getByText(/Nothing validated yet/)).toBeInTheDocument();
   });
 
-  it("shows the validation cycle's feed while the run is validating", () => {
+  it("filters the log to the validation cycle while the run is validating", () => {
     mockValidation = "running";
     mockRun = run({ cycles: [validationCycle] });
-    renderPage(undefined);
+    // ?view=logs, because a validating run now OPENS on its criteria; the log is
+    // one button away rather than the only thing there is.
+    renderPage("logs");
     // The feed streams the WHOLE run; the page filters it to the one phase it
     // owns, so a coding cycle's output never leaks onto the validation page.
     expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
@@ -614,13 +624,18 @@ describe("ValidationPage lifecycle", () => {
     mockDeployVersion = ""; // no spec-build run has SUCCEEDED yet
     mockBuildVersion = "v1"; // ...but v1's run is live and validating
     mockRun = run({ cycles: [validationCycle] });
+    mockCriteria.data = { content: CRITERIA };
 
     renderPage(undefined);
 
     expect(
       screen.queryByText(/Nothing validated yet/),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
+    // The run was found, so the version's criteria are on screen under the tile
+    // that says an attempt is under way.
+    expect(
+      screen.getByText("Shoppers can search the catalog."),
+    ).toBeInTheDocument();
   });
 
   // The same gap on a later build points the other way: deploy.version still
@@ -632,7 +647,7 @@ describe("ValidationPage lifecycle", () => {
     mockBuildVersion = "v2"; // v2's run is validating right now
     mockRun = run({ cycles: [validationCycle] });
 
-    renderPage(undefined);
+    renderPage("logs");
 
     // The run story is fetched for v2 — the version the chip is talking about.
     expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
@@ -743,6 +758,8 @@ describe("ValidationPage lifecycle", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText(/\(last attempt\)$/)).toBeInTheDocument();
+    // And NOT the first-attempt view: real results beat "Pending" everywhere.
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
   });
 
   // The regression this replaced a default with: no state may FORCE a body, because
@@ -1110,5 +1127,144 @@ describe("ValidationPage criterion method badges", () => {
     renderWithCriteria();
 
     expect(screen.queryByText(/Each criterion represents/)).not.toBeInTheDocument();
+  });
+});
+
+// A version's FIRST attempt has no verdict, no report and — until now — nothing on
+// the page but a log. The oracle is what there is to show, and it says the two
+// things a reader in that state wants: what is being checked, and what the agent is
+// never going to check for them.
+describe("ValidationPage first attempt in flight", () => {
+  function runningFirstAttempt() {
+    mockValidation = "running";
+    mockRun = { ...run({ cycles: [validationCycle] }), state: "running" };
+  }
+
+  it("opens on the criteria, not the log", () => {
+    runningFirstAttempt();
+    mockCriteria.data = { content: CRITERIA };
+
+    renderPage(undefined);
+
+    expect(screen.queryByTestId("run-feed")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Shoppers can search the catalog."),
+    ).toBeInTheDocument();
+    // Chip and tile headline both, as with every other state.
+    expect(screen.getAllByText("Validating").length).toBe(2);
+    expect(
+      screen.getByText(
+        "Auto criteria are being validated end to end against the deployed system. Please validate the manual criteria yourself.",
+      ),
+    ).toBeInTheDocument();
+    // Counted off the ORACLE — there is no report to count — and in the same words
+    // the badges below use.
+    expect(screen.getByText("2 auto · 1 manual")).toBeInTheDocument();
+  });
+
+  // The point of the chips: a manual criterion is not queued behind the agent, it is
+  // queued behind the reader, and "Pending" on it would promise a result nobody is
+  // going to produce.
+  it("chips each criterion with what is about to happen to it", () => {
+    runningFirstAttempt();
+    mockCriteria.data = { content: CRITERIA };
+
+    renderPage(undefined);
+
+    expect(screen.getAllByText("Pending")).toHaveLength(2);
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+  });
+
+  it("keeps the log one click away, and the way back from it", () => {
+    runningFirstAttempt();
+    mockCriteria.data = { content: CRITERIA };
+
+    const onViewChange = renderPage(undefined);
+    fireEvent.click(screen.getByRole("button", { name: /View logs/ }));
+    expect(onViewChange).toHaveBeenCalledWith("logs");
+
+    renderPage("logs");
+    expect(screen.getByTestId("run-feed")).toHaveTextContent("validation");
+    expect(
+      screen.getAllByRole("button", { name: /View report/ }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  // The tile's second sentence is an instruction. Pointing a reader at manual
+  // criteria that do not exist sends them looking for an empty list.
+  it("asks for nothing by hand when every criterion is automated", () => {
+    runningFirstAttempt();
+    mockCriteria.data = {
+      content: JSON.stringify({
+        requirements: [
+          {
+            id: "REQ-001",
+            statement: "Shoppers can search the catalog.",
+            criteria: [
+              { id: "AC-001-a", must: "Search returns matches", method: "e2e" },
+            ],
+          },
+        ],
+      }),
+    };
+
+    renderPage(undefined);
+
+    expect(
+      screen.getByText(
+        "Auto criteria are being validated end to end against the deployed system.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 auto")).toBeInTheDocument();
+  });
+
+  // `not_found` is the Files API's answer for a version whose spec authored no
+  // criteria — the state its run eventually settles as `skipped`. The tile is then
+  // the whole body: there is nothing to list under it.
+  it("says the version has no criteria when the read comes back not_found", () => {
+    runningFirstAttempt();
+    mockCriteria.isError = true;
+    mockCriteria.error = new ApiRequestError(
+      { code: "not_found", message: "no spec file at validation-criteria.json" },
+      "Failed to load",
+    );
+
+    renderPage(undefined);
+
+    expect(
+      screen.getByText(
+        "This version has no validation criteria, so there is nothing to check the deployment against.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Failed to load the validation criteria/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("run-feed")).not.toBeInTheDocument();
+    // The log is still reachable — the header reads the same in both running shapes.
+    expect(
+      screen.getByRole("button", { name: /View logs/ }),
+    ).toBeInTheDocument();
+  });
+
+  // The other half of that branch, and the reason it is keyed on the envelope's
+  // code: a read that merely FAILED must not be reported as a spec that authored
+  // nothing.
+  it("offers a retry when the criteria read merely failed", () => {
+    runningFirstAttempt();
+    mockCriteria.isError = true;
+    mockCriteria.error = new ApiRequestError(
+      { code: "internal", message: "upstream unavailable" },
+      "Failed to load",
+    );
+
+    renderPage(undefined);
+
+    expect(
+      screen.getByText(/Failed to load the validation criteria/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no validation criteria/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -31,9 +31,12 @@ import { Fragment, useMemo, useState } from "react";
 import {
   parseValidationCriteria,
   parseValidationReport,
+  tallyCriterionMethods,
   tallyCriterionStates,
   ValidationView,
+  type CriterionMethodCount,
   type CriterionTally,
+  type ValidationCriteria,
 } from "@aep/ui-validation-view";
 import { PageHeader, type PageHeaderStatus } from "../../../components/PageHeader";
 import type { StatusTone } from "../../../components/StatusChip";
@@ -56,6 +59,8 @@ import {
   lastMergedValidationCycle,
   validatingRun,
 } from "../lib/runs";
+import { ApiRequestError } from "../../../api/errors";
+import { PendingTile } from "./PendingTile";
 import { VerdictTile } from "./VerdictTile";
 
 // Validation lives on the DEPLOYMENT surface because the deployment is what is
@@ -139,23 +144,43 @@ function headerChip(view: ReturnType<typeof validationView>): PageHeaderStatus |
   };
 }
 
-// The oracle joined with the run's report, as counts. Parsed here rather than
-// reaching into ValidationView's internals: the tile's copy names run concepts
-// (`validation-unreported`, the milestone staying open) that the shared view
-// package knows nothing about, and a second JSON.parse of a few-KB file inside a
-// useMemo is a cheaper price than teaching that package about runs.
+// The authored oracle. Parsed here rather than reaching into ValidationView's
+// internals: the tiles' copy names run concepts (`validation-unreported`, the
+// milestone staying open) that the shared view package knows nothing about, and a
+// second JSON.parse of a few-KB file inside a useMemo is a cheaper price than
+// teaching that package about runs. A parse failure is `undefined` — the view below
+// renders the error; the tiles simply say less.
+function useOracle(criteria: string | undefined): ValidationCriteria | undefined {
+  return useMemo(() => {
+    if (!criteria) return undefined;
+    const parsed = parseValidationCriteria(criteria);
+    return "kind" in parsed ? undefined : parsed;
+  }, [criteria]);
+}
+
+// The oracle joined with the run's report, as counts — what the verdict tile
+// explains once an attempt has answered.
 function useTally(
-  criteria: string | undefined,
+  oracle: ValidationCriteria | undefined,
   report: string | undefined,
 ): CriterionTally | undefined {
   return useMemo(() => {
-    if (!criteria) return undefined;
-    const oracle = parseValidationCriteria(criteria);
-    if ("kind" in oracle) return undefined;
+    if (!oracle) return undefined;
     const parsed = report ? parseValidationReport(report) : undefined;
     const statuses = parsed && !("kind" in parsed) ? parsed : undefined;
     return tallyCriterionStates(oracle, statuses);
-  }, [criteria, report]);
+  }, [oracle, report]);
+}
+
+// The oracle alone, by method — what the pending tile says while the first attempt
+// is still running, when there is no report to count.
+function useMethods(
+  oracle: ValidationCriteria | undefined,
+): CriterionMethodCount[] | undefined {
+  return useMemo(
+    () => (oracle ? tallyCriterionMethods(oracle) : undefined),
+    [oracle],
+  );
 }
 
 /**
@@ -286,12 +311,26 @@ export function ValidationPage({
   // not the same as "there is a report". Hooks stay unconditional; `enabled` gates
   // them.
   const settled = rawVerdict !== "" && rawVerdict !== "skipped";
+  // The version's FIRST attempt, still in flight: the loop says `running` and nothing
+  // has concluded anything yet, so the oracle is the only thing there is to show — and
+  // it is worth showing, because it says what is being checked and what will never be
+  // checked by an agent at all.
+  //
+  // Deliberately not every `running` state. A repeat attempt has the previous
+  // attempt's verdict and report, which the page renders with its numbers marked as
+  // the last attempt's; replacing that with a page of Pending chips would throw away
+  // the only results anyone has.
+  const awaitingFirstVerdict = state === "running" && rawVerdict === "";
   // `unreported` MEANS no report was committed at that commit, and the server
   // omits reportPath for it. Requesting the file anyway would 404 to rediscover
   // what the verdict already told us, and land the reader on a vague "wasn't
   // found" note instead of the tile that explains the breach.
   const missingReport = rawVerdict === "unreported";
-  const criteria = useValidationCriteria(projectName, version, settled);
+  const criteria = useValidationCriteria(
+    projectName,
+    version,
+    settled || awaitingFirstVerdict,
+  );
   // Pinned to the merge commit of the attempt that produced it. Reading the branch
   // tip would show whichever run last overwrote the path — so an older run in the
   // story would display the newest run's results, and a run that committed no report
@@ -303,7 +342,16 @@ export function ValidationPage({
     reportPath,
     reportCycle?.mergeSha,
   );
-  const tally = useTally(criteria.data?.content, report.data?.content);
+  const oracle = useOracle(criteria.data?.content);
+  const tally = useTally(oracle, report.data?.content);
+  const methods = useMethods(oracle);
+  // No oracle was ever authored — the Files API's answer for a version whose spec has
+  // no criteria, and the reason its run will settle as `skipped`. Told apart from a
+  // read that merely FAILED by the envelope's `code`, so a 500 or a dropped connection
+  // still offers a retry instead of announcing there is nothing to validate.
+  const criteriaAbsent =
+    criteria.error instanceof ApiRequestError &&
+    criteria.error.code === "not_found";
 
   // The run this page can still cancel: one that is live, AND live because of
   // validation.
@@ -344,6 +392,16 @@ export function ValidationPage({
   const cancelling =
     cancel.isPending || (cancelRequestedFor === liveRun?.id && !cancel.isError);
 
+  // Whether this page has a criteria view to offer at all — which is what the header
+  // toggle switches to, so the two must be gated on one value or "View report" points
+  // at nothing. True for a settled run (its report) and for a first attempt in flight
+  // (the oracle, chipped with what is about to happen to it).
+  //
+  // It stays true when the criteria are ABSENT: the pending tile is then the whole
+  // report body, saying why it is empty, and the header reads the same in both
+  // running shapes rather than losing a button depending on what the spec authored.
+  const canShowReport = settled || awaitingFirstVerdict;
+
   // Body rule: the log shows while there is no report to show at all, or the reader
   // asked for it. Nothing else — a state that forces the log makes the "View report"
   // button inert, because `?view=logs | absent` has no third value for a default to
@@ -353,11 +411,12 @@ export function ValidationPage({
   // predecessor's report is real and is what the reader wants while the fix is being
   // re-checked; that it belongs to the previous attempt is said by the tile, in the
   // sentence and again in the tally.
-  const showLogs = !settled || view === "logs";
+  const showLogs = !canShowReport || view === "logs";
 
-  // The verdict tile stays visible in BOTH bodies — a verdict does not stop being
-  // true because the reader switched to the log. `state` is what it leads with, so
-  // a repair in flight reads as one instead of as a run that stopped.
+  // The tile stays visible in BOTH bodies — a verdict does not stop being true
+  // because the reader switched to the log, and neither does an attempt still being
+  // under way. `state` is what the verdict tile leads with, so a repair in flight
+  // reads as one instead of as a run that stopped.
   const tile = settled ? (
     <VerdictTile
       verdict={rawVerdict}
@@ -365,6 +424,8 @@ export function ValidationPage({
       repairing={repairing}
       {...(tally ? { tally } : {})}
     />
+  ) : awaitingFirstVerdict ? (
+    <PendingTile noCriteria={criteriaAbsent} {...(methods ? { methods } : {})} />
   ) : null;
 
   const chip = headerChip(verdict);
@@ -433,7 +494,7 @@ export function ValidationPage({
               tooltip="Open the validation PR"
             />
           )}
-          {settled &&
+          {canShowReport &&
             (showLogs ? (
               <Button
                 size="small"
@@ -579,6 +640,11 @@ export function ValidationPage({
         </Fragment>
       ))}
     </Stack>
+  ) : criteriaAbsent ? (
+    // Nothing under the tile, which has already said there are no criteria and is
+    // the whole body here. An empty report frame beneath it would be a heading over
+    // nothing, and the reader's next move — the log — is one button away.
+    null
   ) : criteria.isPending || (!criteria.isError && !criteria.data) ? (
     <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
       <CircularProgress aria-label="Loading validation report" />
@@ -613,6 +679,9 @@ export function ValidationPage({
         noPadding
         fullWidth
         hideDescription
+        // A first attempt in flight has no report by definition, so every row says
+        // what is ABOUT to happen to it instead of nothing at all.
+        awaitingReport={awaitingFirstVerdict}
         criteria={criteria.data.content}
         {...(report.data ? { report: report.data.content } : {})}
       />

--- a/apps/console/src/mocks/fixtures/validation.ts
+++ b/apps/console/src/mocks/fixtures/validation.ts
@@ -21,6 +21,12 @@ type RunVerdict = NonNullable<
 //   localStorage.setItem('aep:mock:validation', 'failed')
 //   localStorage.removeItem('aep:mock:validation')   // back to the project scenario
 //
+// Two companion keys narrow the `running` scenario further — which ATTEMPT is in
+// flight (see ValidationAttempt below) and whether the repo has an oracle at all:
+//   localStorage.setItem('aep:mock:validation-criteria', 'missing')
+// which drops validation-criteria.json from the file list, so the read 404s the way
+// it does for a version whose spec authored none (handlers/project.ts).
+//
 // Setting it alone is enough: with no `aep:mock:project` chosen, the base scenario
 // becomes `deployed` rather than the usual `building`, because a verdict only
 // exists on a version whose run got that far (see handlers/project.ts).

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -42,6 +42,7 @@ import {
   runHeartbeatLine,
 } from "../fixtures/run-progress";
 import {
+  CRITERIA_PATH,
   VALIDATION_ATTEMPTS,
   VALIDATION_FILE_PATHS,
   VALIDATION_SCENARIOS,
@@ -82,6 +83,16 @@ function validationAttempt(): ValidationAttempt {
     : "first";
 }
 
+// Whether the repo should read as having no acceptance oracle at all
+// (aep:mock:validation-criteria=missing). A separate key from the two above because
+// it names what is IN THE REPO rather than which run or which attempt: the page
+// treats a `not_found` on the criteria as "none were authored" — the state a version
+// eventually settles as `skipped` for — and nothing else can produce it, since every
+// scenario that has a verdict also has an oracle.
+function criteriaMissing(): boolean {
+  return localStorage.getItem("aep:mock:validation-criteria") === "missing";
+}
+
 // The project's files with the two validation artifacts swapped for the ones the
 // overridden verdict implies. Dropping them first is what makes `unreported` and
 // `skipped` reachable: those scenarios contribute FEWER files, not different ones.
@@ -90,7 +101,9 @@ function specFiles(s: Exclude<ProjectScenario, "error">) {
   if (!v) return projectSpecFiles[s];
   return [
     ...projectSpecFiles[s].filter((f) => !VALIDATION_FILE_PATHS.includes(f.path)),
-    ...validationFiles(v, validationAttempt()),
+    ...validationFiles(v, validationAttempt()).filter(
+      (f) => !(criteriaMissing() && f.path === CRITERIA_PATH),
+    ),
   ];
 }
 

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -30,7 +30,11 @@ import {
   type CriterionReport,
   type ValidationReport,
 } from "./report.js";
-import { CRITERION_STATE_LABEL } from "./counts.js";
+import {
+  CRITERION_STATE_LABEL,
+  METHOD_LABEL,
+  tallyCriterionMethods,
+} from "./counts.js";
 
 // Solid background per verification method. Text color is computed for contrast
 // (getContrastText), so labels stay readable in both themes — the same approach
@@ -39,17 +43,6 @@ const METHOD_COLOR: Record<string, string> = {
   e2e: "#1976d2",
   scenario: "#ed6c02",
   manual: "#7b1fa2",
-};
-// Fixed display order for the summary tally; unknown methods sort after these.
-const METHOD_ORDER = ["e2e", "scenario", "manual"];
-// What a method badge SAYS, as against the wire value it is keyed by. `e2e` is
-// the contract shared with the runner, the report generator and the spec-path
-// convention, so it cannot be renamed — but it is an acronym the reader has to
-// expand, which the console lexicon forbids. Same split CRITERION_STATE_LABEL
-// draws for run statuses. A method with no entry here renders verbatim, so
-// `manual` and anything unrecognised are unaffected.
-const METHOD_LABEL: Record<string, string> = {
-  e2e: "auto",
 };
 // One line saying who does the checking, shown on hover. Only the two methods a
 // design turn can author carry one; anything else gets a bare badge rather than
@@ -157,15 +150,36 @@ function StateChip({ status }: { status: string }) {
   );
 }
 
+// What a criterion shows while an attempt is IN FLIGHT and no report exists yet.
+//
+// A `manual` criterion gets its final word rather than "Pending": the run will
+// never answer it — that is what the method means — so a chip promising a result
+// would be a claim the eventual report contradicts. Everything else is genuinely
+// waiting on the run, including the legacy `scenario` method and any method this
+// view does not recognise.
+//
+// "Pending" is local rather than a sixth CRITERION_STATE_LABEL entry: that map is
+// report.json's vocabulary, and a criterion with no report has no status to name.
+function AwaitingChip({ method }: { method: string }) {
+  return method === "manual" ? (
+    <StateChip status="manual" />
+  ) : (
+    <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
+  );
+}
+
 // One acceptance criterion: method badge, its id, the atomic assertion, and —
 // when a run report is joined in — its run-state chip plus healed/flaky markers
-// and (for a failure) the spec path and failure message beneath.
+// and (for a failure) the spec path and failure message beneath. With no report
+// and `awaiting` set, the state chip says what is going to happen to it instead.
 function CriterionRow({
   criterion,
   report,
+  awaiting,
 }: {
   criterion: Criterion;
   report: CriterionReport | undefined;
+  awaiting: boolean;
 }) {
   const failed = report?.status === "fail";
   return (
@@ -189,7 +203,11 @@ function CriterionRow({
         {report?.healed && (
           <Chip size="small" variant="outlined" label="healed" sx={{ flexShrink: 0 }} />
         )}
-        {report && <StateChip status={report.status} />}
+        {report ? (
+          <StateChip status={report.status} />
+        ) : awaiting ? (
+          <AwaitingChip method={criterion.method} />
+        ) : null}
       </Box>
       {/* Failure detail sits full-width beneath the row (indented past the
           method badge) so a long trace never crowds the assertion. */}
@@ -243,9 +261,11 @@ function CriterionRow({
 function RequirementCard({
   requirement,
   statuses,
+  awaiting,
 }: {
   requirement: Requirement;
   statuses: ValidationReport | undefined;
+  awaiting: boolean;
 }) {
   const count = requirement.criteria.length;
   return (
@@ -290,7 +310,12 @@ function RequirementCard({
         // above are their siblings.
         <Box sx={{ "& > *": { borderTop: 1, borderColor: "divider" } }}>
           {requirement.criteria.map((c) => (
-            <CriterionRow key={c.id} criterion={c} report={statuses?.get(c.id)} />
+            <CriterionRow
+              key={c.id}
+              criterion={c}
+              report={statuses?.get(c.id)}
+              awaiting={awaiting}
+            />
           ))}
         </Box>
       )}
@@ -304,6 +329,7 @@ function ValidationBody({
   noPadding,
   fullWidth,
   hideDescription,
+  awaitingReport,
 }: {
   criteria: ValidationCriteria;
   statuses: ValidationReport | undefined;
@@ -312,28 +338,18 @@ function ValidationBody({
   noPadding: boolean;
   fullWidth: boolean;
   hideDescription: boolean;
+  awaitingReport: boolean;
 }) {
   const { requirements } = criteria;
-  // Per-method tally for the summary header, kept in a stable order. The
-  // per-run-state tally is deliberately NOT here: it belongs with the verdict it
-  // explains, which the consumer renders above this view (tallyCriterionStates in
-  // counts.ts), and duplicating it here would put the same numbers on the page
-  // twice.
-  const { total, orderedMethods, methodCounts } = useMemo(() => {
-    const methods = new Map<string, number>();
-    let n = 0;
-    for (const r of requirements) {
-      for (const c of r.criteria) {
-        n += 1;
-        methods.set(c.method, (methods.get(c.method) ?? 0) + 1);
-      }
-    }
-    const orderedM = [
-      ...METHOD_ORDER.filter((m) => methods.has(m)),
-      ...[...methods.keys()].filter((m) => !METHOD_ORDER.includes(m)).sort(),
-    ];
-    return { total: n, orderedMethods: orderedM, methodCounts: methods };
-  }, [requirements]);
+  // Per-method tally for the summary header, from counts.ts so the consumer's own
+  // method line (the console's tile, while an attempt is still running) counts the
+  // same criteria in the same order. The per-run-state tally is deliberately NOT
+  // here: it belongs with the verdict it explains, which the consumer renders above
+  // this view (tallyCriterionStates), and duplicating it here would put the same
+  // numbers on the page twice.
+  const methods = useMemo(() => tallyCriterionMethods(criteria), [criteria]);
+  // Every criterion has exactly one method, so the tally is a partition of them.
+  const total = methods.reduce((n, m) => n + m.count, 0);
 
   const reqCount = requirements.length;
   return (
@@ -380,8 +396,8 @@ function ValidationBody({
             {reqCount} {reqCount === 1 ? "requirement" : "requirements"} ·{" "}
             {total} {total === 1 ? "criterion" : "criteria"}
           </Typography>
-          {orderedMethods.map((m) => (
-            <MethodBadge key={m} method={m} count={methodCounts.get(m) ?? 0} />
+          {methods.map(({ method, count }) => (
+            <MethodBadge key={method} method={method} count={count} />
           ))}
         </Box>
 
@@ -391,7 +407,12 @@ function ValidationBody({
           </Typography>
         ) : (
           requirements.map((r) => (
-            <RequirementCard key={r.id} requirement={r} statuses={statuses} />
+            <RequirementCard
+              key={r.id}
+              requirement={r}
+              statuses={statuses}
+              awaiting={awaitingReport}
+            />
           ))
         )}
       </Box>
@@ -436,6 +457,20 @@ export interface ValidationViewProps {
    * holds them.
    */
   hideDescription?: boolean;
+  /**
+   * Chip every criterion with what is ABOUT to happen to it, for a consumer showing
+   * the oracle while a validation attempt is in flight: "Pending" for the ones an
+   * agent will drive, "Manual" for the ones only a person can judge.
+   *
+   * Off by default, like its neighbours, and ignored for any criterion that
+   * HAS a report — the Spec view's file preview shows the plain oracle with no run
+   * attached to it, and chips there would name a run that does not exist.
+   *
+   * Named for the state rather than `pending`: a boolean prop by that name reads as
+   * react-query's `isPending` — "still loading" — which is the opposite of what this
+   * means. The criteria are loaded; the RESULTS are not.
+   */
+  awaitingReport?: boolean;
 }
 
 export function ValidationView({
@@ -444,6 +479,7 @@ export function ValidationView({
   noPadding = false,
   fullWidth = false,
   hideDescription = false,
+  awaitingReport = false,
 }: ValidationViewProps) {
   const parsed = useMemo(() => parseValidationCriteria(criteria), [criteria]);
   // The report is optional and tolerant: a bad report never blocks the oracle —
@@ -481,6 +517,7 @@ export function ValidationView({
         noPadding={noPadding}
         fullWidth={fullWidth}
         hideDescription={hideDescription}
+        awaitingReport={awaitingReport}
       />
     </>
   );

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -32,18 +32,15 @@ import {
 } from "./report.js";
 import {
   CRITERION_STATE_LABEL,
+  METHOD_COLOR,
+  METHOD_FALLBACK_COLOR,
   METHOD_LABEL,
   tallyCriterionMethods,
 } from "./counts.js";
 
-// Solid background per verification method. Text color is computed for contrast
-// (getContrastText), so labels stay readable in both themes — the same approach
-// as the DesignView type badges and the OpenAPI viewer's method badges.
-const METHOD_COLOR: Record<string, string> = {
-  e2e: "#1976d2",
-  scenario: "#ed6c02",
-  manual: "#7b1fa2",
-};
+// The method colours are solid behind a badge here. Text color is computed for
+// contrast (getContrastText), so labels stay readable in both themes — the same
+// approach as the DesignView type badges and the OpenAPI viewer's method badges.
 // One line saying who does the checking, shown on hover. Only the two methods a
 // design turn can author carry one; anything else gets a bare badge rather than
 // an invented explanation.
@@ -54,7 +51,6 @@ const METHOD_TOOLTIP: Record<string, string> = {
 // Requirement ids are structural, so a muted slate keeps them from competing
 // with the colored method badges.
 const REQ_COLOR = "#546e7a";
-const FALLBACK = "#616161";
 
 const mono = { fontFamily: "monospace", fontSize: "0.875rem" } as const;
 
@@ -129,7 +125,7 @@ function MethodBadge({ method, count }: { method: string; count?: number }) {
   const badge = (
     <SolidBadge
       label={count === undefined ? label : `${label} ${count}`}
-      color={METHOD_COLOR[method] ?? FALLBACK}
+      color={METHOD_COLOR[method] ?? METHOD_FALLBACK_COLOR}
     />
   );
   const tooltip = METHOD_TOOLTIP[method];

--- a/packages/ui/validation-view/src/counts.test.ts
+++ b/packages/ui/validation-view/src/counts.test.ts
@@ -20,6 +20,8 @@ import { describe, expect, it } from "vitest";
 import {
   countOf,
   CRITERION_STATE_LABEL,
+  METHOD_LABEL,
+  tallyCriterionMethods,
   tallyCriterionStates,
   uncoveredCount,
 } from "./counts.js";
@@ -177,5 +179,79 @@ describe("CRITERION_STATE_LABEL", () => {
     for (const s of ["pass", "fail", "not_run", "not_validated", "manual"]) {
       expect(CRITERION_STATE_LABEL[s], `no label for ${s}`).toBeTruthy();
     }
+  });
+});
+
+describe("tallyCriterionMethods", () => {
+  // One requirement per method, so the ORDER of the result cannot be inherited
+  // from the order the criteria were authored in.
+  const mixed: ValidationCriteria = {
+    requirements: [
+      {
+        id: "REQ-1",
+        statement: "s",
+        criteria: [
+          { id: "AC-1", must: "m", method: "manual" },
+          { id: "AC-2", must: "m", method: "e2e" },
+        ],
+      },
+      {
+        id: "REQ-2",
+        statement: "s",
+        criteria: [
+          { id: "AC-3", must: "m", method: "e2e" },
+          { id: "AC-4", must: "m", method: "scenario" },
+        ],
+      },
+    ],
+  };
+
+  it("counts every authored criterion, across requirements", () => {
+    expect(tallyCriterionMethods(mixed)).toEqual([
+      { method: "e2e", count: 2 },
+      { method: "scenario", count: 1 },
+      { method: "manual", count: 1 },
+    ]);
+  });
+
+  // The tally is a partition of the criteria, which is what lets the view's
+  // summary header read its total off it.
+  it("adds up to the number of criteria authored", () => {
+    const total = tallyCriterionMethods(mixed).reduce((n, m) => n + m.count, 0);
+    expect(total).toBe(4);
+  });
+
+  it("surfaces an unknown method after the known ones, alphabetically", () => {
+    const odd: ValidationCriteria = {
+      requirements: [
+        {
+          id: "REQ-1",
+          statement: "s",
+          criteria: [
+            { id: "AC-1", must: "m", method: "smoke" },
+            { id: "AC-2", must: "m", method: "e2e" },
+            { id: "AC-3", must: "m", method: "chaos" },
+          ],
+        },
+      ],
+    };
+    expect(tallyCriterionMethods(odd).map((m) => m.method)).toEqual([
+      "e2e",
+      "chaos",
+      "smoke",
+    ]);
+  });
+
+  it("is empty for an oracle with no criteria", () => {
+    expect(tallyCriterionMethods({ requirements: [] })).toEqual([]);
+  });
+});
+
+describe("METHOD_LABEL", () => {
+  // The wire value is an acronym the console lexicon forbids on screen; every
+  // other method is already a word, so it renders verbatim.
+  it("expands the e2e wire value and leaves the rest alone", () => {
+    expect(METHOD_LABEL["e2e"]).toBe("auto");
+    expect(METHOD_LABEL["manual"]).toBeUndefined();
   });
 });

--- a/packages/ui/validation-view/src/counts.ts
+++ b/packages/ui/validation-view/src/counts.ts
@@ -17,13 +17,14 @@
  */
 
 /**
- * The per-status tally over an oracle joined with a run report — the numbers
- * behind "35 passed · 5 manual".
+ * The tallies over an oracle — by run STATUS once a report is joined in ("35
+ * passed · 5 manual"), and by verification METHOD before one exists ("12 auto ·
+ * 3 manual").
  *
- * A pure derivation kept out of the view because the tally is now rendered by
- * the CONSUMER (the console's verdict tile) rather than inside ValidationView:
- * the verdict is what a reader wants first, and one tally above the criteria
- * beats the same tally twice on one page.
+ * Pure derivations kept out of the view because both are rendered by the
+ * CONSUMER (the console's tiles) rather than inside ValidationView: the verdict —
+ * or, mid-run, what is about to be checked — is what a reader wants first, and
+ * one tally above the criteria beats the same tally twice on one page.
  */
 
 import type { ValidationCriteria } from "./parse.js";
@@ -42,7 +43,24 @@ export const CRITERION_STATE_LABEL: Record<string, string> = {
   manual: "Manual",
 };
 
-/** Display order for the tally — a failure reads first. */
+/**
+ * criterion method → what a badge SAYS, as against the wire value it is keyed by.
+ * `e2e` is the contract shared with the runner, the report generator and the
+ * spec-path convention, so it cannot be renamed — but it is an acronym the reader
+ * has to expand, which the console lexicon forbids. The same split
+ * CRITERION_STATE_LABEL draws for run statuses, and here for the same reason: the
+ * badge on a criterion and the consumer's method tally must call a method by one
+ * name. A method with no entry renders verbatim, so `manual` and anything
+ * unrecognised are unaffected.
+ */
+export const METHOD_LABEL: Record<string, string> = {
+  e2e: "auto",
+};
+
+/** Display order for the method tally; unknown methods sort after these. */
+export const METHOD_ORDER = ["e2e", "scenario", "manual"];
+
+/** Display order for the state tally — a failure reads first. */
 const STATE_ORDER = ["fail", "pass", "not_run", "not_validated", "manual"];
 
 /** The statuses that mean the criterion WAS actually checked and got an answer. */
@@ -126,4 +144,37 @@ export function tallyCriterionStates(
       count: counts.get(status) ?? 0,
     })),
   };
+}
+
+export interface CriterionMethodCount {
+  /** Raw criterion method; one of CriterionMethod in practice. */
+  method: string;
+  count: number;
+}
+
+/**
+ * Tally the oracle's criteria by the METHOD that will verify each one.
+ *
+ * The oracle alone answers this — no report is involved — which is what makes it
+ * the honest thing to show while an attempt is still running: how much of the
+ * version an agent is about to drive end to end, and how much only a person can
+ * judge. The view's own summary header reads it too, so the numbers above the
+ * criteria and the numbers beside them come from one derivation.
+ */
+export function tallyCriterionMethods(
+  criteria: ValidationCriteria,
+): CriterionMethodCount[] {
+  const counts = new Map<string, number>();
+  for (const requirement of criteria.requirements) {
+    for (const criterion of requirement.criteria) {
+      counts.set(criterion.method, (counts.get(criterion.method) ?? 0) + 1);
+    }
+  }
+  // Known methods in their fixed order, then anything unrecognised so a method we
+  // have never seen still shows up rather than vanishing from the tally.
+  const ordered = [
+    ...METHOD_ORDER.filter((m) => counts.has(m)),
+    ...[...counts.keys()].filter((m) => !METHOD_ORDER.includes(m)).sort(),
+  ];
+  return ordered.map((method) => ({ method, count: counts.get(method) ?? 0 }));
 }

--- a/packages/ui/validation-view/src/counts.ts
+++ b/packages/ui/validation-view/src/counts.ts
@@ -57,6 +57,20 @@ export const METHOD_LABEL: Record<string, string> = {
   e2e: "auto",
 };
 
+/**
+ * criterion method → its identifying colour. Solid behind a badge, and a wash
+ * behind the same word said in prose, so a consumer naming a method in a sentence
+ * can mark it with the colour the reader will meet on every row.
+ */
+export const METHOD_COLOR: Record<string, string> = {
+  e2e: "#1976d2",
+  scenario: "#ed6c02",
+  manual: "#7b1fa2",
+};
+
+/** The colour for a method this vocabulary does not know. */
+export const METHOD_FALLBACK_COLOR = "#616161";
+
 /** Display order for the method tally; unknown methods sort after these. */
 export const METHOD_ORDER = ["e2e", "scenario", "manual"];
 

--- a/packages/ui/validation-view/src/index.ts
+++ b/packages/ui/validation-view/src/index.ts
@@ -37,6 +37,8 @@ export type {
 export {
   countOf,
   CRITERION_STATE_LABEL,
+  METHOD_COLOR,
+  METHOD_FALLBACK_COLOR,
   METHOD_LABEL,
   tallyCriterionMethods,
   tallyCriterionStates,

--- a/packages/ui/validation-view/src/index.ts
+++ b/packages/ui/validation-view/src/index.ts
@@ -37,7 +37,13 @@ export type {
 export {
   countOf,
   CRITERION_STATE_LABEL,
+  METHOD_LABEL,
+  tallyCriterionMethods,
   tallyCriterionStates,
   uncoveredCount,
 } from "./counts.js";
-export type { CriterionStateCount, CriterionTally } from "./counts.js";
+export type {
+  CriterionMethodCount,
+  CriterionStateCount,
+  CriterionTally,
+} from "./counts.js";


### PR DESCRIPTION

<img width="1758" height="910" alt="image" src="https://github.com/user-attachments/assets/e88539d8-ebca-47bc-ba0f-9908033972da" />


A version's first validation attempt has no verdict, so the page had nothing to key a report on and fell back to the run's log. A reader watching an agent work for up to two hours could not tell what was being checked, how much of it there was, or that some of it was never going to be checked by an agent at all.

The oracle answers all three before any run does. So while the first attempt is in flight the page opens on the criteria, every row chipped with what is about to happen to it — "Pending" where an agent will drive the assertion, "Manual" where only a person can judge it — under a tile naming the split and counting both halves. The log keeps its place behind the existing View logs button.

Scoped to a first attempt alone. A repeat attempt and a repair both carry the previous attempt's report, which the page already renders with its numbers marked as the last attempt's; a page of Pending chips would throw away the only results anyone has.

A manual criterion gets its final word rather than "Pending", because the run is never going to answer it — that is what the method means — and the tile's ask ("please validate the manual criteria yourself") is withheld from a spec that authored none, so it cannot send a reader after an empty list.

The per-method tally moves to counts.ts beside the per-status one, so the tile's "2 auto · 1 manual" and the badges below it count the same criteria and call a method by the same name. Spec-view's file preview is unaffected: the chips are opt-in, and a preview with no run attached shows the plain oracle as before.

Files reads now throw ApiRequestError, keeping the envelope's code. That is what lets a version whose spec authored no criteria say so — the tile becomes the whole body — while a read that merely failed still offers a retry rather than announcing there is nothing to validate.