### PR TITLE
feat(console): the build page asks for configuration, and its sections label themselves alike

### DIFF
--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -240,27 +240,40 @@ The values an external dependency needs are no longer asked for in front of the
 Build button; they are supplied on a version's build page, as a section sitting
 directly under Tasks.
 
-The PAGE is version-scoped; the VALUES are not. They belong to the project and
-the environment, so every version's page shows the same answer, and a value
-supplied on one releases whichever run is parked on it. Copy here must not imply
-otherwise — "this version's credentials" would promise a per-version answer the
-platform does not have.
+The PAGE is version-scoped; the CONFIGURATION is not. It belongs to the project
+and the environment, so every version's page shows the same answer, and a
+dependency configured on one releases whichever run is parked on it. Copy here
+must not imply otherwise — "this version's credentials" would promise a
+per-version answer the platform does not have.
 
 | | |
 |---|---|
 | Section title | **External resources** |
 | Its chip, all supplied | **`3 of 3 configured`** |
-| Its chip, some outstanding | **`2 of 3 need values`** |
-| Body, all supplied | *Every external dependency has its development values.* |
-| Body, some outstanding | *The agent builds while you supply these. The version is not deployed until every one of them has its development values.* |
-| A row that has its values | **`Configured`** + **Update values** |
-| A row that does not | **`Needs values`** + **Configure** |
-| After a save | *Values saved — the deployment no longer waits on this one.* |
+| Its chip, some outstanding | **`2 of 3 need configuration`** |
+| Body, all supplied | *Every external dependency has its development configuration.* |
+| Body, some outstanding | *The agent builds while you supply these. The version is not deployed until every one of them has its development configuration.* |
+| A row that is configured | **`Configured`** + **Edit configuration** |
+| A row that is not | **`Needs configuration`** + **Configure now** |
+| A row's second line, no description | *2 settings outstanding* / *2 settings stored* |
+| After a save | *Configuration saved — the deployment no longer waits on this one.* |
 
-**`Needs values`, never *Unconfigured* or *Not ready*.** It names what the reader
-must do, not the state machine's word for the row. And *configured* is
+**`Needs configuration`, never *Unconfigured* or *Not ready*.** It names what the
+reader must do, not the state machine's word for the row. And *configured* is
 deliberately not *ready*: OpenChoreo reports these bindings `Ready` while every
 key is still empty, so the two words name different facts and must not merge.
+
+**One noun: *configuration*, never *values* or *credentials*.** The section used
+to say "values", which is the wire's word for what a binding holds, and the
+drawer before it said "credentials", which is only true of the subset that are
+secrets — a webhook URL is neither. *Configuration* covers every key the dialog
+collects and is the word the buttons already used. The individual keys are
+**settings** when they have to be counted.
+
+**The row's status is plain toned text, not a second pill.** The section header
+already carries a chip; a chip on every row competes with the button it is meant
+to lead the eye to. The outstanding row takes the section's one filled button
+(**Configure now**), a configured row the quiet outlined one.
 
 ### A version parked at the deploy gate
 
@@ -270,23 +283,60 @@ and they must agree.
 
 | | |
 |---|---|
-| The page's status pill | **`Waiting for values`** |
-| The summary card's notice, naming what it waits on | **`Waiting for values: stripe, sendgrid`** |
-| The same notice when the run named nothing | **`Waiting for external values`** |
-| Its body | *Everything built. This version is not deployed until every external resource holds its development values — add them under External resources below and the run resumes and deploys on its own, with nothing to restart.* |
-| Its button | **Supply values** |
-| The card's rollout line | ***v2** is built and waiting for its external values.* |
+| The page's status pill | **`Waiting for configuration`** |
+| The summary card's notice, naming what it waits on | **`Waiting for configuration: stripe, sendgrid`** |
+| The same notice when the run named nothing | **`Waiting for external configuration`** |
+| Its body | *Everything built. This version is not deployed until every external resource holds its development configuration — add it under External resources below and the run resumes and deploys on its own, with nothing to restart.* |
+| Its button | **Add configuration** |
+| The card's rollout line | ***v2** is built and waiting for its external configuration.* |
 
 **"with nothing to restart" is the load-bearing half.** Without it the reader
 goes looking for a Build or Retry button that would start a second run.
 
-**The ledger row says `Waiting for values` too, and it is the same words as the
-pill.** `BuildSummary` carries the waiting reason, which is what separates a
+**The ledger row says `Waiting for configuration` too, and it is the same words
+as the pill.** `BuildSummary` carries the waiting reason, which is what separates a
 parked version from a running one — both are `in_progress` — and it costs the
 ledger nothing: the run row it is built from already holds it. The row also goes
 QUIET, no tint and no pulse: those mean "the moving thing", and a park is the
 opposite. The dependency NAMES stay on the build page, where the run read that
 carries them is already being made and there is room to list them.
+
+### The build page's log sections
+
+Tasks, External resources, Coding agent log and Build logs are peers on one
+page, so they label and empty themselves the same way. Two things had drifted:
+one section's placeholder was a bare left-aligned paragraph beside another's
+centred `EmptyState`, and the agent log carried a status pill where Tasks
+carried plain text.
+
+| | |
+|---|---|
+| Header note, Tasks | *7 in this build · 7 done* |
+| Header note, agent log, streaming | *Streaming* + `AgentPulse` |
+| Header note, agent log, run over | *Run finished successfully* / *Run failed* / *Run cancelled* / *Run blocked* |
+| The same, state unknown or absent | *Run ended — `<state>`* / *Run finished* |
+| Any section with nothing to show | a centred `EmptyState compact` |
+| The agent log's stream health | *Attaching to the run feed…* / *Connection lost — reconnecting…* |
+
+**A header note is secondary caption text, never a pill.** The page header
+already carries the version's toned status chip; a second toned pill a few
+inches below competes with it for the same glance.
+
+**`Run finished successfully`, never `run settled — succeeded`.** *Settled* is
+the stream contract's word for the transition, not something a person watching a
+build says, and the state used to be pasted on raw in its lower-case wire
+spelling. The words match the run status chip's, so one run is not `Succeeded`
+in one place and `settled — succeeded` in another.
+
+**How the run ENDED belongs in the header; how the STREAM is doing belongs in
+the body.** They answer different questions and come from different reads — the
+ending from the run list, which the streaming note beside it already reads, so
+the two halves of one label cannot contradict each other. Stream health is
+right-aligned under the log, away from where its content starts.
+
+**A run that is neither streaming nor terminal is labelled by neither.** A run
+parked at the deploy gate has not ended, and *Run finished* over its log would
+contradict the summary card telling the reader it is waiting on them.
 
 ## The project overview
 

--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -325,8 +325,9 @@ inches below competes with it for the same glance.
 **`Run finished successfully`, never `run settled — succeeded`.** *Settled* is
 the stream contract's word for the transition, not something a person watching a
 build says, and the state used to be pasted on raw in its lower-case wire
-spelling. The words match the run status chip's, so one run is not `Succeeded`
-in one place and `settled — succeeded` in another.
+spelling. It draws on the same vocabulary as the run status chip — *succeeded*
+becomes *finished successfully*, never *settled* — so a reader meets one word
+for one outcome, phrased for the slot it sits in.
 
 **How the run ENDED belongs in the header; how the STREAM is doing belongs in
 the body.** They answer different questions and come from different reads — the

