### PR TITLE
feat(skills): user stories are the wireframe's coverage oracle

### DIFF
--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -136,10 +136,6 @@ before the work starts. When every story is walked, say so
 (`No flow: none — stories 1–9 are all walked above`) rather than omitting the
 line, so a reader can tell the question was asked.
 
-The coding agent ticks each flow off when it is walkable end to end, so this
-line is what lets a failing story be traced back to the journey that was meant
-to exercise it — or to the note saying no journey was ever expected.
-
 ## When a tool rejects you
 
 The result names the fix: UNKNOWN_COMPONENT lists the known components;

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -92,15 +92,21 @@ its role, and the stories it walks:
 ```text
 Flows: "Submit an expense" (Employee) — stories 3, 4, 7
        "Approve a claim" (Manager) — stories 5, 6
+       No flow: story 1 (sign-in — platform SSO owns the page), story 9
+       (nightly export job, no view)
 ```
 
-An in-scope story no flow walks is a **gap you state**, not one you drop:
-say so on the line (`stories 9, 10 — no flow walks these`) so a human sees it
-before the work starts. A story with no view at all — a backend rule, a
-scheduled job — is fine; name it as that rather than leaving it unaccounted.
+Every in-scope story lands on one of those lines. A story with no view is
+expected — sign-in and sign-out on a component with an auth dependency, a
+backend rule, a scheduled job, an endpoint another service calls — so put it
+on the `No flow:` line **with the reason**. A story that belongs on a screen
+and has no flow is a real gap: say so in the same place
+(`story 10 — no flow walks this`) rather than dropping it, so a human sees it
+before the work starts.
+
 The coding agent ticks each flow off when it is walkable end to end, so this
 line is what lets a failing story be traced back to the journey that was meant
-to exercise it.
+to exercise it — or to the note saying no journey was ever expected.
 
 ## When a tool rejects you
 

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -86,23 +86,42 @@ into pages.
 **Map the stories to the flows, and check the mapping yourself.** You hold
 both the story list and the wireframe, so you are the one place the two can be
 compared — the designer's coverage pass is not one you inherit on trust. Read
-the `flow` blocks, and add a `Flows:` line under `## Scope` naming each flow,
-its role, and the stories it walks:
+the `flow` blocks and write a **`Flows:` checklist** under `## Scope` — one
+item per flow, numbered `F1`, `F2`, …, carrying the flow's name, its `role`,
+the stories it walks, and its `description` line from the DSL:
 
-```text
-Flows: "Submit an expense" (Employee) — stories 3, 4, 7
-       "Approve a claim" (Manager) — stories 5, 6
-       No flow: story 1 (sign-in — platform SSO owns the page), story 9
-       (nightly export job, no view)
+```markdown
+Flows:
+
+- [ ] **F1 · "Submit an expense"** (Employee) — stories 3, 4, 7
+  An employee files a claim and tracks its approval.
+- [ ] **F2 · "Approve a claim"** (Manager) — stories 5, 6
+  A manager works the pending queue and decides a claim.
+
+No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
+export job, no view).
 ```
 
-Every in-scope story lands on one of those lines. A story with no view is
-expected — sign-in and sign-out on a component with an auth dependency, a
-backend rule, a scheduled job, an endpoint another service calls — so put it
-on the `No flow:` line **with the reason**. A story that belongs on a screen
+Why each part earns its place: the **number** gives the coding agent and the
+reviewer a short handle, so "F2 is not walkable" says exactly which journey
+without quoting a whole name; the **description** is already written in the
+DSL, so copying it saves every later reader from opening the file to learn
+what the journey is for; and the **checkbox** makes it a contract the PR ticks
+back item by item.
+
+**Leave every box unchecked.** The issue states what must be walked; the
+coding agent ticks the same list in its PR body. Re-planning rewrites this
+body, so a tick recorded here would be wiped — the PR is where progress lives.
+
+Every in-scope story lands either on a flow item or the `No flow:` line. A
+story with no view is expected — sign-in and sign-out on a component with an
+auth dependency, a backend rule, a scheduled job, an endpoint another service
+calls — so put it there **with the reason**. A story that belongs on a screen
 and has no flow is a real gap: say so in the same place
 (`story 10 — no flow walks this`) rather than dropping it, so a human sees it
-before the work starts.
+before the work starts. When every story is walked, say so
+(`No flow: none — stories 1–9 are all walked above`) rather than omitting the
+line, so a reader can tell the question was asked.
 
 The coding agent ticks each flow off when it is walkable end to end, so this
 line is what lets a failing story be traced back to the journey that was meant

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -93,29 +93,39 @@ the stories it walks, and its `description` line from the DSL:
 ```markdown
 Flows:
 
