### PR TITLE
fix(helm): set AEP_API_INTERNAL_BASE_URL so design turns get catalog tools

### DIFF
--- a/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
+++ b/deployments/helm-charts/platform/templates/aep-api/deployment.yaml
@@ -141,6 +141,14 @@ spec:
               value: "http://aep-agents.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.aepAgents.port }}"
             - name: AGENT_PLATFORM_URL
               value: "http://aep-api.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.aepApi.port }}"
+            # Design-turn MCP discovery: the agents service calls back into the
+            # BFF's own /internal/v1/mcp to list the org catalog
+            # (list_external_resources / list_platform_resource_types). Without
+            # it mcpForTurn attaches no `mcp` block, the design agent sees no
+            # catalog at all, and it invents resourceTypes that fail at build.
+            # Same in-cluster address as AGENT_PLATFORM_URL above.
+            - name: AEP_API_INTERNAL_BASE_URL
+              value: "http://aep-api.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.aepApi.port }}"
             # The one runner image, used by both task kinds.
             - name: AGENT_RUNNER_IMAGE
               value: {{ .Values.codingAgentRunner.image | quote }}

--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -1422,7 +1422,7 @@ func computeDegradations(cfg config.Config, secretsDelivery bool) []Degradation 
 		off("secrets-delivery", "SecretsProvider not injected — secret writes + external-secret cleanup disabled")
 	}
 	if cfg.AEPInternalBaseURL == "" {
-		off("mcp-discovery", "AEP_INTERNAL_BASE_URL not set — design-turn MCP discovery omitted")
+		off("mcp-discovery", "AEP_API_INTERNAL_BASE_URL not set — design-turn MCP discovery omitted")
 	}
 	thunderBase := cfg.ThunderAdmin.BaseURL
 	if thunderBase == "" {


### PR DESCRIPTION
## Problem

`AEP_API_INTERNAL_BASE_URL` is set in `deployments/docker-compose.yml` and in the cloud overlay, but is **absent from the Helm chart entirely**. So every Helm install ships with design-time MCP discovery silently off, and local dev never reproduces it.

The gate is in `services/aep-api/internal/spec/turn_runner.go`:

```go
func (s *Service) mcpForTurn(ctx context.Context, job turnJob) *agentsvc.MCPBlock {
	if s.mcpTokens == nil || s.mcpBaseURL == "" {
		return nil
	}
```

With an empty base URL the turn carries **no `mcp` block at all**, so the design agent gets neither `list_external_resources` nor `list_platform_resource_types`. This is not a "cluster types work, org types don't" asymmetry — both tools live on the same MCP server and go dark together.

The agent then works only from the resource-type names inlined into the design prompt by the platform skills (`postgres-cnpg`, `thunder-app`) and **invents** a `resourceType` for anything those skills don't name. That saves fine and fails later at build with `ErrUnknownResourceType` (*"resourceType is not installed on this cluster"*).

Only the startup warning hints at it, and it names the wrong variable.

## Observed

On a Helm install at `0.6.0-rc.28`, with `aws-s3` and `resend` both registered in the org catalog, a project asking for image upload plus publish notifications produced:

- storage → `platform-resource` / `object-storage` — **invented, not installed**
- email → `external` / `email-provider` with three guessed vendors (`sendgrid`/`postmark`/`resend`)

`resend` was only pinned after a human typed its name into chat.

## Fix

Set `AEP_API_INTERNAL_BASE_URL` on the `aep-api` Deployment, reusing the in-cluster address the chart already renders for `AGENT_PLATFORM_URL` — no new value or values.yaml key.

Also corrects the degradation message, which printed `AEP_INTERNAL_BASE_URL` while `config_loader.go` reads `AEP_API_INTERNAL_BASE_URL`. Following the log text sets a variable nothing reads.

## Verification

Re-ran the **identical idea text** as a new project on the same cluster after setting the variable:

| | before | after |
|---|---|---|
| image storage | `platform-resource` / `object-storage` (invented) | `external` / **`aws-s3`** |
| email | `external` / `email-provider`, 3 guessed vendors | `external` / **`resend`** |
| cell placement | storage inside the cell | both on **south** |
| config keys | invented | **6/6 exact match** to the registered `spec.parameters`, including which are secret |

The 6/6 key match (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET_NAME`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`) cannot be guessed — it is only reachable by reading the live catalog.

Also verified:

- `helm template` renders the expected value; `helm lint` clean
- the rendered value matches the hand-applied one exactly for a non-default namespace
- `go test ./services/aep-api/internal/{app,config,spec}/...` passes
- the existing `TestAssemble_Degradations` asserts capability *names*, not reason strings, so the message change is safe

## Note for reviewers

There is no chart-render test harness in the repo, so this is verified by `helm template` rather than an automated assertion. Happy to add one if you'd like it, though that felt like scope beyond a two-line fix.

Worth checking whether other Helm-only installs need the same treatment for `OBSERVABILITY_API_URL` and `OBSERVER_URL`, which report the same style of degradation on the cluster I measured this on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)