### PR TITLE
feat(skills): the wireframes skill now teaches the coding agent, not just the design agent

### DIFF
--- a/packages/excalidraw-dsl/test/skill-examples.test.ts
+++ b/packages/excalidraw-dsl/test/skill-examples.test.ts
@@ -42,10 +42,19 @@ import {
 const here = dirname(fileURLToPath(import.meta.url));
 const skillDir = join(here, "..", "..", "..", "skills", "wireframes");
 
-const SKILL_FILES = [
-  "SKILL.md",
-  "references/authoring.md",
-  "references/implementing.md",
+/**
+ * Every skill file that may carry DSL, with how many complete documents it is
+ * expected to hold. The count is asserted, so a fence renamed or an example
+ * deleted fails here instead of silently reducing this suite to a no-op.
+ *
+ * `implementing.md` expects ZERO on purpose: its one fenced block is the PR
+ * fidelity checklist, which is a report format, not DSL. It stays in the list
+ * so that adding a DSL example to it later is caught and checked.
+ */
+const SKILL_FILES: ReadonlyArray<{ file: string; documents: number }> = [
+  { file: "SKILL.md", documents: 1 },
+  { file: "references/authoring.md", documents: 1 },
+  { file: "references/implementing.md", documents: 0 },
 ];
 
 /**
@@ -83,11 +92,16 @@ function dslExamples(markdown: string): string[] {
     .filter((doc) => doc !== "");
 }
 
-for (const file of SKILL_FILES) {
+for (const { file, documents } of SKILL_FILES) {
   const markdown = readFileSync(join(skillDir, file), "utf8");
   const examples = dslExamples(markdown);
 
   test(`${file}: every DSL example is valid`, () => {
+    assert.equal(
+      examples.length,
+      documents,
+      `${file} should yield ${documents} DSL document(s) — update SKILL_FILES when that changes on purpose`,
+    );
     for (const [i, dsl] of examples.entries()) {
       const where = `${file} example #${i + 1}`;
       assert.deepEqual(validateWireframeSyntax(dsl), [], `${where}: syntax`);
@@ -98,11 +112,10 @@ for (const file of SKILL_FILES) {
 }
 
 test("the worked example is actually being checked", () => {
-  // A guard on the extractor: if a refactor renames the fence or moves the
-  // example, the loop above would silently assert over an empty list.
+  // A guard on the extractor: a truncated worked example would still satisfy
+  // the count above, so assert it is the substantial multi-screen document.
   const authoring = readFileSync(join(skillDir, "references", "authoring.md"), "utf8");
   const examples = dslExamples(authoring);
-  assert.ok(examples.length >= 1, "authoring.md should carry a full worked example");
   assert.ok(
     examples.some((e) => e.split("\n").length > 50),
     "the worked example should be a substantial multi-screen document",

--- a/packages/excalidraw-dsl/test/skill-examples.test.ts
+++ b/packages/excalidraw-dsl/test/skill-examples.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The `wireframes` skill teaches the DSL by example, and an agent copies those
+ * examples verbatim. An example this compiler rejects therefore becomes an
+ * INVALID_DSL the agent cannot diagnose — the skill told it to write that.
+ * So every complete DSL document in the skill is held to the same bar as a
+ * document an agent writes: it parses, it lays out, and it compiles.
+ *
+ * Caught in practice: a `flow` block whose member line carried a trailing
+ * `// comment`, which the flow parser matches whole and rejects.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  dslToExcalidraw,
+  validateWireframeLayout,
+  validateWireframeSyntax,
+} from "../src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const skillDir = join(here, "..", "..", "..", "skills", "wireframes");
+
+const SKILL_FILES = [
+  "SKILL.md",
+  "references/authoring.md",
+  "references/implementing.md",
+];
+
+/**
+ * A fenced block turned into something the compiler can accept, or "" for a
+ * block that is not DSL at all. The grammar template is excluded on purpose:
+ * it is pseudo-syntax (`screen <Name>`, `<kind> "<label>"`) illustrating the
+ * shape of a line, not a document.
+ *
+ * A snippet showing only `flow` blocks still has to parse, but the compiler
+ * needs the screens those flows reference — so they are synthesized. A member
+ * line the flow parser would reject (a trailing comment, say) does not match
+ * as a name, gets no stub, and surfaces as the parse error it really is.
+ */
+function asDocument(block: string): string {
+  if (block.includes("<Name>") || block.includes("<kind>")) return "";
+  if (/^screen\s+\w/m.test(block)) return block;
+  if (!/^flow\s/m.test(block)) return "";
+
+  const referenced = new Set<string>();
+  for (const line of block.split("\n")) {
+    const member = /^\s{2,}([A-Za-z_]\w*)\s*$/.exec(line);
+    if (member) referenced.add(member[1]);
+  }
+  if (referenced.size === 0) return "";
+
+  const stubs = [...referenced]
+    .map((name) => `screen ${name} "stub for ${name}"\n  heading "${name}"\n`)
+    .join("\n");
+  return `${stubs}\n${block}`;
+}
+
+function dslExamples(markdown: string): string[] {
+  return [...markdown.matchAll(/```text\n([\s\S]*?)```/g)]
+    .map((m) => asDocument(m[1]))
+    .filter((doc) => doc !== "");
+}
+
+for (const file of SKILL_FILES) {
+  const markdown = readFileSync(join(skillDir, file), "utf8");
+  const examples = dslExamples(markdown);
+
+  test(`${file}: every DSL example is valid`, () => {
+    for (const [i, dsl] of examples.entries()) {
+      const where = `${file} example #${i + 1}`;
+      assert.deepEqual(validateWireframeSyntax(dsl), [], `${where}: syntax`);
+      assert.deepEqual(validateWireframeLayout(dsl), [], `${where}: layout`);
+      assert.doesNotThrow(() => dslToExcalidraw("wireframes", dsl), `${where}: compile`);
+    }
+  });
+}
+
+test("the worked example is actually being checked", () => {
+  // A guard on the extractor: if a refactor renames the fence or moves the
+  // example, the loop above would silently assert over an empty list.
+  const authoring = readFileSync(join(skillDir, "references", "authoring.md"), "utf8");
+  const examples = dslExamples(authoring);
+  assert.ok(examples.length >= 1, "authoring.md should carry a full worked example");
+  assert.ok(
+    examples.some((e) => e.split("\n").length > 50),
+    "the worked example should be a substantial multi-screen document",
+  );
+});

--- a/playground/test/kit-skills.test.ts
+++ b/playground/test/kit-skills.test.ts
@@ -60,9 +60,18 @@ test("loadRepoSkills reads the committed repo-root skill library", () => {
   // The library's reference files ride along (agentskills.io structure).
   const oas = skills.find((s) => s.name === "openapi-conventions")!;
   assert.ok(oas.references?.["references/wso2-rest-api-design-guidelines.md"]);
+  // `wireframes` is split by audience: the body carries only the DSL both
+  // readers share, and each audience's depth rides along as a reference —
+  // the worked example for the design agent, the build rules for the coding
+  // agent. Loading the skill must bring both, or one audience gets a body
+  // that points at a file it does not have.
   const wf = skills.find((s) => s.name === "wireframes")!;
-  // The worked example is inlined in the body (read-before-write is load-bearing).
-  assert.match(wf.content, /Worked example — risk register/);
+  assert.match(wf.content, /## The DSL/);
+  assert.match(
+    wf.references?.["references/authoring.md"] ?? "",
+    /Worked example — risk register/,
+  );
+  assert.ok(wf.references?.["references/implementing.md"]);
 });
 
 test("loadRepoSkills reads references/*.md into the skill's references map", () => {

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -74,6 +74,15 @@ means, at work altitude — the validation oracle owns product acceptance), and
 `## References` (the spec paths the coding agent reads). A Task without a body
 is unfinished planning.
 
+For a `web-application` component the wireframe is the screen contract, so
+its Task always carries two more things: the path
+`specs/design/components/<name>/wireframes.dsl` under `## References`, and a
+`Screens:` line under `## Scope` naming every `screen` in that file the Task
+covers (`Screens: RiskQueue, MyRisks, NewRisk, …`). Names only — the elements
+live in the DSL, and listing them in the issue would go stale the moment the
+wireframe is edited. The coding agent's `wireframes` skill turns the names
+into pages.
+
 ## When a tool rejects you
 
 The result names the fix: UNKNOWN_COMPONENT lists the known components;

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wireframes
-description: Use when creating or updating UI wireframes for a webapp component — sketching screens, forms, tables, dashboards, or navigation flow.
+description: Use when creating or updating UI wireframes for a webapp component (design), or when implementing a web-application component that has a wireframes.dsl (coding) — the DSL is the screen contract the pages must honour, screen for screen and element for element.
 metadata:
   aep:
     kind: platform
@@ -9,10 +9,22 @@ metadata:
 
 # Wireframes (Excalidraw DSL)
 
+This skill has two readers, and this file holds only what both need — the
+DSL itself. Which reader you are decides the reference you load next:
+
+- **Designing** — authoring or updating `wireframes.dsl` — read
+  `references/authoring.md`: where the screens come from, roles, the proven
+  anatomies, a complete worked example.
+- **Implementing** — building a `web-application` component that has a
+  `wireframes.dsl` — read `references/implementing.md`: how each screen,
+  element and arrow becomes a route, a component and working navigation, and
+  the fidelity checklist your PR carries.
+
 Every `web-application` component gets its wireframes as ONE DSL source file at
 `specs/design/components/<name>/wireframes.dsl` — all screens in one file.
-Write ONLY the `.dsl`; the platform compiles it to the `.excalidraw`
-deterministically. NEVER write a `.excalidraw` file by hand.
+The design agent writes ONLY the `.dsl`; the platform compiles it to the
+`.excalidraw` deterministically. NEVER write a `.excalidraw` file by hand, and
+never read one — the `.dsl` is the source of truth for both readers.
 
 Wireframes are **low-fidelity but product-flavored**: they validate layout,
 hierarchy, and flow, not pixel-perfect visuals. The compiler applies the look
@@ -25,145 +37,6 @@ Produce **one canonical set of screens** — the agreed design, not a gallery of
 alternatives. One screen per distinct user task, per role (for a store: a
 product list, a product detail page, a checkout form). Don't ship two takes on
 the same screen.
-
-### Where the screens come from — read the design first
-
-You have up to three sources in context; read them in this order of priority:
-
-1. **`specs/design/design.md`** — the architecture doc for the whole system.
-   This is your **primary** source for screens: it names the user roles, each
-   component's responsibilities, and the main flows. Derive the screen list from
-   here first. (It may not exist on every turn — if it's absent, promote the
-   requirements to primary.)
-2. **`specs/requirements/`** (requirements / user stories) — the **detailed**
-   source. Use it to flesh out each screen and to catch tasks the design doc
-   only summarized: specific fields, states, rules, and edge cases (out-of-
-   stock, guest vs. signed-in, validation errors).
-3. **This component's `specs/design/components/<name>/design.json`** — a thin
-   per-component summary; use it mainly to **scope**, not for screen content:
-   its `type` (draw wireframes only for `web-application`), its one-line
-   `description`, and its `dependencies` (e.g. an auth dependency means there's
-   a signed-in vs. guest distinction → likely role-specific screens).
-
-**Cover every task.** Walk the design and requirements and make sure each
-distinct user-facing task — for each role they name — has a wireframe screen
-that serves it; nothing user-facing should be left without a view. Equally,
-don't invent screens the design doesn't imply. A quick check: list the
-tasks/roles, and for each name the screen that fulfills it — a task with no
-screen is a gap, a screen with no task is noise.
-
-## What makes a wireframe good
-
-A good wireframe reads like a real screen someone could use, and it explains
-itself. What carries the quality:
-
-- **Real content, not placeholders.** Write "Open risks: 24", "Platform team",
-  "Overdue" — never "text here" or "label". The wireframe is a communication
-  artifact; concrete content is what makes a layout legible and reviewable.
-- **Say what each view is.** Give every screen a description (the quoted phrase
-  after its name) so anyone can tell at a glance what the view does and who
-  uses it — not just infer it from the widgets.
-- **A clear visual hierarchy.** A page has a title, then primary content, then
-  secondary detail. Use `heading` for section titles; put the most important
-  thing first (it renders highest). One dominant action per screen (the one
-  `primary` button).
-- **The right primitive for each thing.** A status is a `badge`, not text. A
-  section switch is `tabs`. A person is an `avatar`. Picking the primitive that
-  matches the real UI element is most of what makes screens feel real.
-
-## Roles change the screens — always show them
-
-Most real apps have more than one kind of user, and the *same feature looks
-different for each*. This is the single most common thing wireframes get wrong:
-they show one generic view and hide the fact that an admin and a regular user
-actually see different screens. Don't do that.
-
-**First, identify the roles.** Read `design.md` for distinct user types —
-admin/manager/owner vs. member/employee/developer vs. viewer/customer (the
-design doc usually spells the roles out; the requirements add the detail, and a
-`design.json` auth dependency is a strong hint a signed-in role exists). If the
-app has more than one, roles are in scope even when the prompt doesn't say "per
-role."
-
-**Then, for each role, show its main view and how it differs.** At minimum,
-give every role its own `screen` for the primary task they do, named and
-described for that role — because the difference is usually *capability*, not
-cosmetics. The same feature splits into genuinely different screens:
-
-- The one who **approves/administers** gets a queue or roster with the action
-  and the columns to act on (Approve/Reject, an "assignee" column, bulk
-  controls); the one who **submits/contributes** sees only their own items with
-  a single Submit/Upload action — no approve, no assign.
-- The one who **owns** a record edits it (an Edit form, private stats, a
-  Reassign control); the one who **consumes** it sees the same record read-only,
-  able at most to comment or take the one action meant for them.
-
-Two roles, two screens — the admin's screen simply *has* buttons and columns the
-member's does not. Show both.
-
-Rules of thumb:
-
-- Name the screen for its role and put the role in the description:
-  `screen ReviewQueue "Manager reviews and approves pending requests"`.
-- **Scope the chrome to the role.** An admin screen's `sidebar` lists the
-  admin's destinations; a customer screen's lists the customer's. Real
-  permissioned apps do not show people links they cannot use, and a prototype
-  that does sends the reviewer down another persona's path.
-- **Keep the overlap identical.** Items both roles have use the same label,
-  the same order, and the same `navbar` brand, so the screens still read as one
-  product rather than two. Only the role-specific entries differ.
-- Reflect the real difference in **actions and data** — a role that can't
-  approve/assign/delete simply doesn't have that button or column. Don't reskin
-  one layout and call it two. The role difference should be legible from the
-  screen itself, not spelled out in a caption.
-- A screen that is genuinely identical for everyone (a shared login, a generic
-  detail page) stays single — don't fork it just to have a matching set.
-
-## Proven screen anatomies
-
-Most webapp screens are one of three shapes. Follow these anatomies — they're
-what makes a wireframe read like a designed product instead of a pile of boxes.
-(Every `navbar` includes a notification bell + account avatar at its top-right:
-the compiler draws this account cluster as part of the `navbar` itself — don't
-add your own.)
-
-**Dashboard / landing** (top → bottom):
-
-1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS"), then
-   a `row` with a human `heading` ("Good morning — here's where things stand")
-   and, after `right`, a `search` and a filter `select`.
-2. A `row` of 3–4 stat-tile `card`s — `card "Open items | 47 | across 5 active
-   projects"`. Every number gets its label and a caption that explains it. The
-   row makes them equal-width automatically.
-3. A `row` of rich entity cards (one per project/order/record): a `card` whose
-   title is the entity, with nested children — a `progress "47/60"`, a meta
-   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge`
-   (`success`/`warning`: "On track"/"At risk") that docks to the card's corner
-   automatically.
-4. A `row` with a section `heading` ("Needs your attention") and, after
-   `right`, the page's primary CTA. Then a `table` whose LAST column is the
-   action — put "Review →" / "Follow up →" in each `row`'s final cell.
-
-**List / queue**: `heading`, then a `row` of filter `badge`s with counts
-("All (146)", "Open (23)", "Resolved (98)") or `tabs`, then a full-width
-`table` with real `row`s — status as a word in a status column, owner, due
-date, and a trailing action cell.
-
-**Detail / record** (the screen for ONE item): `breadcrumb`, then a `row` with
-the `heading` and its status `badge`s, a short description `text` — then a
-`split 60/40`:
-
-- **`left` (main)**: the item's content — a bordered panel `card` with detail
-  `text` lines, an items/records `table` with rows, an "Upload new" / primary
-  action.
-- **`right` (rail)**: the collaboration side — a "Discussion" `card` with
-  nested comment `text` lines (author + time + message), a `textarea` + "Post"
-  `button`, then an "Activity" `heading` and timestamped `text` rows ("2 days
-  ago — J. Alvarez uploaded report-final.pdf").
-
-A record's conversation and history belong in this right rail, beside the
-record — not on a separate screen. The divider between the columns is drawn
-automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
 
 ## The DSL
 
@@ -227,11 +100,27 @@ and takes no target; put arrows on the links after it. The rail repeats on
 each screen, so annotate it each time; an item pointing at the screen it sits
 on is correctly inert.
 
+**A `primary` button must lead somewhere.** It is the screen's main action and
+the first thing a reviewer clicks, so one with no `-> Screen` is a dead end
+that reads as broken however good the layout is. Give every `primary` button a
+target unless its action genuinely completes in place — a status toggle, a save
+that stays on the page — and mark that case with a `//` comment so the omission
+reads as a decision. "New…", "Invite…", "Add…", "Assign…", "Create…" are never
+in place: they need a form or picker the user has not seen, which is a view, so
+declare that screen and point at it. Secondary controls may go without an
+arrow; the primary one may not.
+
+The one main action that is **not a screen at all** is sign-in on a component
+with an auth dependency: the platform's SSO hosts that page, the app only
+redirects to it, and the user comes back on their role's home screen. Do not
+draw a `Login` for it (see Flows). A `Sign out` item leaves the app the same
+way, so it carries no arrow — the platform, not the app, shows what comes next.
+
 **Decide the screens and the paths together.** A wireframe set is a flow, not a
 gallery: when you pick the screens, work out how each one is reached. Every
 screen should be reachable by clicking — or be a landing screen whose
-description says which role it serves. Not every control needs an arrow; what
-matters is that no view is stranded.
+description says which role it serves. No view is stranded, and no main action
+is dead.
 
 ### Flows — one per role or journey
 
@@ -249,19 +138,40 @@ its **task** ("Approval queue", "Log a risk"), and carry the persona on a
 flow "Approval queue"
   role "Admin"
   description "An admin reviews queued items and audits the outcome"
-  Login
   AdminQueue
   AuditDetail
 
 flow "My orders"
   role "Customer"
   description "A signed-in customer checks a placed order"
-  Login          // a reference, not a copy — one screen, two memberships
   Orders
+  OrderDetail
 ```
 
-- A flow **references** screens by name; screens stay declared once. List a
-  shared screen (sign-in, a sign-out landing) in every flow that reaches it.
+**A role's flow starts on that role's own screen.** The prototype opens a flow
+on its **first listed screen**, so the admin's flow starts on the admin's
+queue and the customer's on their orders — the first thing each persona
+actually sees.
+
+**Sign-in is not one of the app's screens when the component has an auth
+dependency.** The platform's SSO hosts the sign-in page; the app only redirects
+to it on load and receives the user back on their role's home screen. There is
+nothing to draw and nothing the coding agent could build — so **do not declare
+a `Login` screen**, and do not open any flow with one. A shared `Login` at the
+head of every role flow is the classic mistake: every persona begins in the
+same place, and the one static `-> Screen` on its button sends all of them into
+whichever dashboard it names. Show sign-out as a `navbar` item with no arrow —
+it leaves the app the same way.
+
+Draw a sign-in screen only when the app **owns** its sign-in form — a component
+with no auth dependency that keeps its own credentials. Then it is a real
+screen: put it first in the one flow that walks it, point its button at that
+flow's home screen, and keep it out of the other flows.
+
+- A flow **references** screens by name; screens stay declared once. A screen
+  genuinely shared mid-journey (a settings page both roles reach) may be
+  listed in each flow that reaches it — the rule above is about the **first**
+  screen, which is where the prototype opens.
 - The name is quoted and must be unique — declaring one flow twice rejects the
   write.
 - A name that matches no `screen` rejects the write with its line number.
@@ -310,8 +220,10 @@ The compiler applies the Oxygen theme automatically: white/neutral surfaces,
 brand orange on the active navbar/sidebar item and section-heading rules. You
 add color only through a trailing **variant**, to carry *status meaning*:
 
-- `primary` on the ONE main action per screen — fills brand orange. Every
-  other button stays a plain outline.
+- `primary` on a screen's main action — fills brand orange. Usually that is
+  one button per screen; give it to two only when the screen genuinely has
+  two equal main actions (Approve and Reject on a review). Every other button
+  stays a plain outline.
 - `danger` / `success` / `warning` / `info` on a `badge` or destructive
   `button` (`badge "Overdue" danger`).
 - `ai` (purple) for an automated / AI-driven step, if the product has one.
@@ -321,205 +233,3 @@ add color only through a trailing **variant**, to carry *status meaning*:
 Keep status variants purposeful — a screen dense with red/green/amber badges
 stops communicating.
 
-### Consistency rules
-
-- **One primary navigation, not two.** A content-heavy tool (admin console,
-  dashboard app) uses the `sidebar` for section links and a brand-only
-  `navbar` (`navbar "Acme"`). A simple public flow (storefront, checkout) uses
-  a link-carrying `navbar` and **no sidebar**. Never both on one screen.
-- Repeat the SAME `navbar` on every screen of one app. Repeat the SAME
-  `sidebar` too, EXCEPT where a role's screens scope it to that role's
-  destinations — the items both roles share still keep the same label and
-  order, so the screens read as one product even when the rail isn't
-  word-for-word identical.
-- Comments start with `//`. Every screen should be reachable from some
-  control's `-> Screen`.
-
-## Worked example — risk register webapp wireframes
-
-A complete `wireframes.dsl` for a two-role desktop flow. The manager and the
-owner each get their own dashboard and detail screen — a shared `RiskDetail`
-would need two different sidebars, and a screen can only carry one, so each
-role's landing view and remediation view are split in two. `navbar` stays
-brand-only and identical everywhere; each `sidebar` lists only that role's
-destinations, and the items both roles have (Overview, All Registers, Audits,
-Settings) keep the same label and the same order — only the role-specific
-entry (Review Queue vs. My Risks) differs. Note the rest of the rhythm: blocks
-stack in reading order; `row` groups things side by side; the primary action
-is the one `primary` button per screen; status is carried by `badge`s, not
-prose. No coordinates anywhere — the compiler computes every position.
-
-```text
-// Risk register — two roles, five screens, desktop
-
-screen RiskQueue "Manager monitors open risk across registers and acts on what's overdue"
-  navbar "RiskHub"
-  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
-  row
-    heading "Risk Queue"
-    right
-    select "Register: All"
-  row
-    card "Open risks | 24 | across 6 registers"
-    card "Overdue actions | 6 | need follow-up"
-    card "High severity | 3 | review this week"
-  row
-    heading "Needs review"
-    right
-    button "Review next" primary -> QueueRiskDetail
-  tabs "All | Overdue | High severity"
-  table "Risk | Owner | Severity | Status | Updated" -> QueueRiskDetail
-    row "Unpatched edge servers | Platform team | High | Open | 2h ago"
-    row "Stale access keys | Security | Medium | In review | 1d ago"
-    row "Vendor SOC2 lapse | Compliance | High | Overdue | 3d ago"
-
-screen MyRisks "Owner tracks the risks they own and logs new ones"
-  navbar "RiskHub"
-  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
-  row
-    heading "My Risks"
-    right
-    button "New risk" primary -> NewRisk
-  table "Risk | Severity | Status | Updated" -> RiskDetail
-    row "Unpatched edge servers | High | Open | 2h ago"
-    row "Rotate edge certs | Medium | In progress | 1d ago"
-
-screen NewRisk "An owner logs a new risk into a register"
-  navbar "RiskHub"
-  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
-  breadcrumb "My Risks / New risk"
-  heading "New Risk"
-  input "Title — e.g. Unpatched edge servers"
-  textarea "What is the risk and why does it matter?"
-  row
-    select "Register: Infrastructure"
-    select "Owner: Platform team"
-  row
-    select "Impact: High"
-    select "Likelihood: Likely"
-  checkbox "Notify owner on create" active
-  row
-    right
-    button "Cancel"
-    button "Create risk" primary -> MyRisks
-
-screen QueueRiskDetail "Manager reviews progress and escalates risks that stall"
-  navbar "RiskHub"
-  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
-  breadcrumb "Risk Queue / Unpatched edge servers"
-  row
-    heading "Unpatched edge servers"
-    badge "High" danger
-    badge "Open" info
-  text "Owner: Platform team — Updated 2h ago"
-  split 60/40
-    left
-      heading "Remediation"
-      progress "60%" info
-      text "6 of 10 actions complete"
-      table "Action | Assignee | Due | Status"
-        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
-        row "Rotate edge certs | M. Diaz | Mon | In progress"
-        row "Close inbound 8443 | Platform | Tue | To do"
-      row
-        right
-        button "Reassign owner"
-        button "Escalate" primary
-    right
-      card "Review notes"
-        text "You · 3d: second week overdue — needs a date."
-        text "R. Osei · 1d: agreed, escalate if Monday slips."
-        row
-          textarea "Add a review note…"
-          button "Post note"
-      heading "Review history"
-      text "1d ago — You flagged this risk for review"
-      text "6d ago — R. Osei reassigned it to Platform team"
-
-screen RiskDetail "The owner tracks remediation for the risks they own"
-  navbar "RiskHub"
-  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
-  breadcrumb "My Risks / Unpatched edge servers"
-  row
-    heading "Unpatched edge servers"
-    badge "High" danger
-    badge "Open" info
-  text "Owner: Platform team — Updated 2h ago"
-  split 60/40
-    left
-      heading "Remediation"
-      progress "60%" info
-      text "6 of 10 actions complete"
-      table "Action | Assignee | Due | Status"
-        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
-        row "Rotate edge certs | M. Diaz | Mon | In progress"
-        row "Close inbound 8443 | Platform | Tue | To do"
-      row
-        right
-        button "Update status" primary
-    right
-      card "Discussion"
-        text "K. Smith · 2d: when does the cert rotation land?"
-        text "M. Diaz · 1d: Monday, after the freeze."
-        row
-          textarea "Add a comment…"
-          button "Post"
-      heading "Activity"
-      text "2h ago — A. Chen closed CVE-2026-1"
-      text "1d ago — M. Diaz started cert rotation"
-
-flow "Approval queue"
-  role "Manager"
-  description "A manager triages queued risks and reviews each in detail"
-  RiskQueue
-  QueueRiskDetail
-
-flow "Log a risk"
-  role "Risk owner"
-  description "An owner records a new risk and tracks its remediation"
-  MyRisks
-  NewRisk
-  RiskDetail
-```
-
-The two `flow` blocks close the file: each names its task, carries its `role`
-and a one-line `description`, and lists only its own role's screens, entry
-screen first. Each screen is reachable by clicking from somewhere in its own
-flow — `RiskQueue`'s "Review next" CTA and its table both lead to
-`QueueRiskDetail`; `MyRisks`'s button leads to `NewRisk` and its table leads to
-`RiskDetail`. They are what the prototype's flow picker offers the reviewer —
-the Manager's "Approval queue" walks queue-then-escalate, the Risk owner's
-"Log a risk" walks log-then-remediate — and neither flow references a screen
-the other role can't reach.
-
-Checklist before finishing a wireframe file:
-
-- Every screen from the requirements has a `screen` block; no extras, no
-  duplicate takes on the same screen. Where a role changes the view, there's a
-  screen per role, named and described for it.
-- Every screen has a one-line description saying what it's for.
-- `navbar` is identical across every screen of the app; `sidebar` is scoped
-  to each role's destinations, with shared items kept at the same label and
-  order across roles.
-- Each role or journey named in `design.md` has its own `flow "<name>"` block,
-  entry screen first, referencing existing screens by name.
-- Labels are content-bearing ("Open risks | 24 | across 6 registers",
-  "Platform team", "Overdue"), never placeholders like "text" or "label".
-- The right primitive does each job — `badge` for status, `tabs` for section
-  switching, `avatar` for people, `progress` for completion, `table` + `row`
-  for real data.
-- Color is rare and meaningful: one `primary` action per screen, plus the odd
-  status `badge`.
-- Navigation is on the control that triggers it: the button/link/table that
-  leads to another screen ends with `-> ScreenName`, and every target matches
-  a real `screen`.
-- NO coordinates and no manual sizes unless an element truly needs one — the
-  layout comes from stacking, `row`, and `split`.
-
-## Updating existing wireframes
-
-The DSL is line-oriented, so `editFile` works naturally: anchor on the
-`screen <Name>` line plus the element line you're changing. Add a screen by
-appending a new `screen` block. Add table data by inserting `row` lines under
-the `table`. Insert a new element by adding its line where it should appear in
-the stack — everything below it moves down automatically.

--- a/skills/wireframes/SKILL.md
+++ b/skills/wireframes/SKILL.md
@@ -98,7 +98,10 @@ quote (`"Home | Templates -> Templates"`) — one after the quote attaches to
 nothing and silently does not navigate. The first `navbar` item is the brand
 and takes no target; put arrows on the links after it. The rail repeats on
 each screen, so annotate it each time; an item pointing at the screen it sits
-on is correctly inert.
+on is correctly inert. A rail may also name a section this wireframe set does
+not draw (`Settings`, `Audits`): leave those without a target — they are
+context, and inventing a screen just to receive the arrow is noise. Keep them
+few; a rail where most items go nowhere reads as broken.
 
 **A `primary` button must lead somewhere.** It is the screen's main action and
 the first thing a reviewer clicks, so one with no `-> Screen` is a dead end
@@ -232,4 +235,3 @@ add color only through a trailing **variant**, to carry *status meaning*:
 
 Keep status variants purposeful — a screen dense with red/green/amber badges
 stops communicating.
-

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -1,0 +1,363 @@
+# Authoring wireframes (design agent)
+
+The companion to the `wireframes` skill for the design turn: where the screens
+come from, what makes a set good, how roles split them, the proven anatomies,
+and a complete worked example. The DSL grammar itself is in `SKILL.md`; this
+file is about deciding what to draw with it.
+
+## Where the screens come from — read the design first
+
+You have up to three sources in context; read them in this order of priority:
+
+1. **`specs/design/design.md`** — the architecture doc for the whole system.
+   This is your **primary** source for screens: it names the user roles, each
+   component's responsibilities, and the main flows. Derive the screen list from
+   here first. (It may not exist on every turn — if it's absent, promote the
+   requirements to primary.)
+2. **`specs/requirements/`** (requirements / user stories) — the **detailed**
+   source. Use it to flesh out each screen and to catch tasks the design doc
+   only summarized: specific fields, states, rules, and edge cases (out-of-
+   stock, guest vs. signed-in, validation errors).
+3. **This component's `specs/design/components/<name>/design.json`** — a thin
+   per-component summary; use it mainly to **scope**, not for screen content:
+   its `type` (draw wireframes only for `web-application`), its one-line
+   `description`, and its `dependencies` (e.g. an auth dependency means there's
+   a signed-in vs. guest distinction → likely role-specific screens).
+
+**Cover every task.** Walk the design and requirements and make sure each
+distinct user-facing task — for each role they name — has a wireframe screen
+that serves it; nothing user-facing should be left without a view. Equally,
+don't invent screens the design doesn't imply. A quick check: list the
+tasks/roles, and for each name the screen that fulfills it — a task with no
+screen is a gap, a screen with no task is noise.
+
+## What makes a wireframe good
+
+A good wireframe reads like a real screen someone could use, and it explains
+itself. What carries the quality:
+
+- **Real content, not placeholders.** Write "Open risks: 24", "Platform team",
+  "Overdue" — never "text here" or "label". The wireframe is a communication
+  artifact; concrete content is what makes a layout legible and reviewable.
+- **Say what each view is.** Give every screen a description (the quoted phrase
+  after its name) so anyone can tell at a glance what the view does and who
+  uses it — not just infer it from the widgets.
+- **A clear visual hierarchy.** A page has a title, then primary content, then
+  secondary detail. Use `heading` for section titles; put the most important
+  thing first (it renders highest). A dominant action per screen (the
+  `primary` button — usually one; two only when the screen truly has two
+  equal main actions).
+- **The right primitive for each thing.** A status is a `badge`, not text. A
+  section switch is `tabs`. A person is an `avatar`. Picking the primitive that
+  matches the real UI element is most of what makes screens feel real.
+
+## Roles change the screens — always show them
+
+Most real apps have more than one kind of user, and the *same feature looks
+different for each*. This is the single most common thing wireframes get wrong:
+they show one generic view and hide the fact that an admin and a regular user
+actually see different screens. Don't do that.
+
+**First, identify the roles.** Read `design.md` for distinct user types —
+admin/manager/owner vs. member/employee/developer vs. viewer/customer (the
+design doc usually spells the roles out; the requirements add the detail, and a
+`design.json` auth dependency is a strong hint a signed-in role exists). If the
+app has more than one, roles are in scope even when the prompt doesn't say "per
+role."
+
+**Then, for each role, show its main view and how it differs.** At minimum,
+give every role its own `screen` for the primary task they do, named and
+described for that role — because the difference is usually *capability*, not
+cosmetics. The same feature splits into genuinely different screens:
+
+- The one who **approves/administers** gets a queue or roster with the action
+  and the columns to act on (Approve/Reject, an "assignee" column, bulk
+  controls); the one who **submits/contributes** sees only their own items with
+  a single Submit/Upload action — no approve, no assign.
+- The one who **owns** a record edits it (an Edit form, private stats, a
+  Reassign control); the one who **consumes** it sees the same record read-only,
+  able at most to comment or take the one action meant for them.
+
+Two roles, two screens — the admin's screen simply *has* buttons and columns the
+member's does not. Show both.
+
+Rules of thumb:
+
+- Name the screen for its role and put the role in the description:
+  `screen ReviewQueue "Manager reviews and approves pending requests"`.
+- **Scope the chrome to the role.** An admin screen's `sidebar` lists the
+  admin's destinations; a customer screen's lists the customer's. Real
+  permissioned apps do not show people links they cannot use, and a prototype
+  that does sends the reviewer down another persona's path.
+- **Keep the overlap identical.** Items both roles have use the same label,
+  the same order, and the same `navbar` brand, so the screens still read as one
+  product rather than two. Only the role-specific entries differ.
+- Reflect the real difference in **actions and data** — a role that can't
+  approve/assign/delete simply doesn't have that button or column. Don't reskin
+  one layout and call it two. The role difference should be legible from the
+  screen itself, not spelled out in a caption.
+- A screen that is genuinely identical for everyone (a public landing page, a
+  generic detail page) stays single — don't fork it just to have a matching set.
+
+## Proven screen anatomies
+
+Most webapp screens are one of three shapes. Follow these anatomies — they're
+what makes a wireframe read like a designed product instead of a pile of boxes.
+(Every `navbar` includes a notification bell + account avatar at its top-right:
+the compiler draws this account cluster as part of the `navbar` itself — don't
+add your own.)
+
+**Dashboard / landing** (top → bottom):
+
+1. A small muted eyebrow (`text`, e.g. the team or context: "OPERATIONS"), then
+   a `row` with a human `heading` ("Good morning — here's where things stand")
+   and, after `right`, a `search` and a filter `select`.
+2. A `row` of 3–4 stat-tile `card`s — `card "Open items | 47 | across 5 active
+   projects"`. Every number gets its label and a caption that explains it. The
+   row makes them equal-width automatically.
+3. A `row` of rich entity cards (one per project/order/record): a `card` whose
+   title is the entity, with nested children — a `progress "47/60"`, a meta
+   `text` line ("47 of 60 tasks · Due 14 Sep"), and a status `badge`
+   (`success`/`warning`: "On track"/"At risk") that docks to the card's corner
+   automatically.
+4. A `row` with a section `heading` ("Needs your attention") and, after
+   `right`, the page's primary CTA. Then a `table` whose LAST column is the
+   action — put "Review →" / "Follow up →" in each `row`'s final cell.
+
+**List / queue**: `heading`, then a `row` of filter `badge`s with counts
+("All (146)", "Open (23)", "Resolved (98)") or `tabs`, then a full-width
+`table` with real `row`s — status as a word in a status column, owner, due
+date, and a trailing action cell.
+
+**Detail / record** (the screen for ONE item): `breadcrumb`, then a `row` with
+the `heading` and its status `badge`s, a short description `text` — then a
+`split 60/40`:
+
+- **`left` (main)**: the item's content — a bordered panel `card` with detail
+  `text` lines, an items/records `table` with rows, an "Upload new" / primary
+  action.
+- **`right` (rail)**: the collaboration side — a "Discussion" `card` with
+  nested comment `text` lines (author + time + message), a `textarea` + "Post"
+  `button`, then an "Activity" `heading` and timestamped `text` rows ("2 days
+  ago — J. Alvarez uploaded report-final.pdf").
+
+A record's conversation and history belong in this right rail, beside the
+record — not on a separate screen. The divider between the columns is drawn
+automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
+
+## Consistency rules
+
+- **One primary navigation, not two.** A content-heavy tool (admin console,
+  dashboard app) uses the `sidebar` for section links and a brand-only
+  `navbar` (`navbar "Acme"`). A simple public flow (storefront, checkout) uses
+  a link-carrying `navbar` and **no sidebar**. Never both on one screen.
+- Repeat the SAME `navbar` on every screen of one app. Repeat the SAME
+  `sidebar` too, EXCEPT where a role's screens scope it to that role's
+  destinations — the items both roles share still keep the same label and
+  order, so the screens read as one product even when the rail isn't
+  word-for-word identical.
+- Comments start with `//`. A whole-line comment is safe anywhere; a trailing
+  one is safe on an element line (`button "Escalate" primary  // in place`)
+  but NOT inside a `flow` block, where a screen-name line is matched whole and
+  a trailing comment rejects the write. Every screen should be reachable from some
+  control's `-> Screen`.
+
+## Worked example — risk register webapp wireframes
+
+A complete `wireframes.dsl` for a two-role desktop flow. The manager and the
+owner each get their own dashboard and detail screen — a shared `RiskDetail`
+would need two different sidebars, and a screen can only carry one, so each
+role's landing view and remediation view are split in two. `navbar` stays
+brand-only and identical everywhere; each `sidebar` lists only that role's
+destinations, and the items both roles have (Overview, All Registers, Audits,
+Settings) keep the same label and the same order — only the role-specific
+entry (Review Queue vs. My Risks) differs. Note the rest of the rhythm: blocks
+stack in reading order; `row` groups things side by side; each screen's main
+action is its `primary` button; status is carried by `badge`s, not
+prose. No coordinates anywhere — the compiler computes every position.
+
+```text
+// Risk register — two roles, five screens, desktop
+
+screen RiskQueue "Manager monitors open risk across registers and acts on what's overdue"
+  navbar "RiskHub"
+  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
+  row
+    heading "Risk Queue"
+    right
+    select "Register: All"
+  row
+    card "Open risks | 24 | across 6 registers"
+    card "Overdue actions | 6 | need follow-up"
+    card "High severity | 3 | review this week"
+  row
+    heading "Needs review"
+    right
+    button "Review next" primary -> QueueRiskDetail
+  tabs "All | Overdue | High severity"
+  table "Risk | Owner | Severity | Status | Updated" -> QueueRiskDetail
+    row "Unpatched edge servers | Platform team | High | Open | 2h ago"
+    row "Stale access keys | Security | Medium | In review | 1d ago"
+    row "Vendor SOC2 lapse | Compliance | High | Overdue | 3d ago"
+
+screen MyRisks "Owner tracks the risks they own and logs new ones"
+  navbar "RiskHub"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  row
+    heading "My Risks"
+    right
+    button "New risk" primary -> NewRisk
+  table "Risk | Severity | Status | Updated" -> RiskDetail
+    row "Unpatched edge servers | High | Open | 2h ago"
+    row "Rotate edge certs | Medium | In progress | 1d ago"
+
+screen NewRisk "An owner logs a new risk into a register"
+  navbar "RiskHub"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  breadcrumb "My Risks / New risk"
+  heading "New Risk"
+  input "Title — e.g. Unpatched edge servers"
+  textarea "What is the risk and why does it matter?"
+  row
+    select "Register: Infrastructure"
+    select "Owner: Platform team"
+  row
+    select "Impact: High"
+    select "Likelihood: Likely"
+  checkbox "Notify owner on create" active
+  row
+    right
+    button "Cancel"
+    button "Create risk" primary -> MyRisks
+
+screen QueueRiskDetail "Manager reviews progress and escalates risks that stall"
+  navbar "RiskHub"
+  sidebar "Overview | Review Queue -> RiskQueue | All Registers | Audits | Settings"
+  breadcrumb "Risk Queue / Unpatched edge servers"
+  row
+    heading "Unpatched edge servers"
+    badge "High" danger
+    badge "Open" info
+  text "Owner: Platform team — Updated 2h ago"
+  split 60/40
+    left
+      heading "Remediation"
+      progress "60%" info
+      text "6 of 10 actions complete"
+      table "Action | Assignee | Due | Status"
+        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+        row "Rotate edge certs | M. Diaz | Mon | In progress"
+        row "Close inbound 8443 | Platform | Tue | To do"
+      row
+        right
+        button "Reassign owner"
+        button "Escalate" primary  // in place — raises severity, opens no view
+    right
+      card "Review notes"
+        text "You · 3d: second week overdue — needs a date."
+        text "R. Osei · 1d: agreed, escalate if Monday slips."
+        row
+          textarea "Add a review note…"
+          button "Post note"
+      heading "Review history"
+      text "1d ago — You flagged this risk for review"
+      text "6d ago — R. Osei reassigned it to Platform team"
+
+screen RiskDetail "The owner tracks remediation for the risks they own"
+  navbar "RiskHub"
+  sidebar "Overview | My Risks -> MyRisks | All Registers | Audits | Settings"
+  breadcrumb "My Risks / Unpatched edge servers"
+  row
+    heading "Unpatched edge servers"
+    badge "High" danger
+    badge "Open" info
+  text "Owner: Platform team — Updated 2h ago"
+  split 60/40
+    left
+      heading "Remediation"
+      progress "60%" info
+      text "6 of 10 actions complete"
+      table "Action | Assignee | Due | Status"
+        row "Patch kernel CVE-2026-1 | A. Chen | Fri | Done"
+        row "Rotate edge certs | M. Diaz | Mon | In progress"
+        row "Close inbound 8443 | Platform | Tue | To do"
+      row
+        right
+        button "Update status" primary  // in place — sets status on this page
+    right
+      card "Discussion"
+        text "K. Smith · 2d: when does the cert rotation land?"
+        text "M. Diaz · 1d: Monday, after the freeze."
+        row
+          textarea "Add a comment…"
+          button "Post"
+      heading "Activity"
+      text "2h ago — A. Chen closed CVE-2026-1"
+      text "1d ago — M. Diaz started cert rotation"
+
+flow "Approval queue"
+  role "Manager"
+  description "A manager triages queued risks and reviews each in detail"
+  RiskQueue
+  QueueRiskDetail
+
+flow "Log a risk"
+  role "Risk owner"
+  description "An owner records a new risk and tracks its remediation"
+  MyRisks
+  NewRisk
+  RiskDetail
+```
+
+The two `flow` blocks close the file: each names its task, carries its `role`
+and a one-line `description`, and lists only its own role's screens, entry
+screen first. Each screen is reachable by clicking from somewhere in its own
+flow — `RiskQueue`'s "Review next" CTA and its table both lead to
+`QueueRiskDetail`; `MyRisks`'s button leads to `NewRisk` and its table leads to
+`RiskDetail`. They are what the prototype's flow picker offers the reviewer —
+the Manager's "Approval queue" walks queue-then-escalate, the Risk owner's
+"Log a risk" walks log-then-remediate — and neither flow references a screen
+the other role can't reach.
+
+Checklist before finishing a wireframe file:
+
+- Every screen from the requirements has a `screen` block; no extras, no
+  duplicate takes on the same screen. Where a role changes the view, there's a
+  screen per role, named and described for it.
+- Every screen has a one-line description saying what it's for.
+- `navbar` is identical across every screen of the app; `sidebar` is scoped
+  to each role's destinations, with shared items kept at the same label and
+  order across roles.
+- Each role or journey named in `design.md` has its own `flow "<name>"` block,
+  entry screen first, referencing existing screens by name.
+- **Each role flow opens on that role's own screen, and there is no `Login`
+  screen when the component has an auth dependency** — the platform's SSO
+  hosts sign-in and returns the user to their home screen, so the app never
+  renders one. A shared `Login` at the head of every flow funnels every persona
+  through one static `-> Screen` into the same dashboard. Sign-out is a navbar
+  item with no arrow. Draw a sign-in screen only for an app that owns its own
+  credentials, and then in one flow only.
+- Labels are content-bearing ("Open risks | 24 | across 6 registers",
+  "Platform team", "Overdue"), never placeholders like "text" or "label".
+- The right primitive does each job — `badge` for status, `tabs` for section
+  switching, `avatar` for people, `progress` for completion, `table` + `row`
+  for real data.
+- Color is rare and meaningful: `primary` on each screen's main action
+  (usually one, at most two equals), plus the odd status `badge`.
+- Navigation is on the control that triggers it: the button/link/table that
+  leads to another screen ends with `-> ScreenName`, and every target matches
+  a real `screen`.
+- **Every `primary` button carries a `-> Screen`**, or a `//` comment saying
+  why its action completes in place. Walk the screens and check each one: a
+  "New…"/"Invite…"/"Add…"/"Assign…" primary with no arrow means the form it
+  opens was never declared as a screen — declare it and point at it.
+- NO coordinates and no manual sizes unless an element truly needs one — the
+  layout comes from stacking, `row`, and `split`.
+
+## Updating existing wireframes
+
+The DSL is line-oriented, so `editFile` works naturally: anchor on the
+`screen <Name>` line plus the element line you're changing. Add a screen by
+appending a new `screen` block. Add table data by inserting `row` lines under
+the `table`. Insert a new element by adding its line where it should appear in
+the stack — everything below it moves down automatically.

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -159,8 +159,9 @@ automatically. Keep each comment `text` SHORT (a phrase, not a sentence).
 - Comments start with `//`. A whole-line comment is safe anywhere; a trailing
   one is safe on an element line (`button "Escalate" primary  // in place`)
   but NOT inside a `flow` block, where a screen-name line is matched whole and
-  a trailing comment rejects the write. Every screen should be reachable from some
-  control's `-> Screen`.
+  a trailing comment rejects the write. Every screen should be reachable from
+  some control's `-> Screen`, except a flow's entry screen — it is where the
+  prototype opens, so nothing needs to point at it.
 
 ## Worked example — risk register webapp wireframes
 
@@ -227,8 +228,8 @@ screen NewRisk "An owner logs a new risk into a register"
   checkbox "Notify owner on create" active
   row
     right
-    button "Cancel"
-    button "Create risk" primary -> MyRisks
+    button "Cancel" -> MyRisks
+    button "Create risk" primary -> RiskDetail
 
 screen QueueRiskDetail "Manager reviews progress and escalates risks that stall"
   navbar "RiskHub"
@@ -311,10 +312,11 @@ flow "Log a risk"
 
 The two `flow` blocks close the file: each names its task, carries its `role`
 and a one-line `description`, and lists only its own role's screens, entry
-screen first. Each screen is reachable by clicking from somewhere in its own
-flow — `RiskQueue`'s "Review next" CTA and its table both lead to
-`QueueRiskDetail`; `MyRisks`'s button leads to `NewRisk` and its table leads to
-`RiskDetail`. They are what the prototype's flow picker offers the reviewer —
+screen first. Each flow walks in the order it lists — `RiskQueue`'s "Review
+next" CTA and its table both lead to `QueueRiskDetail`; `MyRisks`'s "New risk"
+leads to `NewRisk`, whose "Create risk" lands on the new risk's `RiskDetail`
+(`MyRisks`'s table reaches the same screen for a risk that already exists).
+They are what the prototype's flow picker offers the reviewer —
 the Manager's "Approval queue" walks queue-then-escalate, the Risk owner's
 "Log a risk" walks log-then-remediate — and neither flow references a screen
 the other role can't reach.

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -1,0 +1,104 @@
+# Implementing wireframes (coding agent)
+
+The companion to the `wireframes` skill for the coding run: how a
+`wireframes.dsl` becomes routes, pages, elements and navigation, and the
+fidelity checklist the PR carries. The grammar you are reading is in
+`SKILL.md`; this file is about honouring it.
+
+The wireframe is the **screen contract** for a `web-application` component.
+The reviewer who validates the deployed app compares the rendered wireframe
+with the running page, screen by screen; a missing screen, a dropped element
+or a reshuffled layout is a defect at that stage. Read the DSL **before**
+writing the first page, and build what it says.
+
+**Read `specs/design/components/<name>/wireframes.dsl`** (never the
+`.excalidraw` — that is the compiled picture). The Task's `## Scope` names
+which screens are yours; the DSL is where their content lives, so it wins
+over the issue text when the two differ.
+
+### Screen for screen
+
+- **One `screen` = one route/page.** Name the route and the page component
+  after the screen (`screen RiskQueue` → `/risk-queue`, `RiskQueuePage`),
+  so the mapping is legible in the PR. The screen's quoted description tells
+  you what the view is for and who uses it — read it as your brief, not as
+  page copy: the visible title is the screen's own `heading` element.
+- **No invented screens, no dropped screens.** A view the DSL does not
+  declare does not exist; a view it declares must exist even when it seems
+  minor. If a screen is genuinely unbuildable as drawn (its data has no API,
+  its action has no endpoint), build the rest of it, leave the gap explicit
+  in the UI, and say so in the PR — never silently fold it into another
+  page.
+- **Every role gets its own screen.** Where the DSL declares a screen per
+  role (`RiskQueue` for the manager, `MyRisks` for the owner), each is its
+  own route with its own chrome, showing only the actions and columns its
+  screen carries. Do not collapse two role screens into one page that toggles
+  on the viewer. How you
+  factor the code behind those routes is your call: share a component where
+  the views genuinely overlap, as long as each route renders exactly what its
+  screen shows. Read the role in the SPA from the sign-in identity the auth
+  dependency provides (`user.profile.groups`; see `thunder-authentication`),
+  and treat it as **presentation only** — the backend enforces permission and
+  answers 403. A component with no auth dependency has no roles: build the
+  screen as drawn.
+
+### Element for element
+
+Walk each `screen` block top to bottom and make every line a real element,
+in that order, with that literal content:
+
+| DSL | Build |
+|---|---|
+| `navbar "App \| Nav -> S"` / `sidebar "…"` | the app's real navigation chrome, identical on every screen of a role; each item that carries `-> S` links there |
+| `heading`, `text`, `link`, `breadcrumb` | the same words on the page |
+| `card "Label \| Value \| Caption"` | a stat tile with that label, that value bound to live data, that caption |
+| `table "A \| B \| C"` + `row` lines | a data table with exactly those columns; the `row`s are example data, so bind the table to the real list |
+| `list`, `tabs`, `badge`, `progress`, `avatar`, `chart`, `image` | the matching UI primitive — a status is a badge, not a paragraph |
+| `input`, `textarea`, `select`, `search`, `checkbox`, `radio`, `toggle` | a real form control whose placeholder/label is the DSL label, wired to submit |
+| `button "X" primary` | a primary-styled button; every button the DSL marks `primary` is primary on the page, and only those. Unmarked buttons take a non-primary style (destructive where the DSL says `danger`) |
+| `row`, `split N/M`, nested `card` children | the same layout: side by side, two columns in that ratio, grouped inside the card |
+| a `variant` (`danger`, `success`, …) | the design system's matching status colour |
+
+Labels are **copy**, not hints: "Open risks", "Review next", "Notify owner
+on create" appear on the page as written. Rename only when the wording is
+wrong for the data the API actually returns, and say so in the PR.
+
+**Empty, loading, and error states** are implied, not drawn: every `table`,
+`list`, and data `card` needs what it shows with no rows, while fetching,
+and when the request fails. A wireframe shows the happy path; the page
+must not break off it.
+
+### Arrow for arrow
+
+Every `-> Screen` — on a button, a link, a table, a navbar or sidebar item —
+is **working navigation** to that screen's route. Every `flow` block is a
+journey a role must be able to walk end to end by clicking: entry screen
+first, each screen reachable from the one before. A screen you cannot reach
+from its flow is a broken page, even if it renders.
+
+### The fidelity checklist
+
+Before the PR, walk the DSL once more and put this in the PR body — one line
+per screen, then one per `flow` — with any gap named beside it:
+
+```text
+Wireframe fidelity (specs/design/components/<name>/wireframes.dsl)
+
+Screens
+- [x] RiskQueue → /risk-queue — all elements; "Review next" → QueueRiskDetail
+- [x] MyRisks → /my-risks — all elements; table → RiskDetail
+- [ ] NewRisk → /risks/new — "Register" select not built: no registers endpoint
+
+Flows
+- [x] "Approval queue" (Manager) — RiskQueue → QueueRiskDetail walks by clicking
+- [ ] "Log a risk" (Risk owner) — MyRisks → NewRisk walks; NewRisk → RiskDetail
+      blocked on the missing select
+```
+
+A screen is ticked only when every element in its block exists on the page
+and every arrow it carries navigates. A flow is ticked only when you can walk
+it end to end by clicking, entry screen first — an unwalkable flow strands the
+screens behind it, so the e2e test written against the acceptance criteria
+cannot reach them either. An unticked line with its reason is fine — it tells
+the reviewer exactly where to look.
+

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -16,7 +16,7 @@ writing the first page, and build what it says.
 which screens are yours; the DSL is where their content lives, so it wins
 over the issue text when the two differ.
 
-### Screen for screen
+## Screen for screen
 
 - **One `screen` = one route/page.** Name the route and the page component
   after the screen (`screen RiskQueue` → `/risk-queue`, `RiskQueuePage`),
@@ -33,16 +33,16 @@ over the issue text when the two differ.
   role (`RiskQueue` for the manager, `MyRisks` for the owner), each is its
   own route with its own chrome, showing only the actions and columns its
   screen carries. Do not collapse two role screens into one page that toggles
-  on the viewer. How you
-  factor the code behind those routes is your call: share a component where
-  the views genuinely overlap, as long as each route renders exactly what its
-  screen shows. Read the role in the SPA from the sign-in identity the auth
+  on the viewer. How you factor the code behind those routes is your call:
+  share a component where the views genuinely overlap, as long as each route
+  renders exactly what its screen shows.
+  Read the role in the SPA from the sign-in identity the auth
   dependency provides (`user.profile.groups`; see `thunder-authentication`),
   and treat it as **presentation only** — the backend enforces permission and
   answers 403. A component with no auth dependency has no roles: build the
   screen as drawn.
 
-### Element for element
+## Element for element
 
 Walk each `screen` block top to bottom and make every line a real element,
 in that order, with that literal content:
@@ -68,15 +68,19 @@ wrong for the data the API actually returns, and say so in the PR.
 and when the request fails. A wireframe shows the happy path; the page
 must not break off it.
 
-### Arrow for arrow
+## Arrow for arrow
 
 Every `-> Screen` — on a button, a link, a table, a navbar or sidebar item —
-is **working navigation** to that screen's route. Every `flow` block is a
-journey a role must be able to walk end to end by clicking: entry screen
-first, each screen reachable from the one before. A screen you cannot reach
-from its flow is a broken page, even if it renders.
+is **working navigation** to that screen's route — including the rail item
+pointing at the screen it sits on, which is the active nav link and still a
+link. A chrome item with no target names a section outside this wireframe set:
+render it and leave it inert rather than inventing a destination for it.
 
-### The fidelity checklist
+Every `flow` block is a journey a role must be able to walk end to end by
+clicking: entry screen first, each screen reachable from the one before. A
+screen you cannot reach from its flow is a broken page, even if it renders.
+
+## The fidelity checklist
 
 Before the PR, walk the DSL once more and put this in the PR body — one line
 per screen, then one per `flow` — with any gap named beside it:
@@ -101,4 +105,3 @@ it end to end by clicking, entry screen first — an unwalkable flow strands the
 screens behind it, so the e2e test written against the acceptance criteria
 cannot reach them either. An unticked line with its reason is fine — it tells
 the reviewer exactly where to look.
-


### PR DESCRIPTION
Closes #674

## Problem

Wireframes are authored at design time, but implementations came back with
missing elements, missing states, and reshuffled layouts — first noticed at
validation. The `wireframes` skill already shipped to the coding agent
(`audience: [design, coding]`), but its entire body was authoring guidance:
nothing told the coding agent how to turn a `screen` block into a page, and
the description only triggered on *creating* wireframes.

## Change

**`skills/wireframes/` split into the shape the skills-experience design doc
already prescribed** (shared core + per-audience references):

- `SKILL.md` (196 lines, was 520) — the DSL grammar both audiences share, a
  dual-trigger description, and a router: designing → `references/authoring.md`,
  implementing → `references/implementing.md`.
- `references/authoring.md` — the design-agent content, moved verbatim, plus
  fixes for two divergence sources found in a real project
  (ae-demo/audit-evidance-app):
  - **Every `primary` button must lead somewhere** — 5 of 7 primaries in the
    real wireframe were dead ends because the guidance only required screens,
    not actions, to be reachable.
  - **No `Login` screen on auth-dependent components; each role's flow opens on
    its own screen** — a shared Login first in every flow funnelled all three
    personas into the manager's dashboard (sign-in is the platform SSO's page,
    not the app's).
  - "One primary per screen" softened to a default (the DSL and compiler never
    enforced a count; two equal actions like Approve/Reject are legitimate).
- `references/implementing.md` (new) — the coding agent's contract:
  one `screen` = one route; every element built in order with its literal
  label; empty/loading/error states implied; every `->` arrow is working
  navigation; role screens never collapse into one page with a toggle
  (role from `user.profile.groups`, presentation-only, backend enforces);
  and a per-screen + per-flow **fidelity checklist** the PR body carries.

**`skills/task-planning/SKILL.md`** — a web-app Task now always carries the
`wireframes.dsl` path under `## References` and a `Screens:` line (names
only) under `## Scope`.

**`packages/excalidraw-dsl/test/skill-examples.test.ts`** (new) — every
complete DSL document in the skill must parse, lay out, and compile. Caught
two real bugs while writing this PR: the skill's own flow example taught a
trailing `//` comment the flow parser rejects, and my first draft repeated it.

## Proof of real execution

- **Playground, full cycle** (requirements → design → tasks → code on a
  two-component fixture): the task issue carried `Screens:` + the DSL path;
  the coding agent read `references/implementing.md` (run transcript) and
  produced one route per screen, elements in DSL order with literal labels
  (`"<- Back to books"`), the one `primary` per DSL, and 9 loading/empty/error
  state branches.
- **Deployed stack, real project** (`audit-evidance`): regenerated wireframes
  have no Login screen, all three role flows open on their own dashboard, and
  every `primary` navigates. Issue of the project repo carries the
  `Screens:` line. The dispatched coding run read `wireframes.dsl` within its
  first minute.
- `packages/excalidraw-dsl`: 114 tests pass. `make typecheck` and
  `make license-check` clean.

Not yet proven: the fidelity checklist rendered in a real PR body — the
dispatched run that would have shown it was starved by provider-side API
latency (run failed on `redispatch-budget`, unrelated to this change).

## Docs

No doc updates needed: `docs/superpowers/specs/2026-07-21-skills-experience-design.md`
already specifies this exact layout for `wireframes` — this PR makes the spec
true. ADR-0014's description of the skill's dual audience is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JzzsQ8QJSWf3AtrYjAe1w