-- [ ] **F1 · "Submit an expense"** (Employee) — stories 3, 4, 7
-  MyClaims → NewClaim → ClaimDetail
+- [ ] **F1 · Submit an expense**
+  Persona: Employee
+  Stories: 3, 4, 7
+  Walk: MyClaims → NewClaim → ClaimDetail
   An employee files a claim and tracks its approval.
-- [ ] **F2 · "Approve a claim"** (Manager) — stories 5, 6
-  ApprovalQueue → ClaimReview
+- [ ] **F2 · Approve a claim**
+  Persona: Manager
+  Stories: 5, 6
+  Walk: ApprovalQueue → ClaimReview
   A manager works the pending queue and decides a claim.
 
 No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
 export job, no view).
 ```
 
-Why each part earns its place: the **number** gives the coding agent and the
-reviewer a short handle, so "F2 is not walkable" says exactly which journey
-without quoting a whole name; the **screen chain** is the flow's own screen
-list in walkthrough order, entry screen first — the `Screens:` line above says
-which routes to build, this says the order someone walks them, and it is the
-walk the PR has to demonstrate; the **description** is already written in the
-DSL, so copying it saves every later reader from opening the file to learn
-what the journey is for; and the **checkbox** makes it a contract the PR ticks
-back item by item.
+One labelled line each, so nothing has to be inferred from punctuation:
 
-Keep the chain to screen names and arrows — no commentary. A screen appearing
-in two flows is listed in both; that is the DSL's shape, not a mistake.
+- **`F1 ·` + the flow's name** — the number is a short handle, so "F2 is not
+  walkable" names one exact journey without quoting a whole title.
+- **`Persona:`** — the flow's `role` line. Say `Persona: any` for a
+  role-less journey rather than dropping the line.
+- **`Stories:`** — the story numbers this journey walks.
+- **`Walk:`** — the flow's screens in walkthrough order, entry screen first.
+  Deliberately not called `Screens:`: that word is taken above for the routes
+  to build, and this is the order someone walks them — the walk the PR has to
+  demonstrate. Names and arrows only, no commentary. A screen in two flows
+  appears in both; that is the DSL's shape, not a mistake.
+- **The last line is the flow's `description`** from the DSL, unlabelled
+  because it is prose. Copying it saves every later reader from opening the
+  file to learn what the journey is for.
+
+The **checkbox** makes the whole thing a contract the PR ticks back item by
+item.
 
 **Leave every box unchecked.** The issue states what must be walked; the
 coding agent ticks the same list in its PR body. Re-planning rewrites this

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -83,6 +83,25 @@ live in the DSL, and listing them in the issue would go stale the moment the
 wireframe is edited. The coding agent's `wireframes` skill turns the names
 into pages.
 
+**Map the stories to the flows, and check the mapping yourself.** You hold
+both the story list and the wireframe, so you are the one place the two can be
+compared — the designer's coverage pass is not one you inherit on trust. Read
+the `flow` blocks, and add a `Flows:` line under `## Scope` naming each flow,
+its role, and the stories it walks:
+
+```text
+Flows: "Submit an expense" (Employee) — stories 3, 4, 7
+       "Approve a claim" (Manager) — stories 5, 6
+```
+
+An in-scope story no flow walks is a **gap you state**, not one you drop:
+say so on the line (`stories 9, 10 — no flow walks these`) so a human sees it
+before the work starts. A story with no view at all — a backend rule, a
+scheduled job — is fine; name it as that rather than leaving it unaccounted.
+The coding agent ticks each flow off when it is walkable end to end, so this
+line is what lets a failing story be traced back to the journey that was meant
+to exercise it.
+
 ## When a tool rejects you
 
 The result names the fix: UNKNOWN_COMPONENT lists the known components;

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -94,15 +94,15 @@ the stories it walks, and its `description` line from the DSL:
 Flows:
 
 - [ ] **F1 · Submit an expense**
+  An employee files a claim and tracks its approval.
   Persona: Employee
   Stories: 3, 4, 7
   Walk: MyClaims → NewClaim → ClaimDetail
-  An employee files a claim and tracks its approval.
 - [ ] **F2 · Approve a claim**
+  A manager works the pending queue and decides a claim.
   Persona: Manager
   Stories: 5, 6
   Walk: ApprovalQueue → ClaimReview
-  A manager works the pending queue and decides a claim.
 
 No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
 export job, no view).
@@ -112,6 +112,10 @@ One labelled line each, so nothing has to be inferred from punctuation:
 
 - **`F1 ·` + the flow's name** — the number is a short handle, so "F2 is not
   walkable" names one exact journey without quoting a whole title.
