### PR TITLE
chore(skaffold): scope per-artifact file watching and skip repeated hook runs

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -13,26 +13,59 @@ build:
           - "--build-context=skills=./skills"
     - image: ghcr.io/wso2/aep/agents
       context: .
-      docker:
-        dockerfile: services/agents/Dockerfile
+      custom:
+        buildCommand: docker build -f services/agents/Dockerfile -t $IMAGE .
+        dependencies:
+          paths:
+            - services/agents/**
+            - packages/**
+            - pnpm-workspace.yaml
+            - package.json
+            - pnpm-lock.yaml
+            - tsconfig.base.json
     - image: ghcr.io/wso2/aep/collab
       context: .
-      docker:
-        dockerfile: services/collab/Dockerfile
+      custom:
+        buildCommand: docker build -f services/collab/Dockerfile -t $IMAGE .
+        dependencies:
+          paths:
+            - services/collab/**
+            - packages/**
+            - pnpm-workspace.yaml
+            - package.json
+            - pnpm-lock.yaml
+            - tsconfig.base.json
     - image: ghcr.io/wso2/aep/aep-mcp-server
       context: .
-      docker:
-        dockerfile: services/aep-mcp-server/Dockerfile
+      custom:
+        buildCommand: docker build -f services/aep-mcp-server/Dockerfile -t $IMAGE .
+        dependencies:
+          paths:
+            - services/aep-mcp-server/**
+            - pnpm-workspace.yaml
+            - package.json
+            - pnpm-lock.yaml
+            - tsconfig.base.json
     - image: ghcr.io/wso2/aep/console
       context: .
-      docker:
-        dockerfile: apps/console/Dockerfile
+      custom:
+        buildCommand: docker build -f apps/console/Dockerfile -t $IMAGE .
+        dependencies:
+          paths:
+            - apps/console/**
+            - packages/**
+            - pnpm-workspace.yaml
+            - package.json
+            - pnpm-lock.yaml
+            - tsconfig.base.json
     - image: ghcr.io/wso2/aep/remote-worker
       context: runners/remote-worker
       docker:
         dockerfile: Dockerfile
         cliFlags:
           - "--build-context=skills=./skills"
+          - "--build-context=bal-library-tool=./packages/bal-library-tool"
+          - "--secret=id=packagePAT,env=PACKAGE_PAT"
       dependencies:
         paths:
           - runners/remote-worker/**

--- a/skaffold/generate-and-apply.sh
+++ b/skaffold/generate-and-apply.sh
@@ -17,10 +17,18 @@
 
 # Applies platform namespaces and secrets, then generates any one-time secrets
 # that cannot be committed to source control.
-# Idempotent: safe to re-run.
+# Idempotent: safe to re-run. Skips on subsequent Skaffold dev cycles once a
+# sentinel ConfigMap is written to the cluster — deleted automatically when the
+# cluster is reset.
 set -e
 
 NAMESPACE=wso2-aep
+SENTINEL=aep-generate-setup-done
+
+if kubectl get configmap "$SENTINEL" -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "Secrets already seeded — skipping (delete configmap/$SENTINEL to force re-run)"
+  exit 0
+fi
 
 # Bootstrap per-developer helm-values.yaml from the example if not present.
 # Developers should set their own smee.io channel in this file.
@@ -45,3 +53,5 @@ else
     --from-literal="task-signing.pem=$RSA_KEY"
   echo "aep-task-signing-key created"
 fi
+
+kubectl create configmap "$SENTINEL" -n "$NAMESPACE" --from-literal=done=true 2>/dev/null || true

--- a/skaffold/thunder-setup.sh
+++ b/skaffold/thunder-setup.sh
@@ -18,10 +18,17 @@
 # Registers all AEP OAuth clients in Thunder and patches its CORS config.
 # Reads client secrets from the aep-thunder-secrets K8s Secret applied by
 # skaffold/secrets.yaml. Called as a Skaffold post-Helm deploy hook.
-# Idempotent: re-running is safe.
+# Idempotent: re-running is safe. Skips on subsequent Skaffold dev cycles once
+# a sentinel ConfigMap is written — deleted automatically when the cluster resets.
 set -e
 
 PLATFORM_NS="${PLATFORM_NS:-wso2-aep}"
+SENTINEL=aep-thunder-setup-done
+
+if kubectl get configmap "$SENTINEL" -n "$PLATFORM_NS" >/dev/null 2>&1; then
+  echo "Thunder clients already registered — skipping (delete configmap/$SENTINEL to force re-run)"
+  exit 0
+fi
 THUNDER_NS="${THUNDER_NS:-thunder}"
 THUNDER_DEPLOYMENT="${THUNDER_DEPLOYMENT:-thunder-deployment}"
 THUNDER_CONFIG_MAP="${THUNDER_CONFIG_MAP:-thunder-config-map}"
@@ -311,3 +318,5 @@ else
 
   echo "Thunder CORS updated"
 fi
+
+kubectl create configmap "$SENTINEL" -n "$PLATFORM_NS" --from-literal=done=true 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Switch `agents`, `collab`, `aep-mcp-server`, and `console` from `docker:` to `custom:` builder with `dependencies.paths` so only the relevant source tree triggers a rebuild — a console change no longer causes agents/collab to rebuild and vice versa
- Add K8s ConfigMap sentinels to `generate-and-apply.sh` and `thunder-setup.sh` so the secret-seeding and Thunder client registration steps run once per cluster lifetime and are skipped on subsequent `skaffold dev` cycles
- Merge `remote-worker`'s upstream `dependencies.paths` scoping with the missing `bal-library-tool` and `packagePAT` cliFlags

## How the sentinel works

Each hook script checks for a ConfigMap (`aep-generate-setup-done` / `aep-thunder-setup-done`) in `wso2-aep` at startup and exits immediately if found. The ConfigMap is created at the end of a successful run. It disappears naturally when the cluster is reset — exactly when the setup needs to run again. To force a re-run without resetting:

```sh
kubectl delete configmap aep-generate-setup-done aep-thunder-setup-done -n wso2-aep
```

## Test plan

- [ ] Fresh cluster: `skaffold dev` runs both hooks end-to-end on first deploy
- [ ] Subsequent file change: hooks are skipped, only the affected image rebuilds
- [ ] Console-only change: only `ghcr.io/wso2/aep/console` rebuilds; agents/collab/mcp-server stay idle
- [ ] `packages/` change: console + agents + collab rebuild; aep-mcp-server stays idle (no packages/ dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)