### PR TITLE
Manual criteria must not show a live run status

### DIFF
--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1406,3 +1406,58 @@ describe("ValidationPage live note is gated on an open cycle", () => {
     expect(screen.getByText(/category option never appeared/)).toBeInTheDocument();
   });
 });
+
+// A run reports `planned` for EVERY criterion in the test plan, and SKILL.md has
+// the agent write a plan section per criterion — manual ones included. So the
+// feed carries a status for a criterion no agent will ever work, and the row used
+// to render it: the method badge read `manual` while the chip beside it read
+// "Planned", for the whole run, with nothing able to supersede it.
+describe("ValidationPage manual criteria ignore the live feed", () => {
+  it("keeps a manual criterion on Manual when the feed reports it planned", () => {
+    mockValidation = "running";
+    mockRun = { ...run({ cycles: [validationCycle] }), state: "running" };
+    mockCriteria.data = { content: CRITERIA };
+    // AC-003-b is the `manual` criterion in CRITERIA; AC-001-a is `e2e`.
+    mockLive = { "AC-001-a": "planned", "AC-003-b": "planned" };
+    renderPage(undefined);
+
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    // Only the e2e row may say Planned — the manual one must not.
+    expect(screen.getAllByText("Planned")).toHaveLength(1);
+  });
+
+  it("keeps it on Manual through every live status, not just planned", () => {
+    // Nothing else is reachable for a manual criterion today, but the rule is
+    // about the METHOD rather than about which status happened to arrive.
+    mockValidation = "running";
+    mockRun = { ...run({ cycles: [validationCycle] }), state: "running" };
+    mockCriteria.data = { content: CRITERIA };
+    mockLive = { "AC-003-b": "running" };
+    renderPage(undefined);
+
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    expect(screen.queryByText("Running…")).not.toBeInTheDocument();
+  });
+
+  it("still says Manual when no report was fetched and nothing is awaiting", () => {
+    // `unreported` settles the run and skips the report read, so `awaiting` is
+    // false and there is no report — the two branches that used to carry a manual
+    // row. Before the guard it fell through to nothing and rendered no chip.
+    mockValidation = "unreported";
+    mockRun = run({
+      validation: { verdict: "unreported" },
+      cycles: [validationCycle],
+    });
+    mockCriteria.data = { content: CRITERIA };
+    mockLive = { "AC-001-a": "authoring" };
+    renderPage(undefined);
+
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    // Asserted negatively too: the method BADGE also carries the word "manual",
+    // so presence alone would still pass if the chip regressed to something else
+    // and only the badge matched. Neither of the two chips it could wrongly show
+    // here may appear on any row.
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    expect(screen.queryByText("Planned")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -189,28 +189,52 @@ function LiveChip({ status }: { status: string }) {
   );
 }
 
-// What a criterion shows while an attempt is IN FLIGHT and no report exists yet.
-//
-// A `manual` criterion gets its final word rather than "Pending": the run will
-// never answer it — that is what the method means — so a chip promising a result
-// would be a claim the eventual report contradicts. Everything else is genuinely
-// waiting on the run, including the legacy `scenario` method and any method this
-// view does not recognise.
-//
-// "Pending" is local rather than a sixth CRITERION_STATE_LABEL entry: that map is
-// report.json's vocabulary, and a criterion with no report has no status to name.
-function AwaitingChip({ method }: { method: string }) {
-  return method === "manual" ? (
-    <StateChip status="manual" />
-  ) : (
-    <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
-  );
+/**
+ * The one chip a criterion's row carries, in precedence order.
+ *
+ * `manual` wins over everything. Such a criterion is answered by a person, so
+ * the run will never answer it — that is what the method means — and any chip
+ * promising a result is a claim the eventual report contradicts. It outranks a
+ * live status as well as a report: a run legitimately reports progress for a
+ * manual criterion (its test plan names every criterion, not only the ones an
+ * agent will work), and rendering that as a run state left the row promising a
+ * result beside a badge saying nobody would produce one.
+ *
+ * Then live over report, and the ordering there is the whole point: a repeat
+ * attempt carries the PREVIOUS attempt's report, so ranking the report higher
+ * would freeze a criterion on the last run's verdict for the entire time the
+ * current run spends re-working it. The report wins again the moment the cycle
+ * settles, because the consumer stops supplying live statuses then.
+ *
+ * `awaiting` last, and only it can yield nothing: the Spec view renders this
+ * same pane with no run attached, where a chip would name a run that does not
+ * exist.
+ */
+function CriterionChip({
+  criterion,
+  report,
+  live,
+  awaiting,
+}: {
+  criterion: Criterion;
+  report: CriterionReport | undefined;
+  live: string | undefined;
+  awaiting: boolean;
+}) {
+  if (criterion.method === "manual") return <StateChip status="manual" />;
+  // pass/fail arrive on the live feed too — report.json's own words, so its chip.
+  if (live) return LIVE_LABEL[live] ? <LiveChip status={live} /> : <StateChip status={live} />;
+  if (report) return <StateChip status={report.status} />;
+  // "Pending" is local rather than a sixth CRITERION_STATE_LABEL entry: that map
+  // is report.json's vocabulary, and a criterion with no report has no status to
+  // name.
+  if (awaiting) return <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />;
+  return null;
 }
 
-// One acceptance criterion: method badge, its id, the atomic assertion, and —
-// when a run report is joined in — its run-state chip plus healed/flaky markers
-// and (for a failure) the spec path and failure message beneath. With no report
-// and `awaiting` set, the state chip says what is going to happen to it instead.
+// One acceptance criterion: method badge, its id, the atomic assertion, its
+// status chip (CriterionChip decides which one wins), healed/flaky markers, and
+// — for a failure — the spec path and message beneath.
 function CriterionRow({
   criterion,
   report,
@@ -244,24 +268,12 @@ function CriterionRow({
         {report?.healed && (
           <Chip size="small" variant="outlined" label="healed" sx={{ flexShrink: 0 }} />
         )}
-        {/* Live FIRST, and the ordering is the whole point. A repeat attempt
-            carries the PREVIOUS attempt's report, so ranking the report higher
-            would freeze a criterion on the last run's verdict for the entire
-            two hours the current run spends re-working it. The report wins
-            again the moment the cycle settles, because the consumer stops
-            supplying live statuses once nothing is in flight. */}
-        {live ? (
-          LIVE_LABEL[live] ? (
-            <LiveChip status={live} />
-          ) : (
-            // pass/fail off the feed: report.json's own words, so the same chip.
-            <StateChip status={live} />
-          )
-        ) : report ? (
-          <StateChip status={report.status} />
-        ) : awaiting ? (
-          <AwaitingChip method={criterion.method} />
-        ) : null}
+        <CriterionChip
+          criterion={criterion}
+          report={report}
+          live={live}
+          awaiting={awaiting}
+        />
       </Box>
       {/* Failure detail sits full-width beneath the row (indented past the
           method badge) so a long trace never crowds the assertion. */}


### PR DESCRIPTION
Closes #691

## The bug

A manual criterion moved to **`Planned`** with everything else and stayed there for the rest of the run — the row promising a result beside a badge saying nobody would produce one:

```
auto    AC-001-a  A shopper can search products by name    ● Authoring…
auto    AC-001-b  A shopper can filter the catalog         ● Running…
manual  AC-003-b  Payment details are encrypted            ○ Planned     <-- wrong
```

Nothing could clear it: every status after `planned` needs a `.spec.ts`, and a manual criterion never has one.

## Why, and where the fix belongs

The runner reports `planned` for every `## AC-…` section in the test plan, and the plan carries a section **per criterion** — manual ones included, on purpose, so a human can check the agent's reading of each (`SKILL.md:270`, `authoring.md:78`).

So the event is not wrong. The agent did plan how the criterion gets checked. What was wrong is rendering it as a **run status** — and that rule already existed one function away, in `AwaitingChip`:

> A `manual` criterion gets its final word rather than "Pending": the run will never answer it — that is what the method means — so a chip promising a result would be a claim the eventual report contradicts.

Live statuses were ranked above it and short-circuited it.

Fixed in the view, not the runner. `progress_item` has exactly one consumer; guarding a hypothetical second one is the speculative genericity `ADR-0009` already rejected when it dropped the `group` field. Teaching the runner about methods would mirror the oracle's taxonomy across the process split and only take effect after an `aep-runner:dev` rebuild. The view already parses the oracle and already had `criterion.method` in scope on the line that needed it.

## What changed

The whole chip precedence now lives in one `CriterionChip` function — four nested ternaries became four early returns, each rule on a statement with its reason beside it:

```tsx
if (criterion.method === "manual") return <StateChip status="manual" />;
if (live) return LIVE_LABEL[live] ? <LiveChip status={live} /> : <StateChip status={live} />;
if (report) return <StateChip status={report.status} />;
if (awaiting) return <Chip … label="Pending" />;
return null;
```

`AwaitingChip` is gone rather than kept alongside it. Keying the guard on **method** rather than on `live` made its manual branch unreachable for every caller — including the Spec view, which renders this pane with no run attached and so never reached it at all. Its reasoning is carried into the function above.

Manual now outranks the **report** too. That costs nothing — `generate-report.mjs:359` sets a manual row's status unconditionally, so the report branch rendered this very chip — and it covers a case the report branch could not: an `unreported` re-dispatch fetches no report and leaves `awaiting` false, which used to drop the row through to **no chip at all**.

## Proof

Three regression tests, each confirmed to **fail without the guard** — verified twice, before and after the refactor, so they are catching the bug rather than passing incidentally:

```
× keeps a manual criterion on Manual when the feed reports it planned
× keeps it on Manual through every live status, not just planned
× still says Manual when no report was fetched and nothing is awaiting
```

The first pins the negative (`getAllByText("Planned")` has length 1 — only the e2e row); the third asserts absence too, since the method badge also carries the word and presence alone could pass on a regression.

**Gates:** 1646 console tests, `@aep/ui-validation-view` tests, `tsc`, eslint, `make license-check` — green.

> [!NOTE]
> **No mock evidence, and that is the point.** The fixture hand-omits the manual criterion (`run-progress.ts:37`, *"deliberately absent — a run never touches it"*), encoding what a run *should* emit rather than what it does. That is why this reached a real run unseen, and is filed as #690 along with the same open question for `scenario` criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