+- **The flow's `description`** from the DSL, straight under the title and
+  unlabelled because it is prose. It says what the journey is, so it comes
+  before the facts about it — and copying it saves every later reader from
+  opening the file to find out.
 - **`Persona:`** — the flow's `role` line. Say `Persona: any` for a
   role-less journey rather than dropping the line.
 - **`Stories:`** — the story numbers this journey walks.
@@ -120,9 +124,6 @@ One labelled line each, so nothing has to be inferred from punctuation:
   to build, and this is the order someone walks them — the walk the PR has to
   demonstrate. Names and arrows only, no commentary. A screen in two flows
   appears in both; that is the DSL's shape, not a mistake.
-- **The last line is the flow's `description`** from the DSL, unlabelled
-  because it is prose. Copying it saves every later reader from opening the
-  file to learn what the journey is for.
 
 The **checkbox** makes the whole thing a contract the PR ticks back item by
 item.

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -108,25 +108,19 @@ No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
 export job, no view).
 ```
 
-One labelled line each, so nothing has to be inferred from punctuation:
+One labelled line each:
 
-- **`F1 ·` + the flow's name** — the number is a short handle, so "F2 is not
-  walkable" names one exact journey without quoting a whole title.
-- **The flow's `description`** from the DSL, straight under the title and
-  unlabelled because it is prose. It says what the journey is, so it comes
-  before the facts about it — and copying it saves every later reader from
-  opening the file to find out.
-- **`Persona:`** — the flow's `role` line. Say `Persona: any` for a
-  role-less journey rather than dropping the line.
+- **`F1 ·` + the flow's name**, numbered in the order the DSL declares them —
+  the number is how a reviewer names one exact journey.
+- **The flow's `description`** from the DSL, straight under the title,
+  unlabelled: it is prose, and it says what the journey is before the facts
+  about it.
+- **`Persona:`** — the flow's `role`. Write `Persona: any` for a role-less
+  journey rather than dropping the line.
 - **`Stories:`** — the story numbers this journey walks.
 - **`Walk:`** — the flow's screens in walkthrough order, entry screen first.
-  Deliberately not called `Screens:`: that word is taken above for the routes
-  to build, and this is the order someone walks them — the walk the PR has to
-  demonstrate. Names and arrows only, no commentary. A screen in two flows
-  appears in both; that is the DSL's shape, not a mistake.
-
-The **checkbox** makes the whole thing a contract the PR ticks back item by
-item.
+  Names and arrows only, no commentary. A screen in two flows appears in
+  both; that is the DSL's shape, not a mistake.
 
 **Leave every box unchecked.** The issue states what must be walked; the
 coding agent ticks the same list in its PR body. Re-planning rewrites this

--- a/skills/task-planning/SKILL.md
+++ b/skills/task-planning/SKILL.md
@@ -94,8 +94,10 @@ the stories it walks, and its `description` line from the DSL:
 Flows:
 
 - [ ] **F1 · "Submit an expense"** (Employee) — stories 3, 4, 7
+  MyClaims → NewClaim → ClaimDetail
   An employee files a claim and tracks its approval.
 - [ ] **F2 · "Approve a claim"** (Manager) — stories 5, 6
+  ApprovalQueue → ClaimReview
   A manager works the pending queue and decides a claim.
 
 No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
@@ -104,10 +106,16 @@ export job, no view).
 
 Why each part earns its place: the **number** gives the coding agent and the
 reviewer a short handle, so "F2 is not walkable" says exactly which journey
-without quoting a whole name; the **description** is already written in the
+without quoting a whole name; the **screen chain** is the flow's own screen
+list in walkthrough order, entry screen first — the `Screens:` line above says
+which routes to build, this says the order someone walks them, and it is the
+walk the PR has to demonstrate; the **description** is already written in the
 DSL, so copying it saves every later reader from opening the file to learn
 what the journey is for; and the **checkbox** makes it a contract the PR ticks
 back item by item.
+
+Keep the chain to screen names and arrows — no commentary. A screen appearing
+in two flows is listed in both; that is the DSL's shape, not a mistake.
 
 **Leave every box unchecked.** The issue states what must be walked; the
 coding agent ticks the same list in its PR body. Re-planning rewrites this

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -34,11 +34,25 @@ only moment anyone can count it, while the requirements are in front of you.
 Do it deliberately, before you write the file:
 
 **Walk the numbered stories in order. For each one, name the flow that walks
-it.** A story every flow misses is a gap: add the screens it needs and put
-them in a flow, or — if it genuinely has no view (a backend rule, a scheduled
-job, an API another service calls) — leave it out knowingly rather than by
-oversight. Each flow will usually serve several stories, and a story may
-appear in more than one flow; what matters is that none is left unserved.
+it.** Each flow will usually serve several stories, and a story may appear in
+more than one flow; what matters is that every story is accounted for — either
+walked, or knowingly set aside.
+
+**Some stories have no screen, and that is correct.** Set a story aside when
+the product genuinely gives it no view:
+
+- **Sign-in and sign-out**, on a component with an auth dependency. "As a user
+  I can sign in" is real, but the platform's SSO owns that page — there is no
+  `Login` screen to draw (see *The DSL* in `SKILL.md`). The story is served by
+  the auth dependency, not by a flow.
+- **Backend rules and jobs** — a nightly export, a retention policy, a
+  validation rule enforced in the API.
+- **Machine-facing stories** — an endpoint another service calls.
+
+Everything else is a gap: add the screens it needs and put them in a flow.
+The distinction to hold onto is *set aside knowingly* versus *missed* — write
+the set-aside list down (it goes in the task issue), so the next reader can
+tell which happened.
 
 Run it the other way too: a flow serving no story is a journey nobody asked
 for, and a screen in no flow is one nobody can reach. Both are noise — cut
@@ -353,9 +367,10 @@ Checklist before finishing a wireframe file:
   order across roles.
 - Each role or journey named in the design's `flows/` files has its own `flow "<name>"` block,
   entry screen first, referencing existing screens by name.
-- **Every numbered user story is walked by at least one flow.** Go through the
-  stories and name the flow for each; a story with no flow is either a missing
-  screen or a deliberate no-view story, and you should know which.
+- **Every numbered user story is accounted for**: walked by at least one flow,
+  or on the set-aside list with its reason (sign-in, a backend rule, a job, a
+  machine-facing endpoint). Go through the stories and say which for each —
+  the one thing that must not happen is a story nobody looked at.
 - **Each role flow opens on that role's own screen, and there is no `Login`
   screen when the component has an auth dependency** — the platform's SSO
   hosts sign-in and returns the user to their home screen, so the app never

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -57,11 +57,11 @@ Then run the check backwards. A flow serving no story is a journey nobody
 asked for; a screen in no flow is one nobody can reach. Cut it, or find the
 story it belongs to — never invent a screen the requirements never asked for.
 
-**Report what you found in your closing message** — which stories each flow
-walks, and which you set aside with the reason. That report is read by the
-human reviewing this turn; the planning turn re-derives the mapping from the
-committed DSL and requirements rather than inheriting yours, so the two are a
-check on each other.
+The count is a check you run while writing, not a report you file: what it
+produces is the flow set itself. The planning turn re-derives the mapping from
+the committed DSL and the requirements and records it on the Task, so a story
+left unwalked here surfaces there — in front of a human, before any code is
+written.
 
 ## What makes a wireframe good
 

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -29,9 +29,9 @@ You have up to three sources in context; read them in this order of priority:
 
 ## Cover every story
 
-The user stories are **numbered**, so coverage is countable — and this is the
-only moment anyone can count it, while the requirements are in front of you.
-Do it deliberately, before you write the file:
+The user stories are **numbered**, so coverage is countable. Count it
+deliberately, before you write the file, while the requirements are in front
+of you:
 
 **Walk the numbered stories in order. For each one, name the flow that walks
 it.** Each flow will usually serve several stories, and a story may appear in
@@ -49,22 +49,16 @@ the product genuinely gives it no view:
   validation rule enforced in the API.
 - **Machine-facing stories** — an endpoint another service calls.
 
-Everything else is a gap: add the screens it needs and put them in a flow.
-The distinction to hold onto is *set aside knowingly* versus *missed* — write
-the set-aside list down (it goes in the task issue), so the next reader can
-tell which happened.
+Every other uncovered story is a gap: add the screens it needs and put them in
+a flow.
 
-Run it the other way too: a flow serving no story is a journey nobody asked
-for, and a screen in no flow is one nobody can reach. Both are noise — cut
-them, or find the story they belong to.
+Then run the check backwards. A flow serving no story is a journey nobody
+asked for; a screen in no flow is one nobody can reach. Cut it, or find the
+story it belongs to — never invent a screen the requirements never asked for.
 
-This is what makes the wireframe reviewable later. The task issue records
-which stories each flow walks, and the coding agent ticks the flow off when it
-is clickable end to end, so a story that fails validation can be traced to the
-flow that was supposed to exercise it. That chain only holds if the mapping is
-true here, at the start.
-
-Equally, don't invent screens the design doesn't imply.
+**Report what you found in your closing message** — which stories each flow
+walks, and which you set aside with the reason. You do not write the task
+issue; the next turn does, from what you report here.
 
 ## What makes a wireframe good
 

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -15,22 +15,42 @@ You have up to three sources in context; read them in this order of priority:
    This is your **primary** source for screens: derive the screen list from
    the flows first. (They may not exist on every turn — if absent, promote
    the requirements to primary.)
-2. **`specs/requirements/`** (requirements / user stories) — the **detailed**
-   source. Use it to flesh out each screen and to catch tasks the design doc
-   only summarized: specific fields, states, rules, and edge cases (out-of-
-   stock, guest vs. signed-in, validation errors).
+2. **`specs/requirements/`** (requirements / user stories) — the **coverage
+   oracle**, and the detailed source. The numbered user stories are what the
+   set has to cover (see *Cover every story* below); they also flesh out each
+   screen and catch tasks the flow files only summarized: specific fields,
+   states, rules, and edge cases (out-of-stock, guest vs. signed-in,
+   validation errors).
 3. **This component's `specs/design/components/<name>/design.json`** — a thin
    per-component summary; use it mainly to **scope**, not for screen content:
    its `type` (draw wireframes only for `web-application`), its one-line
    `description`, and its `dependencies` (e.g. an auth dependency means there's
    a signed-in vs. guest distinction → likely role-specific screens).
 
-**Cover every task.** Walk the design and requirements and make sure each
-distinct user-facing task — for each role they name — has a wireframe screen
-that serves it; nothing user-facing should be left without a view. Equally,
-don't invent screens the design doesn't imply. A quick check: list the
-tasks/roles, and for each name the screen that fulfills it — a task with no
-screen is a gap, a screen with no task is noise.
+## Cover every story
+
+The user stories are **numbered**, so coverage is countable — and this is the
+only moment anyone can count it, while the requirements are in front of you.
+Do it deliberately, before you write the file:
+
+**Walk the numbered stories in order. For each one, name the flow that walks
+it.** A story every flow misses is a gap: add the screens it needs and put
+them in a flow, or — if it genuinely has no view (a backend rule, a scheduled
+job, an API another service calls) — leave it out knowingly rather than by
+oversight. Each flow will usually serve several stories, and a story may
+appear in more than one flow; what matters is that none is left unserved.
+
+Run it the other way too: a flow serving no story is a journey nobody asked
+for, and a screen in no flow is one nobody can reach. Both are noise — cut
+them, or find the story they belong to.
+
+This is what makes the wireframe reviewable later. The task issue records
+which stories each flow walks, and the coding agent ticks the flow off when it
+is clickable end to end, so a story that fails validation can be traced to the
+flow that was supposed to exercise it. That chain only holds if the mapping is
+true here, at the start.
+
+Equally, don't invent screens the design doesn't imply.
 
 ## What makes a wireframe good
 
@@ -333,6 +353,9 @@ Checklist before finishing a wireframe file:
   order across roles.
 - Each role or journey named in the design's `flows/` files has its own `flow "<name>"` block,
   entry screen first, referencing existing screens by name.
+- **Every numbered user story is walked by at least one flow.** Go through the
+  stories and name the flow for each; a story with no flow is either a missing
+  screen or a deliberate no-view story, and you should know which.
 - **Each role flow opens on that role's own screen, and there is no `Login`
   screen when the component has an auth dependency** — the platform's SSO
   hosts sign-in and returns the user to their home screen, so the app never

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -53,9 +53,7 @@ the product genuinely gives it no view:
 Every other uncovered story is a gap: add the screens it needs and put them in
 a flow.
 
-Then run the check backwards. A flow serving no story is a journey nobody
-asked for; a screen in no flow is one nobody can reach. Cut it, or find the
-story it belongs to — never invent a screen the requirements never asked for.
+Equally, don't invent screens the stories don't imply.
 
 ## What makes a wireframe good
 

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -33,10 +33,11 @@ The user stories are **numbered**, so coverage is countable. Count it
 deliberately, before you write the file, while the requirements are in front
 of you:
 
-**Walk the numbered stories in order. For each one, name the flow that walks
-it.** Each flow will usually serve several stories, and a story may appear in
-more than one flow; what matters is that every story is accounted for — either
-walked, or knowingly set aside.
+**Walk the numbered stories in order. For each one, name the `flow` block that
+walks it** — the wireframe's own flows, not the `specs/design/flows/` files
+you read them from. Each usually serves several stories, and a story may
+appear in more than one; what matters is that every story is accounted for —
+either walked, or knowingly set aside.
 
 **Some stories have no screen, and that is correct.** Set a story aside when
 the product genuinely gives it no view:
@@ -57,8 +58,10 @@ asked for; a screen in no flow is one nobody can reach. Cut it, or find the
 story it belongs to — never invent a screen the requirements never asked for.
 
 **Report what you found in your closing message** — which stories each flow
-walks, and which you set aside with the reason. You do not write the task
-issue; the next turn does, from what you report here.
+walks, and which you set aside with the reason. That report is read by the
+human reviewing this turn; the planning turn re-derives the mapping from the
+committed DSL and requirements rather than inheriting yours, so the two are a
+check on each other.
 
 ## What makes a wireframe good
 

--- a/skills/wireframes/references/authoring.md
+++ b/skills/wireframes/references/authoring.md
@@ -57,12 +57,6 @@ Then run the check backwards. A flow serving no story is a journey nobody
 asked for; a screen in no flow is one nobody can reach. Cut it, or find the
 story it belongs to — never invent a screen the requirements never asked for.
 
-The count is a check you run while writing, not a report you file: what it
-produces is the flow set itself. The planning turn re-derives the mapping from
-the committed DSL and the requirements and records it on the Task, so a story
-left unwalked here surfaces there — in front of a human, before any code is
-written.
-
 ## What makes a wireframe good
 
 A good wireframe reads like a real screen someone could use, and it explains

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -104,13 +104,12 @@ Flows
       NewRisk → RiskDetail blocked on the missing select
 ```
 