--- a/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
@@ -254,7 +254,7 @@ describe("BuildDetailPage — external resources", () => {
     expect(screen.getByText("External resources")).toBeInTheDocument();
     expect(screen.getByText("1 of 1 need configuration")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Configure stripe" }),
+      screen.getByRole("button", { name: "Configure now: stripe" }),
     ).toBeInTheDocument();
 
     // ORDER, not membership. It is outstanding work a person must do, so it is

--- a/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
@@ -241,7 +241,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-// ADR-0023 moved the collection of external values off the Build button and
+// ADR-0023 moved the collection of external configuration off the Build button and
 // onto the run. ADR-0021 then made a VERSION's page the place that says why
 // that version is or is not moving, so this is where the section lives.
 describe("BuildDetailPage — external resources", () => {
@@ -252,7 +252,7 @@ describe("BuildDetailPage — external resources", () => {
     renderPage();
 
     expect(screen.getByText("External resources")).toBeInTheDocument();
-    expect(screen.getByText("1 of 1 need values")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 need configuration")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Configure stripe" }),
     ).toBeInTheDocument();
@@ -307,7 +307,7 @@ describe("BuildDetailPage — the deploy gate's park", () => {
     renderPage();
 
     expect(
-      screen.getByText("Waiting for values: stripe, sendgrid"),
+      screen.getByText("Waiting for configuration: stripe, sendgrid"),
     ).toBeInTheDocument();
     // The promise the reader needs most: there is no restart button to hunt for.
     expect(
@@ -315,7 +315,7 @@ describe("BuildDetailPage — the deploy gate's park", () => {
     ).toBeInTheDocument();
     // On THIS page, deliberately — a route would be a second way into one
     // configuration surface.
-    expect(screen.getByRole("link", { name: "Supply values" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Add configuration" })).toHaveAttribute(
       "href",
       "#external-resources",
     );
@@ -328,7 +328,7 @@ describe("BuildDetailPage — the deploy gate's park", () => {
     mockRuns = [parked()];
     renderPage();
 
-    expect(screen.getByText("Waiting for external values")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for external configuration")).toBeInTheDocument();
   });
 
   // The regression this exists to stop. `BuildSummary` has no waiting reason,
@@ -340,11 +340,11 @@ describe("BuildDetailPage — the deploy gate's park", () => {
     mockRuns = [parked(["stripe"])];
     renderPage();
 
-    expect(screen.getByText("Waiting for values")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for configuration")).toBeInTheDocument();
     expect(screen.queryByText("Running · Coding agent")).not.toBeInTheDocument();
     // And the rollout line must not contradict the notice above it.
     expect(
-      screen.getByText("v2 is built and waiting for its external values."),
+      screen.getByText("v2 is built and waiting for its external configuration."),
     ).toBeInTheDocument();
   });
 
@@ -483,12 +483,12 @@ describe("BuildDetailPage — the Duration cell", () => {
   });
 });
 
-describe("BuildDetailPage — the coding agent log's 'streaming' chip", () => {
+describe("BuildDetailPage — the coding agent log's header note", () => {
   it("says streaming while a build session is open", () => {
     mockBuilds = [build()];
     mockRuns = [run({ cycles: [cycle({ endedAt: null })] })];
     renderPage();
-    expect(screen.getByText("streaming")).toBeInTheDocument();
+    expect(screen.getByText("Streaming")).toBeInTheDocument();
   });
 
   it("stops the moment the agent finishes, though the run is still in progress", () => {
@@ -499,7 +499,7 @@ describe("BuildDetailPage — the coding agent log's 'streaming' chip", () => {
       run({ cycles: [cycle({ endedAt: "2026-08-14T16:38:00Z", mergeSha: "abc1234" })] }),
     ];
     renderPage();
-    expect(screen.queryByText("streaming")).not.toBeInTheDocument();
+    expect(screen.queryByText("Streaming")).not.toBeInTheDocument();
   });
 
   it("stays quiet while the run is PARKED, even with a cycle still open", () => {
@@ -515,7 +515,53 @@ describe("BuildDetailPage — the coding agent log's 'streaming' chip", () => {
       }),
     ];
     renderPage();
-    expect(screen.queryByText("streaming")).not.toBeInTheDocument();
+    expect(screen.queryByText("Streaming")).not.toBeInTheDocument();
+  });
+});
+
+// The run's ending labels the SECTION HEADER, beside "Coding agent log", the way
+// every other section on this page carries its status. It used to sit under the
+// log as `run settled — succeeded`: the stream contract's own word for the
+// transition, with the raw state pasted on in its wire spelling.
+describe("BuildDetailPage — the coding agent log's settled label", () => {
+  it("names how the run ended, beside the section title", () => {
+    mockBuilds = [build()];
+    mockRuns = [
+      run({
+        state: "succeeded",
+        cycles: [cycle({ endedAt: "2026-08-14T16:38:00Z" })],
+      }),
+    ];
+    renderPage();
+    expect(screen.getByText("Run finished successfully")).toBeInTheDocument();
+    // The old body line, in either spelling, is gone.
+    expect(screen.queryByText(/settled/)).not.toBeInTheDocument();
+  });
+
+  it("names a cancelled run as cancelled, not as finished", () => {
+    mockBuilds = [build()];
+    mockRuns = [
+      run({ state: "cancelled", cycles: [cycle({ endedAt: "2026-08-14T16:38:00Z" })] }),
+    ];
+    renderPage();
+    expect(screen.getByText("Run cancelled")).toBeInTheDocument();
+  });
+
+  // Live beats settled, and a non-terminal run is labelled by NEITHER: a run
+  // parked at the deploy gate has not ended, and "Run finished" over its log
+  // would contradict the summary card telling the reader it is waiting on them.
+  it("says nothing about a run that has not ended", () => {
+    mockBuilds = [build()];
+    mockRuns = [
+      run({
+        state: "waiting",
+        waitingReason: "external-values",
+        blockingDependencies: ["stripe"],
+        cycles: [cycle({ endedAt: "2026-08-14T16:38:00Z" })],
+      }),
+    ];
+    renderPage();
+    expect(screen.queryByText(/^Run /)).not.toBeInTheDocument();
   });
 });
 

--- a/apps/console/src/features/builds/components/BuildDetailPage.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.tsx
@@ -45,7 +45,6 @@ import { createLink, Link } from "@tanstack/react-router";
 import { EmptyState } from "../../../components/EmptyState";
 import { LogSection } from "../../../components/LogSection";
 import { PageHeader } from "../../../components/PageHeader";
-import { StatusChip } from "../../../components/StatusChip";
 import type { components } from "../../../generated/aep-api";
 import { useAllTasks } from "../../tasks/api/queries";
 import { useProjectStatus } from "../../projects/api/queries";
@@ -66,8 +65,10 @@ import {
   externalValuesPark,
   isAgentStreaming,
   isDeliveryRun,
+  isTerminalRun,
   mergedCycle,
 } from "../lib/runView";
+import { settledLabel } from "../lib/feedTail";
 import { AgentPulse } from "./AgentPulse";
 import { BuildTaskList } from "./BuildTaskList";
 import { CycleBuilds } from "./CycleBuilds";
@@ -190,7 +191,7 @@ export function BuildDetailPage({
         title={`Build ${build.tag}`}
         status={
           park
-            ? { label: "Waiting for values", tone: "warning", variant: "filled" }
+            ? { label: "Waiting for configuration", tone: "warning", variant: "filled" }
             : { label: status.label, tone: status.tone, variant: "filled" }
         }
         backTo={backTo}
@@ -261,6 +262,7 @@ export function BuildDetailPage({
           projectName={projectName}
           runId={current?.id}
           streaming={isAgentStreaming(runList) && park === null}
+          runState={current?.state}
         />
 
         {/* The cycle that MERGED, not the newest one: the cluster read answers
@@ -403,7 +405,7 @@ function BuildSummaryCard({
               color="inherit"
               href={`#${EXTERNAL_RESOURCES_ANCHOR}`}
             >
-              Supply values
+              Add configuration
             </Button>
           }
         >
@@ -412,7 +414,7 @@ function BuildSummaryCard({
           </Typography>
           <Typography variant="body2">
             Everything built. This version is not deployed until every external
-            resource holds its development values — add them under External
+            resource holds its development configuration — add it under External
             resources below and the run resumes and deploys on its own, with
             nothing to restart.
           </Typography>
@@ -437,7 +439,7 @@ function BuildSummaryCard({
         )}
         <Typography variant="caption" color="text.secondary">
           {park
-            ? `${build.tag} is built and waiting for its external values.`
+            ? `${build.tag} is built and waiting for its external configuration.`
             : deploymentNote(build.tag, deploy)}
         </Typography>
       </Stack>
@@ -452,8 +454,8 @@ function BuildSummaryCard({
  * list rendered as punctuation.
  */
 function parkTitle(dependencies: string[]): string {
-  if (dependencies.length === 0) return "Waiting for external values";
-  return `Waiting for values: ${dependencies.join(", ")}`;
+  if (dependencies.length === 0) return "Waiting for external configuration";
+  return `Waiting for configuration: ${dependencies.join(", ")}`;
 }
 
 /**
@@ -566,19 +568,19 @@ function AgentLogSection({
   projectName,
   runId,
   streaming,
+  runState,
 }: {
   projectName: string;
   runId: string | undefined;
   streaming: boolean;
+  /** The run's own state, for the settled half of the header label. Both halves
+   *  read the run list so they cannot disagree — see `settledStatus`. */
+  runState: string | undefined;
 }) {
   return (
     <LogSection
       title="Coding agent log"
-      meta={
-        streaming ? (
-          <StatusChip label="streaming" tone="info" appearance="soft" dot />
-        ) : undefined
-      }
+      meta={<AgentLogMeta streaming={streaming} runState={runState} />}
     >
       {runId ? (
         <RunFeed projectName={projectName} runId={runId} />
@@ -589,6 +591,39 @@ function AgentLogSection({
         />
       )}
     </LogSection>
+  );
+}
+
+/**
+ * The coding agent log's header note — the Tasks header's treatment, applied to
+ * a different fact.
+ *
+ * Secondary caption text beside the title, with `AgentPulse` for "working right
+ * now", exactly as `TasksMeta` renders its counts. It was a `StatusChip` before,
+ * which made two sections one card apart label themselves in two different
+ * shapes.
+ */
+function AgentLogMeta({
+  streaming,
+  runState,
+}: {
+  streaming: boolean;
+  /** The run's own state, for the settled half. Both halves read the run list so
+   *  they cannot disagree — see `settledLabel`. */
+  runState: string | undefined;
+}) {
+  // Live beats settled: `streaming` is the stronger claim and the one a reader
+  // is watching for. A run that is neither streaming nor terminal (parked at the
+  // deploy gate, or between cycles) is labelled by neither — the summary card
+  // above says what it is waiting on, and a note here would only compete.
+  if (!streaming && (!runState || !isTerminalRun(runState))) return null;
+  return (
+    <Stack direction="row" spacing={1.25} sx={{ alignItems: "center" }}>
+      <Typography variant="caption" color="text.secondary">
+        {streaming ? "Streaming" : settledLabel(runState)}
+      </Typography>
+      {streaming && <AgentPulse />}
+    </Stack>
   );
 }
 

--- a/apps/console/src/features/builds/components/BuildDetailPage.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.tsx
@@ -573,8 +573,7 @@ function AgentLogSection({
   projectName: string;
   runId: string | undefined;
   streaming: boolean;
-  /** The run's own state, for the settled half of the header label. Both halves
-   *  read the run list so they cannot disagree — see `settledStatus`. */
+  /** Forwarded to `AgentLogMeta`, which is where it is explained. */
   runState: string | undefined;
 }) {
   return (

--- a/apps/console/src/features/builds/components/BuildsLedger.test.tsx
+++ b/apps/console/src/features/builds/components/BuildsLedger.test.tsx
@@ -258,7 +258,7 @@ describe("BuildsLedger", () => {
     mockBuilds = [build({ tag: "v2", status: "in_progress", waitingReason: "external-values" })];
     renderLedger();
 
-    expect(screen.getByText("Waiting for values")).toBeTruthy();
+    expect(screen.getByText("Waiting for configuration")).toBeTruthy();
     expect(screen.queryByText("Running · Coding agent")).toBeNull();
   });
 
@@ -275,7 +275,7 @@ describe("BuildsLedger", () => {
     fireEvent.mouseDown(screen.getByRole("combobox", { name: /status/i }));
     fireEvent.click(screen.getByRole("option", { name: "In progress" }));
 
-    expect(screen.getByText("Waiting for values")).toBeTruthy();
+    expect(screen.getByText("Waiting for configuration")).toBeTruthy();
     expect(screen.queryByText("Built")).toBeNull();
   });
 

--- a/apps/console/src/features/builds/components/ExternalResources.test.tsx
+++ b/apps/console/src/features/builds/components/ExternalResources.test.tsx
@@ -129,11 +129,11 @@ describe("ExternalResources", () => {
     renderSection();
 
     expect(screen.getByText("External resources")).toBeInTheDocument();
-    expect(screen.getByText("1 of 2 need values")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2 need configuration")).toBeInTheDocument();
     expect(screen.getByText("stripe")).toBeInTheDocument();
     expect(screen.getByText("Payments")).toBeInTheDocument();
     expect(screen.getByText("sendgrid")).toBeInTheDocument();
-    expect(screen.getByText("1 value outstanding")).toBeInTheDocument();
+    expect(screen.getByText("1 setting outstanding")).toBeInTheDocument();
   });
 
   // THE regression this section exists to avoid: a dependency no build has
@@ -149,22 +149,22 @@ describe("ExternalResources", () => {
     });
     renderSection();
 
-    expect(screen.getByText("1 of 1 need values")).toBeInTheDocument();
-    expect(screen.getByText("Needs values")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 need configuration")).toBeInTheDocument();
+    expect(screen.getByText("Needs configuration")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Configure stripe" }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Provisioning/)).not.toBeInTheDocument();
   });
 
-  it("offers Update values once a dependency is configured", () => {
+  it("offers Edit configuration once a dependency is configured", () => {
     mockDesign = design(external("stripe", ["api_key"]));
     mockReadiness = readiness({ name: "stripe", state: "configured" });
     renderSection();
 
     expect(screen.getByText("1 of 1 configured")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Update values for stripe" }),
+      screen.getByRole("button", { name: "Edit configuration for stripe" }),
     ).toBeInTheDocument();
   });
 
@@ -201,7 +201,7 @@ describe("ExternalResources", () => {
     };
     act(() => onSuccess());
     expect(
-      screen.getByText(/Values saved — the deployment no longer waits/),
+      screen.getByText(/Configuration saved — the deployment no longer waits/),
     ).toBeInTheDocument();
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: [
@@ -255,7 +255,7 @@ describe("ExternalResources", () => {
     renderSection();
 
     expect(
-      screen.getByText(/Failed to load which external resources still need values/),
+      screen.getByText(/Failed to load which external resources still need configuration/),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(refetchReadiness).toHaveBeenCalled();
@@ -263,9 +263,9 @@ describe("ExternalResources", () => {
 
   // FINDING 7 — the header chip and the summary used to render ABOVE the error
   // branch off rows defaulted from the design alone, so a failed read printed
-  // "3 of 3 need values" and "the version is not deployed until every one of
+  // "3 of 3 need configuration" and "the version is not deployed until every one of
   // them has its development values" directly on top of "Failed to load which
-  // external resources still need values". A fabricated certainty, stated more
+  // external resources still need configuration". A fabricated certainty, stated more
   // confidently than the truth it sat on.
   it("claims to know nothing about what is outstanding when readiness fails", () => {
     mockDesign = design(
@@ -276,12 +276,12 @@ describe("ExternalResources", () => {
     mockReadinessError = true;
     renderSection();
 
-    expect(screen.queryByText(/need values$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/need configuration$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/of 3/)).not.toBeInTheDocument();
     expect(
       screen.queryByText(/The version is not deployed until every one of them/),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Needs values")).not.toBeInTheDocument();
+    expect(screen.queryByText("Needs configuration")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Configure/ }),
     ).not.toBeInTheDocument();
@@ -304,9 +304,9 @@ describe("ExternalResources", () => {
     mockReadinessError = true;
     renderSection();
 
-    expect(screen.queryByText("1 of 1 need values")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 of 1 need configuration")).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Failed to load which external resources still need values/),
+      screen.getByText(/Failed to load which external resources still need configuration/),
     ).toBeInTheDocument();
   });
 
@@ -326,7 +326,7 @@ describe("ExternalResources", () => {
     });
     renderSection();
 
-    expect(screen.getByText("1 of 1 need values")).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 need configuration")).toBeInTheDocument();
     expect(screen.getByText("stripe")).toBeInTheDocument();
     expect(screen.queryByText("acme-registered")).not.toBeInTheDocument();
     expect(

--- a/apps/console/src/features/builds/components/ExternalResources.test.tsx
+++ b/apps/console/src/features/builds/components/ExternalResources.test.tsx
@@ -152,9 +152,29 @@ describe("ExternalResources", () => {
     expect(screen.getByText("1 of 1 need configuration")).toBeInTheDocument();
     expect(screen.getByText("Needs configuration")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Configure stripe" }),
+      screen.getByRole("button", { name: "Configure now: stripe" }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Provisioning/)).not.toBeInTheDocument();
+  });
+
+  // WCAG 2.5.3 Label in Name: the accessible name must CONTAIN the visible text,
+  // or a voice-control user reading "Configure now" off the screen says a name
+  // the button does not answer to. The row name is appended, never substituted.
+  it("keeps each button's accessible name a superset of what it reads", () => {
+    mockDesign = design(external("stripe", ["api_key"]), external("dhl", ["key"]));
+    mockReadiness = readiness(
+      { name: "stripe", state: "unset", missingKeys: ["api_key"] },
+      { name: "dhl", state: "configured" },
+    );
+    renderSection();
+
+    const outstanding = screen.getByRole("button", { name: /stripe/ });
+    expect(outstanding).toHaveTextContent("Configure now");
+    expect(outstanding.getAttribute("aria-label")).toContain("Configure now");
+
+    const configured = screen.getByRole("button", { name: /dhl/ });
+    expect(configured).toHaveTextContent("Edit configuration");
+    expect(configured.getAttribute("aria-label")).toContain("Edit configuration");
   });
 
   it("offers Edit configuration once a dependency is configured", () => {
@@ -177,7 +197,7 @@ describe("ExternalResources", () => {
     });
     renderSection();
 
-    fireEvent.click(screen.getByRole("button", { name: "Configure stripe" }));
+    fireEvent.click(screen.getByRole("button", { name: "Configure now: stripe" }));
     // The dialog opens on the dependency's own schema.
     expect(screen.getByText("Configure — stripe")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("api_key"), {

--- a/apps/console/src/features/builds/components/ExternalResources.tsx
+++ b/apps/console/src/features/builds/components/ExternalResources.tsx
@@ -26,6 +26,7 @@ import {
   Stack,
   Typography,
 } from "@wso2/oxygen-ui";
+import { CircleCheck } from "@wso2/oxygen-ui-icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { LogSection } from "../../../components/LogSection";
 import { StatusChip } from "../../../components/StatusChip";
@@ -54,6 +55,14 @@ const DEV_ENVIRONMENT = "development";
 /** The anchor the summary card's parked-run notice jumps to — the one place on
  *  the build page where a person can supply anything. */
 export const EXTERNAL_RESOURCES_ANCHOR = "external-resources";
+
+/**
+ * The inset every non-row block in this section shares with a row's own
+ * padding. The section renders `LogSection` with `disablePadding` so its row
+ * dividers reach both edges of the card, which makes the padding this file's
+ * to keep consistent rather than the wrapper's.
+ */
+const SECTION_PADDING = { px: 2.25, py: 2 } as const;
 
 /**
  * External resources — where a person hands the platform the credentials their
@@ -135,12 +144,21 @@ export function ExternalResources({ projectName }: { projectName: string }) {
             />
           ) : undefined
         }
+        // The rows are divider-separated, and a divider that stops short of the
+        // card's edge reads as a mistake rather than a rule. So the section owns
+        // its own padding: `SECTION_PADDING` on everything that is not a row,
+        // and each row pads itself inside a full-bleed border.
+        disablePadding
       >
       {known && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={SECTION_PADDING}
+        >
           {outstanding === 0
-            ? "Every external dependency has its development values."
-            : "The agent builds while you supply these. The version is not deployed until every one of them has its development values."}
+            ? "Every external dependency has its development configuration."
+            : "The agent builds while you supply these. The version is not deployed until every one of them has its development configuration."}
         </Typography>
       )}
 
@@ -150,7 +168,7 @@ export function ExternalResources({ projectName }: { projectName: string }) {
           would be silent about) and not as "everything is outstanding" either.
           All the section may add here is the count the design read proves. */}
       {failed ? (
-        <Stack spacing={1}>
+        <Stack spacing={1} sx={SECTION_PADDING}>
           <Alert
             severity="error"
             action={
@@ -171,57 +189,108 @@ export function ExternalResources({ projectName }: { projectName: string }) {
             <Typography variant="body2" color="text.secondary">
               {`This project declares ${declared} external ${
                 declared === 1 ? "dependency" : "dependencies"
-              }. Which of them still need development values is unknown until this loads.`}
+              }. Which of them still need development configuration is unknown until this loads.`}
             </Typography>
           )}
         </Stack>
       ) : loading ? (
-        <Box sx={{ display: "flex", justifyContent: "center", p: 2 }}>
+        <Box
+          sx={{ ...SECTION_PADDING, display: "flex", justifyContent: "center" }}
+        >
           <CircularProgress
             size={20}
             aria-label="Loading the external resources"
           />
         </Box>
       ) : (
-        <Stack spacing={1}>
-          {rows.map((row) => (
-            <Stack
-              key={row.name}
-              direction="row"
-              spacing={1}
-              sx={{ alignItems: "center", flexWrap: "wrap", rowGap: 0.5 }}
-            >
-              <Box sx={{ minWidth: 0, flexGrow: 1 }}>
-                <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                  {row.name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {secondaryLine(row)}
-                </Typography>
-              </Box>
-              <StatusChip
-                label={row.display === "configured" ? "Configured" : "Needs values"}
-                tone={row.display === "configured" ? "success" : "warning"}
-                appearance="soft"
-                dot={row.display !== "configured"}
-              />
-              <Button
-                size="small"
-                variant={row.display === "configured" ? "text" : "outlined"}
-                color={row.display === "configured" ? "inherit" : "primary"}
-                // The row's name is in its own label; the button's accessible
-                // name must carry it too, or every row reads as "Configure".
-                aria-label={`${
-                  row.display === "configured" ? "Update values for" : "Configure"
-                } ${row.name}`}
-                onClick={() => setTarget(row)}
-                sx={{ flexShrink: 0 }}
+        <Box>
+          {rows.map((row) => {
+            const done = row.display === "configured";
+            return (
+              <Stack
+                key={row.name}
+                direction="row"
+                spacing={2}
+                sx={{
+                  ...SECTION_PADDING,
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                  rowGap: 1,
+                  // A rule between rows, never above the first: the section's
+                  // own description already sits behind one.
+                  borderTop: 1,
+                  borderColor: "divider",
+                }}
               >
-                {row.display === "configured" ? "Update values" : "Configure"}
-              </Button>
-            </Stack>
-          ))}
-        </Stack>
+                {/* The row's own two lines. `flexBasis` keeps a long description
+                    from squeezing the status and the button onto their own line
+                    before the row genuinely runs out of width. */}
+                <Box sx={{ minWidth: 0, flexGrow: 1, flexBasis: "24rem" }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {row.name}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 0.25 }}
+                  >
+                    {secondaryLine(row)}
+                  </Typography>
+                </Box>
+                {/* Status as plain toned text rather than a pill: the section
+                    header already carries a pill, and a second one on every row
+                    competes with the button for the eye it is meant to lead to
+                    the button. */}
+                <Stack
+                  direction="row"
+                  spacing={0.75}
+                  sx={{
+                    alignItems: "center",
+                    flexShrink: 0,
+                    color: done ? "success.main" : "warning.main",
+                  }}
+                >
+                  {done ? (
+                    <CircleCheck size={16} aria-hidden />
+                  ) : (
+                    <Box
+                      aria-hidden
+                      sx={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: "50%",
+                        bgcolor: "warning.main",
+                      }}
+                    />
+                  )}
+                  <Typography
+                    variant="body2"
+                    sx={{ color: "inherit", fontWeight: 500 }}
+                  >
+                    {done ? "Configured" : "Needs configuration"}
+                  </Typography>
+                </Stack>
+                <Button
+                  size="small"
+                  // The outstanding row is the only thing on this page a person
+                  // can act on, so it gets the page's one filled button; a row
+                  // that is already done offers a quieter way back in.
+                  variant={done ? "outlined" : "contained"}
+                  color={done ? "inherit" : "primary"}
+                  // The row's name is in its own label; the button's accessible
+                  // name must carry it too, or every row reads as "Configure".
+                  aria-label={`${
+                    done ? "Edit configuration for" : "Configure"
+                  } ${row.name}`}
+                  onClick={() => setTarget(row)}
+                  sx={{ flexShrink: 0 }}
+                >
+                  {done ? "Edit configuration" : "Configure now"}
+                </Button>
+              </Stack>
+            );
+          })}
+        </Box>
       )}
 
       </LogSection>
@@ -257,7 +326,7 @@ export function ExternalResources({ projectName }: { projectName: string }) {
         onClose={() => setSaved(false)}
       >
         <Alert severity="success" onClose={() => setSaved(false)}>
-          Values saved — the deployment no longer waits on this one.
+          Configuration saved — the deployment no longer waits on this one.
         </Alert>
       </Snackbar>
     </Box>
@@ -277,7 +346,7 @@ function failureMessage(designFailed: boolean, readinessFailed: boolean): string
   if (designFailed) {
     return "Failed to load this project's external dependencies";
   }
-  return "Failed to load which external resources still need values";
+  return "Failed to load which external resources still need configuration";
 }
 
 /** The failing read's own message, appended when it carries one. */
@@ -290,7 +359,7 @@ function readErrorDetail(error: unknown): string {
 function secondaryLine(row: ExternalResourceRow): string {
   if (row.description) return row.description;
   if (row.display === "configured") {
-    return `${row.config.length} value${row.config.length === 1 ? "" : "s"} stored`;
+    return `${row.config.length} setting${row.config.length === 1 ? "" : "s"} stored`;
   }
-  return `${row.missingCount} value${row.missingCount === 1 ? "" : "s"} outstanding`;
+  return `${row.missingCount} setting${row.missingCount === 1 ? "" : "s"} outstanding`;
 }

--- a/apps/console/src/features/builds/components/ExternalResources.tsx
+++ b/apps/console/src/features/builds/components/ExternalResources.tsx
@@ -216,8 +216,8 @@ export function ExternalResources({ projectName }: { projectName: string }) {
                   alignItems: "center",
                   flexWrap: "wrap",
                   rowGap: 1,
-                  // A rule between rows, never above the first: the section's
-                  // own description already sits behind one.
+                  // A rule above every row: between two rows it separates them,
+                  // and above the first it closes off the section's description.
                   borderTop: 1,
                   borderColor: "divider",
                 }}
@@ -278,9 +278,13 @@ export function ExternalResources({ projectName }: { projectName: string }) {
                   variant={done ? "outlined" : "contained"}
                   color={done ? "inherit" : "primary"}
                   // The row's name is in its own label; the button's accessible
-                  // name must carry it too, or every row reads as "Configure".
+                  // name must carry it too, or every row reads the same. It must
+                  // also CONTAIN the visible text (WCAG 2.5.3 Label in Name) —
+                  // "Configure stripe" under a button reading "Configure now"
+                  // leaves a voice-control user saying a name that does not
+                  // match what they can see.
                   aria-label={`${
-                    done ? "Edit configuration for" : "Configure"
+                    done ? "Edit configuration for" : "Configure now:"
                   } ${row.name}`}
                   onClick={() => setTarget(row)}
                   sx={{ flexShrink: 0 }}

--- a/apps/console/src/features/builds/components/RunFeed.test.tsx
+++ b/apps/console/src/features/builds/components/RunFeed.test.tsx
@@ -73,6 +73,32 @@ afterEach(() => {
 });
 
 describe("RunFeed", () => {
+  // The placeholder is drawn by the SHARED `EmptyState`, the same one the Build
+  // logs section one card below uses. It used to be a bare left-aligned
+  // paragraph, which put two differently-drawn placeholders side by side on one
+  // page. `textAlign: center` is the tell that this is the shared component and
+  // not a paragraph that happens to say the same words.
+  it("draws its empty state the way every other section on the page does", () => {
+    mockCycles = [];
+    render(<RunFeed projectName="acme" runId="run-1" />);
+    const note = screen.getByText(
+      "No cycle output yet — the run's first agent has not written a line.",
+    );
+    expect(note.parentElement).toHaveStyle({ textAlign: "center" });
+  });
+
+  // The tail is the feed's connection status, not a log line, so it sits on the
+  // opposite edge from the content. Asserted because nothing else would catch it
+  // drifting back to the left when this block is next edited.
+  it("right-aligns the stream status line", () => {
+    mockCycles = [section("c1", "coding", ["main"])];
+    mockPhase = "reconnecting";
+    render(<RunFeed projectName="acme" runId="run-1" />);
+    expect(screen.getByText(/Connection lost/)).toHaveStyle({
+      textAlign: "right",
+    });
+  });
+
   it("renders one section per cycle, labelled by kind", () => {
     mockCycles = [section("c1", "coding", ["main"]), section("c2", "fix", ["main"])];
     render(<RunFeed projectName="acme" runId="run-1" />);
@@ -286,12 +312,16 @@ describe("RunFeed", () => {
     expect(screen.queryByText("coding")).not.toBeInTheDocument();
   });
 
-  it("says the run settled once the stream ends — only a terminal run does", () => {
+  // How the run ENDED moved to the section header (see BuildDetailPage), so the
+  // feed body must stay quiet about it — a settled stream repeating the header
+  // beneath the log is the duplication that move was meant to remove.
+  it("leaves the run's ending to the section header", () => {
     mockCycles = [section("c1", "coding", ["main"])];
     mockPhase = "ended";
     mockSettled = "succeeded";
     render(<RunFeed projectName="acme" runId="run-1" />);
-    expect(screen.getByText(/run settled — succeeded/)).toBeInTheDocument();
+    expect(screen.queryByText(/Run finished/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/settled/)).not.toBeInTheDocument();
   });
 
   it("says it is reattaching after a dropped connection", () => {

--- a/apps/console/src/features/builds/components/RunFeed.tsx
+++ b/apps/console/src/features/builds/components/RunFeed.tsx
@@ -27,8 +27,10 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { EmptyState } from "../../../components/EmptyState";
 import { GitHubRefChip } from "../../../components/GitHubRefChip";
 import { AgentLogLines, LogSurface } from "./AgentLogLines";
+import { connectionTail } from "../lib/feedTail";
 import { useRunProgress, type RunProgressCycle } from "../hooks/useRunProgress";
 
 // The run feed: ONE SSE stream for the whole run, rendered as one accordion
@@ -193,21 +195,22 @@ export function RunFeed({
   const followed = expandNewest ? (shown[0]?.cycle.id ?? null) : null;
   const openId = chosen === undefined ? followed : chosen;
 
-  let tail: string | undefined;
-  if (feed.phase === "connecting") {
-    tail = "attaching to the run feed…";
-  } else if (feed.phase === "reconnecting") {
-    tail = "connection lost — reconnecting…";
-  } else if (feed.phase === "ended") {
-    tail = `run settled${feed.settledState ? ` — ${feed.settledState}` : ""}`;
-  }
+  // Connection health only. How the run ENDED labels the section header instead
+  // — beside the title, where every other section on this page carries its
+  // status — so repeating it under the log would be the same news twice.
+  const tail = connectionTail(feed.phase);
 
   return (
     <Box>
       {feed.cycles.length === 0 ? (
-        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-          No cycle output yet — the run's first agent has not written a line.
-        </Typography>
+        // The same `EmptyState compact` the Build logs section below uses. Two
+        // placeholders that sit one card apart on this page read as one surface
+        // only if they are drawn the same way — a left-aligned sentence beside a
+        // centred one looks like a mistake, not a distinction.
+        <EmptyState
+          compact
+          description="No cycle output yet — the run's first agent has not written a line."
+        />
       ) : (
         shown.map((section, i) => (
           <CycleSection
@@ -232,7 +235,13 @@ export function RunFeed({
         ))
       )}
       {tail && (
-        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          // Right-aligned: it is the feed's own connection status, not a line
+          // OF the feed, and the left edge is where the log's content starts.
+          sx={{ display: "block", mt: 1, textAlign: "right" }}
+        >
           {tail}
         </Typography>
       )}

--- a/apps/console/src/features/builds/components/RunSpine.test.tsx
+++ b/apps/console/src/features/builds/components/RunSpine.test.tsx
@@ -579,7 +579,7 @@ describe("RunSpine", () => {
 
   // A settled run opens no stream, so it must not narrate one. The hook reports
   // `idle` for a stream nobody asked for; reporting `connecting` had a
-  // connection-free page claiming it was "attaching to the run feed" forever.
+  // connection-free page claiming it was "Attaching to the run feed" forever.
   it("says nothing about the feed while no log has been asked for", () => {
     mockPhase = "idle";
     const done = cycle({
@@ -590,7 +590,7 @@ describe("RunSpine", () => {
     renderSpine(run([done], "succeeded"));
 
     expect(
-      screen.queryByText(/attaching to the run feed/),
+      screen.queryByText(/Attaching to the run feed/),
     ).not.toBeInTheDocument();
     expect(enabledCalls.every((e) => e === false)).toBe(true);
   });
@@ -599,7 +599,7 @@ describe("RunSpine", () => {
     mockPhase = "connecting";
     const live = cycle({ id: "c1" });
     renderSpine(run([live]));
-    expect(screen.getByText(/attaching to the run feed/)).toBeInTheDocument();
+    expect(screen.getByText(/Attaching to the run feed/)).toBeInTheDocument();
     expect(screen.getByText(/Loading agent output/)).toBeInTheDocument();
   });
 

--- a/apps/console/src/features/builds/components/RunSpine.tsx
+++ b/apps/console/src/features/builds/components/RunSpine.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import { Box, Button, Stack, Typography } from "@wso2/oxygen-ui";
 import type { components } from "../../../generated/aep-api";
 import { useCycleBuilds } from "../api/queries";
+import { connectionTail } from "../lib/feedTail";
 import { useRunProgress, type RunProgressCycle, type RunProgressPhase } from "../hooks/useRunProgress";
 import { provisioningStage } from "../lib/provisioning";
 import { BUILD_CYCLE_KINDS, buildSessionLabel, isTerminalRun } from "../lib/runView";
@@ -228,12 +229,9 @@ export function RunSpine({
     );
   }
 
-  let tail: string | undefined;
-  if (progress.phase === "connecting") {
-    tail = "attaching to the run feed…";
-  } else if (progress.phase === "reconnecting") {
-    tail = "connection lost — reconnecting…";
-  }
+  // Connection only: a settled run is already drawn by the stage rows above, so
+  // a second sentence saying it ended would be the same news twice.
+  const tail = connectionTail(progress.phase);
 
   return (
     <Box>

--- a/apps/console/src/features/builds/lib/externalResourceRows.test.ts
+++ b/apps/console/src/features/builds/lib/externalResourceRows.test.ts
@@ -141,7 +141,7 @@ describe("externalResourceRows", () => {
 
   // Two components declaring the same dependency with DISJOINT keys. Readiness
   // is computed against the union, so a dialog offering only the first
-  // component's keys could never satisfy it — the row would stay "Needs values"
+  // component's keys could never satisfy it — the row would stay "Needs configuration"
   // however many times it was saved, and the deploy gate would never open.
   it("unions the config keys of a dependency two components declare differently", () => {
     const rows = externalResourceRows(
@@ -217,7 +217,7 @@ describe("externalResourceRows", () => {
   // record` for one, and the deploy gate deliberately excludes it (naming it
   // would park a run forever on something no project surface can clear), so
   // readiness omits it. Defaulting an unmentioned dependency to
-  // `not-provisioned` would resurrect exactly that row: a "Needs values" chip
+  // `not-provisioned` would resurrect exactly that row: a "Needs configuration" chip
   // and a Configure button that 409s, under a headline contradicting a gate
   // that is not blocked.
   it("does not render an external the readiness read omits", () => {
@@ -294,7 +294,7 @@ describe("externalResourceHeadline", () => {
       ),
     );
     // twilio is unset and segment has no binding yet — both outstanding.
-    expect(externalResourceHeadline(rows)).toBe("2 of 4 need values");
+    expect(externalResourceHeadline(rows)).toBe("2 of 4 need configuration");
   });
 
   // The headline counts the SUPPLIABLE set, so an external readiness omits is
@@ -308,7 +308,7 @@ describe("externalResourceHeadline", () => {
       ]),
       readiness({ name: "stripe", state: "unset", missingKeys: ["api_key"] }),
     );
-    expect(externalResourceHeadline(rows)).toBe("1 of 1 need values");
+    expect(externalResourceHeadline(rows)).toBe("1 of 1 need configuration");
   });
 
   it("says so once every one is configured", () => {
@@ -322,7 +322,7 @@ describe("externalResourceHeadline", () => {
 
 // The one thing the DESIGN read alone supports, and what the section falls
 // back to when readiness is unknown (findings 7 and 8): how many externals
-// somebody could be asked to supply — never how many still need values.
+// somebody could be asked to supply — never how many still need configuration.
 describe("declaredExternalCount", () => {
   it("counts collectable externals once each, whatever readiness says", () => {
     expect(

--- a/apps/console/src/features/builds/lib/externalResourceRows.ts
+++ b/apps/console/src/features/builds/lib/externalResourceRows.ts
@@ -221,7 +221,7 @@ export function externalResourceHeadline(rows: ExternalResourceRow[]): string {
   const outstanding = rows.filter((row) => row.display === "needs-values").length;
   return outstanding === 0
     ? `${rows.length} of ${rows.length} configured`
-    : `${outstanding} of ${rows.length} need values`;
+    : `${outstanding} of ${rows.length} need configuration`;
 }
 
 /**

--- a/apps/console/src/features/builds/lib/feedTail.test.ts
+++ b/apps/console/src/features/builds/lib/feedTail.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { connectionTail, settledLabel } from "./feedTail";
+
+describe("connectionTail", () => {
+  it("speaks only while the stream is not carrying anything", () => {
+    expect(connectionTail("connecting")).toBe("Attaching to the run feed…");
+    expect(connectionTail("reconnecting")).toBe(
+      "Connection lost — reconnecting…",
+    );
+  });
+
+  // Silence is the healthy state. `idle` especially: a surface nobody opened
+  // never attached to anything, and saying "attaching" there is the bug the
+  // phase was introduced to kill.
+  it("says nothing about a live, ended, or never-opened stream", () => {
+    expect(connectionTail("live")).toBeUndefined();
+    expect(connectionTail("ended")).toBeUndefined();
+    expect(connectionTail("idle")).toBeUndefined();
+  });
+});
+
+describe("settledLabel", () => {
+  // The words are the run status chip's, not the wire's. `run settled —
+  // succeeded` put the stream contract's own term in front of a reader and
+  // left the state in its lower-case wire spelling.
+  it("names the ending the way the rest of the page names it", () => {
+    expect(settledLabel("succeeded")).toBe("Run finished successfully");
+    expect(settledLabel("failed")).toBe("Run failed");
+    expect(settledLabel("cancelled")).toBe("Run cancelled");
+    expect(settledLabel("blocked")).toBe("Run blocked");
+  });
+
+  // A run row that carried no state still ended, so the header has to say
+  // something — just nothing it cannot back up.
+  it("still closes the section when the run named no state", () => {
+    expect(settledLabel(undefined)).toBe("Run finished");
+    expect(settledLabel("")).toBe("Run finished");
+  });
+
+  // Same rule as `runStatus`: a state nobody wrote a sentence for is rendered,
+  // not swallowed. Hiding it would leave the section looking cleanly finished
+  // when the platform said something the console does not understand.
+  it("renders an unrecognised state rather than hiding it", () => {
+    expect(settledLabel("timed-out")).toBe("Run ended — timed-out");
+  });
+});

--- a/apps/console/src/features/builds/lib/feedTail.ts
+++ b/apps/console/src/features/builds/lib/feedTail.ts
@@ -60,6 +60,15 @@ export function connectionTail(phase: RunProgressPhase): string | undefined {
  * header uses for its counts, so the two section headers read as one system.
  * The run's outcome is already carried in colour by the page header's own
  * status chip; a second toned pill here would compete with it.
+ *
+ * This switches over the same states as `runStatus` in `runView`, and that
+ * duplication is deliberate rather than a helper waiting to be extracted: the
+ * two answer different questions in different slots. `runStatus` names the run
+ * ("Succeeded", with a tone, in a chip); this names what HAPPENED to it, as a
+ * sentence, untoned. Folding them together would force one phrasing into both.
+ * They must stay on one VOCABULARY — a state `runStatus` learns to name is a
+ * state this owes a sentence — which is what the default case is for until it
+ * has one.
  */
 export function settledLabel(state: string | undefined): string {
   switch (state) {

--- a/apps/console/src/features/builds/lib/feedTail.ts
+++ b/apps/console/src/features/builds/lib/feedTail.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { RunProgressPhase } from "../hooks/useRunProgress";
+
+// THE FOOTNOTE UNDER A RUN FEED, in two halves that answer different questions.
+//
+// `connectionTail` is about the STREAM — is the console attached? Every surface
+// that opens a run feed reports it, so the sentence lives here rather than being
+// retyped per surface (it was, in RunFeed and RunSpine, and only one of the two
+// would have been fixed).
+//
+// `settledLabel` is about the RUN — how did it end? It labels the section
+// HEADER, beside the title, the way the Tasks header carries its counts; the
+// body keeps the connection half, because stream health is not a fact about the
+// run and the header cannot know it.
+
+/** What the CONNECTION is doing, when that is worth saying at all. A live or
+ *  never-opened stream says nothing — silence is the healthy state. */
+export function connectionTail(phase: RunProgressPhase): string | undefined {
+  switch (phase) {
+    case "connecting":
+      return "Attaching to the run feed…";
+    case "reconnecting":
+      return "Connection lost — reconnecting…";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * How the run ENDED, as the sentence beside the section title.
+ *
+ * This used to read `run settled — succeeded` under the log: the platform's own
+ * term for the transition, with the raw state pasted after it in the lower-case
+ * spelling the wire uses.
+ *
+ * It is derived from the RUN, not from the stream's `done` frame, even though
+ * that frame is the more immediate signal. The header's other half — the
+ * streaming note — already reads the run list, and two halves of one label
+ * drawn from two sources can contradict each other for as long as they disagree.
+ * One source, one answer.
+ *
+ * Deliberately UNTONED: it renders as the same secondary caption the Tasks
+ * header uses for its counts, so the two section headers read as one system.
+ * The run's outcome is already carried in colour by the page header's own
+ * status chip; a second toned pill here would compete with it.
+ */
+export function settledLabel(state: string | undefined): string {
+  switch (state) {
+    case "succeeded":
+      return "Run finished successfully";
+    case "failed":
+      return "Run failed";
+    case "cancelled":
+      return "Run cancelled";
+    case "blocked":
+      return "Run blocked";
+    default:
+      // An unrecognised state renders rather than hiding, for the same reason
+      // `runStatus` renders one: a state nobody wrote a sentence for is still a
+      // fact about the run, and swallowing it leaves the section looking
+      // cleanly finished when the platform said something else.
+      return state ? `Run ended — ${state}` : "Run finished";
+  }
+}

--- a/apps/console/src/features/builds/lib/ledger.test.ts
+++ b/apps/console/src/features/builds/lib/ledger.test.ts
@@ -85,7 +85,7 @@ describe("ledgerStatus", () => {
     // The wording is the build page's own pill, so the two surfaces agree.
     expect(
       ledgerStatus(build({ status: "in_progress", waitingReason: "external-values" })),
-    ).toEqual({ label: "Waiting for values", tone: "warning", live: false });
+    ).toEqual({ label: "Waiting for configuration", tone: "warning", live: false });
   });
 
   it("treats `started` as running too", () => {

--- a/apps/console/src/features/builds/lib/ledger.ts
+++ b/apps/console/src/features/builds/lib/ledger.ts
@@ -87,7 +87,7 @@ export function ledgerStatus(
       // stay on that page — the row has no space for them and the ledger read
       // does not carry them.
       if (isAwaitingValues(build)) {
-        return { label: "Waiting for values", tone: "warning", live: false };
+        return { label: "Waiting for configuration", tone: "warning", live: false };
       }
       return { label: "Running · Coding agent", tone: "info", live: true };
     case "failed":


### PR DESCRIPTION
## What

The build page's External resources section and its two log sections, made to read as one surface.

**1. One noun for external dependencies: *configuration*.**

The section spoke three words for one thing — the drawer it replaced said *credentials*, the section said *values*, the buttons said *Configure*. "Credentials" is only true of the subset that are secrets (a webhook URL is neither); "values" is the wire's word for what a binding holds. Settled on **configuration**, which covers every key the dialog collects and is what the buttons already said. Individual keys are **settings** where they have to be counted.

| | before | after |
|---|---|---|
| Section chip | `1 of 2 need values` | `1 of 2 need configuration` |
| Row status | `Needs values` | `Needs configuration` |
| Row buttons | `Configure` / `Update values` | `Configure now` / `Edit configuration` |
| Row subline | `2 values outstanding` | `2 settings outstanding` |
| Page status pill + ledger row | `Waiting for values` | `Waiting for configuration` |
| Parked-run notice button | `Supply values` | `Add configuration` |
| Save confirmation | `Values saved — …` | `Configuration saved — …` |

The rows are redrawn with it: divider-separated with room to breathe, status as plain toned text instead of a second pill competing with the header's, and the section's one filled button on the row that is actually outstanding.

**2. The log sections label and empty themselves alike.**

- The Coding agent log's placeholder was a bare left-aligned paragraph next to Build logs' centred `EmptyState`. Both now use the same shared component.
- Its status read `run settled — succeeded` under the log. *Settled* is the stream contract's word for the transition, not something a person watching a build says, and the state was pasted on raw in its lower-case wire spelling. It now reads **Run finished successfully** beside the section title, as the secondary caption Tasks already uses for its counts.
- How the run **ended** and how the **stream** is doing answer different questions, so they are split: the ending labels the header and is read from the run list — which the streaming note beside it already reads, so the two halves of one label cannot disagree — while stream health stays under the log, right-aligned away from where the content starts.
- The connection copy was duplicated in `RunFeed` and `RunSpine`; it now lives in `lib/feedTail.ts`, so a change to it cannot fix only one of them.

## Proof

Rendered against mocks and confirmed in the DOM, not by eye alone:

```
$ node scripts/pr-shots.mjs
has 'Configure now': true
has 'need configuration': true
```

Deployed to the local compose stack (`docker build -f apps/console/Dockerfile -t deployments-console:latest .` → `docker compose up -d --no-deps --force-recreate console`) and verified in the served bundle, not just in tests:

```
$ docker exec aep-console cat /usr/share/nginx/html/assets/index-*.js | grep -oE 'Run finished successfully.{0,20}'
Run finished successfully"

$ docker inspect aep-console --format '{{.Image}}'   # matches the freshly built tag
sha256:316ae41c4a4124902a8cd2e5ef6943364813bba6fae51ccd1cbd030a9293ba54
```

## Tests

`apps/console` suite: **1653 passing, 133 files.** New coverage, each of which fails against `main`:

- `lib/feedTail.test.ts` (new) — every settled state, the empty-state fallback, the unrecognised-state passthrough, and that a live/idle stream says nothing.
- `RunFeed.test.tsx` — the placeholder uses the shared centred `EmptyState`; the stream tail is right-aligned; the body stays **quiet** about how the run ended.
- `BuildDetailPage.test.tsx` — the header names a succeeded and a cancelled run, and says nothing about a run that has not ended (a run parked at the deploy gate must not read as finished).
- `ExternalResources.test.tsx` / `externalResourceRows.test.ts` / `ledger.test.ts` — the copy above.

Gates: `make lint` 0 issues · `make typecheck` clean · `make license-check` clean · `make deadcode-ts-check` clean.

## Docs

`apps/console/design/lexicon.md` is the console's copy reference and pinned the old wording verbatim, so it moves with the code: the External resources and deploy-gate tables are rewritten, and a new **The build page's log sections** section records the header-note treatment, the placeholder rule, and the header/body split.

## Notes for review

- `settledLabel` switches over the same run states as `runStatus` in `runView`. The duplication is deliberate and commented: the two answer different questions in different slots (`runStatus` names the run — "Succeeded", toned, in a chip; this names what happened to it, as an untoned sentence). Folding them together would force one phrasing into both.
- Sourcing the header label from the run list rather than the stream's `done` frame is a deliberate trade: the frame is the more immediate signal, so the label flips when the run list refreshes rather than the instant the stream closes. It buys the guarantee that the two halves of the header can never contradict each other.

<img width="1122" height="177" alt="externalresources" src="https://github.com/user-attachments/assets/302b9a2a-1801-4f49-8339-ba5382a4afe5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
