### PR TITLE
fix(console): quiet the overview track, split on the page's own width, and give the web app its link back

### DIFF
--- a/apps/console/src/features/agent-chat/components/WorkingIndicator.tsx
+++ b/apps/console/src/features/agent-chat/components/WorkingIndicator.tsx
@@ -44,6 +44,17 @@ export function WorkingPulse() {
           "0%, 100%": { opacity: 0.3, transform: "scale(0.85)" },
           "50%": { opacity: 1, transform: "scale(1)" },
         },
+        // A reader who has asked their OS for less motion still needs to know
+        // an agent is working, so the dot stays — at the animation's bright
+        // end, rather than at whatever opacity it happened to stop on. The
+        // overview track brought this guard with it (#575 unified the three
+        // surfaces on this component; the ring it replaced honoured the
+        // preference and this did not), and it belongs here, where all three
+        // get it.
+        "@media (prefers-reduced-motion: reduce)": {
+          animation: "none",
+          opacity: 1,
+        },
       }}
     />
   );

--- a/apps/console/src/features/projects/components/ComponentsList.test.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../../generated/aep-api";
+
+type Component = components["schemas"]["Component"];
+
+const PROJECT = "demo-shop";
+
+// The web app's public URL is a read of its DEPLOYMENTS (#196), keyed by
+// component — so the stub answers per component name, which is also how the
+// "not deployed yet" case is expressed: no entry, no URL.
+const endpointUrls = vi.hoisted(() => ({
+  current: {} as Record<string, string | undefined>,
+}));
+const endpointCalls = vi.hoisted(() => [] as string[]);
+
+vi.mock("../api/queries", () => ({
+  useComponentEndpointUrl: (_projectName: string, componentName: string) => {
+    endpointCalls.push(componentName);
+    return { data: endpointUrls.current[componentName] };
+  },
+}));
+
+// The contract dialog is a lazy read behind a Suspense-y query of its own; the
+// list's job here is only to offer the row that opens it.
+vi.mock("./ComponentOpenApiDialog", () => ({
+  ComponentOpenApiDialog: () => null,
+}));
+
+import { ComponentsList } from "./ComponentsList";
+
+const webApp: Component = {
+  name: "storefront",
+  displayName: "storefront",
+  type: "web-application",
+  description: "The shop",
+};
+
+const service: Component = {
+  name: "catalog-api",
+  displayName: "catalog-api",
+  type: "service",
+  description: "Products",
+};
+
+beforeEach(() => {
+  endpointUrls.current = {};
+  endpointCalls.length = 0;
+});
+
+describe("a web app's row", () => {
+  it("opens the running app in a new tab once it has a URL", () => {
+    endpointUrls.current = { storefront: "https://storefront.dev.example.io" };
+    render(<ComponentsList projectName={PROJECT} items={[webApp]} />);
+
+    const link = screen.getByRole("link", { name: /storefront/ });
+    expect(link).toHaveAttribute("href", "https://storefront.dev.example.io");
+    expect(link).toHaveAttribute("target", "_blank");
+    // No opener handed to a page the platform deployed but does not control.
+    expect(link.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  // A link offered before the app is up is a link to a 404.
+  it("goes nowhere while the app has not deployed", () => {
+    render(<ComponentsList projectName={PROJECT} items={[webApp]} />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("storefront")).toBeInTheDocument();
+  });
+});
+
+describe("a service's row", () => {
+  it("still opens its contract, and asks for no endpoint URL", () => {
+    render(<ComponentsList projectName={PROJECT} items={[service]} />);
+
+    expect(screen.getByRole("button", { name: /catalog-api/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(endpointCalls).toEqual([]);
+  });
+});

--- a/apps/console/src/features/projects/components/ComponentsList.tsx
+++ b/apps/console/src/features/projects/components/ComponentsList.tsx
@@ -21,6 +21,7 @@ import { Card, Chip, Tooltip } from "@wso2/oxygen-ui";
 import { Box as BoxIcon, Boxes } from "@wso2/oxygen-ui-icons-react";
 import { EmptyState } from "../../../components/EmptyState";
 import type { components } from "../../../generated/aep-api";
+import { useComponentEndpointUrl } from "../api/queries";
 import { ComponentOpenApiDialog } from "./ComponentOpenApiDialog";
 import { OverviewRow } from "./OverviewRow";
 
@@ -30,6 +31,75 @@ type Component = components["schemas"]["Component"];
 const isWebApp = (c: Component) => c.type === "web-application";
 
 const typeLabel = (c: Component) => (isWebApp(c) ? "Web app" : "Service");
+
+/** The row itself, so both kinds render identically apart from where they go. */
+function ComponentRow({
+  component: c,
+  last,
+  onClick,
+  href,
+}: {
+  component: Component;
+  last: boolean;
+  onClick?: (() => void) | undefined;
+  href?: string | undefined;
+}) {
+  return (
+    <OverviewRow
+      icon={<BoxIcon size={18} />}
+      title={c.displayName ?? c.name}
+      trailing={
+        <Chip
+          size="small"
+          variant="outlined"
+          label={typeLabel(c)}
+          sx={{ height: 22, flexShrink: 0, fontSize: "0.75rem" }}
+        />
+      }
+      caption={c.description ?? undefined}
+      last={last}
+      onClick={onClick}
+      href={href}
+    />
+  );
+}
+
+/**
+ * A web app's row, which opens the RUNNING APP rather than a contract.
+ *
+ * A web app has no OpenAPI document, so this row used to go nowhere at all —
+ * the one component on the page a reader most wants to click was the one that
+ * did nothing. It has a public URL instead, and that URL is the answer to
+ * "what did the platform actually build me".
+ *
+ * The URL comes from the component's DEPLOYMENTS, not from the component:
+ * `Component.endpointUrl` is on the contract but the backend never fills it
+ * (noted drift, #196), while the dev binding's resolved URL rides on
+ * list-deployments. Its own component so the read is one hook per web app,
+ * rather than a hook called inside a map.
+ *
+ * Until it deploys there is no URL, and the row then stays inert — a link
+ * offered before the app is up is a link to a 404.
+ */
+function WebAppRow({
+  projectName,
+  component,
+  last,
+}: {
+  projectName: string;
+  component: Component;
+  last: boolean;
+}) {
+  const url = useComponentEndpointUrl(projectName, component.name).data;
+  if (!url) return <ComponentRow component={component} last={last} />;
+  return (
+    <Tooltip title="Open the app" placement="left">
+      <div>
+        <ComponentRow component={component} last={last} href={url} />
+      </div>
+    </Tooltip>
+  );
+}
 
 /**
  * The project's components.
@@ -72,35 +142,26 @@ export function ComponentsList({
   return (
     <>
       <Card variant="outlined">
-        {items.map((c, i) => {
-          // A web app has no contract to open, so its row goes nowhere and
-          // shows no chevron: only rows that do something look like they do.
-          const openable = !isWebApp(c);
-          const row = (
-            <OverviewRow
-              icon={<BoxIcon size={18} />}
-              title={c.displayName ?? c.name}
-              trailing={
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  label={typeLabel(c)}
-                  sx={{ height: 22, flexShrink: 0, fontSize: "0.75rem" }}
-                />
-              }
-              caption={c.description ?? undefined}
+        {items.map((c, i) =>
+          isWebApp(c) ? (
+            <WebAppRow
+              key={c.name}
+              projectName={projectName}
+              component={c}
               last={i === items.length - 1}
-              {...(openable && { onClick: () => setContractComponent(c.name) })}
             />
-          );
-          return openable ? (
-            <Tooltip key={c.name} title="View API contract" placement="left">
-              <div>{row}</div>
-            </Tooltip>
           ) : (
-            <div key={c.name}>{row}</div>
-          );
-        })}
+            <Tooltip key={c.name} title="View API contract" placement="left">
+              <div>
+                <ComponentRow
+                  component={c}
+                  last={i === items.length - 1}
+                  onClick={() => setContractComponent(c.name)}
+                />
+              </div>
+            </Tooltip>
+          ),
+        )}
       </Card>
       <ComponentOpenApiDialog
         projectName={projectName}

--- a/apps/console/src/features/projects/components/OverviewArchitecture.tsx
+++ b/apps/console/src/features/projects/components/OverviewArchitecture.tsx
@@ -74,6 +74,40 @@ const READ_ONLY_SX = {
 const DIAGRAM_MIN_HEIGHT = 340;
 
 /**
+ * The page width, IN PIXELS, at which the overview splits into two columns —
+ * measured on the overview's own body, not on the viewport, and applied by
+ * `ProjectOverview` as a container query.
+ *
+ * It lives here because the DIAGRAM is what sets it. The lists reflow to any
+ * width; this panel does not, so the threshold is "wide enough that 7/12 of it
+ * still shows the cell whole". A viewport breakpoint cannot express that — the
+ * nav rail takes ~280px of the viewport before the page sees any of it, and the
+ * agent chat panel can take half of what is left, which is how a `md` split
+ * ended up cropping the diagram on a 1440px screen.
+ */
+export const OVERVIEW_SPLIT_PX = 1100;
+
+/**
+ * The height the panel takes when it is BELOW the lists rather than beside
+ * them.
+ *
+ * Stacking is what a narrow page does with the diagram, and 340px is the wrong
+ * box for it once the card runs the full width of the page: what the renderer
+ * shows is governed by the box's HEIGHT (a cell is taller than it is wide), so
+ * a short, very wide card spends its extra width on empty margins and shows
+ * strictly less of the graph. Full width only helps if the height comes with
+ * it.
+ *
+ * It still does not show all of it. On a real cell the renderer draws at close
+ * to 1:1 whatever box it is handed and crops the rest — the same clamp
+ * `DIAGRAM_MIN_HEIGHT` describes, and the reason this panel is a preview with a
+ * link rather than a diagram you read. 560px covers the cell's own ring of
+ * components; the externals hanging off its north and south gates are what
+ * "Open in spec" is for.
+ */
+const DIAGRAM_STACKED_HEIGHT = 560;
+
+/**
  * The project's shape, on the page that answers "what is this".
  *
  * Same renderer as the spec workspace's Architecture tab, same source file, and
@@ -136,7 +170,17 @@ export function OverviewArchitecture({ projectName }: { projectName: string }) {
       </SectionTitle>
       <Card
         variant="outlined"
-        sx={{ flex: 1, minHeight: DIAGRAM_MIN_HEIGHT, display: "flex" }}
+        sx={{
+          flex: 1,
+          display: "flex",
+          // Stacked is the default here, and the split is the exception: the
+          // query below fires only when the overview body is wide enough to
+          // have put this panel beside the lists.
+          minHeight: DIAGRAM_STACKED_HEIGHT,
+          [`@container (min-width: ${OVERVIEW_SPLIT_PX}px)`]: {
+            minHeight: DIAGRAM_MIN_HEIGHT,
+          },
+        }}
       >
         <Box sx={drawn ? READ_ONLY_SX : { flex: 1, minWidth: 0, display: "flex" }}>
           <Body

--- a/apps/console/src/features/projects/components/OverviewRow.tsx
+++ b/apps/console/src/features/projects/components/OverviewRow.tsx
@@ -18,7 +18,7 @@
 
 import type { ReactNode } from "react";
 import { Box, ButtonBase, Stack, Typography } from "@wso2/oxygen-ui";
-import { ChevronRight } from "@wso2/oxygen-ui-icons-react";
+import { ArrowUpRight, ChevronRight } from "@wso2/oxygen-ui-icons-react";
 
 /**
  * One row of a project's inventory, built to the build page's task-row
@@ -57,6 +57,7 @@ export function OverviewRow({
   meta,
   caption,
   onClick,
+  href,
   last = false,
 }: {
   /** Goes in the leading tile. Sized 18px by the caller, as on the build page. */
@@ -73,6 +74,16 @@ export function OverviewRow({
   caption?: string | undefined;
   /** Omit for a row that does not go anywhere — it then renders no chevron. */
   onClick?: (() => void) | undefined;
+  /**
+   * An EXTERNAL destination, opened in a new tab. Pass this instead of
+   * `onClick` — the row then renders as a real anchor, so the browser's own
+   * ways of following a link (middle click, ⌘-click, "copy link address") all
+   * work, which they never do on a button that calls `window.open`.
+   *
+   * Its affordance is the outward arrow rather than the chevron: a chevron
+   * promises the next panel of this console, and this one leaves it.
+   */
+  href?: string | undefined;
   last?: boolean;
 }) {
   const body = (
@@ -154,7 +165,7 @@ export function OverviewRow({
           display: "flex",
           flexShrink: 0,
           color: "text.disabled",
-          visibility: onClick ? "visible" : "hidden",
+          visibility: onClick || href ? "visible" : "hidden",
           opacity: 0.5,
           transition: (theme) =>
             theme.transitions.create("opacity", {
@@ -162,10 +173,23 @@ export function OverviewRow({
             }),
         }}
       >
-        <ChevronRight size={18} />
+        {href ? <ArrowUpRight size={18} /> : <ChevronRight size={18} />}
       </Box>
     </Stack>
   );
+
+  const interactiveSx = {
+    display: "block",
+    width: "100%",
+    textAlign: "left",
+    "&:hover": { bgcolor: "action.hover" },
+    "&:focus-visible": {
+      outline: 2,
+      outlineColor: "primary.main",
+      outlineOffset: -2,
+    },
+    "&:hover .row-chevron, &:focus-visible .row-chevron": { opacity: 1 },
+  } as const;
 
   return (
     <Box
@@ -174,22 +198,18 @@ export function OverviewRow({
         borderColor: "divider",
       }}
     >
-      {onClick ? (
+      {href ? (
         <ButtonBase
-          onClick={onClick}
-          sx={{
-            display: "block",
-            width: "100%",
-            textAlign: "left",
-            "&:hover": { bgcolor: "action.hover" },
-            "&:focus-visible": {
-              outline: 2,
-              outlineColor: "primary.main",
-              outlineOffset: -2,
-            },
-            "&:hover .row-chevron, &:focus-visible .row-chevron": { opacity: 1 },
-          }}
+          component="a"
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          sx={interactiveSx}
         >
+          {body}
+        </ButtonBase>
+      ) : onClick ? (
+        <ButtonBase onClick={onClick} sx={interactiveSx}>
           {body}
         </ButtonBase>
       ) : (

--- a/apps/console/src/features/projects/components/OverviewTrack.tsx
+++ b/apps/console/src/features/projects/components/OverviewTrack.tsx
@@ -24,6 +24,7 @@ import type { components } from "../../../generated/aep-api";
 import { useSession } from "../../../auth/SessionContext";
 import { useAgentEngaged } from "../../agent-chat/useAgentEngaged";
 import { useConversationLog } from "../../agent-chat/useConversationLog";
+import { WorkingPulse } from "../../agent-chat/components/WorkingIndicator";
 import { trackView, type LegState, type TrackLeg } from "../lib/track";
 
 type ProjectStatus = components["schemas"]["ProjectStatus"];
@@ -46,6 +47,20 @@ const LegLink = createLink(ButtonBase);
  * `theme.spacing(1.5)` is 12px. Same literal, two different corners.
  */
 const TRACK_RADIUS_PX = 12;
+
+/**
+ * The breakpoint at and above which the three legs sit in a ROW; below it they
+ * stack into a column.
+ *
+ * A leg carries a stage name, a version, a sentence and sometimes a call to
+ * action. Three of those across a phone — or across the half-window the
+ * overview gets whenever the agent chat panel is open — leaves each one about
+ * 110px, at which the sentence wraps to four lines and the card becomes a wall
+ * of broken text. Stacked, every leg gets the full width and the flow simply
+ * runs downward instead of across; the seam and the corner radii follow it (see
+ * `SeamBreak` and `Leg`).
+ */
+const TRACK_ROW_UP = "md";
 
 /**
  * The palette family a leg reads from. `waiting` has none — it is the theme's
@@ -103,35 +118,6 @@ function litStyles(theme: Theme, state: LegState) {
 }
 
 /**
- * The pulse: shown for `live` only.
- *
- * It is the page's only animation, and it means "the platform is working".
- * A leg waiting on the USER (`hold`) deliberately does not pulse — a page that
- * animates while it waits for you to type is lying about who is busy.
- */
-function LivePulse() {
-  return (
-    <Box
-      aria-hidden
-      sx={(theme) => ({
-        width: theme.spacing(0.875),
-        height: theme.spacing(0.875),
-        borderRadius: "50%",
-        flexShrink: 0,
-        boxSizing: "border-box",
-        border: 2,
-        borderColor: "primary.main",
-        "@keyframes legPulse": {
-          "50%": { boxShadow: `0 0 0 ${theme.spacing(0.625)} ${alpha(theme.palette.primary.main, 0.14)}` },
-        },
-        animation: "legPulse 2.2s ease-in-out infinite",
-        "@media (prefers-reduced-motion: reduce)": { animation: "none" },
-      })}
-    />
-  );
-}
-
-/**
  * The seam: the rule breaks, and a chevron stands in the break.
  *
  * The line runs down, stops, the chevron carries it across, the line resumes.
@@ -141,9 +127,9 @@ function LivePulse() {
  * mid-way along a full-height divider: the divider read as the dominant thing
  * and the triangle as decoration on it, so nothing looked connected.
  *
- * Order still comes from the step numeral and direction from here; no thread is
- * run through the whole bar, which an earlier pass tried and which read as a
- * progress meter the legs were already carrying.
+ * Order and direction both come from here, now that the step numeral is gone;
+ * no thread is run through the whole bar, which an earlier pass tried and which
+ * read as a progress meter the legs were already carrying.
  */
 function SeamBreak() {
   return (
@@ -151,8 +137,20 @@ function SeamBreak() {
       aria-hidden
       sx={(theme) => ({
         position: "absolute",
-        insetInlineEnd: theme.spacing(-1.125),
-        insetBlockStart: "50%",
+        // Straddles whichever edge the next leg is on: the end edge while the
+        // legs sit in a row, the bottom edge once they stack.
+        //
+        // Stacked, it is centred by AUTO MARGINS rather than by an inset plus a
+        // half-width translate. The translate would have been the shorter
+        // spelling and it is wrong in RTL: `insetInlineEnd` flips with the
+        // writing mode and `translateX` does not, so the two disagree and the
+        // chevron lands a full width off the seam. Auto margins have no
+        // direction to disagree about — and they leave ONE transform for both
+        // layouts instead of two.
+        insetInlineStart: { xs: 0, [TRACK_ROW_UP]: "auto" },
+        insetInlineEnd: { xs: 0, [TRACK_ROW_UP]: theme.spacing(-1.125) },
+        marginInline: { xs: "auto", [TRACK_ROW_UP]: 0 },
+        insetBlockStart: { xs: "100%", [TRACK_ROW_UP]: "50%" },
         transform: "translateY(-50%)",
         zIndex: 2,
         width: theme.spacing(2.25),
@@ -165,7 +163,16 @@ function SeamBreak() {
         color: seamInk(0.55),
       })}
     >
-      <ChevronRight size={14} strokeWidth={2.25} />
+      {/* The glyph turns with the flow. A chevron still pointing right under a
+          leg that continues DOWNWARD points at the page margin. */}
+      <Box
+        sx={{
+          display: "flex",
+          transform: { xs: "rotate(90deg)", [TRACK_ROW_UP]: "none" },
+        }}
+      >
+        <ChevronRight size={14} strokeWidth={2.25} />
+      </Box>
     </Box>
   );
 }
@@ -210,19 +217,29 @@ function Leg({
           gap: 0.75,
           px: 2.25,
           py: 1.75,
-          // The card's corners on the outer edges, square where legs meet.
+          // The card's corners on the outer edges, square where legs meet —
+          // and "outer" moves when the legs stack. The two corners on the
+          // flow's own axis (top-start, bottom-end) belong to the first and
+          // last leg either way; the other two swap owners.
           borderStartStartRadius: first ? TRACK_RADIUS_PX : 0,
-          borderEndStartRadius: first ? TRACK_RADIUS_PX : 0,
-          borderStartEndRadius: last ? TRACK_RADIUS_PX : 0,
           borderEndEndRadius: last ? TRACK_RADIUS_PX : 0,
+          borderStartEndRadius: {
+            xs: first ? TRACK_RADIUS_PX : 0,
+            [TRACK_ROW_UP]: last ? TRACK_RADIUS_PX : 0,
+          },
+          borderEndStartRadius: {
+            xs: last ? TRACK_RADIUS_PX : 0,
+            [TRACK_ROW_UP]: first ? TRACK_RADIUS_PX : 0,
+          },
           // Same reason as the seam: a separator at `divider` weight does not
           // survive the dark theme, and the legs read as one undivided block.
+          // It runs along whichever edge the next leg is on.
           ...(!last && {
-            borderInlineEnd: 1,
             borderStyle: "solid",
             borderColor: seamInk(0.12),
-            borderBlockWidth: 0,
-            borderInlineStartWidth: 0,
+            borderWidth: 0,
+            borderInlineEndWidth: { xs: 0, [TRACK_ROW_UP]: 1 },
+            borderBlockEndWidth: { xs: 1, [TRACK_ROW_UP]: 0 },
           }),
           transition: theme.transitions.create("background-color", {
             duration: theme.transitions.duration.shortest,
@@ -232,17 +249,6 @@ function Leg({
         })}
       >
         <Stack direction="row" spacing={1} sx={{ alignItems: "center", width: "100%" }}>
-          <Typography
-            variant="caption"
-            sx={{
-              fontFamily: "monospace",
-              fontVariantNumeric: "tabular-nums",
-              color: family && !muted ? `${family}.main` : "text.disabled",
-              flexShrink: 0,
-            }}
-          >
-            {leg.step}
-          </Typography>
           {/* The heaviest title on the page, deliberately.
               `subtitle2` renders at weight 400 in this theme, which put the
               stage name BELOW both a component row's name (14.5px/500) and the
@@ -258,17 +264,44 @@ function Leg({
           >
             {leg.name}
           </Typography>
-          {leg.state === "live" && <LivePulse />}
+          {/* Shown for `live` only, and it is `WorkingPulse` — the same dot the
+              chat footer and the spec rail use, NOT a ring of this file's own.
+              That component was extracted (#575) so "an agent is working" looks
+              identical everywhere it appears, and this leg had grown exactly the
+              second animation it exists to prevent: a hollow ring breathing an
+              expanding shadow at 2.2s next to a solid dot pulsing at 1.2s two
+              panels away. One fact, one animation.
+
+              A leg waiting on the USER (`hold`) still does not pulse — a page
+              that animates while it waits for you to type is lying about who is
+              busy. */}
+          {leg.state === "live" && <WorkingPulse />}
           <Box sx={{ flexGrow: 1 }} />
           {/* Version only when one exists — no em-dash placeholder. Blank says
-              "not yet" better than a dash pretending to be a value. */}
+              "not yet" better than a dash pretending to be a value.
+
+              A LABEL, NOT A BADGE. This was a filled chip in the leg's own
+              state colour, and with three legs carrying one it put three solid
+              lozenges across the widest band on the page — the version, which
+              is the same "v1" three times over in the common case, ended up
+              shouting louder than the stage names it sits beside. The state is
+              already told by the lit ring, the pulse and the line; the version
+              only has to be READABLE. So: still a Chip — the console's tag
+              everywhere, and what the component rows beside it use — but
+              outlined, unstyled by state, monospace and in secondary ink. */}
           {leg.version && (
             <Chip
               size="small"
+              variant="outlined"
               label={leg.version}
-              color={family ?? "default"}
-              variant={leg.state === "waiting" ? "outlined" : "filled"}
-              sx={{ fontFamily: "monospace", flexShrink: 0 }}
+              sx={{
+                height: 20,
+                flexShrink: 0,
+                fontFamily: "monospace",
+                fontSize: "0.6875rem",
+                color: "text.secondary",
+                borderColor: seamInk(0.18),
+              }}
             />
           )}
         </Stack>
@@ -336,6 +369,7 @@ export function OverviewTrack({
         variant="outlined"
         sx={{
           display: "flex",
+          flexDirection: { xs: "column", [TRACK_ROW_UP]: "row" },
           overflow: "hidden",
           borderRadius: `${TRACK_RADIUS_PX}px`,
         }}

--- a/apps/console/src/features/projects/components/ProjectOverview.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverview.tsx
@@ -22,7 +22,6 @@ import {
   Avatar,
   Box,
   Button,
-  Grid,
   Link as MuiLink,
   Skeleton,
   Stack,
@@ -35,7 +34,7 @@ import { SectionTitle } from "../../../components/SectionTitle";
 import { useProject, useProjectComponents, useProjectStatus } from "../api/queries";
 import { ComponentsList } from "./ComponentsList";
 import { OverviewTrack } from "./OverviewTrack";
-import { OverviewArchitecture } from "./OverviewArchitecture";
+import { OverviewArchitecture, OVERVIEW_SPLIT_PX } from "./OverviewArchitecture";
 import { OverviewDependencies } from "./OverviewDependencies";
 
 function SectionError({
@@ -158,34 +157,61 @@ export function ProjectOverview({ projectName }: { projectName: string }) {
           already names what belongs there and when it turns up, so the
           explainer was a fourth surface teaching the same thing in worse
           words, and it hid the shape of the page from the one reader who has
-          never seen it. */}
-        <Grid container spacing={4}>
-          <Grid size={{ xs: 12, md: 5 }}>
-            <SectionTitle>Components</SectionTitle>
-            {componentsQuery.isError ? (
-              <SectionError
-                what="components"
-                message={
-                  componentsQuery.error instanceof Error
-                    ? componentsQuery.error.message
-                    : undefined
-                }
-                onRetry={() => void componentsQuery.refetch()}
-              />
-            ) : componentsQuery.isPending ? (
-              <Skeleton variant="rounded" height={120} />
-            ) : (
-              <ComponentsList
-                projectName={projectName}
-                items={componentsQuery.data.items ?? []}
-              />
-            )}
-            <OverviewDependencies projectName={projectName} />
-          </Grid>
-          <Grid size={{ xs: 12, md: 7 }}>
-            <OverviewArchitecture projectName={projectName} />
-          </Grid>
-        </Grid>
+          never seen it.
+
+          THE SPLIT IS A CONTAINER QUERY, NOT A BREAKPOINT. The two halves are
+          not equally squeezable: the lists reflow to any width, while the
+          diagram is a fixed-aspect drawing that can only scale down, and below
+          about 600px of column it stops shrinking and starts being CROPPED
+          (`DIAGRAM_MIN_HEIGHT` explains the clamp). A viewport breakpoint gets
+          this wrong every time, because the viewport is not what the page gets:
+          the nav rail takes ~280px of it, and the agent chat panel can take
+          half of what is left. At `md` the diagram was cropped on a 1440px
+          screen — a picture you cannot read sitting next to a list you can,
+          which is the worst of both halves.
+
+          Measured against the page's own width instead, the two columns appear
+          exactly when there is room for both and not a pixel sooner. Under the
+          threshold the diagram goes below the lists at FULL width, where it
+          gets more room than the split ever gave it. */}
+        <Box sx={{ containerType: "inline-size" }}>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 4,
+              gridTemplateColumns: "1fr",
+              [`@container (min-width: ${OVERVIEW_SPLIT_PX}px)`]: {
+                gridTemplateColumns: "5fr 7fr",
+              },
+            }}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <SectionTitle>Components</SectionTitle>
+              {componentsQuery.isError ? (
+                <SectionError
+                  what="components"
+                  message={
+                    componentsQuery.error instanceof Error
+                      ? componentsQuery.error.message
+                      : undefined
+                  }
+                  onRetry={() => void componentsQuery.refetch()}
+                />
+              ) : componentsQuery.isPending ? (
+                <Skeleton variant="rounded" height={120} />
+              ) : (
+                <ComponentsList
+                  projectName={projectName}
+                  items={componentsQuery.data.items ?? []}
+                />
+              )}
+              <OverviewDependencies projectName={projectName} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <OverviewArchitecture projectName={projectName} />
+            </Box>
+          </Box>
+        </Box>
       </Stack>
     </>
   );

--- a/apps/console/src/features/projects/components/ProjectOverviewLayout.browser.test.tsx
+++ b/apps/console/src/features/projects/components/ProjectOverviewLayout.browser.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The overview's split, measured rather than asserted from the source.
+//
+// This lives in the BROWSER lane because there is nothing here jsdom can
+// answer. The split is a CONTAINER QUERY — `@container (min-width: 1100px)` on
+// the overview's own body — so the thing under test is a layout computation,
+// and jsdom has no layout engine to compute it. A unit test could only re-read
+// the `sx` object this file is meant to be checking.
+//
+// It is measured on the PAGE's width, not the viewport's, which is the whole
+// point of the change and the reason the wrapper below sets a width rather than
+// resizing the window: the nav rail takes ~280px before the page sees any of
+// it, and the agent chat panel can take half of what is left, so a viewport
+// breakpoint put the diagram in a ~480px column on a 1440px screen and cropped
+// it. These two widths are the states either side of that threshold.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElementType } from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { OxygenTheme, OxygenUIThemeProvider } from "@wso2/oxygen-ui";
+
+// Every read is left PENDING on purpose. The panels then render their
+// skeletons, and the skeletons sit inside the very boxes under test — the grid
+// container and the architecture card both lay out identically whether or not
+// their contents arrived. Mocking data in would add fixtures that no assertion
+// here reads.
+const pending = { isPending: true, isError: false, data: undefined, refetch: vi.fn() };
+
+// Spread the real modules and override only the reads this page makes. Listing
+// exports exhaustively instead breaks the moment a sibling drawer imports one
+// more hook, which is exactly how the first cut of this file failed.
+vi.mock("../api/queries", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useProject: () => pending,
+  useProjectStatus: () => pending,
+  useProjectComponents: () => pending,
+  useWorkloadDependencies: () => pending,
+  useComponentEndpointUrl: () => ({ data: undefined }),
+  useComponentOpenApi: () => ({ ...pending, isLoading: false, error: null }),
+}));
+vi.mock("../../settings/api/queries", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  usePlatformResourceTypes: () => pending,
+  useExternalResources: () => pending,
+}));
+vi.mock("../../spec/api/queries", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSpecFiles: () => pending,
+  useSpecFileContent: () => pending,
+}));
+
+// The router is not what this measures; each link becomes a plain anchor.
+vi.mock("@tanstack/react-router", () => ({
+  Link: (props: Record<string, unknown>) => <a {...props} />,
+  useNavigate: () => vi.fn(),
+  createLink: (Component: ElementType) =>
+    function MockLink({ to, params, ...rest }: Record<string, unknown>) {
+      void to;
+      void params;
+      return <Component component="a" href="#" {...rest} />;
+    },
+}));
+
+import { ProjectOverview } from "./ProjectOverview";
+
+/** The threshold itself, and a width comfortably either side of it. */
+const SPLIT_PX = 1100;
+const WIDE = 1240;
+const NARROW = 960;
+
+async function renderAt(width: number) {
+  const view = render(
+    <QueryClientProvider client={new QueryClient()}>
+      <OxygenUIThemeProvider theme={OxygenTheme}>
+      {/* Stands in for the page's content column — the box the container query
+          actually measures, which is never the window. */}
+        <div style={{ width: `${width}px` }}>
+          <ProjectOverview projectName="demo-shop" />
+        </div>
+      </OxygenUIThemeProvider>
+    </QueryClientProvider>,
+  );
+  // The grid is the only element on the page that declares its own container
+  // context, so it identifies itself without a test id.
+  const grid = await waitFor(() => {
+    const el = view.container.querySelector<HTMLElement>(
+      '[style*="container-type"], .MuiBox-root',
+    );
+    const found = [...view.container.querySelectorAll<HTMLElement>("*")].find(
+      (n) => getComputedStyle(n).display === "grid",
+    );
+    if (!found) throw new Error("no grid found");
+    void el;
+    return found;
+  });
+  return { view, grid };
+}
+
+afterEach(cleanup);
+
+describe("the overview body splits on its own width, not the viewport's", () => {
+  it(`stacks into one column below ${SPLIT_PX}px`, async () => {
+    const { grid } = await renderAt(NARROW);
+    const tracks = getComputedStyle(grid).gridTemplateColumns.split(/\s+/);
+    expect(tracks).toHaveLength(1);
+  });
+
+  it(`splits into two columns at ${SPLIT_PX}px and above`, async () => {
+    const { grid } = await renderAt(WIDE);
+    const tracks = getComputedStyle(grid)
+      .gridTemplateColumns.split(/\s+/)
+      .map((t) => parseFloat(t));
+    expect(tracks).toHaveLength(2);
+    // 5fr : 7fr, checked as the ratio rather than as two pixel values, so the
+    // assertion survives a change of gap or page width.
+    const ratio = tracks[0]! / (tracks[0]! + tracks[1]!);
+    expect(ratio).toBeGreaterThan(5 / 12 - 0.03);
+    expect(ratio).toBeLessThan(5 / 12 + 0.03);
+  });
+});
+
+describe("the architecture card takes the height its layout needs", () => {
+  // A cell is taller than it is wide, and the renderer fits what it shows to
+  // the box's HEIGHT — so the full-width stacked card would show LESS of the
+  // graph than the narrow split one unless it also gets taller.
+  const cardHeight = (root: HTMLElement) => {
+    const cards = [...root.querySelectorAll<HTMLElement>(".MuiCard-root")];
+    const card = cards[cards.length - 1]!;
+    return parseFloat(getComputedStyle(card).minHeight);
+  };
+
+  it("is taller when stacked below the threshold", async () => {
+    const { view } = await renderAt(NARROW);
+    expect(cardHeight(view.container)).toBe(560);
+  });
+
+  it("is shorter when it sits beside the lists", async () => {
+    const { view } = await renderAt(WIDE);
+    expect(cardHeight(view.container)).toBe(340);
+  });
+});

--- a/apps/console/src/features/projects/lib/track.test.ts
+++ b/apps/console/src/features/projects/lib/track.test.ts
@@ -55,10 +55,9 @@ const states = (s: ProjectStatus, engaged = false): LegState[] =>
 const leg = (s: ProjectStatus, i: number, engaged = false) =>
   trackView(s, engaged).legs[i]!;
 
-describe("the track is always three numbered legs", () => {
-  it("numbers them in flow order whatever the state", () => {
+describe("the track is always three legs", () => {
+  it("names them in flow order whatever the state", () => {
     const view = trackView(status({}), false);
-    expect(view.legs.map((l) => l.step)).toEqual(["01", "02", "03"]);
     expect(view.legs.map((l) => l.name)).toEqual(["Spec", "Build", "Deploy"]);
   });
 

--- a/apps/console/src/features/projects/lib/track.ts
+++ b/apps/console/src/features/projects/lib/track.ts
@@ -22,11 +22,17 @@ import { validationView } from "./pipeline";
 type ProjectStatus = components["schemas"]["ProjectStatus"];
 
 /**
- * THE TRACK: spec → build → deploy as one numbered flow.
+ * THE TRACK: spec → build → deploy as one flow.
  *
  * This replaced three separate stage cards. Three cards with three borders read
  * as three features; they are one version moving through three gates, so they
- * are one bar whose legs carry a step number and an arrowhead at the seam.
+ * are one bar whose legs are divided by a seam a chevron points across.
+ *
+ * The legs carried a step numeral ("01", "02", "03") until it was cut. Three
+ * stages laid left to right with a chevron between each pair are already in
+ * order; the numeral said the same thing a second time, in the loudest slot on
+ * the row, and it read as an identifier — a version, a count — rather than as
+ * a position nobody was in any doubt about.
  *
  * Two rules the card grammar could not express, both forced by states the cards
  * rendered wrong:
@@ -50,8 +56,6 @@ type ProjectStatus = components["schemas"]["ProjectStatus"];
 export type LegState = "waiting" | "live" | "hold" | "done" | "failed";
 
 export interface TrackLeg {
-  /** Position in the flow, said out loud: "01", "02", "03". */
-  step: string;
   name: string;
   /** Version chip text; "" renders nothing — there is no em-dash placeholder. */
   version: string;
@@ -95,7 +99,7 @@ export interface TrackView {
 
 function specLeg(status: ProjectStatus, engaged: boolean): TrackLeg {
   const { exists, version, dirty, agent } = status.spec;
-  const leg = { step: "01", name: "Spec", to: "/projects/$projectName/spec", version } as const;
+  const leg = { name: "Spec", to: "/projects/$projectName/spec", version } as const;
 
   // A live state overrides the LINE only — the version is a separate fact, so
   // an amendment interview on v2 still reads as v2.
@@ -151,7 +155,7 @@ function specLeg(status: ProjectStatus, engaged: boolean): TrackLeg {
 
 function buildLeg(status: ProjectStatus): TrackLeg {
   const { version, status: state } = status.build;
-  const leg = { step: "02", name: "Build", to: "/projects/$projectName/builds" } as const;
+  const leg = { name: "Build", to: "/projects/$projectName/builds" } as const;
   switch (state) {
     case "running":
       return { ...leg, version, state: "live", line: "Building" };
@@ -181,7 +185,7 @@ function validationInFlight(validation: string): boolean {
 
 function deployLeg(status: ProjectStatus): TrackLeg {
   const { version, status: state, components: comps, validation } = status.deploy;
-  const leg = { step: "03", name: "Deploy", to: "/projects/$projectName/deployments" } as const;
+  const leg = { name: "Deploy", to: "/projects/$projectName/deployments" } as const;
   // Validation is a PHASE OF DEPLOYING, not a fourth gate: it only runs once
   // the components are up, so it rides this line rather than adding a leg that
   // would be empty in most states of the flow.


### PR DESCRIPTION
Closes #683.

## What changed

| | Before | After |
|---|---|---|
| Track legs | `01` `02` `03` leading each leg | numeral gone; order from the chevron seams |
| Version | filled Chip in the leg's state colour | outlined Chip, monospace, secondary ink |
| Body split | `md` viewport breakpoint | container query on the page's own width (1100px) |
| Architecture, stacked | 340px tall, full width | 560px — a cell is taller than it is wide |
| Track, narrow | 3 legs side by side to phone width | stacks below `md`, seam chevron turns |
| Live animation | a ring of the track's own (2.2s) | `WorkingPulse`, the shared dot (1.2s) |
| Web app row | inert, no affordance | opens the running app, outward arrow |

## The regression this turned up

#196 is **closed** on the premise that the console already showed a web app's public URL — its
walkthrough says the "Open app" link was *"already implemented, `ComponentsList.tsx:36-51`"*, scope
*"Console: none (verify only)"*. That link is not in the tree. Today's comment reads *"A web app has
no contract to open, so its row goes nowhere and shows no chevron"*, and `useComponentEndpointUrl`
had **no caller at all** — the overview rework dropped the link and orphaned the hook. This restores
it.

`OverviewRow` gains an `href` that renders a real anchor rather than a button calling `window.open`,
so middle-click, ⌘-click and "copy link address" work. Its affordance is the outward arrow, not the
chevron — a chevron promises the next panel of this console, and this one leaves it.

**Still open, deliberately out of scope:** #196's actual backend half — filling `Component.endpointUrl`
in `list-components` — still looks unfulfilled. `queries.ts` reads the URL from the component's
*deployments* and notes the drift inline. That deserves its own issue rather than being quietly
re-closed here.

## Why a container query, not a breakpoint

The viewport is not what the page gets: the nav rail takes ~280px before the page sees any of it,
and the agent chat panel can take half of what is left. At `md` on a 1440px screen the diagram
landed in a ~480px column and was cropped — a picture you cannot read beside a list you can. Measured
on the page's own width, the two columns appear exactly when there is room for both.

## Proof of execution

Driven in mock mode (`VITE_API_MODE=mock`) at 1920 / 1440 / 820 / 390 px, and against the real local
stack (k3d + compose, Vite dev server on :8091 proxying aep-api :9090).

The shared-pulse change, read back off the live DOM — one element, no second curve left on the page:

```
{"count":1,"dots":[{"w":"8px","h":"8px","bg":"rgb(250, 123, 63)",
  "anim":"agentChatWorkingPulse 1.2s","border":"0px"}],
 "legacyRing": false}
```

The cropping that motivated the layout change, measured on the renderer's own viewport transform —
it draws at ~1:1 whatever box it is handed, in both the old split and the new stack:

```
split  (721x364)  -> scale(0.933033)
stacked(1060x518) -> scale(0.97527)
```

Gates, after the review fixes below:

```
tsc -p tsconfig.json          clean
eslint .                      clean
vitest run                    133 files, 1646 tests passed
knip --production             clean
make license-check            clean
```

New coverage: `ComponentsList.test.tsx` — the row links out once a URL exists (`href`, `target`,
`rel`), stays inert while the app has not deployed, and a `service` row still opens its contract and
asks for no endpoint URL.

## Review findings, fixed before opening

`/code-review` per `AGENTS.md`, both axes. Three findings, all addressed in the commit:

1. **Standards** — the version tag was first hand-rolled as a styled `Box component="span"`. The
   design-system doc puts Oxygen components ahead of local widgets, and `ComponentsList` one file
   over already does exactly this with `<Chip size="small" variant="outlined">`. Now matches.
2. **Correctness (RTL)** — the stacked seam centred itself with a logical `insetInlineEnd` plus a
   physical `translateX(50%)`. Those two disagree under RTL and the chevron lands a full width off
   the seam. Replaced with auto-margin centring, which has no direction to disagree about — and
   leaves one transform for both layouts instead of two.
3. **Accessibility** — the ring being replaced honoured `prefers-reduced-motion`; the shared
   `WorkingPulse` did not, so unifying them would have lost the guard. The guard moves onto
   `WorkingPulse`, so the chat footer and the spec rail gain it too.

## Not fixed here

- **The cell renderer ignores its box.** `scale(0.97)` in 1060x518 and `scale(0.93)` in 721x364 — it
  draws near 1:1 and crops, on the old layout and the new one alike. Lives in
  `@aep/ui-cell-diagram-react`; "Open in spec" remains the way to see a cell whole.
- **The shell's fixed 64px page gutters.** At a 390px viewport that leaves a 198px content column and
  component names ellipsize to a single letter. `PageContent` is shared by every page, so it is not
  an overview change.