-Copy the flow list from the Task's `Flows:` checklist — same numbers, same
-names, same story sets — and tick what you verified. Each Task flow carries a
-`Walk:` line: that is the order you click through, and where it breaks is what
-you report on the line. Keeping `F1`/`F2` lets a reviewer say "F2 is not
-walkable" and mean one exact journey. A flow the Task lists must appear here
-even when you could not build it; dropping the line is how a missing journey
-goes unnoticed.
+Carry every flow over from the Task's `Flows:` checklist, keeping its number,
+name and story set — one line each here, rather than the Task's labelled
+block — and tick what you verified. Each Task flow's `Walk:` line is the order
+you click through; where it breaks is what you report. A flow the Task lists
+appears here even when you could not build it: dropping the line is how a
+missing journey goes unnoticed.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -105,10 +105,12 @@ Flows
 ```
 
 Copy the flow list from the Task's `Flows:` checklist — same numbers, same
-names, same story sets — and tick what you verified. Keeping `F1`/`F2` lets a
-reviewer say "F2 is not walkable" and mean one exact journey. A flow the Task
-lists must appear here even when you could not build it; dropping the line is
-how a missing journey goes unnoticed.
+names, same story sets — and tick what you verified. The Task gives each
+flow's screen chain in walkthrough order; that chain is what you walk, and
+where it breaks is what you report. Keeping `F1`/`F2` lets a reviewer say "F2
+is not walkable" and mean one exact journey. A flow the Task lists must appear
+here even when you could not build it; dropping the line is how a missing
+journey goes unnoticed.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -98,15 +98,20 @@ Screens
 - [ ] NewRisk → /risks/new — "Register" select not built: no registers endpoint
 
 Flows
-- [x] "Approval queue" (Manager) — RiskQueue → QueueRiskDetail walks by clicking
-- [ ] "Log a risk" (Risk owner) — MyRisks → NewRisk walks; NewRisk → RiskDetail
-      blocked on the missing select
+- [x] "Approval queue" (Manager) — stories 2, 5 — RiskQueue → QueueRiskDetail
+      walks by clicking
+- [ ] "Log a risk" (Risk owner) — stories 1, 3 — MyRisks → NewRisk walks;
+      NewRisk → RiskDetail blocked on the missing select
 ```
