### PR TITLE
Fail the build immediately when a design asks for a platform resource the cluster does not have

### DIFF
--- a/runners/remote-worker/src/lib/workflow_skill.test.ts
+++ b/runners/remote-worker/src/lib/workflow_skill.test.ts
@@ -227,6 +227,21 @@ test("architecture description still triggers on resolving a dependency", () => 
   assert.match(frontmatter, /resolving\/reconsidering any dependency/);
 });
 
+test("architecture copies platform-resource resourceType from this turn's catalog", () => {
+  const skill = fs.readFileSync(ARCHITECTURE, "utf8");
+  assert.ok(skill.includes("list_platform_resource_types"), "discover types from the live catalog");
+  assert.ok(
+    skill.includes("omit the entry and list the gap under **Needs your input**"),
+    "a missing catalog type is a gap, not a coined resourceType",
+  );
+});
+
+test("cell-design does not teach invented cluster resource types", () => {
+  const cell = fs.readFileSync(path.join(LIBRARY, "cell-design", "SKILL.md"), "utf8");
+  assert.ok(!cell.includes("postgres-cnpg/redis"), "CRT names belong to this turn's catalog list, not the cell table");
+  assert.ok(cell.includes("list_platform_resource_types"), "placement defers resourceType to the catalog");
+});
+
 test("architecture prefers a Registered External resource over a new-name Project External", () => {
   const skill = fs.readFileSync(ARCHITECTURE, "utf8");
   assert.ok(skill.includes("Registered External resource"), "lost Registered External resource");

--- a/services/aep-api/internal/app/build_adapters.go
+++ b/services/aep-api/internal/app/build_adapters.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
 	"github.com/wso2/aep/aep-api/internal/delivery/build"
+	"github.com/wso2/aep/aep-api/internal/dependencies"
 	"github.com/wso2/aep/aep-api/internal/dependencies/provisioning"
 	"github.com/wso2/aep/aep-api/internal/spec"
 )
@@ -129,14 +130,28 @@ func (b buildGateResolver) ProvisionForBuild(ctx context.Context, orgID, project
 	if err != nil {
 		return err
 	}
+	return aggregateProvisionFailures(fails)
+}
+
+func aggregateProvisionFailures(fails []provisioning.ProvisionFailure) error {
 	if len(fails) == 0 {
 		return nil
 	}
 	reasons := make([]string, 0, len(fails))
+	permanent := false
+	var cause error
 	for _, f := range fails {
 		reasons = append(reasons, f.Dependency+": "+f.Reason)
+		if errors.Is(f.Err, dependencies.ErrProvisionPermanent) {
+			permanent = true
+			cause = f.Err
+		}
 	}
-	return fmt.Errorf("provision %d dependenc(ies) failed: %s", len(fails), strings.Join(reasons, "; "))
+	joined := fmt.Errorf("provision %d dependenc(ies) failed: %s", len(fails), strings.Join(reasons, "; "))
+	if !permanent {
+		return joined
+	}
+	return fmt.Errorf("%w: %w: %w", delivery.ErrProvisionPermanent, cause, joined)
 }
 
 // mapProvisionInputs maps the delivery-root payload onto the provisioning

--- a/services/aep-api/internal/app/build_adapters.go
+++ b/services/aep-api/internal/app/build_adapters.go
@@ -67,6 +67,8 @@ func (d buildDesignDeriver) DerivePlatformResourceFactsAtHead(ctx context.Contex
 		return nil
 	case errors.Is(err, spec.ErrEndUserAuthConflict):
 		return fmt.Errorf("%w: %v", build.ErrEndUserAuthConflict, err)
+	case errors.Is(err, spec.ErrUnknownResourceType):
+		return fmt.Errorf("%w: %v", build.ErrUnknownResourceType, err)
 	case errors.Is(err, spec.ErrResourceCatalogUnavailable):
 		return fmt.Errorf("%w: %v", build.ErrResourceCatalogUnavailable, err)
 	default:

--- a/services/aep-api/internal/app/build_adapters_test.go
+++ b/services/aep-api/internal/app/build_adapters_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/dependencies"
+	"github.com/wso2/aep/aep-api/internal/dependencies/provisioning"
+)
+
+func TestAggregateProvisionFailures_PreservesPermanentSentinel(t *testing.T) {
+	t.Parallel()
+	err := aggregateProvisionFailures([]provisioning.ProvisionFailure{{
+		Dependency: "parcel-receipts",
+		Reason:     "resources: resource \"x\" produced no new ResourceRelease within 1m0s",
+		Err:        fmt.Errorf("%w: timed out", dependencies.ErrProvisionPermanent),
+	}})
+	if !errors.Is(err, delivery.ErrProvisionPermanent) {
+		t.Fatalf("delivery.ErrProvisionPermanent must survive aggregation, got %v", err)
+	}
+	if !errors.Is(err, dependencies.ErrProvisionPermanent) {
+		t.Fatalf("dependencies.ErrProvisionPermanent must survive aggregation, got %v", err)
+	}
+}
+
+func TestAggregateProvisionFailures_BlipIsNotPermanent(t *testing.T) {
+	t.Parallel()
+	err := aggregateProvisionFailures([]provisioning.ProvisionFailure{{
+		Dependency: "orders-db",
+		Reason:     "connection refused",
+		Err:        errors.New("connection refused"),
+	}})
+	if errors.Is(err, delivery.ErrProvisionPermanent) {
+		t.Fatalf("a blip must not be marked permanent: %v", err)
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/resource_client.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client.go
@@ -875,10 +875,16 @@ func resourceTerminalCondition(r *Resource) *OCCondition {
 }
 
 // ErrReleaseWaitTimeout is a wait-boundary answer: the poll deadline expired
-// without a new ResourceRelease, or the Resource reported a terminal
-// Ready=False (ResourceTypeNotFound). GetResource transport errors and
-// context.Canceled / DeadlineExceeded are not this sentinel.
+// without a new ResourceRelease. GetResource transport errors and
+// context.Canceled / DeadlineExceeded are not this sentinel. A missing
+// ClusterResourceType is ErrResourceTypeNotFound, not a timeout: that answer
+// is terminal even when a prior release already exists.
 var ErrReleaseWaitTimeout = errors.New("release wait timed out")
+
+// ErrResourceTypeNotFound is a wait-boundary answer: the Resource reported
+// Ready=False with reason ResourceTypeNotFound. The controller will never cut
+// a release for a type that is not installed.
+var ErrResourceTypeNotFound = errors.New("cluster resource type not found")
 
 // WaitForReleaseChange polls GetResource until status.latestRelease.Name is
 // non-empty AND differs from prior, returning the release name the caller pins
@@ -896,8 +902,10 @@ var ErrReleaseWaitTimeout = errors.New("release wait timed out")
 // error quoting the condition message. Other Ready=False reasons are not
 // treated as terminal (a controller may set False transiently).
 //
-// Deadline expiry and ResourceTypeNotFound are wrapped with
-// ErrReleaseWaitTimeout so callers can tell a wait answer from a poll blip.
+// Deadline expiry wraps ErrReleaseWaitTimeout; ResourceTypeNotFound wraps
+// ErrResourceTypeNotFound. Callers tell a wait answer from a poll blip via
+// those two sentinels, and tell a missing type from a slow reconcile via
+// which sentinel they got.
 // It bounds ONLY the (fast) release-cut — the controller hashing spec.parameters
 // into an immutable ResourceRelease — never the readiness of the backing infra
 // that release eventually provisions (a real database can take minutes; callers
@@ -916,7 +924,7 @@ func WaitForReleaseChange(ctx context.Context, rc ResourceClient, namespace, res
 			if msg == "" {
 				msg = c.Reason
 			}
-			return "", fmt.Errorf("%w: resource %q: %s", ErrReleaseWaitTimeout, resourceName, msg)
+			return "", fmt.Errorf("%w: resource %q: %s", ErrResourceTypeNotFound, resourceName, msg)
 		}
 		if name := ReleaseName(got); name != "" && name != prior {
 			return name, nil

--- a/services/aep-api/internal/clients/openchoreo/resource_client.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client.go
@@ -874,6 +874,12 @@ func resourceTerminalCondition(r *Resource) *OCCondition {
 	return nil
 }
 
+// ErrReleaseWaitTimeout is a wait-boundary answer: the poll deadline expired
+// without a new ResourceRelease, or the Resource reported a terminal
+// Ready=False (ResourceTypeNotFound). GetResource transport errors and
+// context.Canceled / DeadlineExceeded are not this sentinel.
+var ErrReleaseWaitTimeout = errors.New("release wait timed out")
+
 // WaitForReleaseChange polls GetResource until status.latestRelease.Name is
 // non-empty AND differs from prior, returning the release name the caller pins
 // a ResourceReleaseBinding to. `prior` is the release observed at apply time
@@ -890,6 +896,8 @@ func resourceTerminalCondition(r *Resource) *OCCondition {
 // error quoting the condition message. Other Ready=False reasons are not
 // treated as terminal (a controller may set False transiently).
 //
+// Deadline expiry and ResourceTypeNotFound are wrapped with
+// ErrReleaseWaitTimeout so callers can tell a wait answer from a poll blip.
 // It bounds ONLY the (fast) release-cut — the controller hashing spec.parameters
 // into an immutable ResourceRelease — never the readiness of the backing infra
 // that release eventually provisions (a real database can take minutes; callers
@@ -908,13 +916,13 @@ func WaitForReleaseChange(ctx context.Context, rc ResourceClient, namespace, res
 			if msg == "" {
 				msg = c.Reason
 			}
-			return "", fmt.Errorf("resource %q: %s", resourceName, msg)
+			return "", fmt.Errorf("%w: resource %q: %s", ErrReleaseWaitTimeout, resourceName, msg)
 		}
 		if name := ReleaseName(got); name != "" && name != prior {
 			return name, nil
 		}
 		if time.Now().After(deadline) {
-			return "", fmt.Errorf("resource %q produced no new ResourceRelease within %s", resourceName, timeout)
+			return "", fmt.Errorf("%w: resource %q produced no new ResourceRelease within %s", ErrReleaseWaitTimeout, resourceName, timeout)
 		}
 		select {
 		case <-ctx.Done():

--- a/services/aep-api/internal/clients/openchoreo/resource_client.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client.go
@@ -310,6 +310,7 @@ type ResourceLatestRelease struct {
 // ResourceStatus is Resource.status.
 type ResourceStatus struct {
 	LatestRelease *ResourceLatestRelease `json:"latestRelease,omitempty"`
+	Conditions    []OCCondition          `json:"conditions,omitempty"`
 }
 
 // Resource is the openchoreo.dev/v1alpha1 Resource CR.
@@ -338,9 +339,10 @@ type ResourceReleaseBindingSpec struct {
 
 // OCCondition mirrors a k8s CR's status.conditions[] entry.
 type OCCondition struct {
-	Type   string `json:"type"`
-	Status string `json:"status"` // "True" | "False" | "Unknown"
-	Reason string `json:"reason,omitempty"`
+	Type    string `json:"type"`
+	Status  string `json:"status"` // "True" | "False" | "Unknown"
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // ResolvedOutput is one entry of a binding's status.outputs — a
@@ -854,6 +856,24 @@ func (c *resourceClient) ListWorkloadConsumerDeps(ctx context.Context, orgHandle
 	return deps, nil
 }
 
+const resourceTypeNotFound = "ResourceTypeNotFound"
+
+// resourceTerminalCondition returns the Ready=False condition whose reason is
+// known to be unrecoverable (a missing ClusterResourceType). Other Ready=False
+// reasons are left for the poll loop — a controller may set False transiently.
+func resourceTerminalCondition(r *Resource) *OCCondition {
+	if r == nil || r.Status == nil {
+		return nil
+	}
+	for i := range r.Status.Conditions {
+		c := &r.Status.Conditions[i]
+		if c.Type == "Ready" && c.Status == "False" && c.Reason == resourceTypeNotFound {
+			return c
+		}
+	}
+	return nil
+}
+
 // WaitForReleaseChange polls GetResource until status.latestRelease.Name is
 // non-empty AND differs from prior, returning the release name the caller pins
 // a ResourceReleaseBinding to. `prior` is the release observed at apply time
@@ -864,6 +884,11 @@ func (c *resourceClient) ListWorkloadConsumerDeps(ctx context.Context, orgHandle
 //   - the stale release when an EXISTING Resource was reconciled — the wait then
 //     holds until the OC controller cuts the NEW release for the changed spec,
 //     so a reconcile never pins the binding to the pre-reconcile release.
+//
+// A Ready=False condition with reason ResourceTypeNotFound is terminal: the
+// controller will never cut a release, so the wait returns immediately with an
+// error quoting the condition message. Other Ready=False reasons are not
+// treated as terminal (a controller may set False transiently).
 //
 // It bounds ONLY the (fast) release-cut — the controller hashing spec.parameters
 // into an immutable ResourceRelease — never the readiness of the backing infra
@@ -877,6 +902,13 @@ func WaitForReleaseChange(ctx context.Context, rc ResourceClient, namespace, res
 		got, err := rc.GetResource(ctx, namespace, resourceName)
 		if err != nil {
 			return "", fmt.Errorf("poll resource %q: %w", resourceName, err)
+		}
+		if c := resourceTerminalCondition(got); c != nil {
+			msg := c.Message
+			if msg == "" {
+				msg = c.Reason
+			}
+			return "", fmt.Errorf("resource %q: %s", resourceName, msg)
 		}
 		if name := ReleaseName(got); name != "" && name != prior {
 			return name, nil

--- a/services/aep-api/internal/clients/openchoreo/resource_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client_test.go
@@ -385,8 +385,8 @@ func TestWaitForReleaseChange_ReadyFalseResourceTypeNotFoundIsPermanent(t *testi
 	if err == nil {
 		t.Fatal("want permanent error, got nil")
 	}
-	if !errors.Is(err, ErrReleaseWaitTimeout) {
-		t.Fatalf("want ErrReleaseWaitTimeout wait-answer sentinel, got %v", err)
+	if !errors.Is(err, ErrResourceTypeNotFound) {
+		t.Fatalf("want ErrResourceTypeNotFound wait-answer sentinel, got %v", err)
 	}
 	if !strings.Contains(err.Error(), "object-storage") && !strings.Contains(err.Error(), "ResourceTypeNotFound") {
 		t.Fatalf("error must quote the terminal condition, got %v", err)

--- a/services/aep-api/internal/clients/openchoreo/resource_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // newTestResourceClient builds a resourceClient pointed at srv with no auth
@@ -334,6 +335,84 @@ func TestGetResource_NotFound(t *testing.T) {
 	_, err := c.GetResource(context.Background(), "wc-abc", "missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetResource_DecodesConditions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, map[string]any{
+			"metadata": map[string]any{"name": "r1"},
+			"status": map[string]any{
+				"conditions": []map[string]any{{
+					"type": "Ready", "status": "False",
+					"reason":  "ResourceTypeNotFound",
+					"message": `ClusterResourceType "object-storage" not found`,
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestResourceClient(t, srv)
+	got, err := c.GetResource(context.Background(), "ns", "r1")
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+	if got.Status == nil || len(got.Status.Conditions) != 1 || got.Status.Conditions[0].Reason != "ResourceTypeNotFound" {
+		t.Fatalf("conditions not decoded: %+v", got.Status)
+	}
+}
+
+// ---- WaitForReleaseChange -----------------------------------------------------
+
+func TestWaitForReleaseChange_ReadyFalseResourceTypeNotFoundIsPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, Resource{
+			Metadata: OCObjectMeta{Name: "order-processing-dca538e7"},
+			Status: &ResourceStatus{
+				Conditions: []OCCondition{{
+					Type:    "Ready",
+					Status:  "False",
+					Reason:  "ResourceTypeNotFound",
+					Message: `ClusterResourceType "object-storage" not found`,
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestResourceClient(t, srv)
+
+	_, err := WaitForReleaseChange(context.Background(), c, "default", "order-processing-dca538e7", "", time.Hour, time.Hour)
+	if err == nil {
+		t.Fatal("want permanent error, got nil")
+	}
+	if !strings.Contains(err.Error(), "object-storage") && !strings.Contains(err.Error(), "ResourceTypeNotFound") {
+		t.Fatalf("error must quote the terminal condition, got %v", err)
+	}
+}
+
+func TestWaitForReleaseChange_ReadyFalseOtherReasonStillWaitsUntilTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, Resource{
+			Metadata: OCObjectMeta{Name: "r1"},
+			Status: &ResourceStatus{
+				Conditions: []OCCondition{{
+					Type:   "Ready",
+					Status: "False",
+					Reason: "Reconciling",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := newTestResourceClient(t, srv)
+
+	start := time.Now()
+	_, err := WaitForReleaseChange(context.Background(), c, "ns", "r1", "", 5*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("want timeout, got nil")
+	}
+	if time.Since(start) < 15*time.Millisecond {
+		t.Fatalf("non-terminal Ready=False must not return immediately: %v after %s", err, time.Since(start))
 	}
 }
 

--- a/services/aep-api/internal/clients/openchoreo/resource_client_test.go
+++ b/services/aep-api/internal/clients/openchoreo/resource_client_test.go
@@ -385,6 +385,9 @@ func TestWaitForReleaseChange_ReadyFalseResourceTypeNotFoundIsPermanent(t *testi
 	if err == nil {
 		t.Fatal("want permanent error, got nil")
 	}
+	if !errors.Is(err, ErrReleaseWaitTimeout) {
+		t.Fatalf("want ErrReleaseWaitTimeout wait-answer sentinel, got %v", err)
+	}
 	if !strings.Contains(err.Error(), "object-storage") && !strings.Contains(err.Error(), "ResourceTypeNotFound") {
 		t.Fatalf("error must quote the terminal condition, got %v", err)
 	}
@@ -410,6 +413,9 @@ func TestWaitForReleaseChange_ReadyFalseOtherReasonStillWaitsUntilTimeout(t *tes
 	_, err := WaitForReleaseChange(context.Background(), c, "ns", "r1", "", 5*time.Millisecond, 20*time.Millisecond)
 	if err == nil {
 		t.Fatal("want timeout, got nil")
+	}
+	if !errors.Is(err, ErrReleaseWaitTimeout) {
+		t.Fatalf("deadline expiry must wrap ErrReleaseWaitTimeout, got %v", err)
 	}
 	if time.Since(start) < 15*time.Millisecond {
 		t.Fatalf("non-terminal Ready=False must not return immediately: %v after %s", err, time.Since(start))

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -126,7 +126,10 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   gate → whole-spec gate + `v<N>` tag cut → milestone → supersede → run row → plan. The ORDER is the
   domain fact `build` owns; the two halves it does not own (the planning turn, the gate resolvers) are
   root ports. Preflight emits no `external-config` collect for a **Registered External
-  resource** the org catalog already holds (ADR-0021).
+  resource** the org catalog already holds (ADR-0021). Pre-tag also refuses an unknown
+  `resourceType` (`ErrUnknownResourceType` → 409) the same way it refuses an end-user-auth
+  conflict: the design is unsatisfiable on this cluster, so the click claims no version and
+  starts no workflow.
 - **What preflight gates**: it reports what a version's dependencies still need, and only
   `needsResolution` — a dependency the design itself cannot name (ambiguous, unresolved, missing spec,
   or an org service awaiting access) — blocks the version cut. `needsInput` stays the broad "there is
@@ -377,7 +380,11 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   secondary rate limit wears a 403 and is deliberately NOT one — and `run/errors.go` owns turning them
   into Temporal's vocabulary. The guard is per call site, so an activity added later that returns a
   source-control error raw is back on unbounded retry; `CloseMilestone` is the one deliberate exception,
-  swallowing its error by contract and so never retrying.
+  swallowing its error by contract and so never retrying. The same split applies to provision and
+  deploy: `provisionErr` / `deployErr` mark `ErrProvisionPermanent` / `ErrDeployPermanent` non-retryable.
+  A provision wait-answer (Resource `Ready=False` / `ResourceTypeNotFound`, or a create that never
+  cuts a release) is permanent; a GetResource blip or cancelled wait is not. Do not bound
+  `activityCtx` with `MaximumAttempts` — permanence is the activity's to declare.
 - **Every terminal reason names exactly one failure class.** `redispatch-budget` is agent death (including
   a Job that exited without a pull request); `build-retrigger-budget` is a build that stayed red through
   its one automatic re-trigger with no fix issue to recover it; `deploy-budget` is a component that

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -382,7 +382,8 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   source-control error raw is back on unbounded retry; `CloseMilestone` is the one deliberate exception,
   swallowing its error by contract and so never retrying. The same split applies to provision and
   deploy: `provisionErr` / `deployErr` mark `ErrProvisionPermanent` / `ErrDeployPermanent` non-retryable.
-  A provision wait-answer (Resource `Ready=False` / `ResourceTypeNotFound`, or a create that never
+  A provision wait-answer (Resource `Ready=False` / `ResourceTypeNotFound` — even when a
+  prior release exists — or a create that never
   cuts a release) is permanent; a GetResource blip or cancelled wait is not. Do not bound
   `activityCtx` with `MaximumAttempts` — permanence is the activity's to declare.
 - **Every terminal reason names exactly one failure class.** `redispatch-budget` is agent death (including

--- a/services/aep-api/internal/delivery/build/build_service.go
+++ b/services/aep-api/internal/delivery/build/build_service.go
@@ -355,10 +355,13 @@ func (s *Service) Run(ctx context.Context, orgID, projectID string, inputs []Bui
 
 // mapPreTagError maps the coordinator's pre-tag failures onto the edge
 // vocabulary: an end-user-auth conflict is a 409 (the design self-contradicts),
-// an unreachable CRT catalog is a retryable 503, anything else a 500.
+// an unknown resourceType is a 409 (unsatisfiable on this cluster), an
+// unreachable CRT catalog is a retryable 503, anything else a 500.
 func mapPreTagError(err error) error {
 	switch {
 	case errors.Is(err, ErrEndUserAuthConflict):
+		return &EdgeError{Status: 409, Message: err.Error()}
+	case errors.Is(err, ErrUnknownResourceType):
 		return &EdgeError{Status: 409, Message: err.Error()}
 	case errors.Is(err, ErrResourceCatalogUnavailable):
 		return &EdgeError{Status: 503, Message: err.Error()}

--- a/services/aep-api/internal/delivery/build/build_test.go
+++ b/services/aep-api/internal/delivery/build/build_test.go
@@ -854,6 +854,45 @@ type noopAuth struct{}
 
 func (noopAuth) DerivePlatformResourceFactsAtHead(context.Context, string, string) error { return nil }
 
+type errAuth struct{ err error }
+
+func (e errAuth) DerivePlatformResourceFactsAtHead(context.Context, string, string) error {
+	return e.err
+}
+
+// An uninstalled resourceType is refused at the click: HTTP 409, no tag, no
+// Temporal run. The design is unsatisfiable on this cluster; retrying provision
+// cannot invent a ClusterResourceType.
+func TestBuild_UnknownResourceType_409_NoTagNoWorkflow(t *testing.T) {
+	spy := newPlanSpy()
+	tagger := &fakeTagger{res: &spec.SpecSaveResult{Tag: "v1"}}
+	coord := build.NewInputsCoordinator(nil, errAuth{err: build.ErrUnknownResourceType}, nil)
+	svc := withPlanPath(build.NewService(build.Deps{
+		Repos: fakeRepos{}, Tagger: tagger, Coord: coord,
+	}), spy)
+
+	code, body := postBuild(t, svc, "shop")
+	if code != 409 {
+		t.Fatalf("status = %d, want 409 (body=%s)", code, body)
+	}
+	e := componenttest.DecodeEnvelope(t, body)
+	if e.Code != "conflict" {
+		t.Fatalf("409 envelope = %+v", e)
+	}
+	if !strings.Contains(e.Message, "resourceType is not installed") {
+		t.Errorf("409 message = %q, want it to name the missing resourceType", e.Message)
+	}
+	if tagger.called != 0 {
+		t.Errorf("tagger called %d times, want 0 — unknown type must block before the tag-cut", tagger.called)
+	}
+	if len(spy.milestones()) != 0 {
+		t.Errorf("a rejected click minted a milestone: %v", spy.milestones())
+	}
+	if len(spy.startedRuns()) != 0 {
+		t.Errorf("a rejected click started a run: %v", spy.startedRuns())
+	}
+}
+
 // A doctored client (no inputs at all) cannot skip the drawer: an ambiguous
 // external dependency blocks with a failure, no tag is cut, and no workflow
 // starts.

--- a/services/aep-api/internal/delivery/build/inputs_coordinator_test.go
+++ b/services/aep-api/internal/delivery/build/inputs_coordinator_test.go
@@ -147,6 +147,15 @@ func TestApplyPreTag_AuthConflictReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, ErrEndUserAuthConflict)
 }
 
+// An unknown resourceType is the same shape: a pre-tag error, not a drawer
+// failure, so the handler can map it to 409 and cut no tag.
+func TestApplyPreTag_UnknownResourceTypeReturnsError(t *testing.T) {
+	auth := &recordingAuth{err: ErrUnknownResourceType}
+	c := &InputsCoordinator{spec: &recordingSpec{}, auth: auth}
+	_, err := c.ApplyPreTag(ctx, "acme", "shop", nil)
+	require.ErrorIs(t, err, ErrUnknownResourceType)
+}
+
 // When a spec collection fails the build is aborting, so auth derivation must
 // NOT run (it would commit to HEAD for a build that cuts no tag) and the spec
 // failures must be returned intact rather than masked by an auth error.

--- a/services/aep-api/internal/delivery/build/ports.go
+++ b/services/aep-api/internal/delivery/build/ports.go
@@ -25,11 +25,11 @@ import (
 	"github.com/wso2/aep/aep-api/internal/spec"
 )
 
-// ErrEndUserAuthConflict and ErrResourceCatalogUnavailable are the build-local
-// pre-tag sentinels the handler maps to 409 / 503. build cannot import the
-// design feature (arch allowlist), so the DesignFactDeriver adapter wired at the
-// composition root translates design's equivalents into these before they cross
-// the port boundary.
+// ErrEndUserAuthConflict, ErrUnknownResourceType, and ErrResourceCatalogUnavailable
+// are the build-local pre-tag sentinels the handler maps to 409 / 409 / 503.
+// build cannot import the design feature (arch allowlist), so the DesignFactDeriver
+// adapter wired at the composition root translates design's equivalents into these
+// before they cross the port boundary.
 var (
 	ErrEndUserAuthConflict        = errors.New("end-user auth conflict")
 	ErrResourceCatalogUnavailable = errors.New("resource-type catalog unavailable")
@@ -43,9 +43,10 @@ type SpecCollector interface {
 	CollectSpec(ctx context.Context, orgID, projectID, component, depName string, rawSpec []byte, specURL string) (string, error)
 }
 
-// DesignFactDeriver runs the end-user-auth derivation against the design at HEAD and
-// commits any stamped exposesAPI.auth BEFORE the tag-cut. The adapter maps
-// design's conflict/catalog sentinels onto ErrEndUserAuthConflict /
+// DesignFactDeriver runs the end-user-auth and catalog-membership derivations
+// against the design at HEAD and commits any stamped exposesAPI.auth BEFORE the
+// tag-cut. The adapter maps design's conflict / unknown-type / catalog sentinels
+// onto ErrEndUserAuthConflict / ErrUnknownResourceType /
 // ErrResourceCatalogUnavailable.
 type DesignFactDeriver interface {
 	DerivePlatformResourceFactsAtHead(ctx context.Context, orgID, projectID string) error

--- a/services/aep-api/internal/delivery/build/ports.go
+++ b/services/aep-api/internal/delivery/build/ports.go
@@ -33,6 +33,7 @@ import (
 var (
 	ErrEndUserAuthConflict        = errors.New("end-user auth conflict")
 	ErrResourceCatalogUnavailable = errors.New("resource-type catalog unavailable")
+	ErrUnknownResourceType        = errors.New("resourceType is not installed on this cluster")
 )
 
 // SpecCollector fetches/accepts an external dependency's OpenAPI contract and

--- a/services/aep-api/internal/delivery/build_fanout.go
+++ b/services/aep-api/internal/delivery/build_fanout.go
@@ -167,6 +167,16 @@ func BuildRunName(projectID, component, sha string, attempt int) string {
 // between them, so neither has to import the other's world.
 var ErrDeployPermanent = errors.New("permanent deploy failure")
 
+// ErrProvisionPermanent marks a provisioning failure that repeating cannot
+// change: the ClusterResourceType is missing, or the Resource never cuts a
+// release.
+//
+// It is the same seam as ErrDeployPermanent: WHICH provision failures are
+// permanent belongs to the dependencies domain; turning that into Temporal's
+// vocabulary belongs to run/errors.go. This sentinel is the seam so run does
+// not import dependencies.
+var ErrProvisionPermanent = errors.New("permanent provision failure")
+
 // ComponentDeploy is one component's deployment in one environment, as the run
 // loop reasons about it: which release was pinned, and what the cluster says
 // about the binding that pins it.

--- a/services/aep-api/internal/delivery/run/activities.go
+++ b/services/aep-api/internal/delivery/run/activities.go
@@ -442,7 +442,7 @@ func (a *Activities) ProvisionGates(ctx context.Context, in PlanMilestoneInput) 
 	if a.gates == nil {
 		return nil
 	}
-	return planErr(a.gates.ProvisionForBuild(ctx, in.OrgID, in.ProjectID, in.Tag, in.MilestoneNumber, in.ProvisionInputs))
+	return provisionErr(a.gates.ProvisionForBuild(ctx, in.OrgID, in.ProjectID, in.Tag, in.MilestoneNumber, in.ProvisionInputs))
 }
 
 // PlanMilestone runs the version's planning turn.

--- a/services/aep-api/internal/delivery/run/errors.go
+++ b/services/aep-api/internal/delivery/run/errors.go
@@ -109,3 +109,19 @@ func deployErr(err error) error {
 	}
 	return temporal.NewNonRetryableApplicationError(err.Error(), errTypePermanentDeploy, err)
 }
+
+// errTypePermanentProvision is the ApplicationError type a permanent provision
+// failure carries: the ClusterResourceType is missing, or the Resource never
+// cuts a release.
+const errTypePermanentProvision = "PermanentProvisionFailure"
+
+// provisionErr is deployErr's twin for ProvisionGates: an answer must not be
+// retried like a blip. WHICH provision failures are permanent is the
+// dependencies domain's to say (delivery.ErrProvisionPermanent) — this package
+// only knows how to say it to Temporal.
+func provisionErr(err error) error {
+	if err == nil || !errors.Is(err, delivery.ErrProvisionPermanent) {
+		return err
+	}
+	return temporal.NewNonRetryableApplicationError(err.Error(), errTypePermanentProvision, err)
+}

--- a/services/aep-api/internal/delivery/run/errors_test.go
+++ b/services/aep-api/internal/delivery/run/errors_test.go
@@ -29,6 +29,7 @@ package run
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -253,4 +254,61 @@ func TestPlanMilestoneStopsAtTheFirstPermanentFailure(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.Equal(t, 1, planner.count(), "a permanent planning failure must be asked exactly once")
+}
+
+// scriptedGates answers ProvisionForBuild from a queued script — one entry per
+// call, the last repeating — and counts how often it was asked.
+type scriptedGates struct {
+	mu     sync.Mutex
+	script []error
+	calls  int
+}
+
+func (s *scriptedGates) ProvisionForBuild(context.Context, string, string, string, int, []delivery.ProvisionInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.script[min(s.calls-1, len(s.script)-1)]
+}
+
+func (s *scriptedGates) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// gatesEnv wires the real ProvisionGates over a scripted port. Planner
+// succeeds so a provision blip-then-nil still completes the workflow; the
+// test measures ProvisionGates attempts, not planning.
+func gatesEnv(t *testing.T, script ...error) (*testsuite.TestWorkflowEnvironment, *scriptedGates) {
+	t.Helper()
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestWorkflowEnvironment()
+	gates := &scriptedGates{script: script}
+	acts := NewActivities(Deps{
+		Milestones: &scriptedMilestones{script: []error{nil}},
+		Gates:      gates,
+		Planner:    &scriptedPlanner{script: []error{nil}},
+	})
+	env.RegisterActivity(acts)
+	env.OnActivity(acts.SetRunState, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(acts.SettleRun, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(acts.SetValidationVerdict, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(acts.ReadCycleFacts, mock.Anything, mock.Anything).Return(CycleFacts{}, nil)
+	return env, gates
+}
+
+func TestProvisionGatesStopsAtTheFirstPermanentFailure(t *testing.T) {
+	env, gates := gatesEnv(t, fmt.Errorf("%w: object-storage missing", delivery.ErrProvisionPermanent))
+	executePlan(env)
+	require.True(t, env.IsWorkflowCompleted())
+	require.Equal(t, 1, gates.count(), "a permanent provision failure must be asked exactly once")
+}
+
+func TestProvisionGatesRetriesABlip(t *testing.T) {
+	env, gates := gatesEnv(t, errors.New("openchoreo unreachable"), nil)
+	executePlan(env)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2, gates.count(), "a transient provision failure must be asked again")
 }

--- a/services/aep-api/internal/dependencies/README.md
+++ b/services/aep-api/internal/dependencies/README.md
@@ -142,9 +142,10 @@ slices.
   catalog does not 409 every build. Any future entry point that discovers platform
   resource types must honor the same flag.
 - **A provision wait-answer is permanent; a transport blip is not.** `ErrProvisionPermanent`
-  wraps only wait answers — `Ready=False` / `ResourceTypeNotFound` on the Resource, or a
-  create whose `latestRelease` never appears — and survives aggregation with `%w` so
-  `ProvisionGates` can mark it non-retryable. GetResource blips stay retryable. After the
+  wraps wait answers — `Ready=False` / `ResourceTypeNotFound` on the Resource (even when
+  a prior release exists), or a create whose `latestRelease` never appears — and survives
+  aggregation with `%w` so `ProvisionGates` can mark it non-retryable. GetResource blips
+  stay retryable. After the
   first permanent platform fault, remaining **platform-resource** waits in that sequential
   loop are skipped (externals and org-services still run). Delivery's twin sentinel
   (`ErrProvisionPermanent` on `build_fanout.go`) is the Temporal seam, matching

--- a/services/aep-api/internal/dependencies/README.md
+++ b/services/aep-api/internal/dependencies/README.md
@@ -138,5 +138,15 @@ slices.
   `ResourceTypeCatalog.List` returns an empty slice without calling OpenChoreo. HTTP
   `GET .../platform-resource-types`, MCP `list_platform_resource_types`, and design-save
   marker/wiring stamping all degrade off that empty catalog (no separate API signal).
-  Any future entry point that discovers platform resource types must honor the same flag.
+  Spec's build-claim membership check also skip-opens on that empty map so a disabled
+  catalog does not 409 every build. Any future entry point that discovers platform
+  resource types must honor the same flag.
+- **A provision wait-answer is permanent; a transport blip is not.** `ErrProvisionPermanent`
+  wraps only wait answers — `Ready=False` / `ResourceTypeNotFound` on the Resource, or a
+  create whose `latestRelease` never appears — and survives aggregation with `%w` so
+  `ProvisionGates` can mark it non-retryable. GetResource blips stay retryable. After the
+  first permanent platform fault, remaining **platform-resource** waits in that sequential
+  loop are skipped (externals and org-services still run). Delivery's twin sentinel
+  (`ErrProvisionPermanent` on `build_fanout.go`) is the Temporal seam, matching
+  `ErrDeployPermanent`.
 - Platform-wide rules (tenant gate, secrets fence, feature-free domains) → [../../README.md](../../README.md).

--- a/services/aep-api/internal/dependencies/errors.go
+++ b/services/aep-api/internal/dependencies/errors.go
@@ -37,4 +37,10 @@ var (
 
 	// ErrProvisionFailed is returned when the ResourceProvisioner call fails.
 	ErrProvisionFailed = errors.New("platform provisioner failed")
+
+	// ErrProvisionPermanent marks a provisioning answer that retrying cannot
+	// change: the ClusterResourceType does not exist, or the Resource never
+	// cuts a release. Distinct from ErrProvisionFailed, which is also used
+	// for blips (OC down) that must stay retryable.
+	ErrProvisionPermanent = errors.New("platform provisioner failed permanently")
 )

--- a/services/aep-api/internal/dependencies/platform_provisioner.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner.go
@@ -127,8 +127,12 @@ func (p *OCNativeProvisioner) Provision(
 	// fast poll for the release NAME, not a readiness wait. A reconcile carries
 	// the stale pre-reconcile release on `applied`, so wait for a CHANGE off it;
 	// a create leaves it empty (wait-for-nonempty).
-	latest, err := openchoreo.WaitForReleaseChange(ctx, p.rc, orgHandle, res.Metadata.Name, openchoreo.ReleaseName(applied), p.pollInterval, p.pollTimeout)
+	prior := openchoreo.ReleaseName(applied)
+	latest, err := openchoreo.WaitForReleaseChange(ctx, p.rc, orgHandle, res.Metadata.Name, prior, p.pollInterval, p.pollTimeout)
 	if err != nil {
+		if provisionWaitPermanent(prior, err) {
+			return nil, fmt.Errorf("%w: resources: %w", ErrProvisionPermanent, err)
+		}
 		return nil, fmt.Errorf("resources: %w", err)
 	}
 
@@ -226,6 +230,14 @@ func BuildPlatformBinding(project, depName, env, latestRelease string, params ma
 		b.Spec.ResourceTypeEnvironmentConfigs = json.RawMessage(raw)
 	}
 	return b, nil
+}
+
+// provisionWaitPermanent reports whether a WaitForReleaseChange failure is an
+// answer rather than a blip: the wait expired against a Resource that has
+// never cut a release. A wait that expired while a stale release still sat
+// on the Resource is not classified permanent (reconcile can be slow).
+func provisionWaitPermanent(prior string, err error) bool {
+	return err != nil && prior == ""
 }
 
 // OCNativeProvisioner is the only registered ResourceProvisioner impl today.

--- a/services/aep-api/internal/dependencies/platform_provisioner.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner.go
@@ -233,11 +233,13 @@ func BuildPlatformBinding(project, depName, env, latestRelease string, params ma
 }
 
 // provisionWaitPermanent reports whether a WaitForReleaseChange failure is an
-// answer rather than a blip: the wait expired against a Resource that has
-// never cut a release. A wait that expired while a stale release still sat
-// on the Resource is not classified permanent (reconcile can be slow).
+// answer rather than a blip: the wait expired (or reported ResourceTypeNotFound)
+// against a Resource that has never cut a release. A wait that expired while a
+// stale release still sat on the Resource is not classified permanent
+// (reconcile can be slow). Transport / context errors are not wait answers
+// even when prior is empty.
 func provisionWaitPermanent(prior string, err error) bool {
-	return err != nil && prior == ""
+	return prior == "" && errors.Is(err, openchoreo.ErrReleaseWaitTimeout)
 }
 
 // OCNativeProvisioner is the only registered ResourceProvisioner impl today.

--- a/services/aep-api/internal/dependencies/platform_provisioner.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner.go
@@ -233,12 +233,15 @@ func BuildPlatformBinding(project, depName, env, latestRelease string, params ma
 }
 
 // provisionWaitPermanent reports whether a WaitForReleaseChange failure is an
-// answer rather than a blip: the wait expired (or reported ResourceTypeNotFound)
-// against a Resource that has never cut a release. A wait that expired while a
-// stale release still sat on the Resource is not classified permanent
-// (reconcile can be slow). Transport / context errors are not wait answers
-// even when prior is empty.
+// answer rather than a blip. ResourceTypeNotFound is always permanent — the
+// type is gone, whether or not a prior release exists. A never-cut timeout
+// (prior empty) is also permanent. A wait that expired while a stale release
+// still sat on the Resource is not (reconcile can be slow). Transport /
+// context errors are not wait answers even when prior is empty.
 func provisionWaitPermanent(prior string, err error) bool {
+	if errors.Is(err, openchoreo.ErrResourceTypeNotFound) {
+		return true
+	}
 	return prior == "" && errors.Is(err, openchoreo.ErrReleaseWaitTimeout)
 }
 

--- a/services/aep-api/internal/dependencies/platform_provisioner_test.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner_test.go
@@ -250,10 +250,43 @@ func TestPlatformProvision_GetResourceBlipIsNotPermanent(t *testing.T) {
 	}
 }
 
+// ResourceTypeNotFound is terminal even when Apply returns an existing
+// release: the type is gone, so waiting for a NEW release cannot succeed.
+// Distinct from StaleReleaseWaitIsNotPermanent, which is ordinary deadline
+// expiry on a still-valid type.
+func TestPlatformProvision_ResourceTypeNotFoundWithPriorReleaseIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ApplyResourceFunc: func(_ context.Context, _ string, r *openchoreo.Resource) (*openchoreo.Resource, error) {
+			r.Status = &openchoreo.ResourceStatus{LatestRelease: &openchoreo.ResourceLatestRelease{Name: "shop-maindb-r1"}}
+			return r, nil
+		},
+		GetResourceFunc: func(_ context.Context, _, name string) (*openchoreo.Resource, error) {
+			return &openchoreo.Resource{
+				Metadata: openchoreo.OCObjectMeta{Name: name},
+				Status: &openchoreo.ResourceStatus{
+					LatestRelease: &openchoreo.ResourceLatestRelease{Name: "shop-maindb-r1"},
+					Conditions: []openchoreo.OCCondition{{
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "ResourceTypeNotFound",
+						Message: `ClusterResourceType "object-storage" not found`,
+					}},
+				},
+			}, nil
+		},
+	}
+	p := NewOCNativeProvisioner(rc)
+
+	_, err := p.Provision(context.Background(), "default", "shop", "maindb", "object-storage", nil, []string{"development"})
+	if !errors.Is(err, ErrProvisionPermanent) {
+		t.Fatalf("want ErrProvisionPermanent on ResourceTypeNotFound even with a prior release, got %v", err)
+	}
+}
+
 // ResourceTypeNotFound is a wait-boundary answer on a new Resource (empty
-// prior): the controller will never cut a release. It must wrap the same
-// wait-answer sentinel as a never-cut timeout so provisionWaitPermanent
-// classifies it permanent.
+// prior): the controller will never cut a release.
 func TestPlatformProvision_ResourceTypeNotFoundIsPermanent(t *testing.T) {
 	t.Parallel()
 

--- a/services/aep-api/internal/dependencies/platform_provisioner_test.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner_test.go
@@ -225,6 +225,27 @@ func TestPlatformProvision_ReconcileWaitsForNewRelease(t *testing.T) {
 	}
 }
 
+func TestPlatformProvision_NeverCutReleaseIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ApplyResourceFunc: func(_ context.Context, _ string, r *openchoreo.Resource) (*openchoreo.Resource, error) {
+			return r, nil
+		},
+		GetResourceFunc: func(_ context.Context, _, name string) (*openchoreo.Resource, error) {
+			return &openchoreo.Resource{Metadata: openchoreo.OCObjectMeta{Name: name}}, nil
+		},
+	}
+	p := NewOCNativeProvisioner(rc)
+	p.pollInterval = time.Millisecond
+	p.pollTimeout = 20 * time.Millisecond
+
+	_, err := p.Provision(context.Background(), "default", "shop", "maindb", "postgres-cnpg", nil, []string{"development"})
+	if !errors.Is(err, ErrProvisionPermanent) {
+		t.Fatalf("want ErrProvisionPermanent when latestRelease never appears, got %v", err)
+	}
+}
+
 func TestPlatformProvision_RequiresArgs(t *testing.T) {
 	t.Parallel()
 

--- a/services/aep-api/internal/dependencies/platform_provisioner_test.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner_test.go
@@ -246,6 +246,37 @@ func TestPlatformProvision_NeverCutReleaseIsPermanent(t *testing.T) {
 	}
 }
 
+// A wait that expired while a stale release still sat on the Resource is not
+// classified permanent: reconcile can be slow. Twin of NeverCutReleaseIsPermanent
+// — Apply reports a prior release, Get keeps returning it.
+func TestPlatformProvision_StaleReleaseWaitIsNotPermanent(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ApplyResourceFunc: func(_ context.Context, _ string, r *openchoreo.Resource) (*openchoreo.Resource, error) {
+			r.Status = &openchoreo.ResourceStatus{LatestRelease: &openchoreo.ResourceLatestRelease{Name: "shop-maindb-r1"}}
+			return r, nil
+		},
+		GetResourceFunc: func(_ context.Context, _, name string) (*openchoreo.Resource, error) {
+			return &openchoreo.Resource{
+				Metadata: openchoreo.OCObjectMeta{Name: name},
+				Status:   &openchoreo.ResourceStatus{LatestRelease: &openchoreo.ResourceLatestRelease{Name: "shop-maindb-r1"}},
+			}, nil
+		},
+	}
+	p := NewOCNativeProvisioner(rc)
+	p.pollInterval = time.Millisecond
+	p.pollTimeout = 20 * time.Millisecond
+
+	_, err := p.Provision(context.Background(), "default", "shop", "maindb", "postgres-cnpg", nil, []string{"development"})
+	if err == nil {
+		t.Fatal("want timeout error when the stale release never changes")
+	}
+	if errors.Is(err, ErrProvisionPermanent) {
+		t.Fatalf("a wait that expired on a stale release is not permanent (reconcile can be slow), got %v", err)
+	}
+}
+
 func TestPlatformProvision_RequiresArgs(t *testing.T) {
 	t.Parallel()
 

--- a/services/aep-api/internal/dependencies/platform_provisioner_test.go
+++ b/services/aep-api/internal/dependencies/platform_provisioner_test.go
@@ -225,6 +225,64 @@ func TestPlatformProvision_ReconcileWaitsForNewRelease(t *testing.T) {
 	}
 }
 
+// A GetResource transport/5xx blip on a freshly created Resource (empty prior)
+// is not a wait answer. Classifying every empty-prior wait error as permanent
+// would stamp OC blips as Temporal NonRetryableApplicationError.
+func TestPlatformProvision_GetResourceBlipIsNotPermanent(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ApplyResourceFunc: func(_ context.Context, _ string, r *openchoreo.Resource) (*openchoreo.Resource, error) {
+			return r, nil
+		},
+		GetResourceFunc: func(_ context.Context, _, _ string) (*openchoreo.Resource, error) {
+			return nil, errors.New("connection reset")
+		},
+	}
+	p := NewOCNativeProvisioner(rc)
+
+	_, err := p.Provision(context.Background(), "default", "shop", "maindb", "postgres-cnpg", nil, []string{"development"})
+	if err == nil {
+		t.Fatal("want poll error when GetResource fails")
+	}
+	if errors.Is(err, ErrProvisionPermanent) {
+		t.Fatalf("GetResource transport error must stay retryable, got %v", err)
+	}
+}
+
+// ResourceTypeNotFound is a wait-boundary answer on a new Resource (empty
+// prior): the controller will never cut a release. It must wrap the same
+// wait-answer sentinel as a never-cut timeout so provisionWaitPermanent
+// classifies it permanent.
+func TestPlatformProvision_ResourceTypeNotFoundIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	rc := &ocmocks.ResourceClientMock{
+		ApplyResourceFunc: func(_ context.Context, _ string, r *openchoreo.Resource) (*openchoreo.Resource, error) {
+			return r, nil
+		},
+		GetResourceFunc: func(_ context.Context, _, name string) (*openchoreo.Resource, error) {
+			return &openchoreo.Resource{
+				Metadata: openchoreo.OCObjectMeta{Name: name},
+				Status: &openchoreo.ResourceStatus{
+					Conditions: []openchoreo.OCCondition{{
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "ResourceTypeNotFound",
+						Message: `ClusterResourceType "object-storage" not found`,
+					}},
+				},
+			}, nil
+		},
+	}
+	p := NewOCNativeProvisioner(rc)
+
+	_, err := p.Provision(context.Background(), "default", "shop", "maindb", "object-storage", nil, []string{"development"})
+	if !errors.Is(err, ErrProvisionPermanent) {
+		t.Fatalf("want ErrProvisionPermanent on ResourceTypeNotFound, got %v", err)
+	}
+}
+
 func TestPlatformProvision_NeverCutReleaseIsPermanent(t *testing.T) {
 	t.Parallel()
 

--- a/services/aep-api/internal/dependencies/provisioning/build_provision.go
+++ b/services/aep-api/internal/dependencies/provisioning/build_provision.go
@@ -18,6 +18,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -57,6 +58,10 @@ type ProvisionFailure struct {
 	Component  string
 	Dependency string
 	Reason     string
+	// Err is the underlying cause, carried so aggregation can preserve
+	// ErrProvisionPermanent through errors.Is. Reason is still the string
+	// form: Temporal cannot round-trip an error value on this struct.
+	Err error
 }
 
 // ProvisionForBuild authors the project's dependencies from the inputs the dev
@@ -110,6 +115,7 @@ func (s *Service) ProvisionForBuild(ctx context.Context, orgID, ocOrgID, project
 	for _, in := range inputs {
 		provisioned[strings.ToLower(in.Dependency)] = true
 	}
+	skipPlatform := false
 	for _, in := range inputs {
 		gate := gateByDep[strings.ToLower(in.Dependency)]
 		switch in.Kind {
@@ -118,8 +124,14 @@ func (s *Service) ProvisionForBuild(ctx context.Context, orgID, ocOrgID, project
 				failures = append(failures, ProvisionFailure{Component: in.Component, Dependency: in.Dependency, Reason: err.Error()})
 			}
 		case buildKindPlatformResrc:
+			if skipPlatform {
+				continue
+			}
 			if err := s.provisionResource(ctx, orgID, projectID, in.Dependency, gate, in.Parameters, nil, tag); err != nil {
-				failures = append(failures, ProvisionFailure{Component: in.Component, Dependency: in.Dependency, Reason: err.Error()})
+				failures = append(failures, ProvisionFailure{Component: in.Component, Dependency: in.Dependency, Reason: err.Error(), Err: err})
+				if errors.Is(err, dependencies.ErrProvisionPermanent) {
+					skipPlatform = true
+				}
 			}
 		case buildKindOrgService:
 			// Cross-project org-service visibility (issue #164, Task 4): for an

--- a/services/aep-api/internal/dependencies/provisioning/build_provision_test.go
+++ b/services/aep-api/internal/dependencies/provisioning/build_provision_test.go
@@ -18,6 +18,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	"github.com/wso2/aep/aep-api/internal/contracts/taskmeta"
 	"github.com/wso2/aep/aep-api/internal/delivery"
+	"github.com/wso2/aep/aep-api/internal/dependencies"
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/platform/ocname"
 	"github.com/wso2/aep/aep-api/internal/spec"
@@ -121,6 +123,45 @@ func TestProvisionForBuild_UsesMintedPlatformGateDespiteListRace(t *testing.T) {
 	}
 	if row := provisionRowFor(execs, "orders-db"); row == nil || row.IssueNumber != platformGate {
 		t.Fatalf("platform provision row = %+v, want captured gate #%d", row, platformGate)
+	}
+}
+
+// designWithPlatformDeps is a local fixture for the fail-fast test: three
+// platform-resource names that designWithDeps() does not carry, so the
+// provisioner is reached instead of a 404 from findDepInProject.
+func designWithPlatformDeps(names ...string) []spec.DesignComponent {
+	deps := make([]spec.Dependency, 0, len(names))
+	for _, n := range names {
+		deps = append(deps, spec.Dependency{
+			Kind:         spec.DependencyKindPlatformResource,
+			Name:         n,
+			ResourceType: "postgres-cnpg",
+		})
+	}
+	return []spec.DesignComponent{{Name: "orders", Dependencies: deps}}
+}
+
+func TestProvisionForBuild_PermanentPlatformFailureSkipsRemainingPlatformWaits(t *testing.T) {
+	issues := newFakeIssues(nil)
+	plat := &fakePlatProv{err: fmt.Errorf("%w: no release", dependencies.ErrProvisionPermanent)}
+	svc := newTestService(issues, &fakeExecStore{}, fakeDesign{comps: designWithPlatformDeps("bad-a", "bad-b", "bad-c")}, &fakeExtProv{}, plat, &fakeBindings{})
+
+	fails, err := svc.ProvisionForBuild(context.Background(), "acme", "acme", "proj", "v3", 0, []BuildProvisionInput{
+		{Component: "orders", Dependency: "bad-a", Kind: "platform-resource", Approved: true},
+		{Component: "orders", Dependency: "bad-b", Kind: "platform-resource", Approved: true},
+		{Component: "orders", Dependency: "bad-c", Kind: "platform-resource", Approved: true},
+	})
+	if err != nil {
+		t.Fatalf("batch error: %v", err)
+	}
+	if plat.calls != 1 {
+		t.Fatalf("permanent platform failure must skip remaining platform waits, got %d calls", plat.calls)
+	}
+	if len(fails) != 1 {
+		t.Fatalf("want 1 failure, got %+v", fails)
+	}
+	if !errors.Is(fails[0].Err, dependencies.ErrProvisionPermanent) {
+		t.Fatalf("failure must carry ErrProvisionPermanent, got %v", fails[0].Err)
 	}
 }
 

--- a/services/aep-api/internal/dependencies/provisioning/resource_service.go
+++ b/services/aep-api/internal/dependencies/provisioning/resource_service.go
@@ -97,7 +97,7 @@ func (s *Service) provisionResource(ctx context.Context, orgID, projectID, depNa
 		if execID != "" {
 			s.failProvisionRow(ctx, orgID, projectID, gateNumber, execID, perr.Error())
 		}
-		return fmt.Errorf("%w: %v", dependencies.ErrProvisionFailed, perr)
+		return fmt.Errorf("%w: %w", dependencies.ErrProvisionFailed, perr)
 	}
 
 	// Async: mark the run RUNNING pinned to the development binding name; the

--- a/services/aep-api/internal/spec/README.md
+++ b/services/aep-api/internal/spec/README.md
@@ -171,6 +171,14 @@ the genai turn engine (runner/broker/sweeper), and the files / design / skills s
     resource that does not exist; a bounded-name test pins it.
   - Fail-closed: a design declaring a platform-resource whose catalog is unreachable returns
     `ErrResourceCatalogUnavailable` (503) rather than silently skipping either derivation.
+  - **Unknown `resourceType` is refused at build claim, not at design save.** After the catalog
+    fetch, a membership pass (`rejectUnknownResourceTypes`) returns `ErrUnknownResourceType`
+    when a `platform-resource` names a CRT that is not installed. Delivery maps that to HTTP 409
+    and cuts no tag — a design/task-breakdown agent inventing a type must not start a Temporal
+    run. An empty or nil catalog (`PLATFORM_RESOURCES_ENABLED=false`) skips membership so the
+    disabled path does not reject every build. Membership is against the live catalog map, never
+    a hardcoded type name (ADR-0007). Wiring derivation still treats an unknown type as "not
+    derivable yet"; the membership pass is a separate gate before persist.
 - The `/collab/validate` oracle recovers the acting org from VERIFIED claims and refuses any room whose
   `spec-<org>-` prefix mismatches — never a hint of whether the room exists. Platform-wide rules (tenant
   gate, secrets fence) → [../../README.md](../../README.md).

--- a/services/aep-api/internal/spec/derive.go
+++ b/services/aep-api/internal/spec/derive.go
@@ -40,11 +40,13 @@ import (
 // the thin POST /build path runs BEFORE its own tag-cut, so the derived values
 // are captured in the version tag (issue #164) and are already what the NEXT
 // design read sees. Returns ErrEndUserAuthConflict on an explicit conflicting
-// service-required and ErrResourceCatalogUnavailable when a platform-resource
-// dependency exists but the CRT catalog is unreachable (fail-closed). A design
-// with nothing to derive (missing/empty design, no resource dependency) is a
-// no-op returning nil. The caller re-reads HEAD after (its TagSpec re-resolves
-// HEAD), so this does not return the mutated design.
+// service-required, ErrUnknownResourceType when a platform-resource dependency
+// names a resourceType absent from the installed CRT catalog, and
+// ErrResourceCatalogUnavailable when a platform-resource dependency exists but
+// the CRT catalog is unreachable (fail-closed). A design with nothing to derive
+// (missing/empty design, no resource dependency) is a no-op returning nil. The
+// caller re-reads HEAD after (its TagSpec re-resolves HEAD), so this does not
+// return the mutated design.
 func (s *designService) DerivePlatformResourceFactsAtHead(ctx context.Context, orgID, projectID string) error {
 	designFile, err := s.store.ReadDesign(ctx, orgID, projectID)
 	if err != nil {
@@ -58,6 +60,9 @@ func (s *designService) DerivePlatformResourceFactsAtHead(ctx context.Context, o
 	}
 	markers, err := s.resourceTypesForDerivation(ctx, designFile)
 	if err != nil {
+		return err
+	}
+	if err := rejectUnknownResourceTypes(designFile.Components, markers); err != nil {
 		return err
 	}
 	if _, err := s.persistPlatformResourceDerivation(ctx, orgID, projectID, designFile, markers); err != nil {

--- a/services/aep-api/internal/spec/derive_auth.go
+++ b/services/aep-api/internal/spec/derive_auth.go
@@ -19,6 +19,8 @@ package spec
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // Auth-as-platform-resource (learning/thunder-resource/PLAN-generalization.md):
@@ -126,6 +128,38 @@ func hasPlatformResourceDependency(components []DesignComponent) bool {
 		}
 	}
 	return false
+}
+
+// rejectUnknownResourceTypes fails when any platform-resource dependency names
+// a resourceType absent from the installed CRT catalog. An empty or nil catalog
+// (PLATFORM_RESOURCES_ENABLED=false) skips membership — fail-open for the
+// disabled path. Membership is against the live catalog map, never a hardcoded
+// resourceType name (ADR-0007).
+func rejectUnknownResourceTypes(components []DesignComponent, types map[string]CRTType) error {
+	if len(types) == 0 {
+		return nil
+	}
+	available := make([]string, 0, len(types))
+	for name := range types {
+		available = append(available, name)
+	}
+	sort.Strings(available)
+	var unknown []string
+	for i := range components {
+		for _, d := range components[i].Dependencies {
+			if d.Kind != DependencyKindPlatformResource {
+				continue
+			}
+			if _, ok := types[d.ResourceType]; !ok {
+				unknown = append(unknown, fmt.Sprintf("%s (%q)", d.Name, d.ResourceType))
+			}
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s; available: %s",
+		ErrUnknownResourceType, strings.Join(unknown, ", "), strings.Join(available, ", "))
 }
 
 // exposesAPIEqual reports whether two (possibly nil) ExposesAPI pointers

--- a/services/aep-api/internal/spec/derive_auth_test.go
+++ b/services/aep-api/internal/spec/derive_auth_test.go
@@ -322,3 +322,54 @@ func TestDeriveEndUserAuthAtHead_NoPlatformResourceDepNoOp(t *testing.T) {
 		t.Fatalf("auth-free derive must not touch catalog/committer: calls=%d commits=%d", cat.calls, fc.commits)
 	}
 }
+
+func TestDeriveAtHead_UnknownResourceTypeReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	deps := `[{"kind":"platform-resource","name":"parcel-receipts","resourceType":"object-storage"}]`
+	svc := newService(happySave(designFilesWithDeps(deps)))
+	fc := &fakeCommitter{}
+	svc.fileCommitter = fc
+	svc.resourceCatalog = &fakeTypeCatalog{types: map[string]CRTType{
+		"postgres-cnpg": {},
+		"thunder-app":   {},
+	}}
+
+	err := svc.DerivePlatformResourceFactsAtHead(context.Background(), "acme", "web")
+	if !errors.Is(err, ErrUnknownResourceType) {
+		t.Fatalf("want ErrUnknownResourceType, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "object-storage") {
+		t.Fatalf("error must name the unknown type: %v", err)
+	}
+	if !strings.Contains(msg, "postgres-cnpg") || !strings.Contains(msg, "thunder-app") {
+		t.Fatalf("error must list installed types: %v", err)
+	}
+	if fc.commits != 0 {
+		t.Fatalf("unknown type must commit nothing, got %d", fc.commits)
+	}
+}
+
+func TestDeriveAtHead_InstalledResourceTypePasses(t *testing.T) {
+	t.Parallel()
+	deps := `[{"kind":"platform-resource","name":"orders-db","resourceType":"postgres-cnpg"}]`
+	svc := newService(happySave(designFilesWithDeps(deps)))
+	svc.fileCommitter = &fakeCommitter{}
+	svc.resourceCatalog = &fakeTypeCatalog{types: map[string]CRTType{"postgres-cnpg": {}}}
+
+	if err := svc.DerivePlatformResourceFactsAtHead(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("installed type must pass: %v", err)
+	}
+}
+
+func TestDeriveAtHead_EmptyCatalogDoesNotReject(t *testing.T) {
+	t.Parallel()
+	deps := `[{"kind":"platform-resource","name":"orders-db","resourceType":"postgres-cnpg"}]`
+	svc := newService(happySave(designFilesWithDeps(deps)))
+	svc.fileCommitter = &fakeCommitter{}
+	svc.resourceCatalog = &fakeTypeCatalog{types: map[string]CRTType{}}
+
+	if err := svc.DerivePlatformResourceFactsAtHead(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("empty/disabled catalog must not reject: %v", err)
+	}
+}

--- a/services/aep-api/internal/spec/derive_auth_test.go
+++ b/services/aep-api/internal/spec/derive_auth_test.go
@@ -373,3 +373,15 @@ func TestDeriveAtHead_EmptyCatalogDoesNotReject(t *testing.T) {
 		t.Fatalf("empty/disabled catalog must not reject: %v", err)
 	}
 }
+
+func TestDeriveAtHead_NilCatalogDoesNotReject(t *testing.T) {
+	t.Parallel()
+	deps := `[{"kind":"platform-resource","name":"orders-db","resourceType":"postgres-cnpg"}]`
+	svc := newService(happySave(designFilesWithDeps(deps)))
+	svc.fileCommitter = &fakeCommitter{}
+	svc.resourceCatalog = &fakeTypeCatalog{types: nil}
+
+	if err := svc.DerivePlatformResourceFactsAtHead(context.Background(), "acme", "web"); err != nil {
+		t.Fatalf("nil/disabled catalog must not reject: %v", err)
+	}
+}

--- a/services/aep-api/internal/spec/design_service.go
+++ b/services/aep-api/internal/spec/design_service.go
@@ -63,6 +63,12 @@ var ErrEndUserAuthConflict = errors.New("service component declares an end-user-
 // platform-resource dependency) never fetch the catalog and so never hit this.
 var ErrResourceCatalogUnavailable = errors.New("resource-type catalog unavailable — retry the save")
 
+// ErrUnknownResourceType is returned when a platform-resource dependency names
+// a resourceType that is not in the installed ClusterResourceType catalog.
+// Surfaced as 409 at build claim — the design is unsatisfiable on this cluster,
+// and no version tag or Temporal run is created.
+var ErrUnknownResourceType = errors.New("resourceType is not installed on this cluster")
+
 // Spec-collection sentinels (dependency-management — the collect-dependency-spec
 // route). The HTTP layer maps each to a status: ErrDependencyNotFound→404,
 // ErrDependencyWrongKind/ErrInvalidSpec→400, ErrSpecFetchFailed→502,

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -194,8 +194,9 @@ type for `resourceType`). This step is done when every `external`,
 `org-service`, and `platform-resource` emitted this turn is taken from this
 turn's matching `list_*` result (exact `name` or `resourceType`), unless this
 turn is a user-asked reconsider. When nothing the catalog returns fills the
-role, leave the dependency unresolved rather than forcing a fit: a name that
-resolves to nothing is worse than an absent one.
+role, omit the entry and list the gap under **Needs your input** rather than
+coining a name: a `resourceType` that was not in this turn's
+`list_platform_resource_types` result fails Build.
 
 ```json
 "dependencies": [
@@ -229,8 +230,10 @@ operations its contract actually exposes:
   list one "for reference".
 - **A role is not a name.** The requirement says "the organization's directory
   service"; the provider is usually called something else (`employee-service`).
-  Look it up — a name coined from the role words matches no provider and
-  hard-fails the build.
+  The same for a `platform-resource`: the PRD names a capability, `resourceType`
+  is the catalog row's `name` from this turn's `list_platform_resource_types`.
+  Copy that `name`. Look it up — a name coined from the role or capability words
+  matches no provider or type and hard-fails the build.
 - **A `platform-resource`'s `name` becomes the env-var prefix** for every one of
   its outputs (`orders-db` → `ORDERS_DB_HOST`, and for a SPA
   `window._env_.ORDERS_DB_*`), so pick a clear one: renaming it later renames the
@@ -341,11 +344,12 @@ which fields are present, first match wins:
 5. `style: "sdk"` with no `package` → `unresolved`/`needs-input`
 6. otherwise → `resolved`
 
-`component` and `platform-resource` are always `resolved` here. An `org-service`
-resolves on catalog visibility, and is `blocked`/`access-required` when the
-provider exists but this project cannot see it. The old `needsSpec` boolean is
-REMOVED from the schema — a draft carrying it fails the write-gate; migrate
-`needsSpec: true` to `style: "rest-api"`.
+`component` is always `resolved` here. A `platform-resource` is too — once
+emitted — so only emit one whose `resourceType` is a `name` from this turn's
+`list_platform_resource_types`. An `org-service` resolves on catalog visibility,
+and is `blocked`/`access-required` when the provider exists but this project
+cannot see it. The old `needsSpec` boolean is REMOVED from the schema — a draft
+carrying it fails the write-gate; migrate `needsSpec: true` to `style: "rest-api"`.
 
 ### Narrating the design turn
 

--- a/skills/cell-design/SKILL.md
+++ b/skills/cell-design/SKILL.md
@@ -45,7 +45,7 @@ what kind of thing it is:
 | What it is | design.json signal | Where it goes |
 |---|---|---|
 | Your own component (service, web-app, worker) | a `components/<name>/` folder | INSIDE the cell — `component …` |
-| Project-scoped resource (db, cache, object store) | `platform-resource` (postgres-cnpg/redis/…) | INSIDE the cell — `component <id> … database` |
+| Project-scoped backing resource (db, cache, …) | `platform-resource` — `resourceType` copied from this turn's `list_platform_resource_types` during enrichment | INSIDE the cell — `component <id> … database` |
 | Auth (Thunder) | `platform-resource` `thunder-app` | **east** — `east <id> as "Thunder Auth" identity-server` |
 | Another project's / org service | `org-service` | **east** |
 | Third-party SaaS / external system | `external` | **south** |


### PR DESCRIPTION
## What was going wrong

A project design can declare a **platform resource** (for example object storage or a database) by naming a resource type that OpenChoreo must install on the cluster.

If that type is **not actually installed**, clicking **Build** used to start a run anyway. The run sat in planning forever, retrying the same provision step, because:

1. Nothing checked the type against the cluster’s catalog before starting the run.
2. The platform did report a terminal error (`ClusterResourceType "…" not found`), but we dropped that signal and treated every provision failure as a transient blip worth retrying.
3. We waited up to 60 seconds for a new release that could never appear.

Users saw a timeout like “produced no new ResourceRelease within 1m0s”, not the real reason. The live incident was `order-processing-demo` asking for `object-storage` on a cluster that only had types such as `postgres-cnpg` and `valkey`.

The design agent also had a live catalog tool, but the skills still taught invented type names (`object store`, `redis`, …) and treated every platform-resource as already resolved — so a capability word in the PRD became a `resourceType` the cluster does not have.

## What this PR does

**Reject the Build click.** If the design names a resource type the cluster does not have, the API returns HTTP 409 with a message that names the unknown type and lists the installed ones. No version tag is cut and no workflow is started. Agent mistakes must not create a stuck run.

**If provision still runs** (catalog was empty/disabled, or another permanent fault), fail that step **once** instead of retrying forever. After the first permanent platform fault, skip waiting on the remaining platform resources in that pass. Ordinary network blips still retry. “Type not found” is permanent even when the resource already has an old release; only a slow reconcile timeout on a still-valid type stays retryable.

**Read the resource’s status conditions** so “type not found” is recognized immediately, instead of polling until the 60s wait expires.

**Teach the design agent to copy the catalog.** `architecture` takes `resourceType` from this turn’s `list_platform_resource_types`. If nothing fits, it omits the entry and lists the gap under Needs your input. `cell-design` no longer lists invented cluster type names.

When platform resources are turned off (`PLATFORM_RESOURCES_ENABLED=false`), the catalog is empty and we **do not** reject every build — that path stays fail-open.

## Test plan

- [x] Unit/component tests: unknown type is rejected before persist; empty or nil catalog does not reject; Build HTTP 409 cuts no tag and starts no run; a permanent provision failure is asked once, a blip is asked again; resource conditions decode and `ResourceTypeNotFound` returns immediately; `ResourceTypeNotFound` is still permanent when a prior release exists.
- [x] Local Agentic Engineer: added an `object-storage` platform resource to `weather-api`, posted Build, got 409 listing the real installed types (`postgres`, `postgres-cnpg`, `thunder-app`). No new run started. Restored the original design.
- [x] Skill pin tests: architecture omits a missing catalog type; cell-design does not list `postgres-cnpg/redis`.

## How to review

Start at the Build click (`mapPreTagError` / catalog membership in spec derive), then the `%w` error chain through provision aggregation, then `WaitForReleaseChange` reading conditions. Skills are `skills/architecture/SKILL.md` and `skills/cell-design/SKILL.md`. Do not key anything on the name `object-storage` — membership is always against the live catalog.