+
+Take each flow's name, role and story numbers from the Task's `Flows:` line —
+that is the mapping a reviewer will check you against.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was
 walked end to end by clicking, entry screen first — an unwalkable flow strands
-the screens behind it, so the e2e test written against the acceptance criteria
-cannot reach them either. An unticked line with its reason is fine — it tells
-the reviewer exactly where to look, and a screen whose story could not be judged
-against a mock says that in the same place.
+the screens behind it, so the stories it carries cannot be exercised and the e2e
+test written against the acceptance criteria cannot reach them either. An
+unticked line with its reason is fine — it tells the reviewer exactly where to
+look and which stories are affected, and a screen whose story could not be
+judged against a mock says that in the same place.

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -105,12 +105,12 @@ Flows
 ```
 
 Copy the flow list from the Task's `Flows:` checklist — same numbers, same
-names, same story sets — and tick what you verified. The Task gives each
-flow's screen chain in walkthrough order; that chain is what you walk, and
-where it breaks is what you report. Keeping `F1`/`F2` lets a reviewer say "F2
-is not walkable" and mean one exact journey. A flow the Task lists must appear
-here even when you could not build it; dropping the line is how a missing
-journey goes unnoticed.
+names, same story sets — and tick what you verified. Each Task flow carries a
+`Walk:` line: that is the order you click through, and where it breaks is what
+you report on the line. Keeping `F1`/`F2` lets a reviewer say "F2 is not
+walkable" and mean one exact journey. A flow the Task lists must appear here
+even when you could not build it; dropping the line is how a missing journey
+goes unnoticed.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -82,12 +82,17 @@ screen you cannot reach from its flow is a broken page, even if it renders.
 
 ## The fidelity checklist
 
-The checklist is **evidence, not a claim**. A web application is opened and
-walked in a browser before its work is committed — mock mode, no cluster behind
-it, one verdict per story (`mock-verification`) — so a tick here means the screen
-was rendered and its arrows were clicked, never that the code looks as though it
-would. Write it once the walk has settled, and put it in the PR body — one
-line per screen, then one per `flow` — with any gap named beside it:
+Two lists, one pair. The **Task** carries a `Screens:` line and a `Flows:`
+checklist with every box unchecked — that is what must be built, and it is
+what you work from. The **PR body** carries this one: the same two lists, with
+the boxes you earned ticked. You never tick the Task's copy; re-planning
+rewrites that body.
+
+It is **evidence, not a claim**. A web application is opened and walked in a
+browser before its work is committed — mock mode, no cluster behind it, one
+verdict per story (`mock-verification`) — so a tick here means the screen was
+rendered and its arrows were clicked, never that the code looks as though it
+would. Write it once the walk has settled, with any gap named beside its line:
 
 ```text
 Wireframe fidelity (specs/design/components/<name>/wireframes.dsl)
@@ -103,13 +108,16 @@ Flows
       "Register" select is not built
 ```
 
-Carry every flow over from the Task's `Flows:` checklist, keeping its number,
-name and story set — one line each here, not the Task's labelled block, since
-its persona and `Walk:` chain are already recorded there. Walk each flow's
-`Walk:` chain in order and tick the ones that go through; on a flow that does
-not, name the step it breaks at instead of the tick. A flow the Task lists
-appears here even when you could not build it: dropping the line is how a
-missing journey goes unnoticed.
+**Screens** come from the Task's `Screens:` line, one line each, naming the
+route you built it at.
+
+**Flows** carry over from the Task's `Flows:` checklist, keeping each one's
+number, name and story set — one line each here, not the Task's labelled
+block, since its persona and `Walk:` chain are recorded there. Walk each
+flow's `Walk:` chain in order and tick the ones that go through; where one
+does not, name the step it breaks at instead of the tick. A flow the Task
+lists appears here even when you could not build it: dropping the line is how
+a missing journey goes unnoticed.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -98,14 +98,17 @@ Screens
 - [ ] NewRisk → /risks/new — "Register" select not built: no registers endpoint
 
 Flows
-- [x] "Approval queue" (Manager) — stories 2, 5 — RiskQueue → QueueRiskDetail
-      walks by clicking
-- [ ] "Log a risk" (Risk owner) — stories 1, 3 — MyRisks → NewRisk walks;
+- [x] F1 · "Approval queue" (Manager) — stories 2, 5 — RiskQueue →
+      QueueRiskDetail walks by clicking
+- [ ] F2 · "Log a risk" (Risk owner) — stories 1, 3 — MyRisks → NewRisk walks;
       NewRisk → RiskDetail blocked on the missing select
 ```
 
-Take each flow's name, role and story numbers from the Task's `Flows:` line —
-that is the mapping a reviewer will check you against.
+Copy the flow list from the Task's `Flows:` checklist — same numbers, same
+names, same story sets — and tick what you verified. Keeping `F1`/`F2` lets a
+reviewer say "F2 is not walkable" and mean one exact journey. A flow the Task
+lists must appear here even when you could not build it; dropping the line is
+how a missing journey goes unnoticed.
 
 A screen is ticked only when every element in its block was on the page and
 every arrow it carries navigated when clicked. A flow is ticked only when it was

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -98,16 +98,16 @@ Screens
 - [ ] NewRisk → /risks/new — "Register" select not built: no registers endpoint
 
 Flows
-- [x] F1 · "Approval queue" (Manager) — stories 2, 5 — RiskQueue →
-      QueueRiskDetail walks by clicking
-- [ ] F2 · "Log a risk" (Risk owner) — stories 1, 3 — MyRisks → NewRisk walks;
-      NewRisk → RiskDetail blocked on the missing select
+- [x] F1 · Approval queue — stories 2, 5 — walked end to end
+- [ ] F2 · Log a risk — stories 1, 3 — breaks at NewRisk → RiskDetail: the
+      "Register" select is not built
 ```
 
 Carry every flow over from the Task's `Flows:` checklist, keeping its number,
-name and story set — one line each here, rather than the Task's labelled
-block — and tick what you verified. Each Task flow's `Walk:` line is the order
-you click through; where it breaks is what you report. A flow the Task lists
+name and story set — one line each here, not the Task's labelled block, since
+its persona and `Walk:` chain are already recorded there. Walk each flow's
+`Walk:` chain in order and tick the ones that go through; on a flow that does
+not, name the step it breaks at instead of the tick. A flow the Task lists
 appears here even when you could not build it: dropping the line is how a
 missing journey goes unnoticed.
 


### PR DESCRIPTION
Closes #694

Follows #675, which split the `wireframes` skill into the shared DSL core plus
`references/authoring.md` and `references/implementing.md` — the files this PR
edits.

## Problem

Wireframe coverage was *"cover every distinct user-facing task, for each role"* —
a rule nobody can count. A story could end up with no screen and no flow, and
nothing caught it until validation could not reach the behaviour it described.

Two of the three traceability links already existed: `validation-criteria.json`
carries `stories` per requirement (story → what to test), and task issues carry
`Serves stories` (story → which component). The missing edge was **story → the
journey that walks it**.

## Change

**User stories become the coverage oracle**, checked three times by three agents
with different prompts:

| Stage | Who | What it catches |
|---|---|---|
| Design | design agent, PRD in context | a story with no flow |
| Task planning | tech-lead — the one stage holding both the story list and the DSL | a story the designer talked itself past |
| Coding | coding agent, walking the app before it commits | a flow that exists on paper but is not walkable |

**`references/authoring.md`** — walk the numbered stories; for each, name the
`flow` block that walks it. Stories that legitimately have **no view** are set
aside *with a reason* rather than dropped: sign-in/sign-out under an auth
dependency (the platform's SSO owns that page, so there is no `Login` screen to
draw), backend rules, scheduled jobs, machine-facing endpoints.

**`skills/task-planning/SKILL.md`** — the tech-lead re-derives the mapping from
the committed DSL and requirements, and records it on the Task as an unchecked
checklist:

```markdown
Flows:

- [ ] **F1 · Submit an expense**
  An employee files a claim and tracks its approval.
  Persona: Employee
  Stories: 3, 4, 7
  Walk: MyClaims → NewClaim → ClaimDetail
- [ ] **F2 · Approve a claim**
  A manager works the pending queue and decides a claim.
  Persona: Manager
  Stories: 5, 6
  Walk: ApprovalQueue → ClaimReview

No flow: story 1 (sign-in — platform SSO owns the page), story 9 (nightly
export job, no view).
```

One labelled line per fact. `F1`/`F2` is the handle a reviewer uses to name one
journey; `Walk:` is deliberately not `Screens:`, which is already taken above
for the routes to build. Boxes stay unchecked — re-planning rewrites the Task
body, so a tick recorded there would be wiped.

**`references/implementing.md`** — the PR body carries the other half of the
pair: the same two lists with the boxes the walk earned, each flow keeping its
number, name and story set.

```text
Flows
- [x] F1 · Approval queue — stories 2, 5 — walked end to end
- [ ] F2 · Log a risk — stories 1, 3 — breaks at NewRisk → RiskDetail: the
      "Register" select is not built
```

Every in-scope story now lands somewhere visible. A deliberately viewless story
and a missed one used to look identical in the output; they no longer do.

## Deliberately not done

**No story IDs in the DSL.** The compiler never sees the PRD, so it could not
verify that `stories "3, 4, 7"` were real, complete, or invented — the check
would only *look* enforced. And PRD regeneration can renumber stories, leaving
stale IDs in a file nothing validates. The mapping lives where it is read: the
Task and the PR.

## Proof of real execution

Full playground cycle on a fixture built to exercise this — an expense tool
whose PRD yields two sign-in stories (1, 5), a nightly-job story (9), and six
story-bearing screens.

**Design** produced no `Login` screen despite stories 1 and 5 being literally
"sign in with the organization's SSO"; each role flow opens on its own screen
(`MyClaims` / `ApprovalQueue`); every `primary` navigates; `Reject` took
`danger` rather than becoming a second primary.

**Task planning** accounted for all nine stories unprompted — six walked by two
flows, and the three set aside with the right reasons (both SSO sign-ins, the
backend job).

That run predates the labelled-checklist format above, which landed while
reviewing the wording: it validated the coverage behaviour, not the current
rendering. The layout itself is unexercised, as is the coding stage's PR
checklist — the same gap #675 records.

## Checks

`packages/excalidraw-dsl` 114 pass; playground 98 pass; no markdownlint
regressions.

Correcting an earlier note in this description: I had reported four playground
files as failing on `upstream/main` too. They were failing on a stale
`@aep/agent-stream` build, not on main — a `turbo build` clears them. Nothing
was pre-existing.

Rebased onto `main` after #689, whose `mock-verification` work rewrote the same
fidelity-checklist section. Both intents are kept: a tick means the screen was
rendered and its arrows clicked in a real browser walk, *and* it names the
stories that walk carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCDKZyNpkf1H7BMFUFSDq
