### PR TITLE
feat: deploy reconciles the version, and delivery asserts it

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,12 +67,15 @@ behind `gen`, and CI runs `gen` + `git diff --exit-code` to catch staleness. See
 A spec version is cut as a `v<N>` tag and executed as **one supervised run over
 one GitHub milestone**: the run mints prose issues into it as its first phase, one coding agent
 works the whole milestone per cycle, its pull request auto-merges, the merge
-fans out to a build per changed component, the supervisor then promotes each
-built component and waits for it to serve, and the run settles when the working
-set is empty and validation has a verdict. The decisions and their costs are
+fans out to a build per changed component, the supervisor then **reconciles the
+version**: every component the design declares whose newest green build is not
+what its binding pins is promoted, providers before consumers, and the run
+settles when the working set is empty *and* every component is serving. The
+decisions and their costs are
 [ADR-0011](decisions/ADR-0011-milestone-is-the-unit-of-execution.md),
 [ADR-0017](decisions/ADR-0017-the-platform-owns-deploy.md),
-[ADR-0018](decisions/ADR-0018-planning-is-a-run-phase.md) and
-[ADR-0024](decisions/ADR-0024-cancel-reaches-the-planning-phase.md); the
+[ADR-0018](decisions/ADR-0018-planning-is-a-run-phase.md),
+[ADR-0024](decisions/ADR-0024-cancel-reaches-the-planning-phase.md) and
+[ADR-0026](decisions/ADR-0026-deploy-reconciles-the-version.md); the
 mechanism is
 [`internal/delivery/README.md`](../services/aep-api/internal/delivery/README.md).

--- a/docs/decisions/ADR-0019-deploy-order-follows-the-hard-wiring-edges.md
+++ b/docs/decisions/ADR-0019-deploy-order-follows-the-hard-wiring-edges.md
@@ -77,6 +77,16 @@ Three properties follow:
   exists in the design but has never deployed at all would still be published unconfigured. That is
   not reachable from the run loop (the deploy set comes from a build fan-out that is red if any
   component failed, and a first build builds everything), but it is an assumption, not a proof.
+
+  > **Superseded by [ADR-0026](ADR-0026-deploy-reconciles-the-version.md).** The assumption was
+  > false, and the counterexample shipped: a red build stops the fan-out being green, but the cycle
+  > that follows it rebuilds only what its own fix touched — so a component green at the earlier
+  > commit is in no later deploy set, and a consumer's provider can exist in the design having never
+  > deployed. Project `track-each-hire7321` delivered v1 that way, with its API unbound. The planner
+  > now reads the whole design's edges over the version's own state, so a provider with no serving
+  > release is an unsatisfied edge rather than an assumed-satisfied one. Everything else in this ADR
+  > stands: the grading of edges, the waves, the commitless converge, the one deadline, the permanent
+  > cycle refusal.
 - **The converge carries no commit.** `Deploy` with an empty commit SHA re-asserts wiring at whatever
   release is already serving (the verb a config edit has always used). Nothing is re-cut, so the
   pass cannot fail on a release that already exists — the wedge in (1) is removed by the shape rather

--- a/docs/decisions/ADR-0026-deploy-reconciles-the-version.md
+++ b/docs/decisions/ADR-0026-deploy-reconciles-the-version.md
@@ -1,0 +1,205 @@
+# ADR-0026 — Deploy reconciles the version
+
+**Status:** Accepted · **Refines:** [ADR-0017](ADR-0017-the-platform-owns-deploy.md) (the platform
+still owns the deploy verb) · **Supersedes one claim of**
+[ADR-0019](ADR-0019-deploy-order-follows-the-hard-wiring-edges.md) (the deploy set, and the scope the
+waves are planned over)
+
+## Context
+
+A version shipped that was not running.
+
+Project `track-each-hire7321`, version `v1`, two components. Cycle one merged both; the API's build
+went green and the web app's went red. The supervisor read the red verdict, returned before its
+deploy stage, and the event plane filed the web app's fix issue. Cycle two merged the fix — two
+files, both under the web app — so the merge's path diff named the web app alone. It built, deployed,
+and the milestone emptied. The run settled **succeeded**, minted the version's validation task and
+closed the increment.
+
+The API was never promoted. No `ComponentRelease`, no `ReleaseBinding`, no pod. Its image had existed
+since cycle one. Every cycle in that run was correct on its own terms, and nothing in the sequence
+was a lie — the predicate was:
+
+```text
+"deployed-green" was inferred from   the working set is empty
+                                   ∧ the last cycle ended green
+```
+
+Neither conjunct is a statement about the API, so neither could contradict it. Two shapes combined to
+produce it:
+
+1. **The deploy set was the cycle's path diff** — `ListPullRequestFiles ∩ ComponentPaths`, classified
+   only at that cycle's merge SHA. So *what is serving* was a function of which files a fix happened
+   to edit. A component whose files stop changing is in no later deploy set, whatever state its
+   release is in.
+2. **A red build returned before the deploy stage.** The cycle that could have promoted the API was
+   the one whose sibling failed, and it never reached the promote.
+
+The consumer then went live against a provider with no address at all — the case
+[ADR-0019](ADR-0019-deploy-order-follows-the-hard-wiring-edges.md) named as "an assumption, not a
+proof". The assumption was that the run loop could not produce it. It could, in the most ordinary way
+available: one red build.
+
+## Decision
+
+**The deploy stage reconciles the VERSION against what has been built, on every cycle, red or
+green.** It no longer promotes a cycle's diff.
+
+Two states per component, re-derived from ground truth on every pass:
+
+```text
+desired(c)  the release the component's newest SUCCEEDED build would cut
+              — OpenChoreo WorkflowRuns · delivery.ReleaseNameFor
+actual(c)   the release its ReleaseBinding pins, and whether that is Ready
+              — ReleaseBinding spec.releaseName + the aggregate Ready condition
+```
+
+and five states over the difference:
+
+| state | condition | the pass |
+|---|---|---|
+| `serving` | pinned = desired, Ready | nothing owed |
+| `behind` | pinned ≠ desired (including no binding) | the only state written to |
+| `converging` | pinned = desired, not Ready yet | waited on |
+| `held` | behind, a hard provider not serving | left alone, named |
+| `unbuilt` | no succeeded build at any commit | left alone |
+
+**Promotable, not green.** This is the answer to "A needs B; A is green, B is red — deploy A?"
+
+```text
+promotable(c) = behind(c) ∧ ∀p ∈ HardConfigEdges[c]: serving(p) ∨ promotable(p)
+```
+
+Anything else behind is `held`, carrying the providers it waits on. The rule is a fixpoint, not one
+pass: a consumer waiting on a provider that is itself held has to fall out too. The edges are read
+over the **whole design** — `spec.HardConfigEdges` already returns exactly that — which is what makes
+a provider with no serving release an unsatisfied edge instead of the assumed-satisfied one that
+published the web app.
+
+`held` and `unbuilt` are not deploy failures and are never waited on. A red build has already minted
+its fix issue; a component nobody has written yet has its development issue open. Filing a deployment
+bug against either would send an agent to debug a deployment that is healthy and has simply not
+happened. Before this, neither state could be named at all: the incident's API was behind for fifty
+minutes and no code path had a word for it.
+
+**Running on a red cycle is the deliberate half.** It is what makes *what is serving* a monotone
+function of what has been built, rather than of cycle luck. The promotable rule is what makes it
+safe: the only components written are ones whose dependencies are met. A provider's DB wiring gets
+exercised in cycle one instead of cycle three.
+
+**Idempotent by construction.** A fully serving version has nothing behind, so a pass writes nothing,
+plans nothing, starts no deadline and never consults the deploy gate. That is the property that lets
+it run every cycle, and it is the one ADR-0019 already engineered into the verb: `EnsureRelease` is
+idempotent by read-back and the binding write is an upsert.
+
+**And the delivery gate asserts it.** `serving(V) := ∀c ∈ design: state(c) = serving`, read fresh at
+the cycle boundary — never carried from the reconcile, because between the two the world may have
+moved and the whole value of the gate is that it asserts what is true now.
+
+```text
+working set empty ∧ serving(V)      mint the validation task · settle succeeded
+working set empty ∧ ¬serving(V)     settle FAILED · version-incomplete, naming each
+                                    component and its state
+working set non-empty               next cycle, as before
+```
+
+By the invariants above the second row should be unreachable — a behind component whose providers are
+met is promoted by the cycle's reconcile, and a failed deployment mints a fix issue that keeps the
+working set non-empty. It exists because the alternative to unreachable is **silent**: the shape it
+replaces settled such a version succeeded and filed a validation task against software that was not
+running. A gate that should never fire is worth having when the thing it catches is
+indistinguishable from success.
+
+## Shape
+
+```text
+agent stage → merge → awaitBuilds(this SHA, PR diff)     unchanged: the CYCLE verdict
+                        any red → build verdict red      (fix issue minted, as before)
+                    ↓
+                    ReadVersionState                     every design component, classified
+                    ↓
+                    reconcileVersion                     runs on EITHER build verdict
+                      plan   := behind ∩ promotable, levelled by hard edges
+                      write  := wave by wave, each at its OWN commit
+                      wait   := promoted ∪ converging, ONE deadline from the first write
+                      converge soft facts over waited ∪ already-serving, no promotion
+                    ↓
+                    cycle result = build verdict × deploy verdict
+```
+
+Three consequences of the shape are worth stating outright:
+
+- **The commit is per component.** `delivery.DeployTarget` pairs each component with the commit its
+  own newest green build was cut from. One commit for a whole list was only ever right when the list
+  was what a single merge built.
+- **The result is a pair folded to a scalar, build verdict first.** A cycle can now be red *and* have
+  a deploy failure. Both mint their work; `lastResult` takes the build verdict because the deploy
+  verdict is downstream of it, and `lastResult` only decides the next cycle's kind and the terminal
+  reason at an empty boundary — where both would name a budget that has already produced its issue.
+- **The converge covers what was already serving, not just what this pass wrote.** Soft facts flow
+  from consumer to provider: promoting a web app in cycle two has to finish the wiring of an API
+  promoted in cycle one. A converge scoped to the pass would leave that API permanently unaware of
+  the SPA it serves.
+
+## Evidence
+
+| Claim | Evidence |
+|---|---|
+| Cycle two's diff named the web app alone | `gh api repos/asdlc-repos/track-each-hire7321/compare/main...aep/m1-c2` — two files, both under the web app |
+| The API had no binding while the version was "delivered" | `kubectl get releasebinding -n default` — no `…-onboarding-api-development` object |
+| The web app knew it was unsatisfied | `releasebinding …-onboarding-webapp-development -o json` → `status.pendingConnections[0].reason` names the missing API |
+| The API's image existed from cycle one | its cycle-one `WorkflowRun` is `WorkflowSucceeded` |
+| A hand-written binding brought it up in ~1 minute | `ComponentRelease` cut through `POST …/generate-release`, binding `Ready=True` |
+| The console had said so all along | the Development column accounts for every design component, and rendered the API as "not deployed" |
+
+The last row is why this ADR adds no console change: the read model was already honest. What was
+wrong was the loop's own predicate, which is the only thing that decides whether a version ships.
+
+## Consequences
+
+- `PollCycleBuilds` stays diff-scoped and SHA-scoped, which is correct for the cycle verdict. It no
+  longer feeds the deploy — `awaitBuilds` answers a verdict and nothing else.
+- `ReadVersionState` is an activity, so the classification lands in workflow history the way the wave
+  plan does: which components were behind, which were held, and what each was waiting on is readable
+  off the run rather than inferred from what the stage went on to write.
+- `RunStatus` carries the last `VersionState` as live status, not as a column. It is a fact about the
+  world; what outlives the run is the terminal reason plus the settle log naming the components.
+- `ReleaseBindingSummary` gains `ReleaseName` and `BuildRunInfo` gains `CommitSHA` + `StartedAt`.
+  Both reads existed; both were one field short of being able to compare desired with actual. The
+  commit is read from the WorkflowRun's own spec, never parsed out of its name —
+  `k8sname.Bounded` truncates a long readable head and appends a digest, so parsing is sound for
+  some projects and silently wrong for others.
+- A deliberate `Undeploy` binding reads as `serving`: nothing is owed. Promoting over it would be the
+  platform overruling the person who asked for it, and refusing to deliver would fail a run over the
+  same decision.
+
+## Cost accepted: in-flight runs do not survive the upgrade
+
+`ReadVersionState` is a new activity call ahead of existing ones, in two places, and three deploy
+activities are renamed. A dev or task run inside its deploy stage when the worker restarts fails on
+non-determinism and stalls as a workflow task failure — not as a settled run. Runs that have not
+reached deploy replay unchanged.
+
+ADR-0019 took the identical edit at the identical cost and deliberately did not reach for
+`workflow.GetVersion`, because that would keep the diff-scoped promote alive for old histories — the
+very code being removed. Deploying this drains rather than migrates: ship it when no dev or task run
+is inside its deploy stage, and cancel the ones that are.
+
+## Not done, deliberately
+
+**Undeploy.** A component removed from the design is not in the reconcile and keeps serving. That is
+a separate decision about withdrawal semantics.
+
+**A converging provider does not satisfy its consumer.** Only a serving release proves an address
+exists, so a consumer whose provider is still rolling out is held and costs one cycle. The
+conservative direction, and rare: within one stage the provider's wave is waited on before the
+consumer's is planned.
+
+**Promotion outside a run.** `ConvergeWatcher` keeps re-asserting only bindings that already exist.
+Moving what is serving under a validation would break the ordering ADR-0017 exists to guarantee, so
+promotion stays the stage's alone.
+
+**Gating the no-cycles ending.** A run whose planning turn minted nothing settles succeeded without
+passing the gate (`onEmptyWorkingSet` case 1). It never dispatched anything, so it claims to have
+delivered nothing; widening the gate to cover it would fail rebuilds of versions whose work is all
+closed. Worth revisiting if a version is ever seen shipping through that path.

--- a/services/aep-api/internal/app/eventcore_adapters.go
+++ b/services/aep-api/internal/app/eventcore_adapters.go
@@ -204,20 +204,17 @@ func (a eventcoreBuilds) StageBuildCredential(ctx context.Context, orgID, projec
 // long-lived component's whole history on every build terminal would cost far
 // more than the two rows the count needs.
 func (a eventcoreBuilds) ListBuildRuns(ctx context.Context, orgID, projectID, component string) ([]eventcore.BuildRun, error) {
-	list, err := a.oc.ListWorkflowRuns(ctx, orgID, projectID, component, 0, "")
+	runs, err := a.oc.ListBuildRuns(ctx, orgID, projectID, component)
 	if err != nil {
 		return nil, err
 	}
-	if list == nil {
-		return nil, nil
-	}
-	out := make([]eventcore.BuildRun, 0, len(list.Items))
-	for _, item := range list.Items {
+	out := make([]eventcore.BuildRun, 0, len(runs))
+	for _, r := range runs {
 		out = append(out, eventcore.BuildRun{
-			Name:      item.Name,
-			Status:    item.Status,
-			Completed: item.Completed,
-			Succeeded: item.Status == openchoreo.ReasonWorkflowSucceeded,
+			Name:      r.Name,
+			Status:    r.Status,
+			Completed: r.Completed,
+			Succeeded: r.Succeeded,
 		})
 	}
 	return out, nil

--- a/services/aep-api/internal/app/run_adapters.go
+++ b/services/aep-api/internal/app/run_adapters.go
@@ -161,19 +161,18 @@ func (a runCycles) Latest(ctx context.Context, orgID, runID string) (*delivery.R
 type runBuilds struct{ oc openchoreo.ComponentClient }
 
 func (a runBuilds) ListBuildRuns(ctx context.Context, orgID, projectID, component string) ([]run.BuildRunInfo, error) {
-	list, err := a.oc.ListWorkflowRuns(ctx, orgID, projectID, component, 0, "")
+	runs, err := a.oc.ListBuildRuns(ctx, orgID, projectID, component)
 	if err != nil {
 		return nil, err
 	}
-	if list == nil {
-		return nil, nil
-	}
-	out := make([]run.BuildRunInfo, 0, len(list.Items))
-	for _, item := range list.Items {
+	out := make([]run.BuildRunInfo, 0, len(runs))
+	for _, r := range runs {
 		out = append(out, run.BuildRunInfo{
-			Name:      item.Name,
-			Terminal:  item.Completed,
-			Succeeded: item.Status == openchoreo.ReasonWorkflowSucceeded,
+			Name:      r.Name,
+			Terminal:  r.Completed,
+			Succeeded: r.Succeeded,
+			CommitSHA: r.CommitSHA,
+			StartedAt: r.StartedAt,
 		})
 	}
 	return out, nil

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -1279,40 +1279,72 @@ func (c *componentClient) ListWorkflowRuns(ctx context.Context, orgName, project
 		fmt.Sprintf("%s=%s", string(LabelKeyComponent), scopedComp), limit, cursor)
 }
 
-// ListBuildRuns lists a component's WorkflowRuns with the commit each one
-// built. It takes the host's default page for the reason the re-trigger count
-// does: the runs a decision turns on are the newest a component has, and paging
-// a long-lived component's whole history on every poll would cost far more than
-// the handful of rows the answer needs.
+// ListBuildRuns lists a component's build WorkflowRuns with the commit each one
+// built, FOLLOWING PAGINATION to the end.
+//
+// Every page, not the first, and that is a correctness requirement rather than
+// thoroughness. The caller picks the newest SUCCEEDED run to decide which
+// release a component should be serving, and this list is paged with Kubernetes
+// continuation tokens: a page is a slice of the collection in the API server's
+// own order, so a newer green run can sit on a later page. Reading one page
+// would then name an older release as the desired one — and the deploy stage
+// would faithfully promote the component BACKWARDS onto it.
+//
+// The cost is bounded by the page size rather than by the component's history
+// being small: one round trip per buildRunPageSize runs, once per version-state
+// read. The re-trigger budget's own read (eventcore) is a different question —
+// it counts attempts at ONE commit, which are always among the newest runs — and
+// it is free to keep taking the first page.
 func (c *componentClient) ListBuildRuns(ctx context.Context, orgName, projectName, componentName string) ([]BuildRunSummary, error) {
 	scopedComp := ScopedComponentName(projectName, componentName)
 	sel := ocgen.LabelSelectorParam(fmt.Sprintf("%s=%s", string(LabelKeyComponent), scopedComp))
-	resp, err := c.oc.ListWorkflowRunsWithResponse(ctx, orgName, &ocgen.ListWorkflowRunsParams{LabelSelector: &sel})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list workflow runs: %w", err)
+	limit := ocgen.LimitParam(buildRunPageSize)
+	params := &ocgen.ListWorkflowRunsParams{LabelSelector: &sel, Limit: &limit}
+
+	var out []BuildRunSummary
+	for {
+		resp, err := c.oc.ListWorkflowRunsWithResponse(ctx, orgName, params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list workflow runs: %w", err)
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return nil, handleErrorResponse(resp.StatusCode(), ErrorResponses{
+				JSON400: resp.JSON400,
+				JSON401: resp.JSON401,
+				JSON403: resp.JSON403,
+				JSON500: resp.JSON500,
+			})
+		}
+		for _, run := range resp.JSON200.Items {
+			model := workflowRunToModel(run)
+			out = append(out, BuildRunSummary{
+				Name:      model.Name,
+				Status:    model.Status,
+				Completed: model.Completed,
+				Succeeded: model.Status == ReasonWorkflowSucceeded,
+				CommitSHA: buildRunCommit(run),
+				StartedAt: derefTime(run.Metadata.CreationTimestamp),
+			})
+		}
+		next := resp.JSON200.Pagination.NextCursor
+		if next == nil || *next == "" {
+			return out, nil
+		}
+		// A non-advancing cursor would spin this loop forever — fail instead,
+		// exactly as the release-binding listing does.
+		if params.Cursor != nil && *next == string(*params.Cursor) {
+			return nil, fmt.Errorf("list workflow runs for %q: pagination did not advance (cursor %q)",
+				componentName, *next)
+		}
+		cur := ocgen.CursorParam(*next)
+		params.Cursor = &cur
 	}
-	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-		return nil, handleErrorResponse(resp.StatusCode(), ErrorResponses{
-			JSON400: resp.JSON400,
-			JSON401: resp.JSON401,
-			JSON403: resp.JSON403,
-			JSON500: resp.JSON500,
-		})
-	}
-	out := make([]BuildRunSummary, 0, len(resp.JSON200.Items))
-	for _, run := range resp.JSON200.Items {
-		model := workflowRunToModel(run)
-		out = append(out, BuildRunSummary{
-			Name:      model.Name,
-			Status:    model.Status,
-			Completed: model.Completed,
-			Succeeded: model.Status == ReasonWorkflowSucceeded,
-			CommitSHA: buildRunCommit(run),
-			StartedAt: derefTime(run.Metadata.CreationTimestamp),
-		})
-	}
-	return out, nil
 }
+
+// buildRunPageSize is how many WorkflowRuns one page of the build listing asks
+// for. Large enough that an ordinary component's whole history arrives in a
+// single round trip, small enough that one response stays a sensible size.
+const buildRunPageSize = 100
 
 // buildRunCommit reads back the commit the trigger pinned the run to —
 // `spec.workflow.parameters.repository.revision.commit`, the exact path

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -152,6 +152,18 @@ type ComponentClient interface {
 	// See TriggerBuild for the `runName` + `secretRef` contracts.
 	TriggerBuildAtCommit(ctx context.Context, orgName, projectName, componentName, commitSHA, secretRef, runName string) (*gen.WorkflowRun, error)
 	ListWorkflowRuns(ctx context.Context, orgName, projectName, componentName string, limit int, cursor string) (*gen.WorkflowRunList, error)
+	// ListBuildRuns is the same read reduced to the facts the milestone loop
+	// decides on: the run's name, whether it is terminal, whether it succeeded,
+	// and the COMMIT it built.
+	//
+	// It exists beside ListWorkflowRuns because the two answer different
+	// audiences. That one returns the served contract model, which the console
+	// renders; this one returns the commit, which the contract does not carry and
+	// which both halves of the loop need — the event plane to count a commit's
+	// attempts, the supervisor to learn which release a component's newest green
+	// build should be serving. Mapping OpenChoreo's condition vocabulary once,
+	// here, is what keeps two adapters from spelling "succeeded" differently.
+	ListBuildRuns(ctx context.Context, orgName, projectName, componentName string) ([]BuildRunSummary, error)
 	// ListProjectWorkflowRuns is the same read widened to every component in
 	// the project — one call instead of one per component. The run read uses it
 	// to derive a cycle's builds from its merge SHA without first having to
@@ -1064,6 +1076,7 @@ func releaseBindingSummary(rb ocgen.ReleaseBinding) ReleaseBindingSummary {
 		componentName = rb.Spec.Owner.ComponentName
 		s.Environment = rb.Spec.Environment
 		s.Undeploy = rb.Spec.State != nil && *rb.Spec.State == ocgen.ReleaseBindingSpecStateUndeploy
+		s.ReleaseName = derefStr(rb.Spec.ReleaseName)
 	}
 	s.ComponentName = FriendlyComponentName(componentName, projectName)
 	if rb.Status != nil && rb.Status.Conditions != nil {
@@ -1264,6 +1277,66 @@ func (c *componentClient) ListWorkflowRuns(ctx context.Context, orgName, project
 	scopedComp := ScopedComponentName(projectName, componentName)
 	return c.listWorkflowRunsBySelector(ctx, orgName,
 		fmt.Sprintf("%s=%s", string(LabelKeyComponent), scopedComp), limit, cursor)
+}
+
+// ListBuildRuns lists a component's WorkflowRuns with the commit each one
+// built. It takes the host's default page for the reason the re-trigger count
+// does: the runs a decision turns on are the newest a component has, and paging
+// a long-lived component's whole history on every poll would cost far more than
+// the handful of rows the answer needs.
+func (c *componentClient) ListBuildRuns(ctx context.Context, orgName, projectName, componentName string) ([]BuildRunSummary, error) {
+	scopedComp := ScopedComponentName(projectName, componentName)
+	sel := ocgen.LabelSelectorParam(fmt.Sprintf("%s=%s", string(LabelKeyComponent), scopedComp))
+	resp, err := c.oc.ListWorkflowRunsWithResponse(ctx, orgName, &ocgen.ListWorkflowRunsParams{LabelSelector: &sel})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workflow runs: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON400: resp.JSON400,
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON500: resp.JSON500,
+		})
+	}
+	out := make([]BuildRunSummary, 0, len(resp.JSON200.Items))
+	for _, run := range resp.JSON200.Items {
+		model := workflowRunToModel(run)
+		out = append(out, BuildRunSummary{
+			Name:      model.Name,
+			Status:    model.Status,
+			Completed: model.Completed,
+			Succeeded: model.Status == ReasonWorkflowSucceeded,
+			CommitSHA: buildRunCommit(run),
+			StartedAt: derefTime(run.Metadata.CreationTimestamp),
+		})
+	}
+	return out, nil
+}
+
+// buildRunCommit reads back the commit the trigger pinned the run to —
+// `spec.workflow.parameters.repository.revision.commit`, the exact path
+// injectCommitSHA writes.
+//
+// Read from the spec rather than parsed out of the run's NAME, which also
+// embeds a short commit: that name is composed through k8sname.Bounded, which
+// truncates a long readable head and appends a digest, so the commit is not
+// recoverable from it for every project and component. A build triggered
+// without a pinned commit (a manual build of the branch tip) answers "".
+func buildRunCommit(run ocgen.WorkflowRun) string {
+	if run.Spec == nil || run.Spec.Workflow.Parameters == nil {
+		return ""
+	}
+	repo, ok := (*run.Spec.Workflow.Parameters)["repository"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	rev, ok := repo["revision"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	commit, _ := rev["commit"].(string)
+	return commit
 }
 
 func (c *componentClient) ListProjectWorkflowRuns(ctx context.Context, orgName, projectName string, limit int, cursor string) (*gen.WorkflowRunList, error) {

--- a/services/aep-api/internal/clients/openchoreo/component_client_build_runs_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client_build_runs_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package openchoreo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ListBuildRuns is the read behind "which release should this component be
+// serving": the caller picks the newest SUCCEEDED run and derives the release
+// name from its commit. That makes PAGINATION a correctness property rather
+// than a nicety — the list is paged with Kubernetes continuation tokens, so a
+// newer green run can sit on a later page, and a reader that stops at the first
+// page names an older release as the desired one and promotes the component
+// backwards onto it.
+
+// buildRun is one WorkflowRun document. Authored as a document rather than the
+// typed model because the fixture's POINT is where the commit lives —
+// `spec.workflow.parameters.repository.revision.commit`, the exact path the
+// trigger writes — which no typed field on the summary carries.
+func buildRun(name, commit, reason string, created string) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
+			"name":              name,
+			"creationTimestamp": created,
+			"labels":            map[string]any{string(LabelKeyComponent): "widgets-order-service"},
+		},
+		"spec": map[string]any{
+			"workflow": map[string]any{
+				"name": "dockerfile-builder",
+				"parameters": map[string]any{
+					"repository": map[string]any{
+						"revision": map[string]any{"commit": commit},
+					},
+				},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":               WorkflowConditionCompleted,
+					"status":             "True",
+					"reason":             reason,
+					"lastTransitionTime": created,
+				},
+			},
+		},
+	}
+}
+
+// serveBuildRunPages answers each successive workflowruns request with the next
+// page, handing out a cursor until the pages run out. It also records the
+// cursor it was given, so a test can assert the client actually followed it
+// rather than re-requesting the first page.
+func serveBuildRunPages(t *testing.T, pages ...[]map[string]any) (*httptest.Server, *[]string) {
+	t.Helper()
+	cursors := make([]string, 0, len(pages))
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/workflowruns") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		cursors = append(cursors, r.URL.Query().Get("cursor"))
+		if page >= len(pages) {
+			t.Fatalf("client asked for page %d of %d", page+1, len(pages))
+		}
+		body := map[string]any{"items": pages[page], "pagination": map[string]any{}}
+		if page < len(pages)-1 {
+			body["pagination"] = map[string]any{"nextCursor": "cursor-" + string(rune('a'+page))}
+		}
+		page++
+		writeJSON(t, w, http.StatusOK, body)
+	}))
+	return srv, &cursors
+}
+
+// The failure this closes: the newest green build is on page two, so a
+// single-page read would call the OLDER release the desired one — and the
+// deploy stage would promote the component backwards onto it.
+func TestListBuildRuns_FollowsPaginationToTheNewestRun(t *testing.T) {
+	srv, cursors := serveBuildRunPages(t,
+		[]map[string]any{
+			buildRun("widgets-order-service-aaa1-1", "aaa1", ReasonWorkflowSucceeded, "2026-09-01T10:00:00Z"),
+		},
+		[]map[string]any{
+			buildRun("widgets-order-service-bbb2-1", "bbb2", ReasonWorkflowSucceeded, "2026-09-01T11:00:00Z"),
+			buildRun("widgets-order-service-ccc3-1", "ccc3", "WorkflowFailed", "2026-09-01T12:00:00Z"),
+		},
+	)
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListBuildRuns(context.Background(), "org", "widgets", "order-service")
+	if err != nil {
+		t.Fatalf("ListBuildRuns: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want every run across both pages, got %d: %+v", len(got), got)
+	}
+	if len(*cursors) != 2 || (*cursors)[0] != "" || (*cursors)[1] == "" {
+		t.Fatalf("the second request did not carry the first page's cursor: %v", *cursors)
+	}
+	// The commit is read from the run's own spec, and the terminal verdict from
+	// its Completed condition's reason — both of which decide which release the
+	// caller names as desired.
+	newest := got[1]
+	if newest.CommitSHA != "bbb2" || !newest.Succeeded || !newest.Completed {
+		t.Errorf("page-two run lost its facts: %+v", newest)
+	}
+	if got[2].Succeeded {
+		t.Errorf("a failed run must not read as succeeded: %+v", got[2])
+	}
+	if newest.StartedAt.IsZero() {
+		t.Error("StartedAt is empty, so two green builds cannot be ordered")
+	}
+}
+
+// A cursor that does not advance would spin the loop forever. Failing is the
+// only safe answer: this read is on the path of every deploy decision, and a
+// hung activity is indistinguishable from a slow one.
+func TestListBuildRuns_RefusesANonAdvancingCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, map[string]any{
+			"items":      []any{buildRun("widgets-order-service-aaa1-1", "aaa1", ReasonWorkflowSucceeded, "2026-09-01T10:00:00Z")},
+			"pagination": map[string]any{"nextCursor": "stuck"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	_, err := c.ListBuildRuns(context.Background(), "org", "widgets", "order-service")
+	if err == nil {
+		t.Fatal("a cursor that repeats itself was accepted; the loop would never end")
+	}
+	if !strings.Contains(err.Error(), "pagination did not advance") {
+		t.Errorf("the error does not name the cause: %v", err)
+	}
+}
+
+// A build triggered without a pinned commit (a manual build of the branch tip)
+// names no release the platform could pin, and the caller skips it. It must not
+// arrive as a parse error or as somebody else's commit.
+func TestListBuildRuns_AnUnpinnedBuildHasNoCommit(t *testing.T) {
+	run := buildRun("widgets-order-service-manual-1", "", ReasonWorkflowSucceeded, "2026-09-01T10:00:00Z")
+	spec := run["spec"].(map[string]any)
+	spec["workflow"] = map[string]any{"name": "dockerfile-builder"}
+	srv, _ := serveBuildRunPages(t, []map[string]any{run})
+	defer srv.Close()
+
+	c := NewComponentClient(Config{BaseURL: srv.URL})
+	got, err := c.ListBuildRuns(context.Background(), "org", "widgets", "order-service")
+	if err != nil {
+		t.Fatalf("ListBuildRuns: %v", err)
+	}
+	if len(got) != 1 || got[0].CommitSHA != "" {
+		t.Fatalf("want one run with no commit, got %+v", got)
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/component_types.go
+++ b/services/aep-api/internal/clients/openchoreo/component_types.go
@@ -232,8 +232,37 @@ type ReleaseBindingSummary struct {
 	// ReadyReason is the Ready-typed condition's reason (OC copies the
 	// failing sub-condition's reason into the aggregate).
 	ReadyReason string
+	// ReleaseName is the ComponentRelease the binding PINS (spec.releaseName),
+	// "" when it pins none.
+	//
+	// It is what separates "this component is serving the release it should be"
+	// from "this component is serving an older one": Ready alone says only that
+	// whatever is pinned came up, and a version behind by one release is Ready
+	// and wrong. The run supervisor compares it against the release the
+	// component's newest succeeded build would cut (delivery.ReleaseNameFor).
+	ReleaseName string
 }
 
 // -- ComponentOpenAPI (Test tab) ----------------------------------------------
+
+// BuildRunSummary is one build WorkflowRun reduced to the facts the milestone
+// loop decides on, with OpenChoreo's condition vocabulary already mapped.
+//
+// Status is carried verbatim beside the two booleans because OC's status is a
+// condition REASON — an open string, not a closed set — so it is display and
+// logging material, while Completed and Succeeded are what anything branches on.
+type BuildRunSummary struct {
+	Name      string
+	Status    string
+	Completed bool
+	Succeeded bool
+	// CommitSHA is the commit the run was pinned to, "" for a build of whatever
+	// the branch tip was.
+	CommitSHA string
+	// StartedAt is the run's creation timestamp — what orders two succeeded
+	// builds of the same component. The list is not ordered by the host, so
+	// "the newest green build" has to be decided on a fact the run carries.
+	StartedAt time.Time
+}
 
 // -- Build Logs ---------------------------------------------------------------

--- a/services/aep-api/internal/clients/openchoreo/helpers.go
+++ b/services/aep-api/internal/clients/openchoreo/helpers.go
@@ -43,6 +43,15 @@ func derefTimeRFC3339(t *time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
+// derefTime returns *t, or the zero Time if t is nil — for the callers that
+// order objects by when the cluster admitted them rather than render a date.
+func derefTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
 // annotation reads key from a pointer-to-map without panicking on nil.
 // Annotations are `*map[string]string` on every gen ObjectMeta.
 func annotation(ann *map[string]string, key string) string {

--- a/services/aep-api/internal/clients/openchoreo/mocks/component_client_mock.go
+++ b/services/aep-api/internal/clients/openchoreo/mocks/component_client_mock.go
@@ -54,6 +54,9 @@ var _ openchoreo.ComponentClient = &ComponentClientMock{}
 //			GetWorkflowRunFunc: func(ctx context.Context, orgName string, runName string) (*gen.WorkflowRun, error) {
 //				panic("mock out the GetWorkflowRun method")
 //			},
+//			ListBuildRunsFunc: func(ctx context.Context, orgName string, projectName string, componentName string) ([]openchoreo.BuildRunSummary, error) {
+//				panic("mock out the ListBuildRuns method")
+//			},
 //			ListComponentsFunc: func(ctx context.Context, orgName string, projectName string, limit int, cursor string) (*gen.ComponentList, error) {
 //				panic("mock out the ListComponents method")
 //			},
@@ -120,6 +123,9 @@ type ComponentClientMock struct {
 
 	// GetWorkflowRunFunc mocks the GetWorkflowRun method.
 	GetWorkflowRunFunc func(ctx context.Context, orgName string, runName string) (*gen.WorkflowRun, error)
+
+	// ListBuildRunsFunc mocks the ListBuildRuns method.
+	ListBuildRunsFunc func(ctx context.Context, orgName string, projectName string, componentName string) ([]openchoreo.BuildRunSummary, error)
 
 	// ListComponentsFunc mocks the ListComponents method.
 	ListComponentsFunc func(ctx context.Context, orgName string, projectName string, limit int, cursor string) (*gen.ComponentList, error)
@@ -277,6 +283,17 @@ type ComponentClientMock struct {
 			// RunName is the runName argument value.
 			RunName string
 		}
+		// ListBuildRuns holds details about calls to the ListBuildRuns method.
+		ListBuildRuns []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OrgName is the orgName argument value.
+			OrgName string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// ComponentName is the componentName argument value.
+			ComponentName string
+		}
 		// ListComponents holds details about calls to the ListComponents method.
 		ListComponents []struct {
 			// Ctx is the ctx argument value.
@@ -404,6 +421,7 @@ type ComponentClientMock struct {
 	lockGetComponent                           sync.RWMutex
 	lockGetReleaseBindingStatus                sync.RWMutex
 	lockGetWorkflowRun                         sync.RWMutex
+	lockListBuildRuns                          sync.RWMutex
 	lockListComponents                         sync.RWMutex
 	lockListDeployments                        sync.RWMutex
 	lockListInternalComponents                 sync.RWMutex
@@ -908,6 +926,50 @@ func (mock *ComponentClientMock) GetWorkflowRunCalls() []struct {
 	mock.lockGetWorkflowRun.RLock()
 	calls = mock.calls.GetWorkflowRun
 	mock.lockGetWorkflowRun.RUnlock()
+	return calls
+}
+
+// ListBuildRuns calls ListBuildRunsFunc.
+func (mock *ComponentClientMock) ListBuildRuns(ctx context.Context, orgName string, projectName string, componentName string) ([]openchoreo.BuildRunSummary, error) {
+	if mock.ListBuildRunsFunc == nil {
+		panic("ComponentClientMock.ListBuildRunsFunc: method is nil but ComponentClient.ListBuildRuns was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		OrgName       string
+		ProjectName   string
+		ComponentName string
+	}{
+		Ctx:           ctx,
+		OrgName:       orgName,
+		ProjectName:   projectName,
+		ComponentName: componentName,
+	}
+	mock.lockListBuildRuns.Lock()
+	mock.calls.ListBuildRuns = append(mock.calls.ListBuildRuns, callInfo)
+	mock.lockListBuildRuns.Unlock()
+	return mock.ListBuildRunsFunc(ctx, orgName, projectName, componentName)
+}
+
+// ListBuildRunsCalls gets all the calls that were made to ListBuildRuns.
+// Check the length with:
+//
+//	len(mockedComponentClient.ListBuildRunsCalls())
+func (mock *ComponentClientMock) ListBuildRunsCalls() []struct {
+	Ctx           context.Context
+	OrgName       string
+	ProjectName   string
+	ComponentName string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		OrgName       string
+		ProjectName   string
+		ComponentName string
+	}
+	mock.lockListBuildRuns.RLock()
+	calls = mock.calls.ListBuildRuns
+	mock.lockListBuildRuns.RUnlock()
 	return calls
 }
 

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -159,13 +159,15 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   `ended_at IS NULL`: usage arrives from the terminal-log capture, and a cycle closes on the merge webhook
   seconds after its Job exits — fencing it would discard nearly every capture. Entries are keyed
   `(source, source_id)`, so a re-read of the same log updates one entry rather than adding a second.
-- The **deploy stage** (`run`): once a cycle's builds are green, the supervisor cuts each touched
-  component's release from the Workload its build posted, writes the binding that pins it — release
-  pin, trait env configs and workload overrides in ONE object write — and waits for every binding to
-  report Ready before the cycle is green. Components carry `autoDeploy: false`, so nothing else
-  promotes a release. It promotes WAVE BY WAVE (providers before the consumers whose start-up config
-  carries their address) and finishes with one converge for the facts that flow the other way — see
-  the invariant below and ADR-0019.
+- The **deploy stage** (`run`): every cycle, red or green, the supervisor RECONCILES THE VERSION. It
+  reads every component the design declares, compares the release its newest succeeded build would
+  cut against the release its binding pins, and promotes the difference — cutting each release from
+  the Workload that build posted and writing the binding that pins it, release pin plus trait env
+  configs plus workload overrides in ONE object write — then waits for Ready. Components carry
+  `autoDeploy: false`, so nothing else promotes a release. It promotes WAVE BY WAVE (providers before
+  the consumers whose start-up config carries their address), holds a component whose provider is not
+  serving, and finishes with one converge for the facts that flow the other way — see the invariants
+  below, ADR-0019 and ADR-0026.
 - The **run loop** (`run`): one Temporal workflow per SPECIES per milestone —
   `<kind>-<org>-<project>-<milestoneNumber>`, whose id is REUSED after a terminal run because a
   milestone sees sequential runs of one kind across its life. `dev` and `task` are the same cycle loop
@@ -433,9 +435,27 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   without committing a report at all, which proves nothing about the software and is a breach of the
   runner contract. `ValidationVerdictFailsRun` / `IsValidationTerminalReason` are the executable copy of
   that pair. A run that settles for a reason outside this list is a bug in the loop, not a new state.
+- **The deploy set is the VERSION's, not the cycle's** (ADR-0026). `desired(c)` is the release
+  `c`'s newest SUCCEEDED build would cut; `actual(c)` is what its binding pins and whether that is
+  Ready; the difference classifies every design component as `serving`, `behind`, `converging`,
+  `held` or `unbuilt`, and only `behind` is ever written to. A component is promoted when it is
+  behind AND every hard provider is serving or promoted ahead of it in the same pass — otherwise it
+  is `held`, which is neither waited on nor filed against. This runs on a RED cycle too: a red build
+  has already minted its fix issue, and its green siblings are still built. What it replaced promoted
+  the cycle's path diff, which made "what is serving" a function of which files a fix touched — one
+  version shipped with its API never promoted at all, because the cycle that built it was red and no
+  later cycle's diff mentioned it again. A fully serving version reconciles in one read and zero
+  writes, which is what lets the pass run every cycle.
+- **A version is delivered when it is SERVING, asserted rather than inferred.** The boundary re-reads
+  the version state and requires every design component `serving` before it mints the validation task;
+  anything else settles `version-incomplete` naming what was not. "Deployed-green" used to be inferred
+  from an empty working set plus a green last cycle — neither of which is a statement about a component
+  the cycles never touched. By the loop's own invariants the failure should be unreachable, which is
+  exactly why it must be loud rather than silent.
 - **A cycle is green when its components are DEPLOYED, not built.** The supervisor performs the
-  promote itself — `EnsureRelease` at the merge commit, then one `ApplyReleaseBinding` carrying the
-  pin and the wiring together — and then waits on each binding's Ready condition. While OpenChoreo's
+  promote itself — `EnsureRelease` at each component's own commit, then one `ApplyReleaseBinding`
+  carrying the pin and the wiring together — and then waits on each binding's Ready condition. While
+  OpenChoreo's
   AutoDeploy promoted releases on its own, a green WorkflowRun meant a deployment had been ASKED for:
   the chain was kicked off from inside the build and reconciled afterwards with no link back to the
   cycle that caused it. Everything downstream depended on the weaker fact — validation asserted
@@ -444,7 +464,9 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
   component's own start-up config — a web app reads its backend's out of `window._env_` and throws at
   module load without it, so publishing the SPA alongside its backend serves a blank page. Those edges
   (`spec.HardConfigEdges`) put the provider in an earlier wave, and each wave must be Ready before the
-  next is promoted. What flows the other way is SOFT — a protected API's CORS allowlist is the
+  next is promoted. The edges are read over the WHOLE design rather than over the set being deployed,
+  so a provider with no serving release is an unsatisfied edge rather than an assumed-satisfied one
+  (ADR-0026 — the reading that published a SPA against an API that had never deployed). What flows the other way is SOFT — a protected API's CORS allowlist is the
   project's SPA origins, an OIDC resource wants the SPA's callback registered — and is written by ONE
   converge at the end, which passes an EMPTY commit so it re-asserts wiring without re-cutting a
   release. Grading them together is what made the graph look circular: the SPA needs the API's

--- a/services/aep-api/internal/delivery/build_fanout.go
+++ b/services/aep-api/internal/delivery/build_fanout.go
@@ -193,12 +193,20 @@ var ErrProvisionPermanent = errors.New("permanent provision failure")
 type ComponentDeploy struct {
 	Component   string `json:"component"`
 	Environment string `json:"environment"`
-	// Release is the ComponentRelease this deployment pinned. Empty on a read
-	// that only observed the binding.
+	// Release is the ComponentRelease this deployment pins — the release a
+	// promote just wrote, or the one a READ found on the binding. Empty when the
+	// binding does not exist yet, and on a converge, which deliberately moves no
+	// pin.
 	Release string `json:"release,omitempty"`
 	// Ready is the binding's aggregate Ready condition being True (or the
 	// component being deliberately undeployed).
 	Ready bool `json:"ready"`
+	// Undeploy is spec.state == Undeploy: somebody took this component out of
+	// the environment on purpose. It rides beside Ready, which it also sets,
+	// because the two mean opposite things to a RECONCILE — "it is up" versus
+	// "nothing is owed here" — and a pass that could not tell them apart would
+	// promote a release over a deliberate withdrawal.
+	Undeploy bool `json:"undeploy,omitempty"`
 	// Failed is Ready=False — a verdict, not a wait.
 	Failed bool `json:"failed,omitempty"`
 	// Reason is OpenChoreo's own condition reason, carried verbatim for the

--- a/services/aep-api/internal/delivery/eventcore/mint.go
+++ b/services/aep-api/internal/delivery/eventcore/mint.go
@@ -88,10 +88,16 @@ func (e *Events) mintFixIssue(ctx context.Context, run *delivery.MilestoneRun, e
 // The dedupe key is (component, commit): a redeploy of the same commit that
 // fails the same way finds the open issue and files nothing, while the next
 // version's failure is genuinely new work.
+//
+// The commit rides each FAILURE rather than the call, because one reconcile pass
+// promotes each component at its own newest green build (delivery.DeployTarget):
+// a single commit for the whole list would key at least one issue against a
+// commit that component was never built at.
 func (e *Events) MintDeployFixIssues(ctx context.Context, orgID, projectID string, milestoneNumber int,
-	components []string, reasons map[string]string, commitSHA string) ([]int, error) {
-	filed := make([]int, 0, len(components))
-	for _, component := range components {
+	failed []delivery.DeployTarget, reasons map[string]string) ([]int, error) {
+	filed := make([]int, 0, len(failed))
+	for _, target := range failed {
+		component, commitSHA := target.Component, target.CommitSHA
 		reason := reasons[component]
 		body := fmt.Sprintf(
 			"Component **%s** built successfully at merge commit `%s`, but its deployment never became ready. "+

--- a/services/aep-api/internal/delivery/milestone_run.go
+++ b/services/aep-api/internal/delivery/milestone_run.go
@@ -115,12 +115,25 @@ const (
 	// two send a human to different places: a red build is code that did not
 	// compile, while this is code that compiled and would not run — a bad image,
 	// an unrenderable trait, a missing dependency at runtime.
-	RunReasonDeployBudget     = "deploy-budget"
-	RunReasonFixChainBudget   = "fix-chain-budget"
-	RunReasonConflictBudget   = "conflict-budget"
-	RunReasonNoProgress       = "no-progress"
-	RunReasonCycleCeiling     = "cycle-ceiling"
-	RunReasonValidationFailed = "validation-failed"
+	RunReasonDeployBudget = "deploy-budget"
+	// RunReasonVersionIncomplete — the milestone has no work left, and the
+	// version is still not serving. Every component that is not serving is named
+	// in the settle log and on the run's live status (ADR-0026).
+	//
+	// By the loop's own invariants it should be unreachable: a component that is
+	// behind and whose providers are met is promoted by the cycle's reconcile,
+	// and one whose deployment failed mints a fix issue that keeps the working
+	// set non-empty. It exists because the alternative to being unreachable is
+	// being SILENT — the shape it replaces settled such a version `succeeded`,
+	// minted its validation task and closed the increment with an API nothing had
+	// ever bound. A gate that should never fire is worth having when the thing it
+	// catches is indistinguishable from success.
+	RunReasonVersionIncomplete = "version-incomplete"
+	RunReasonFixChainBudget    = "fix-chain-budget"
+	RunReasonConflictBudget    = "conflict-budget"
+	RunReasonNoProgress        = "no-progress"
+	RunReasonCycleCeiling      = "cycle-ceiling"
+	RunReasonValidationFailed  = "validation-failed"
 	// RunReasonValidationUnreported is its own failure class, distinct from
 	// validation-failed: the suite going red and the agent delivering no report at
 	// all are different explanations, and a terminal reason exists to explain.

--- a/services/aep-api/internal/delivery/run/activities.go
+++ b/services/aep-api/internal/delivery/run/activities.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sort"
 
 	"go.temporal.io/sdk/temporal"
 
@@ -514,71 +515,152 @@ func (a *Activities) CheckDeployReadiness(ctx context.Context, in ProjectRef) (D
 	return DeployGateVerdict{Unconfigured: unconfigured, Provisioning: provisioning}, nil
 }
 
-// DeployCycleInput promotes the components a cycle's merge touched, at the
-// commit it merged.
-type DeployCycleInput struct {
-	OrgID      string   `json:"orgId"`
-	ProjectID  string   `json:"projectId"`
-	Components []string `json:"components"`
-	CommitSHA  string   `json:"commitSha"`
+// ReadVersionState classifies EVERY component in the design against what has
+// been built and what is deployed — the read behind both the reconcile and the
+// delivery gate (ADR-0026).
+//
+// One activity rather than three, so the classification lands in workflow
+// history the way the wave plan does: which components were behind, which were
+// held and what each was waiting on is then readable off the run rather than
+// inferred from what the stage went on to write.
+//
+// Unwired degrades to an EMPTY state, which reads as serving — the same answer
+// DeployCycle's missing deployer gives, and for the same reason: a plane with no
+// OpenChoreo behind it must not have its runs fail on a gate that has nothing to
+// gate.
+func (a *Activities) ReadVersionState(ctx context.Context, in ProjectRef) (delivery.VersionState, error) {
+	if a.design == nil || a.builds == nil || a.deployRead == nil {
+		return delivery.VersionState{}, nil
+	}
+	paths, err := a.design.ComponentPaths(ctx, in.OrgID, in.ProjectID)
+	if err != nil {
+		return delivery.VersionState{}, sourceControlErr(err)
+	}
+	// Sorted, because the map's iteration order is random and this list decides
+	// the order of every promote, log line and issue that follows. The waves
+	// re-order it by the design's edges; within a wave it is this order.
+	components := make([]string, 0, len(paths))
+	for name := range paths {
+		components = append(components, name)
+	}
+	sort.Strings(components)
+
+	builds := make(map[string][]BuildRunInfo, len(components))
+	for _, name := range components {
+		runs, lerr := a.builds.ListBuildRuns(ctx, in.OrgID, in.ProjectID, name)
+		if lerr != nil {
+			return delivery.VersionState{}, lerr
+		}
+		builds[name] = runs
+	}
+	states, err := a.deployRead.DeploymentState(ctx, in.OrgID, in.ProjectID, components)
+	if err != nil {
+		return delivery.VersionState{}, deployErr(err)
+	}
+	deploys := make(map[string]delivery.ComponentDeploy, len(states))
+	for _, st := range states {
+		deploys[st.Component] = st
+	}
+
+	out := versionState(in.ProjectID, components, builds, deploys)
+	// Logged like the wave plan, and for the same reason: what is serving is the
+	// premise every later decision rests on, and the symptom of getting it wrong
+	// appears in a browser rather than anywhere near this code.
+	serving, total := out.ServingCount()
+	slog.InfoContext(ctx, "run: version state read",
+		"orgID", in.OrgID, "projectID", in.ProjectID,
+		"serving", serving, "components", total, "notServing", out.Describe())
+	return out, nil
 }
 
-// DeployCycle promotes each of the cycle's components: cut the release from the
-// Workload its build posted, then write the binding that pins it — wiring and
-// pin in one object write.
+// PromoteInput promotes each target at its own commit — one wave of a plan, or
+// the stage's closing converge.
+type PromoteInput struct {
+	OrgID     string                  `json:"orgId"`
+	ProjectID string                  `json:"projectId"`
+	Targets   []delivery.DeployTarget `json:"targets"`
+}
+
+// PromoteWave promotes one wave: cut each component's release from the Workload
+// its build posted, then write the binding that pins it — wiring and pin in one
+// object write.
+//
+// Each target carries its OWN commit, which is what makes this a reconcile
+// rather than a cycle deploy: a pass promotes every behind component at the
+// commit its newest green build was cut from, and those differ. A target with
+// an empty commit CONVERGES — no release is re-cut and no component's live
+// release moves.
 //
 // Degrades to "nothing to do" when unwired, like the other optional
 // collaborators. That is a real configuration (a plane with no OpenChoreo
 // behind it), not a failed run — but note what it means for the loop: with no
-// deployer, a cycle's components never become Ready and the stage reports them
-// all deployed, which is the same answer the loop gave before it had a deploy
-// stage at all.
-func (a *Activities) DeployCycle(ctx context.Context, in DeployCycleInput) ([]delivery.ComponentDeploy, error) {
-	if a.deployer == nil || len(in.Components) == 0 {
+// deployer nothing ever becomes Ready and the stage reports everything
+// deployed, which is the same answer the loop gave before it had a deploy stage
+// at all.
+func (a *Activities) PromoteWave(ctx context.Context, in PromoteInput) ([]delivery.ComponentDeploy, error) {
+	if a.deployer == nil || len(in.Targets) == 0 {
 		return nil, nil
 	}
-	out, err := a.deployer.Deploy(ctx, in.OrgID, in.ProjectID, in.Components, in.CommitSHA)
+	out, err := a.deployer.Deploy(ctx, in.OrgID, in.ProjectID, in.Targets)
 	if err != nil {
 		// Logged as well as returned: Temporal retries this activity, and the
 		// per-attempt cause is otherwise only visible in workflow history.
 		slog.ErrorContext(ctx, "run: deploy failed",
-			"orgID", in.OrgID, "projectID", in.ProjectID, "components", in.Components, "error", err)
+			"orgID", in.OrgID, "projectID", in.ProjectID,
+			"targets", delivery.TargetNames(in.Targets), "error", err)
 		return nil, deployErr(err)
 	}
 	return out, nil
 }
 
-// PlanDeployWaves orders the cycle's components into the levels they can be
-// promoted in — providers before the consumers whose start-up config carries
-// their address.
+// PlanDeployInput asks what one reconcile pass should do, given what the
+// version is serving.
+type PlanDeployInput struct {
+	OrgID     string                `json:"orgId"`
+	ProjectID string                `json:"projectId"`
+	Version   delivery.VersionState `json:"version"`
+}
+
+// PlanDeployWaves plans the pass: the behind components that may be promoted,
+// levelled so every provider precedes the consumers whose start-up config
+// carries its address, plus what to wait for and what is held.
 //
-// Unwired degrades to ONE wave rather than none, matching DeployCycle's own
+// Unwired degrades to ONE wave of everything behind, matching PromoteWave's own
 // no-deployer behaviour: a plane without OpenChoreo still walks the stage, it
 // just has nothing to write.
-func (a *Activities) PlanDeployWaves(ctx context.Context, in DeployCycleInput) ([][]string, error) {
-	if a.deployer == nil || len(in.Components) == 0 {
-		return [][]string{in.Components}, nil
+func (a *Activities) PlanDeployWaves(ctx context.Context, in PlanDeployInput) (delivery.DeployPlan, error) {
+	if a.deployer == nil {
+		return unorderedPlan(in.Version), nil
 	}
-	waves, err := a.deployer.PlanDeploymentWaves(ctx, in.OrgID, in.ProjectID, in.Components)
+	plan, err := a.deployer.PlanDeploymentWaves(ctx, in.OrgID, in.ProjectID, in.Version)
 	if err != nil {
-		slog.ErrorContext(ctx, "run: deploy order could not be planned",
-			"orgID", in.OrgID, "projectID", in.ProjectID, "components", in.Components, "error", err)
-		return nil, deployErr(err)
+		slog.ErrorContext(ctx, "run: deploy pass could not be planned",
+			"orgID", in.OrgID, "projectID", in.ProjectID, "error", err)
+		return delivery.DeployPlan{}, deployErr(err)
 	}
 	// Logged, not merely returned. The order is the stage's whole premise — a
 	// consumer promoted before its provider is a blank page, and the symptom
-	// appears in a browser rather than anywhere near this code. Reading the plan
-	// off the run beats inferring it from what broke.
-	slog.InfoContext(ctx, "run: deploy order planned",
-		"orgID", in.OrgID, "projectID", in.ProjectID, "waves", waves)
-	return waves, nil
+	// appears in a browser rather than anywhere near this code. So is the HELD
+	// set, which is the one thing a reader cannot infer from what was written.
+	slog.InfoContext(ctx, "run: deploy pass planned",
+		"orgID", in.OrgID, "projectID", in.ProjectID,
+		"waves", planWaveNames(plan), "waiting", plan.Waited, "held", heldNames(plan))
+	return plan, nil
 }
 
-// PollCycleDeployments reads back each component's binding — the readiness poll.
+// WaitSetInput is the readiness poll's population: everything a pass promoted,
+// plus what was already converging.
+type WaitSetInput struct {
+	OrgID      string   `json:"orgId"`
+	ProjectID  string   `json:"projectId"`
+	Components []string `json:"components"`
+}
+
+// PollDeployments reads back each waited-on component's binding.
 //
 // With no reader wired every component reads as Ready, which keeps a plane
 // without OpenChoreo from parking its runs in the deploy stage forever.
-func (a *Activities) PollCycleDeployments(ctx context.Context, in DeployCycleInput) (CycleDeployState, error) {
+func (a *Activities) PollDeployments(ctx context.Context, in WaitSetInput) (CycleDeployState, error) {
 	if a.deployRead == nil || len(in.Components) == 0 {
 		return CycleDeployState{Expected: len(in.Components), Ready: len(in.Components)}, nil
 	}
@@ -589,14 +671,14 @@ func (a *Activities) PollCycleDeployments(ctx context.Context, in DeployCycleInp
 	return classifyCycleDeploys(len(in.Components), states), nil
 }
 
-// MintDeployFixIssuesInput names the components a cycle could not get running.
+// MintDeployFixIssuesInput names the components a pass could not get running,
+// each at the commit whose release it was promoting.
 type MintDeployFixIssuesInput struct {
-	OrgID           string            `json:"orgId"`
-	ProjectID       string            `json:"projectId"`
-	MilestoneNumber int               `json:"milestoneNumber"`
-	Components      []string          `json:"components"`
-	Reasons         map[string]string `json:"reasons,omitempty"`
-	CommitSHA       string            `json:"commitSha"`
+	OrgID           string                  `json:"orgId"`
+	ProjectID       string                  `json:"projectId"`
+	MilestoneNumber int                     `json:"milestoneNumber"`
+	Failed          []delivery.DeployTarget `json:"failed"`
+	Reasons         map[string]string       `json:"reasons,omitempty"`
 }
 
 // MintDeployFixIssues files one issue per component that did not come up.
@@ -608,11 +690,11 @@ type MintDeployFixIssuesInput struct {
 // delivered that never started. Wiring it is not optional in any real
 // deployment.
 func (a *Activities) MintDeployFixIssues(ctx context.Context, in MintDeployFixIssuesInput) ([]int, error) {
-	if a.deployMint == nil || len(in.Components) == 0 {
+	if a.deployMint == nil || len(in.Failed) == 0 {
 		return nil, nil
 	}
 	filed, err := a.deployMint.MintDeployFixIssues(ctx, in.OrgID, in.ProjectID, in.MilestoneNumber,
-		in.Components, in.Reasons, in.CommitSHA)
+		in.Failed, in.Reasons)
 	return filed, sourceControlErr(err)
 }
 

--- a/services/aep-api/internal/delivery/run/activities_version_test.go
+++ b/services/aep-api/internal/delivery/run/activities_version_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package run
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+// The ReadVersionState activity composes three ports, and the composition is
+// where a silent mistake would live: the three of them have to agree on how a
+// component is NAMED, or every component reads as behind and the reconcile
+// re-promotes the whole design on every cycle. The classification itself is
+// pinned as a pure function in policy_test.go.
+
+type stubDesign struct{ paths map[string]string }
+
+func (d stubDesign) ComponentPaths(context.Context, string, string) (map[string]string, error) {
+	return d.paths, nil
+}
+
+type stubBuilds struct{ runs map[string][]BuildRunInfo }
+
+func (b stubBuilds) ListBuildRuns(_ context.Context, _, _, component string) ([]BuildRunInfo, error) {
+	return b.runs[component], nil
+}
+
+type stubDeployments struct {
+	states []delivery.ComponentDeploy
+	asked  [][]string
+}
+
+func (d *stubDeployments) DeploymentState(_ context.Context, _, _ string,
+	components []string) ([]delivery.ComponentDeploy, error) {
+	d.asked = append(d.asked, components)
+	return d.states, nil
+}
+
+func TestReadVersionState_ComposesTheThreeReads(t *testing.T) {
+	const project = "shop7321"
+	greenAt := func(sha string) []BuildRunInfo {
+		return []BuildRunInfo{{
+			Name: "build-" + sha, Terminal: true, Succeeded: true, CommitSHA: sha,
+			StartedAt: time.Now(),
+		}}
+	}
+	deploys := &stubDeployments{states: []delivery.ComponentDeploy{
+		{Component: "api", Release: delivery.ReleaseNameFor(project, "api", "aaa1"), Ready: true},
+		// The webapp's binding was never written — the incident's own shape.
+		{Component: "webapp"},
+	}}
+	acts := NewActivities(Deps{
+		// App Paths are what the design read answers; the deploy set is its KEYS.
+		Design:      stubDesign{paths: map[string]string{"webapp": "apps/web", "api": "services/api"}},
+		Builds:      stubBuilds{runs: map[string][]BuildRunInfo{"api": greenAt("aaa1"), "webapp": greenAt("bbb2")}},
+		Deployments: deploys,
+	})
+
+	got, err := acts.ReadVersionState(context.Background(), ProjectRef{OrgID: "acme", ProjectID: project})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"api", "webapp"}, deploys.asked[0],
+		"the deployment read is asked about every component in the DESIGN, sorted — "+
+			"a random map order would reorder every promote and log line the pass produces")
+	require.Equal(t, []delivery.ComponentState{{
+		Component: "api", State: delivery.ComponentStateServing,
+		DesiredSHA: "aaa1", DesiredRelease: delivery.ReleaseNameFor(project, "api", "aaa1"),
+		Pinned: delivery.ReleaseNameFor(project, "api", "aaa1"), Ready: true,
+	}, {
+		Component: "webapp", State: delivery.ComponentStateBehind,
+		DesiredSHA: "bbb2", DesiredRelease: delivery.ReleaseNameFor(project, "webapp", "bbb2"),
+	}}, got.Components)
+	require.False(t, got.Serving(), "a component with a green build and no binding is not serving")
+	require.Equal(t, "webapp=behind", got.Describe())
+}
+
+// A plane with no OpenChoreo behind it must not have its runs fail on a gate
+// that has nothing to gate — the same degradation every other optional
+// collaborator makes, and the reason VersionState.Serving() reads an empty state
+// as serving.
+func TestReadVersionState_UnwiredIsAnEmptyStateThatServes(t *testing.T) {
+	got, err := NewActivities(Deps{}).ReadVersionState(context.Background(),
+		ProjectRef{OrgID: "acme", ProjectID: "shop"})
+
+	require.NoError(t, err)
+	require.Empty(t, got.Components)
+	require.True(t, got.Serving())
+}

--- a/services/aep-api/internal/delivery/run/doc.go
+++ b/services/aep-api/internal/delivery/run/doc.go
@@ -34,21 +34,28 @@
 //
 // # dev and task: the cycle loop
 //
-//	WAIT ──► dispatch the coding agent ──► PR opened ──► auto-merge ──► builds + deploy
-//	 ▲        (prompt = milestone reference only)                            │
-//	 │  all green, open issues remain ─────────────► next cycle (re-WAIT)    │
-//	 │  red after the one automatic re-trigger ─► FIX issue ─► next cycle    │
-//	 │  merge conflict ─────────────────────────► CONFLICT issue ─► next     │
+//	WAIT ──► dispatch the coding agent ──► PR opened ──► auto-merge ──► builds
+//	 ▲        (prompt = milestone reference only)                          │
+//	 │                                        RECONCILE the version ◄──────┘
+//	 │                                        (on EITHER build verdict)    │
+//	 │  all green, open issues remain ─────────────► next cycle (re-WAIT)  │
+//	 │  red after the one automatic re-trigger ─► FIX issue ─► next cycle  │
+//	 │  merge conflict ─────────────────────────► CONFLICT issue ─► next   │
 //	 └─ working set empty ──► the run's own BOOKEND ──► settle
 //	    budgets exhausted / no progress / cancel ─► failed | blocked | cancelled
+//	    working set empty but the version is not serving ─► version-incomplete
 //
 // They are the SAME loop with different bookends — one `bookends` value, never
 // two cycle loops that drift apart:
 //
 //	dev   work:    DevWork  — armed, kind ∈ development/bug/conflict
 //	      before:  provisionGates → planTasks (it owns the version it is filling)
-//	      onEmpty: mint the version's validation task → settle succeeded, and
-//	               LEAVE THE MILESTONE OPEN: the version is deployed and unjudged
+//	      onEmpty: ASSERT the version is serving, mint its validation task →
+//	               settle succeeded, and LEAVE THE MILESTONE OPEN: the version is
+//	               deployed and unjudged. A version that is not serving settles
+//	               FAILED `version-incomplete` (ADR-0026) — the read is what makes
+//	               "delivered" a claim about the cluster rather than about the
+//	               sequence of cycles that led here
 //	task  work:    TaskWork — armed, kind ∈ bug/conflict, NEVER development
 //	      before:  nothing (the milestone was filled by the build that shipped it)
 //	      onEmpty: reopen the validation task IFF it worked a `src/validation`
@@ -196,7 +203,15 @@
 // The supervisor DECIDES; it detects nothing. Every fact about the world
 // arrives from `delivery/eventcore` as a run signal, and the supervisor
 // re-derives that fact from GROUND TRUTH before acting on it — a signal is a
-// wake-up, never evidence. That is what makes a lost delivery cost latency
+// wake-up, never evidence.
+//
+// The DEPLOY is where that rule earns the most. What is serving is derived from
+// the cluster and from the builds, never accumulated in workflow state: a
+// component's desired release is its newest succeeded build's, its actual
+// release is what its binding pins, and the stage writes the difference
+// (ADR-0026). State carried across cycles instead would fix nothing that
+// matters — a rebuild, a task run or a crash resume starts empty — which is why
+// the version state is READ twice per cycle rather than remembered once. That is what makes a lost delivery cost latency
 // instead of correctness, and it is why the wait state can be unbounded: the
 // cycle-boundary poll and the reconcile sweep both re-read the milestone.
 //
@@ -215,8 +230,9 @@
 //
 //	activities.go            the single Activities struct — ONE RegisterActivity
 //	stage_agent.go           append cycle · dispatch · await landing · re-dispatch
-//	stage_build.go           await the merge's fan-out
-//	stage_deploy.go          plan waves · promote · await Ready · converge
+//	stage_build.go           await the merge's fan-out — the CYCLE's verdict only
+//	stage_deploy.go          reconcile the version: classify · plan · promote each
+//	                         component at its own commit · await Ready · converge
 //	stage_boundary.go        the shared loop · poll · dispatchable? · budgets · park
 //	workflow_dev.go          gates + plan (skipped on a rebuild) + boundary loop +
 //	                         mint the validation task

--- a/services/aep-api/internal/delivery/run/policy.go
+++ b/services/aep-api/internal/delivery/run/policy.go
@@ -299,7 +299,11 @@ func classifyComponentState(projectID, component string, runs []BuildRunInfo,
 		// deliberate undeploy would be the platform overruling the person who
 		// asked for it, and refusing to deliver the version would fail a run
 		// over the same decision.
-		st.State = delivery.ComponentStateServing
+		//
+		// The marker rides along because it does NOT make this component a
+		// satisfied hard provider — it has no active release, so it has no
+		// address (ComponentState.ServesConsumers).
+		st.State, st.Undeploy = delivery.ComponentStateServing, true
 		return st
 	}
 	st.DesiredSHA = newestGreenCommit(runs)

--- a/services/aep-api/internal/delivery/run/policy.go
+++ b/services/aep-api/internal/delivery/run/policy.go
@@ -17,6 +17,7 @@
 package run
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
@@ -234,15 +235,226 @@ type CycleBuildState struct {
 	Expected int      `json:"expected"`
 	Settled  int      `json:"settled"`
 	Red      []string `json:"red,omitempty"`
-	// Components is the set the merge touched, in the fan-out's own order. The
-	// DEPLOY stage promotes exactly this list rather than re-deriving it from
-	// GitHub: the two stages must agree on which components a cycle owns, and a
-	// second path to that answer is a second chance to disagree.
+	// Components is the set the merge touched, in the fan-out's own order.
+	//
+	// It is the poll's own bookkeeping — what Expected was counted over — and
+	// NOTHING downstream reads it. It used to be the deploy stage's input, which
+	// is what made the deploy set the cycle's path diff: a component green at an
+	// earlier commit was in no later cycle's list, so nothing ever promoted it.
+	// The deploy reads the version's own state instead (ADR-0026). Kept on the
+	// wire because an activity result lives in Temporal history and a run in
+	// flight across an upgrade decodes what its old worker recorded.
 	Components []string `json:"components,omitempty"`
 }
 
 // Green reports whether every component the merge touched has built.
 func (s CycleBuildState) Green() bool { return len(s.Red) == 0 && s.Settled >= s.Expected }
+
+// ---- the version's deploy state (ADR-0026) ---------------------------------
+
+// versionState classifies every component in the design against what has been
+// built and what is deployed.
+//
+// DESIRED is the release the component's newest succeeded build would cut;
+// ACTUAL is the release its binding pins, plus whether that is Ready. The
+// difference between those two is the whole model: the deploy set used to be
+// the cycle's path diff, so a component whose build went green in a cycle a
+// sibling failed was promoted by nothing, ever — its files had stopped
+// changing. Classifying the DESIGN instead makes "what is serving" a function
+// of what has been built rather than of which files a fix happened to touch.
+//
+// A component the deployment read did not answer for reads as having no binding
+// — which is `behind`, and correct: it has a green build and nothing pinning
+// it.
+func versionState(projectID string, components []string, builds map[string][]BuildRunInfo,
+	deploys map[string]delivery.ComponentDeploy) delivery.VersionState {
+	out := delivery.VersionState{Components: make([]delivery.ComponentState, 0, len(components))}
+	for _, name := range components {
+		out.Components = append(out.Components,
+			classifyComponentState(projectID, name, builds[name], deploys[name]))
+	}
+	return out
+}
+
+// classifyComponentState is one component's state, as a pure function of its
+// builds and its binding.
+//
+// It does NOT branch on the binding's Failed verdict, and that is deliberate. A
+// binding pinned at the right release that will never be Ready is `converging`
+// here, because a pin cannot tell a doomed rollout from a slow one — and it does
+// not have to: converging components are waited on, and the readiness poll turns
+// a terminal Ready reason into a deploy failure within one tick. Folding failure
+// into a sixth state would put the same verdict in two places, which is how the
+// two come to disagree.
+func classifyComponentState(projectID, component string, runs []BuildRunInfo,
+	deploy delivery.ComponentDeploy) delivery.ComponentState {
+	st := delivery.ComponentState{
+		Component: component,
+		Pinned:    deploy.Release,
+		Ready:     deploy.Ready,
+		Reason:    deploy.Reason,
+	}
+	if deploy.Undeploy {
+		// Withdrawn on purpose. Nothing is owed: promoting a release over a
+		// deliberate undeploy would be the platform overruling the person who
+		// asked for it, and refusing to deliver the version would fail a run
+		// over the same decision.
+		st.State = delivery.ComponentStateServing
+		return st
+	}
+	st.DesiredSHA = newestGreenCommit(runs)
+	if st.DesiredSHA == "" {
+		// Never built. Not a failure: a red build already minted its fix issue,
+		// and a component nobody has written yet has its development issue open.
+		st.State = delivery.ComponentStateUnbuilt
+		return st
+	}
+	st.DesiredRelease = delivery.ReleaseNameFor(projectID, component, st.DesiredSHA)
+	switch {
+	case st.Pinned != st.DesiredRelease:
+		st.State = delivery.ComponentStateBehind
+	case st.Ready:
+		st.State = delivery.ComponentStateServing
+	default:
+		st.State = delivery.ComponentStateConverging
+	}
+	return st
+}
+
+// newestGreenCommit is the commit of a component's newest SUCCEEDED build.
+//
+// Succeeded rather than newest: a component whose latest attempt failed is
+// still built, at the commit that worked, and a version does not un-deploy
+// because somebody pushed a broken commit afterwards — the red build's own fix
+// issue is what moves it forward.
+//
+// Ordered by the run's creation time because the host returns the list
+// unordered, with the NAME as the tie-break so two runs admitted in the same
+// instant classify the same way on every poll. A green run with no commit
+// (a build of whatever the branch tip was, triggered outside a cycle) is
+// skipped: it names no release the platform could pin.
+func newestGreenCommit(runs []BuildRunInfo) string {
+	best := BuildRunInfo{}
+	for _, r := range runs {
+		if !r.Terminal || !r.Succeeded || r.CommitSHA == "" {
+			continue
+		}
+		if best.CommitSHA == "" || r.StartedAt.After(best.StartedAt) ||
+			(r.StartedAt.Equal(best.StartedAt) && r.Name > best.Name) {
+			best = r
+		}
+	}
+	return best.CommitSHA
+}
+
+// unorderedPlan is the plan a run with no deployer wired gets: everything
+// behind in one wave, nothing held. It mirrors PromoteWave's own no-deployer
+// behaviour — the stage is walked, there is simply nothing to write.
+func unorderedPlan(v delivery.VersionState) delivery.DeployPlan {
+	plan := delivery.DeployPlan{}
+	var wave []delivery.DeployTarget
+	for _, c := range v.Components {
+		switch c.State {
+		case delivery.ComponentStateBehind:
+			wave = append(wave, delivery.DeployTarget{Component: c.Component, CommitSHA: c.DesiredSHA})
+			plan.Waited = append(plan.Waited, c.Component)
+		case delivery.ComponentStateConverging:
+			plan.Waited = append(plan.Waited, c.Component)
+		}
+	}
+	if len(wave) > 0 {
+		plan.Waves = [][]delivery.DeployTarget{wave}
+	}
+	return plan
+}
+
+// planWaveNames / heldNames render a plan for the log — the names, wave by
+// wave, and what each held component is waiting on.
+func planWaveNames(plan delivery.DeployPlan) [][]string {
+	out := make([][]string, 0, len(plan.Waves))
+	for _, wave := range plan.Waves {
+		out = append(out, delivery.TargetNames(wave))
+	}
+	return out
+}
+
+func heldNames(plan delivery.DeployPlan) []string {
+	out := make([]string, 0, len(plan.Held))
+	for _, c := range plan.Held {
+		entry := c.Component
+		if len(c.WaitingOn) > 0 {
+			entry += " waiting on " + strings.Join(c.WaitingOn, ", ")
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// reconcileWork reports whether a version state gives the deploy stage anything
+// to do at all: something to promote, or something to wait for.
+//
+// Asked in the WORKFLOW, off the state it already has, because it decides
+// whether the stage runs — and a fully serving version must reconcile in one
+// read and zero writes, never park on a deploy gate it will not use.
+func reconcileWork(v delivery.VersionState) bool {
+	for _, c := range v.Components {
+		if c.State == delivery.ComponentStateBehind || c.State == delivery.ComponentStateConverging {
+			return true
+		}
+	}
+	return false
+}
+
+// convergeSet is what the stage's closing pass re-asserts the wiring of: every
+// component this pass waited on, plus every component that was ALREADY serving.
+//
+// The already-serving half is load-bearing and was the narrow reading's bug. A
+// soft edge runs from consumer to provider — a protected API's CORS allowlist is
+// the project's SPA origins — so promoting a web app in a later pass has to
+// finish the wiring of an api that was promoted in an earlier one. A converge
+// scoped to what this pass promoted would leave that api permanently unaware of
+// the SPA it serves.
+//
+// Held and unbuilt components are excluded: a converge writes a binding with no
+// release pinned, which OpenChoreo cannot render, so a component that has never
+// been promoted must not be in it.
+func convergeSet(v delivery.VersionState, waited []string) []string {
+	seen := make(map[string]struct{}, len(waited)+len(v.Components))
+	out := make([]string, 0, len(waited)+len(v.Components))
+	add := func(name string) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for _, name := range waited {
+		add(name)
+	}
+	for _, c := range v.Components {
+		if c.State == delivery.ComponentStateServing && c.Pinned != "" {
+			add(c.Component)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// targetsFor pairs component names with the commit each one's release was being
+// cut from, for the fix issues a failed pass files. A name the state does not
+// know answers an empty commit rather than being dropped: a failure the platform
+// cannot attribute to a commit is still a failure that needs an issue.
+func targetsFor(names []string, v delivery.VersionState) []delivery.DeployTarget {
+	commits := make(map[string]string, len(v.Components))
+	for _, c := range v.Components {
+		commits[c.Component] = c.DesiredSHA
+	}
+	out := make([]delivery.DeployTarget, 0, len(names))
+	for _, name := range names {
+		out = append(out, delivery.DeployTarget{Component: name, CommitSHA: commits[name]})
+	}
+	return out
+}
 
 // CycleDeployState is how far a cycle's DEPLOY has got: how many components were
 // promoted, how many are serving, and which ones the cluster has given up on.

--- a/services/aep-api/internal/delivery/run/policy_test.go
+++ b/services/aep-api/internal/delivery/run/policy_test.go
@@ -268,6 +268,9 @@ func TestClassifyComponentState(t *testing.T) {
 		deploy     delivery.ComponentDeploy
 		want       string
 		wantDesire string
+		// wantWithdrawn is the undeploy marker, which rides beside `serving` so
+		// the planner can tell "owes nothing" from "offers an address".
+		wantWithdrawn bool
 	}{
 		{
 			name: "no build at all — nothing to promote",
@@ -329,11 +332,13 @@ func TestClassifyComponentState(t *testing.T) {
 		},
 		{
 			// Withdrawn on purpose. Promoting over it would be the platform
-			// overruling the person who asked for it.
-			name:   "undeployed on purpose — nothing is owed",
-			runs:   []BuildRunInfo{green("aaa1", 0)},
-			deploy: delivery.ComponentDeploy{Undeploy: true, Ready: true},
-			want:   delivery.ComponentStateServing,
+			// overruling the person who asked for it — but it offers no address
+			// either, which is what the marker below is carried for.
+			name:          "undeployed on purpose — nothing is owed",
+			runs:          []BuildRunInfo{green("aaa1", 0)},
+			deploy:        delivery.ComponentDeploy{Undeploy: true, Ready: true},
+			want:          delivery.ComponentStateServing,
+			wantWithdrawn: true,
 		},
 		{
 			// A build of whatever the branch tip was names no commit, so it names
@@ -359,6 +364,15 @@ func TestClassifyComponentState(t *testing.T) {
 			}
 			if c.wantDesire != "" && got.DesiredRelease != at(c.wantDesire) {
 				t.Errorf("desired release = %q, want %q", got.DesiredRelease, at(c.wantDesire))
+			}
+			if got.Undeploy != c.wantWithdrawn {
+				t.Errorf("undeploy = %v, want %v", got.Undeploy, c.wantWithdrawn)
+			}
+			// The two questions a serving component is asked, and they differ for
+			// exactly one state: a withdrawn component owes the version nothing
+			// and offers a consumer nothing.
+			if want := c.want == delivery.ComponentStateServing && !c.wantWithdrawn; got.ServesConsumers() != want {
+				t.Errorf("ServesConsumers() = %v, want %v", got.ServesConsumers(), want)
 			}
 		})
 	}

--- a/services/aep-api/internal/delivery/run/policy_test.go
+++ b/services/aep-api/internal/delivery/run/policy_test.go
@@ -18,6 +18,7 @@ package run
 
 import (
 	"testing"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
 )
@@ -237,5 +238,162 @@ func TestClassifyCycleDeploys_SeparatesFailedFromPending(t *testing.T) {
 	}
 	if len(got.Pending) != 1 || got.Pending[0] != "rolling" {
 		t.Errorf("Pending = %v", got.Pending)
+	}
+}
+
+// TestClassifyComponentState pins the five states, which are the model's whole
+// premise: what a component SHOULD be serving against what it IS.
+//
+// The desired release is composed, never parsed — delivery.ReleaseNameFor is
+// what both the writer and this reader spell it with — so the cases pin the
+// classification against a name built the same way the deployer builds it.
+func TestClassifyComponentState(t *testing.T) {
+	const project, component = "shop7321", "onboarding-api"
+	at := func(sha string) string { return delivery.ReleaseNameFor(project, component, sha) }
+	green := func(sha string, minutes int) BuildRunInfo {
+		return BuildRunInfo{
+			Name: "run-" + sha, Terminal: true, Succeeded: true, CommitSHA: sha,
+			StartedAt: time.Date(2026, 9, 1, 10, minutes, 0, 0, time.UTC),
+		}
+	}
+	red := func(sha string, minutes int) BuildRunInfo {
+		r := green(sha, minutes)
+		r.Succeeded = false
+		return r
+	}
+
+	cases := []struct {
+		name       string
+		runs       []BuildRunInfo
+		deploy     delivery.ComponentDeploy
+		want       string
+		wantDesire string
+	}{
+		{
+			name: "no build at all — nothing to promote",
+			want: delivery.ComponentStateUnbuilt,
+		},
+		{
+			name: "a build that only failed is not a release",
+			runs: []BuildRunInfo{red("aaa1", 0), red("aaa1", 5)},
+			want: delivery.ComponentStateUnbuilt,
+		},
+		{
+			name:       "green, and nothing pins it — the incident",
+			runs:       []BuildRunInfo{green("aaa1", 0)},
+			want:       delivery.ComponentStateBehind,
+			wantDesire: "aaa1",
+		},
+		{
+			name:       "pinned at an older release",
+			runs:       []BuildRunInfo{green("aaa1", 0), green("bbb2", 5)},
+			deploy:     delivery.ComponentDeploy{Release: at("aaa1"), Ready: true},
+			want:       delivery.ComponentStateBehind,
+			wantDesire: "bbb2",
+		},
+		{
+			name:       "pinned at the right release, not up yet",
+			runs:       []BuildRunInfo{green("aaa1", 0)},
+			deploy:     delivery.ComponentDeploy{Release: at("aaa1")},
+			want:       delivery.ComponentStateConverging,
+			wantDesire: "aaa1",
+		},
+		{
+			name:       "pinned at the right release and Ready",
+			runs:       []BuildRunInfo{green("aaa1", 0)},
+			deploy:     delivery.ComponentDeploy{Release: at("aaa1"), Ready: true},
+			want:       delivery.ComponentStateServing,
+			wantDesire: "aaa1",
+		},
+		{
+			// The case that decides whether a version un-deploys because somebody
+			// pushed a broken commit afterwards. It must not: the older green
+			// release is still what the component should be serving, and the red
+			// build's own fix issue is what moves it forward.
+			name:       "newest build red, older one green — serving the older release",
+			runs:       []BuildRunInfo{green("aaa1", 0), red("bbb2", 5), red("bbb2", 9)},
+			deploy:     delivery.ComponentDeploy{Release: at("aaa1"), Ready: true},
+			want:       delivery.ComponentStateServing,
+			wantDesire: "aaa1",
+		},
+		{
+			// A binding pinned at the right release that will never render is
+			// CONVERGING here on purpose: the pin cannot tell a doomed rollout from
+			// a slow one, and the readiness poll turns the terminal reason into a
+			// deploy failure within one tick.
+			name:       "a failed binding at the right release is still converging",
+			runs:       []BuildRunInfo{green("aaa1", 0)},
+			deploy:     delivery.ComponentDeploy{Release: at("aaa1"), Failed: true, Reason: "RenderingFailed"},
+			want:       delivery.ComponentStateConverging,
+			wantDesire: "aaa1",
+		},
+		{
+			// Withdrawn on purpose. Promoting over it would be the platform
+			// overruling the person who asked for it.
+			name:   "undeployed on purpose — nothing is owed",
+			runs:   []BuildRunInfo{green("aaa1", 0)},
+			deploy: delivery.ComponentDeploy{Undeploy: true, Ready: true},
+			want:   delivery.ComponentStateServing,
+		},
+		{
+			// A build of whatever the branch tip was names no commit, so it names
+			// no release the platform could pin.
+			name: "a green build with no pinned commit is not a release",
+			runs: []BuildRunInfo{{Name: "manual-1", Terminal: true, Succeeded: true}},
+			want: delivery.ComponentStateUnbuilt,
+		},
+		{
+			name: "a green run still in flight is not terminal",
+			runs: []BuildRunInfo{{Name: "run-1", Succeeded: true, CommitSHA: "aaa1"}},
+			want: delivery.ComponentStateUnbuilt,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyComponentState(project, component, c.runs, c.deploy)
+			if got.State != c.want {
+				t.Errorf("state = %q, want %q", got.State, c.want)
+			}
+			if got.DesiredSHA != c.wantDesire {
+				t.Errorf("desired = %q, want %q", got.DesiredSHA, c.wantDesire)
+			}
+			if c.wantDesire != "" && got.DesiredRelease != at(c.wantDesire) {
+				t.Errorf("desired release = %q, want %q", got.DesiredRelease, at(c.wantDesire))
+			}
+		})
+	}
+}
+
+// TestVersionStateServing pins the delivery predicate. Serving is ALL of the
+// design's components, and every other state — including the two that are
+// nobody's failure — refuses it.
+func TestVersionStateServing(t *testing.T) {
+	serving := delivery.ComponentState{Component: "api", State: delivery.ComponentStateServing}
+	for _, state := range []string{
+		delivery.ComponentStateBehind,
+		delivery.ComponentStateConverging,
+		delivery.ComponentStateHeld,
+		delivery.ComponentStateUnbuilt,
+	} {
+		v := delivery.VersionState{Components: []delivery.ComponentState{
+			serving, {Component: "web", State: state},
+		}}
+		if v.Serving() {
+			t.Errorf("a version with a %s component reads as serving", state)
+		}
+		if got := v.Describe(); got != "web="+state {
+			t.Errorf("Describe() = %q, want %q", got, "web="+state)
+		}
+	}
+	all := delivery.VersionState{Components: []delivery.ComponentState{
+		serving, {Component: "web", State: delivery.ComponentStateServing},
+	}}
+	if !all.Serving() {
+		t.Error("a version whose every component is serving does not read as serving")
+	}
+	// An empty state is serving: a project with no design has no component that
+	// could fail to serve, and a plane with no OpenChoreo answers the same way.
+	if !(delivery.VersionState{}).Serving() {
+		t.Error("an empty version state must read as serving")
 	}
 }

--- a/services/aep-api/internal/delivery/run/ports.go
+++ b/services/aep-api/internal/delivery/run/ports.go
@@ -18,6 +18,7 @@ package run
 
 import (
 	"context"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
 	"github.com/wso2/aep/aep-api/internal/sourcecontrol"
@@ -155,7 +156,7 @@ type DesignReader interface {
 	ComponentPaths(ctx context.Context, orgID, projectID string) (map[string]string, error)
 }
 
-// BuildRunInfo is one OpenChoreo WorkflowRun reduced to the two facts the
+// BuildRunInfo is one OpenChoreo WorkflowRun reduced to the facts the
 // supervisor needs. The OpenChoreo status vocabulary is deliberately mapped in
 // the adapter: this package knows "terminal" and "succeeded", nothing about
 // condition reasons.
@@ -163,6 +164,20 @@ type BuildRunInfo struct {
 	Name      string `json:"name"`
 	Terminal  bool   `json:"terminal"`
 	Succeeded bool   `json:"succeeded"`
+	// CommitSHA is the commit this run built. It is the version state's DESIRED
+	// half: the newest succeeded run's commit names the release the component
+	// should be serving.
+	//
+	// A field rather than a substring of Name, which also carries a short
+	// commit: the name is composed through k8sname.Bounded, which truncates a
+	// long readable head and appends a digest, so parsing it back is sound for
+	// some projects and silently wrong for others. Empty for a run triggered
+	// without a pinned commit, which cannot be matched to a merge and therefore
+	// cannot be promoted.
+	CommitSHA string `json:"commitSha,omitempty"`
+	// StartedAt is when the cluster admitted the run — what orders two green
+	// builds of one component, since the host returns them unordered.
+	StartedAt time.Time `json:"startedAt"`
 }
 
 // BuildReader reads back a component's WorkflowRuns.
@@ -246,20 +261,29 @@ type Dispatcher interface {
 // call a green WorkflowRun the end of the cycle and validate against whatever
 // happened to be running.
 //
-// Idempotent and convergent: the release name is derived from the merge commit,
-// so a retried deploy re-pins the same release and changes nothing.
+// Idempotent and convergent: the release name is derived from the commit, so a
+// retried deploy re-pins the same release and changes nothing.
 //
-// An EMPTY commitSHA converges instead of promoting — it re-asserts the wiring
-// of components that are already serving without moving which release is live.
-// That is how the stage's last pass supplies the facts that only exist once
-// everything is up (a protected API's CORS allowlist is the project's SPA
+// An EMPTY commitSHA on a target converges instead of promoting — it re-asserts
+// the wiring of components that are already serving without moving which release
+// is live. That is how the stage's last pass supplies the facts that only exist
+// once everything is up (a protected API's CORS allowlist is the project's SPA
 // origins) without cutting a second release for them.
 type Deployer interface {
-	Deploy(ctx context.Context, orgID, projectID string, components []string, commitSHA string) ([]delivery.ComponentDeploy, error)
-	// PlanDeploymentWaves orders the set: every component in a wave has each of
-	// its hard providers in an earlier one. Ordering lives with the deployer
-	// because it is read off the same design the writes are composed from.
-	PlanDeploymentWaves(ctx context.Context, orgID, projectID string, components []string) ([][]string, error)
+	// Deploy promotes each target at ITS OWN commit. Per target rather than per
+	// call because a reconcile promotes each component at its own newest green
+	// build, which is a different commit for each of them in exactly the case
+	// that motivated the model (ADR-0026).
+	Deploy(ctx context.Context, orgID, projectID string, targets []delivery.DeployTarget) ([]delivery.ComponentDeploy, error)
+	// PlanDeploymentWaves plans one reconcile pass over the version's state:
+	// which behind components may be promoted, in which order, which to wait for
+	// and which are held on a provider that is not serving.
+	//
+	// Planning lives with the deployer because it is read off the same design the
+	// writes are composed from — and it reads the WHOLE design's edges, which is
+	// what makes a provider with no release an unsatisfied edge rather than an
+	// assumed-satisfied one.
+	PlanDeploymentWaves(ctx context.Context, orgID, projectID string, state delivery.VersionState) (delivery.DeployPlan, error)
 }
 
 // Gates authors the version's dependencies and mints its `provision` gate
@@ -353,6 +377,10 @@ type WorkCanceller interface {
 // becomes Ready delivers nothing. The supervisor observes it and asks; the plane
 // still owns the write, the labels and the dedupe key.
 type DeployIssueMinter interface {
+	// The commit is per component, riding the target: a reconcile's failures can
+	// be at different commits in one pass, and the dedupe key is (component,
+	// commit) — so one commit for the whole list would file the next version's
+	// failure against the previous version's key, or the reverse.
 	MintDeployFixIssues(ctx context.Context, orgID, projectID string, milestoneNumber int,
-		components []string, reasons map[string]string, commitSHA string) ([]int, error)
+		failed []delivery.DeployTarget, reasons map[string]string) ([]int, error)
 }

--- a/services/aep-api/internal/delivery/run/stage_boundary.go
+++ b/services/aep-api/internal/delivery/run/stage_boundary.go
@@ -250,7 +250,11 @@ type loop struct {
 	// has its issue minted for it by the EVENT PLANE, which sees the failure
 	// first-hand; a deployment has no webhook, so the supervisor is the only
 	// thing that ever knows which component did not come up.
-	deployFailed   []string
+	//
+	// Each failure carries the COMMIT its release was being cut from, because the
+	// issue's dedupe key is (component, commit) and one reconcile pass can promote
+	// two components at two different commits.
+	deployFailed   []delivery.DeployTarget
 	deployFailures map[string]string
 	// cycleID is the current cycle's record id. Surfaced on the loop because the
 	// verdict write lands after the agent stage has returned.
@@ -439,12 +443,18 @@ func (l *loop) work(ctx workflow.Context, ends bookends) (RunResult, error) {
 			return l.settle(ctx, delivery.RunStateBlocked, delivery.RunReasonAgentQuotaBlocked)
 		case cyclePublisherCredentials:
 			return l.settle(ctx, delivery.RunStateBlocked, delivery.RunReasonPublisherCredentials)
-		case cycleDeployFailed:
-			// File the work before looping. Unlike a red build or a conflict —
-			// where the event plane has already minted the issue by the time the
-			// supervisor hears about it — nothing else observes a deployment, so
-			// if this does not mint, the next boundary finds an empty working set
-			// and settles a run whose version is not running.
+		default:
+			// File the deploy's work before looping, on whatever the cycle's
+			// RESULT was: a red cycle can also have a failed deployment now that
+			// the reconcile runs on both verdicts, and the result carries the
+			// build's verdict. Keying on the failures themselves is what keeps
+			// the two independent.
+			//
+			// Unlike a red build or a conflict — where the event plane has already
+			// minted the issue by the time the supervisor hears about it — nothing
+			// else observes a deployment, so if this does not mint, the next
+			// boundary finds an empty working set and settles a run whose version
+			// is not running.
 			if err := l.mintDeployFixIssues(ctx); err != nil {
 				return l.result(), err
 			}
@@ -536,16 +546,33 @@ func (l *loop) onEmptyWorkingSet(ctx workflow.Context, ends bookends) (settled b
 //	                                    ├─ conflict  ─► cycleConflict
 //	                                    ├─ no landing within the deadline ─► re-dispatch
 //	                                    └─ merged ─► wait for the fan-out's builds
-//	                                                 ├─ a component red ─► cycleRed
-//	                                                 └─ all green ─► DEPLOY, then wait for Ready
-//	                                                                ├─ all ready ─► cycleGreen
-//	                                                                └─ a component failed ─► cycleDeployFailed
+//	                                                 ├─ a component red ─► build verdict red
+//	                                                 └─ all green ─► build verdict green
+//	                                                 then, on EITHER verdict:
+//	                                                 RECONCILE the version, wait for Ready
+//	                                                 ├─ all ready ─► deploy verdict green
+//	                                                 └─ a component failed ─► cycleDeployFailed
 //
 // It composes the three stages, which is why it lives with the boundary that
 // drives it rather than in any one of them: what a cycle IS — code that merges,
 // builds and then serves — is the boundary's definition of a delivered
 // increment. A validation run has no such cycle: its pull request touches only
 // `tests/`, so it runs the agent stage alone (workflow_validation.go).
+//
+// The deploy runs on a RED build too (ADR-0026). A red build has already minted
+// its fix issue and cannot be helped by holding its siblings back; the version's
+// other components are built, and promoting them is what keeps "what is serving"
+// a function of what has been built rather than of which files a fix touched.
+// What makes that safe is the promotable rule, not this call site: the reconcile
+// writes only components whose hard providers are serving or promoted ahead of
+// them.
+//
+// A cycle can therefore be red AND have a deploy failure. Both mint their work —
+// the build's issue by the event plane, the deploy's by the boundary — and the
+// cycle's RESULT is the earlier stage's verdict, because the deploy verdict is
+// downstream of it and the result only decides the next cycle's kind and the
+// terminal reason at an empty boundary, where both would name a budget that has
+// already produced its issue.
 func (l *loop) runCycle(ctx workflow.Context, kind string, anchorIssue int) (cycleResult, error) {
 	landed, res, err := l.agentStage(ctx, kind, anchorIssue)
 	if err != nil || !landed {
@@ -553,21 +580,38 @@ func (l *loop) runCycle(ctx workflow.Context, kind string, anchorIssue int) (cyc
 	}
 
 	l.st.Phase = delivery.RunPhaseBuilding
-	res, components, err := l.awaitBuilds(ctx)
+	buildRes, err := l.awaitBuilds(ctx)
 	if err != nil {
 		return cycleNone, err
 	}
-	if res != cycleGreen {
-		return res, nil
+	if buildRes != cycleGreen && buildRes != cycleRed {
+		// Cancelled mid-build. Nothing to reconcile — the run is over.
+		return buildRes, nil
 	}
+
 	// Built, not yet running. The deploy is the platform's own act — nothing
-	// promotes a release on its own — so the cycle is not over until the
-	// components this merge touched are serving. Everything downstream of a
-	// green cycle depends on that being true rather than merely requested:
-	// validation asserts against the deployment, and the version is called
-	// delivered on the strength of it.
+	// promotes a release on its own — so the cycle is not over until the version
+	// is serving what has been built. Everything downstream of a green cycle
+	// depends on that being true rather than merely requested: validation asserts
+	// against the deployment, and the version is called delivered on the strength
+	// of it.
 	l.st.Phase = delivery.RunPhaseDeploying
-	return l.deployCycle(ctx, components)
+	version, err := l.readVersionState(ctx)
+	if err != nil {
+		return cycleNone, err
+	}
+	deployRes, err := l.reconcileVersion(ctx, version)
+	if err != nil {
+		return cycleNone, err
+	}
+	switch {
+	case deployRes == cycleCancelled:
+		return cycleCancelled, nil
+	case buildRes == cycleRed:
+		return cycleRed, nil
+	default:
+		return deployRes, nil
+	}
 }
 
 // settle ends the run, and each terminal state carries its own consequence for
@@ -858,6 +902,25 @@ func (l *loop) pollMilestone(ctx workflow.Context) (MilestoneSnapshot, error) {
 	return out, err
 }
 
+// readVersionState re-derives what the version is serving, and mirrors it onto
+// the live status so a console reading a run mid-deploy sees the same five
+// states the loop decided on.
+//
+// It is READ, never carried. The reconcile's own classification is a moment old
+// by the time the boundary asks — a converge may have landed, a binding may
+// have been hand-edited — and the whole value of the delivery gate is that it
+// asserts what is true NOW rather than what the stage believed when it wrote.
+// Same rule the working-set poll follows.
+func (l *loop) readVersionState(ctx workflow.Context) (delivery.VersionState, error) {
+	var out delivery.VersionState
+	if err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).ReadVersionState,
+		ProjectRef{OrgID: l.in.OrgID, ProjectID: l.in.ProjectID}).Get(ctx, &out); err != nil {
+		return delivery.VersionState{}, err
+	}
+	l.st.Version = out
+	return out, nil
+}
+
 func (l *loop) milestoneRef() MilestoneRef {
 	return MilestoneRef{OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, MilestoneNumber: l.in.MilestoneNumber}
 }
@@ -1015,6 +1078,11 @@ func (l *loop) closeCancelledWork(ctx workflow.Context) error {
 // mintDeployFixIssues files one issue per component that did not come up, so the
 // next cycle can work it like any other fix.
 //
+// Only components this pass WROTE, or was already waiting on, can appear here —
+// that is a property of the wait set, not a filter applied at this call. Held and
+// unbuilt components are never waited on, so a healthy web app whose api is red
+// cannot be handed a deployment bug it does not have.
+//
 // This is the supervisor minting an issue, which it does nowhere else — every
 // other recovery issue belongs to the event plane, which observes the failure
 // through a webhook. A deployment produces no webhook, so there is no event
@@ -1029,15 +1097,14 @@ func (l *loop) mintDeployFixIssues(ctx workflow.Context) error {
 			OrgID:           l.in.OrgID,
 			ProjectID:       l.in.ProjectID,
 			MilestoneNumber: l.in.MilestoneNumber,
-			Components:      l.deployFailed,
+			Failed:          l.deployFailed,
 			Reasons:         l.deployFailures,
-			CommitSHA:       l.mergeSHA,
 		}).Get(ctx, nil)
 	if err != nil {
 		return err
 	}
 	workflow.GetLogger(ctx).Info("deployment failed; filed fix work",
-		"components", l.deployFailed, "commit", l.mergeSHA)
+		"components", delivery.TargetNames(l.deployFailed))
 	l.deployFailed, l.deployFailures = nil, nil
 	return nil
 }

--- a/services/aep-api/internal/delivery/run/stage_build.go
+++ b/services/aep-api/internal/delivery/run/stage_build.go
@@ -44,21 +44,28 @@ import (
 // fix belongs there too — at the point of creation, where the cause is still
 // known — and not in a timeout here, which could only report "something took too
 // long" about a run that was never going to start.
-func (l *loop) awaitBuilds(ctx workflow.Context) (cycleResult, []string, error) {
+//
+// It answers the CYCLE's verdict and nothing else. It used to hand the deploy
+// stage the components its poll had seen, which is what made the deploy set the
+// cycle's path diff — and a component whose build went green in a cycle a
+// sibling failed was then promoted by nothing, ever. The deploy reads the
+// version's own state instead (ADR-0026); this stage's answer is only "did the
+// code this merge built compile".
+func (l *loop) awaitBuilds(ctx workflow.Context) (cycleResult, error) {
 	for {
 		state, err := l.pollBuilds(ctx)
 		if err != nil {
-			return cycleNone, nil, err
+			return cycleNone, err
 		}
 		if len(state.Red) > 0 {
-			return cycleRed, state.Components, nil
+			return cycleRed, nil
 		}
 		if state.Green() {
-			return cycleGreen, state.Components, nil
+			return cycleGreen, nil
 		}
 
 		if cancelled, _ := l.awaitWake(ctx, buildPollInterval, nil); cancelled {
-			return cycleCancelled, nil, nil
+			return cycleCancelled, nil
 		}
 	}
 }

--- a/services/aep-api/internal/delivery/run/stage_deploy.go
+++ b/services/aep-api/internal/delivery/run/stage_deploy.go
@@ -27,10 +27,27 @@ import (
 	"github.com/wso2/aep/aep-api/internal/delivery"
 )
 
-// The DEPLOY STAGE: plan the waves, promote them in order, wait for each to
-// serve, and converge the wiring that only exists once everything is up.
+// The DEPLOY STAGE: reconcile the VERSION. Plan what is behind and may be
+// promoted, promote it wave by wave, wait for each wave to serve, and converge
+// the wiring that only exists once everything is up.
 
-// deployCycle promotes the cycle's components and waits for them to serve.
+// reconcileVersion moves the version towards what has been built (ADR-0026).
+//
+// It takes the version's STATE — every component in the design, classified as
+// serving, behind, converging, held or unbuilt — and writes only the behind ones
+// whose hard providers are met. What it replaced promoted the components the
+// cycle's merge happened to touch, which made "what is serving" a function of
+// which files a fix edited: a component whose build went green in a cycle a
+// sibling failed was promoted by nothing, ever, because its files had stopped
+// changing. One such component shipped as a delivered version with no
+// ReleaseBinding at all.
+//
+// It therefore runs on a RED cycle as well as a green one, which is the
+// deliberate half of the change. A red build has already minted its fix issue;
+// its green siblings are still built, and holding their release hostage to a
+// failure in another component is what created the stranding. The promotable
+// rule is what makes that safe: the only components written are ones whose
+// providers are serving or promoted ahead of them in the same pass.
 //
 // WAVE BY WAVE, then one CONVERGE — because the wiring between components splits
 // into two kinds that want opposite treatment (spec.HardConfigEdges).
@@ -52,26 +69,22 @@ import (
 // not a third promote: nothing is re-cut, so it cannot fail on a release that is
 // already there, and no component's live release can move under a pass whose job
 // is only to finish the wiring.
-func (l *loop) deployCycle(ctx workflow.Context, components []string) (cycleResult, error) {
-	if len(components) == 0 {
-		// A merge that touched no component has nothing to promote and nothing to
-		// wait for.
+//
+// Re-running it against a fully serving version writes NOTHING — every component
+// is serving, so nothing is behind — which is what lets it run every cycle. That
+// idempotence is not new: it is the property ADR-0019 already engineered into the
+// verb, where EnsureRelease is idempotent by read-back and the binding write is
+// an upsert.
+func (l *loop) reconcileVersion(ctx workflow.Context, version delivery.VersionState) (cycleResult, error) {
+	if !reconcileWork(version) {
+		// Nothing behind and nothing converging: the version already serves what
+		// has been built. One read, zero writes, no deadline started — and no
+		// deploy gate consulted, because a pass that writes nothing must not park
+		// on a credential it will not use.
 		return cycleGreen, nil
 	}
-	// THE DEPLOY GATE (ADR-0023). Before anything is ordered or promoted: every
-	// external dependency configured, every platform resource provisioned.
-	//
-	// It sits here, and not at settle, because ADR-0017 put the deploy between
-	// builds-green and validation so validation asserts against a version that is
-	// genuinely serving. A gate after validation would be gating the wrong thing.
-	// It sits after the empty-components return above, so a converge/validation
-	// cycle — which promotes nothing — is never parked on a credential it will
-	// not use.
-	if res, err := l.awaitDeployable(ctx, components); err != nil || res != cycleGreen {
-		return res, err
-	}
 
-	waves, err := l.planDeployWaves(ctx, components)
+	plan, err := l.planDeployWaves(ctx, version)
 	if err != nil {
 		// An unsatisfiable ORDER is a deployment failure like any other, and has to
 		// arrive as one. Returned raw it would fail the workflow outright: the
@@ -84,32 +97,121 @@ func (l *loop) deployCycle(ctx workflow.Context, components []string) (cycleResu
 		if !isPermanentDeploy(err) {
 			return cycleNone, err
 		}
-		l.deployFailed = components
-		l.deployFailures = reasonForAll(components, err)
+		l.failDeploy(behindNames(version), version, err)
 		return cycleDeployFailed, nil
+	}
+	if len(plan.Held) > 0 {
+		// Reported and then left alone. A held component is not a failure and
+		// nothing is filed against it — the provider it waits on has its own work
+		// in the milestone, and the first pass that finds that provider serving
+		// promotes this one.
+		workflow.GetLogger(ctx).Info("some components are held behind a provider that is not serving",
+			"held", heldNames(plan))
+	}
+	if !plan.Writes() && len(plan.Waited) == 0 {
+		return cycleGreen, nil
+	}
+
+	// THE DEPLOY GATE (ADR-0023). Before anything is WRITTEN: every external
+	// dependency configured, every platform resource provisioned.
+	//
+	// It sits after the plan and before the promote — the plan only reads the
+	// design — so the run parks on a credential only when it is about to publish
+	// something that needs one, and the failure it can produce is attributed to
+	// the components this pass would have promoted rather than to the whole
+	// design.
+	//
+	// It sits inside the stage rather than at settle because ADR-0017 put the
+	// deploy between builds-green and validation, so validation asserts against a
+	// version that is genuinely serving. A gate after validation would be gating
+	// the wrong thing.
+	if plan.Writes() {
+		promoting := delivery.TargetNames(flattenWaves(plan.Waves))
+		if res, err := l.awaitDeployable(ctx, promoting, version); err != nil || res != cycleGreen {
+			return res, err
+		}
 	}
 
 	// ONE deadline for the whole stage rather than one per wave. What a version
 	// is owed is a time to be serving; a per-wave budget would silently multiply
 	// that allowance by however many levels the design happens to have.
+	//
+	// It starts HERE — after the plan, at the first write — so a pass that only
+	// waits on a converge somebody else started is still bounded, and a pass with
+	// nothing behind (or with everything held) starts no timer at all.
 	deadlineCtx, stopDeadline := workflow.WithCancel(ctx)
 	defer stopDeadline()
 	deadline := workflow.NewTimer(deadlineCtx, deployReadyTimeout)
 
-	for _, wave := range waves {
-		if err := l.deploy(ctx, wave, l.mergeSHA); err != nil {
+	for _, wave := range plan.Waves {
+		if err := l.promote(ctx, wave); err != nil {
 			return cycleNone, err
 		}
-		res, err := l.awaitDeployments(ctx, wave, deadline)
+		res, err := l.awaitDeployments(ctx, delivery.TargetNames(wave), version, deadline)
 		if err != nil || res != cycleGreen {
 			return res, err
 		}
 	}
+	// Everything this pass wrote, plus what was already converging: a component
+	// promoted by an EARLIER pass may still be rolling out, and the version does
+	// not serve until it does.
+	if res, err := l.awaitDeployments(ctx, plan.Waited, version, deadline); err != nil || res != cycleGreen {
+		return res, err
+	}
 
-	if err := l.deploy(ctx, components, convergeNoPromotion); err != nil {
+	if !plan.Writes() {
+		// Nothing was promoted, so there is no new address for a soft fact to
+		// carry and nothing to converge. It also matters that this returns rather
+		// than writing: the deploy gate is only consulted when the pass promotes,
+		// and a converge is a write like any other — so a pass that skipped the
+		// gate must not go on to write a binding.
+		return cycleGreen, nil
+	}
+	converge := convergeSet(version, plan.Waited)
+	if len(converge) == 0 {
+		return cycleGreen, nil
+	}
+	if err := l.promote(ctx, delivery.ConvergeTargets(converge)); err != nil {
 		return cycleNone, err
 	}
-	return l.awaitDeployments(ctx, components, deadline)
+	return l.awaitDeployments(ctx, converge, version, deadline)
+}
+
+// behindNames is every component the version state says is behind — the
+// attribution for a failure of the PLAN, which is nobody's individual fault
+// (see reasonForAll).
+func behindNames(v delivery.VersionState) []string {
+	var out []string
+	for _, c := range v.Components {
+		if c.State == delivery.ComponentStateBehind {
+			out = append(out, c.Component)
+		}
+	}
+	return out
+}
+
+// flattenWaves is every target the plan will promote, in wave order.
+func flattenWaves(waves [][]delivery.DeployTarget) []delivery.DeployTarget {
+	var out []delivery.DeployTarget
+	for _, wave := range waves {
+		out = append(out, wave...)
+	}
+	return out
+}
+
+// failDeploy records a deploy failure for the boundary to file, pairing each
+// component with the commit its release was being cut from.
+//
+// The commit is per component because the dedupe key is (component, commit): a
+// redeploy of the same commit that fails the same way finds the open issue and
+// files nothing, while the next version's failure is genuinely new work. A pass
+// can promote two components at two different commits, so one commit for the
+// whole list would key at least one of them wrongly.
+func (l *loop) failDeploy(components []string, version delivery.VersionState, cause error) {
+	l.deployFailed = targetsFor(components, version)
+	if cause != nil {
+		l.deployFailures = reasonForAll(components, cause)
+	}
 }
 
 // awaitDeployable holds the deploy stage until the project may deploy, and is
@@ -150,10 +252,13 @@ func (l *loop) deployCycle(ctx workflow.Context, components []string) (cycleResu
 //
 // Returns cycleGreen when the gate opens, cycleCancelled if a human gave up,
 // and cycleDeployFailed when the provisioning budget runs out — in which case
-// components are the ones the failure is filed against, since a resource that
-// will not provision is a stage-wide failure of the whole cycle rather than any
-// one component's fault (see reasonForAll).
-func (l *loop) awaitDeployable(ctx workflow.Context, components []string) (cycleResult, error) {
+// promoting names the components the failure is filed against, since a resource
+// that will not provision is a stage-wide failure of the whole pass rather than
+// any one component's fault (see reasonForAll). Components this pass was NOT
+// going to write are absent from that list on purpose: a held component gets no
+// deploy-fix issue for a credential it was never waiting on.
+func (l *loop) awaitDeployable(ctx workflow.Context, promoting []string,
+	version delivery.VersionState) (cycleResult, error) {
 	parked := false
 	// leaveValuesPark undoes setWaitingOnValues, and every exit from the values
 	// park goes through it — not only the one that finds the gate open. The park
@@ -218,11 +323,11 @@ func (l *loop) awaitDeployable(ctx workflow.Context, components []string) (cycle
 			}
 			if budget.expired {
 				// Out of time. Reported the way a binding that never served is:
-				// the cycle's components could not be delivered, and each fix
-				// issue carries the same stage-wide cause, which names the
-				// resources rather than the component it is filed against.
-				l.deployFailed = components
-				l.deployFailures = reasonForAll(components, errProvisioningTimedOut(verdict.Provisioning))
+				// the components this pass would have promoted could not be
+				// delivered, and each fix issue carries the same stage-wide
+				// cause, which names the resources rather than the component it
+				// is filed against.
+				l.failDeploy(promoting, version, errProvisioningTimedOut(verdict.Provisioning))
 				return cycleDeployFailed, nil
 			}
 			workflow.GetLogger(ctx).Info("deploy gate: platform resources still provisioning",
@@ -324,13 +429,6 @@ func (l *loop) setWaitingOnValues(ctx workflow.Context, deps []string) error {
 	return nil
 }
 
-// convergeNoPromotion is the commit a converge deploys at: none. The deployer
-// reads an empty commit as "re-assert the wiring at whatever release is already
-// serving", so this is the difference between finishing a component's wiring and
-// promoting it again — named rather than spelled `""` at the call site, because
-// which of those two a pass does is the whole point of the pass.
-const convergeNoPromotion = ""
-
 // awaitDeployments waits for the promoted components to reach a verdict.
 //
 // Unlike awaitBuilds this stage HAS a deadline, and the difference is not
@@ -346,7 +444,11 @@ const convergeNoPromotion = ""
 //
 // The deadline is the STAGE's and is passed in, so a run cannot buy itself more
 // time by having more waves to wait through.
-func (l *loop) awaitDeployments(ctx workflow.Context, components []string, deadline workflow.Future) (cycleResult, error) {
+func (l *loop) awaitDeployments(ctx workflow.Context, components []string,
+	version delivery.VersionState, deadline workflow.Future) (cycleResult, error) {
+	if len(components) == 0 {
+		return cycleGreen, nil
+	}
 	expired := false
 
 	for {
@@ -355,8 +457,8 @@ func (l *loop) awaitDeployments(ctx workflow.Context, components []string, deadl
 			return cycleNone, err
 		}
 		if len(state.Failed) > 0 {
+			l.failDeploy(state.Failed, version, nil)
 			l.deployFailures = state.Reasons
-			l.deployFailed = state.Failed
 			return cycleDeployFailed, nil
 		}
 		if state.Green() {
@@ -364,10 +466,10 @@ func (l *loop) awaitDeployments(ctx workflow.Context, components []string, deadl
 		}
 		if expired {
 			// Out of time. Reported as a failure of the components that have not
-			// come up — and ONLY those: a cycle can expire with some components
+			// come up — and ONLY those: a pass can expire with some components
 			// serving and others still rolling out, and filing fix work against
 			// one that deployed fine would send an agent after nothing.
-			l.deployFailed = state.Pending
+			l.failDeploy(state.Pending, version, nil)
 			return cycleDeployFailed, nil
 		}
 
@@ -381,28 +483,28 @@ func (l *loop) awaitDeployments(ctx workflow.Context, components []string, deadl
 
 // ---- deploy activity calls -------------------------------------------------
 
-// deploy promotes at commitSHA, or converges when it is empty.
-func (l *loop) deploy(ctx workflow.Context, components []string, commitSHA string) error {
-	return workflow.ExecuteActivity(activityCtx(ctx), (*Activities).DeployCycle, DeployCycleInput{
-		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Components: components, CommitSHA: commitSHA,
+// promote writes one wave — or the converge, whose targets carry no commit.
+func (l *loop) promote(ctx workflow.Context, targets []delivery.DeployTarget) error {
+	return workflow.ExecuteActivity(activityCtx(ctx), (*Activities).PromoteWave, PromoteInput{
+		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Targets: targets,
 	}).Get(ctx, nil)
 }
 
-// planDeployWaves asks for the order. No commit rides the request: the order is
-// a property of the DESIGN, not of the release being promoted, and sending one
-// would imply the plan changes with the commit.
-func (l *loop) planDeployWaves(ctx workflow.Context, components []string) ([][]string, error) {
-	var waves [][]string
-	err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).PlanDeployWaves, DeployCycleInput{
-		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Components: components,
-	}).Get(ctx, &waves)
-	return waves, err
+// planDeployWaves asks what this pass should do. The VERSION STATE rides the
+// request and no commit does: the order is a property of the design and of what
+// is already serving, not of any one release being promoted.
+func (l *loop) planDeployWaves(ctx workflow.Context, version delivery.VersionState) (delivery.DeployPlan, error) {
+	var plan delivery.DeployPlan
+	err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).PlanDeployWaves, PlanDeployInput{
+		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Version: version,
+	}).Get(ctx, &plan)
+	return plan, err
 }
 
 func (l *loop) pollDeployments(ctx workflow.Context, components []string) (CycleDeployState, error) {
 	var state CycleDeployState
-	err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).PollCycleDeployments, DeployCycleInput{
-		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Components: components, CommitSHA: l.mergeSHA,
+	err := workflow.ExecuteActivity(activityCtx(ctx), (*Activities).PollDeployments, WaitSetInput{
+		OrgID: l.in.OrgID, ProjectID: l.in.ProjectID, Components: components,
 	}).Get(ctx, &state)
 	return state, err
 }
@@ -423,7 +525,7 @@ func isPermanentDeploy(err error) bool {
 //
 // An unsatisfiable order is nobody's individual fault — the components are stuck
 // on each other — so each fix issue carries the same cause, which names the whole
-// cycle rather than the component it happens to be filed against.
+// pass rather than the component it happens to be filed against.
 func reasonForAll(components []string, err error) map[string]string {
 	out := make(map[string]string, len(components))
 	for _, name := range components {

--- a/services/aep-api/internal/delivery/run/stage_deploy.go
+++ b/services/aep-api/internal/delivery/run/stage_deploy.go
@@ -97,7 +97,19 @@ func (l *loop) reconcileVersion(ctx workflow.Context, version delivery.VersionSt
 		if !isPermanentDeploy(err) {
 			return cycleNone, err
 		}
-		l.failDeploy(behindNames(version), version, err)
+		// Attributed to what is BEHIND, and to every non-serving component when
+		// nothing is behind. The second half is not tidiness: a pass is entered
+		// when anything is behind OR converging, so a version whose components are
+		// all converging can reach a permanent plan failure with an empty behind
+		// set — and a failure attributed to nobody mints no issue, which settles
+		// the run on the deploy budget with no named component and nothing to work.
+		// That is exactly the wedge the paragraph above describes. An unsatisfiable
+		// order is nobody's individual fault either way (see reasonForAll).
+		failed := behindNames(version)
+		if len(failed) == 0 {
+			failed = notServingNames(version)
+		}
+		l.failDeploy(failed, version, err)
 		return cycleDeployFailed, nil
 	}
 	if len(plan.Held) > 0 {
@@ -177,15 +189,28 @@ func (l *loop) reconcileVersion(ctx workflow.Context, version delivery.VersionSt
 	return l.awaitDeployments(ctx, converge, version, deadline)
 }
 
-// behindNames is every component the version state says is behind — the
-// attribution for a failure of the PLAN, which is nobody's individual fault
-// (see reasonForAll).
+// behindNames is every component the version state says is behind — the first
+// choice of attribution for a failure of the PLAN, which is nobody's individual
+// fault (see reasonForAll).
 func behindNames(v delivery.VersionState) []string {
 	var out []string
 	for _, c := range v.Components {
 		if c.State == delivery.ComponentStateBehind {
 			out = append(out, c.Component)
 		}
+	}
+	return out
+}
+
+// notServingNames is every component that is not serving — the attribution of
+// last resort, so a stage-wide failure always names somebody and therefore
+// always files work. A failure nobody is filed against is a run that settles on
+// the deploy budget with an empty milestone behind it.
+func notServingNames(v delivery.VersionState) []string {
+	off := v.NotServing()
+	out := make([]string, 0, len(off))
+	for _, c := range off {
+		out = append(out, c.Component)
 	}
 	return out
 }

--- a/services/aep-api/internal/delivery/run/stage_deploy_gate_test.go
+++ b/services/aep-api/internal/delivery/run/stage_deploy_gate_test.go
@@ -241,8 +241,8 @@ func TestDeployGate_AResourceThatNeverProvisionsFailsTheCycle(t *testing.T) {
 
 	mints := h.deployMintInputs()
 	require.Len(t, mints, 1, "a wedged deploy has to become work, or the next boundary poll settles a version that is not running")
-	require.Equal(t, []string{"order-service"}, mints[0].Components,
-		"the cycle's components are what could not be delivered; the resource is nobody's individual fault")
+	require.Equal(t, []string{"order-service"}, delivery.TargetNames(mints[0].Failed),
+		"what this pass would have promoted is what could not be delivered; the resource is nobody's individual fault")
 	require.Contains(t, mints[0].Reasons["order-service"], "orders-db",
 		"the cause names the resource, which is the one fact the reader cannot derive")
 }

--- a/services/aep-api/internal/delivery/run/workflow_dev.go
+++ b/services/aep-api/internal/delivery/run/workflow_dev.go
@@ -175,8 +175,8 @@ func (l *loop) fillMilestone(ctx workflow.Context) (settled bool, res RunResult,
 	return false, RunResult{}, nil
 }
 
-// deliverVersion is the dev run's onEmpty bookend: the version is deployed-green,
-// so file its validation task and settle.
+// deliverVersion is the dev run's onEmpty bookend: the milestone has no work
+// left, so — IF the version is serving — file its validation task and settle.
 //
 // Minting HERE, and not at plan time, is load-bearing twice over. An issue
 // nothing can work until every component deploys would sit in the working set and
@@ -195,7 +195,32 @@ func (l *loop) fillMilestone(ctx workflow.Context) (settled bool, res RunResult,
 // EnsureValidationIssue answers 0, so no validation task exists, so nothing will
 // ever judge this version — and an empty verdict would read as "any moment now"
 // forever. `skipped` says what is true.
+//
+// # The gate: serving(V), asserted rather than inferred
+//
+// "Deployed-green" used to be INFERRED from a sequence of correct cycles — the
+// working set emptied and the last cycle ended green, so everything must be up.
+// That is the same class of predicate ADR-0017 removed from validation, and it
+// failed the same way: a component the cycles never promoted was never
+// contradicted by any of them, so a version shipped with an API nothing had
+// bound, its validation task filed against software that was not running.
+//
+// So the version is READ here (ADR-0026) and every component in the DESIGN must
+// be serving. Anything else settles `version-incomplete` naming what was not,
+// which by the loop's invariants should be unreachable — a behind component
+// whose providers are met is promoted by the cycle's reconcile, and a failed
+// deployment mints a fix issue that keeps the working set non-empty. It is the
+// case that survives being unreachable that this exists for.
 func (l *loop) deliverVersion(ctx workflow.Context) (RunResult, error) {
+	version, err := l.readVersionState(ctx)
+	if err != nil {
+		return l.result(), err
+	}
+	if !version.Serving() {
+		workflow.GetLogger(ctx).Error("the milestone has no work left and the version is not serving",
+			"milestone", l.in.MilestoneNumber, "tag", l.in.Tag, "notServing", version.Describe())
+		return l.settle(ctx, delivery.RunStateFailed, delivery.RunReasonVersionIncomplete)
+	}
 	issue, err := l.ensureValidationIssue(ctx)
 	if err != nil {
 		return l.result(), err

--- a/services/aep-api/internal/delivery/run/workflow_test.go
+++ b/services/aep-api/internal/delivery/run/workflow_test.go
@@ -1186,7 +1186,7 @@ func TestReconcile_AServingVersionWritesNothing(t *testing.T) {
 	h.env.AssertNotCalled(t, "PollDeployments", mock.Anything, mock.Anything)
 }
 
-// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.
+// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.
 //
 // A web app reads its backend's address out of window._env_ at module load, and
 // that address exists only once the backend has a rendered binding — so the
@@ -1280,6 +1280,46 @@ func TestDeployOrderUnsatisfiable_SettlesAsADeployFailure(t *testing.T) {
 		"a cycle is nobody's individual fault — every component in it is named")
 	require.Contains(t, h.deployMints[0].Reasons["web-a"], "hard dependency cycle",
 		"the cause reaches the issue body rather than only the workflow history")
+}
+
+// A permanent plan failure must always NAME somebody, because the fix issue is
+// what stops the next boundary settling a version that is not running.
+//
+// The reachable hole this closes: a pass is entered when anything is behind OR
+// converging, so a version whose components are all converging can hit an
+// unsatisfiable order with an empty behind set. Attributed to the behind set
+// alone, the failure would name nobody, mint nothing, and settle the run on the
+// deploy budget with an empty milestone behind it — the exact wedge the stage
+// exists to stop producing.
+func TestDeployOrderPermanentlyUnsatisfiable_NamesEveryNonServingComponent(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(workable(1, 1), MilestoneSnapshot{})
+	// Nothing behind: both components are converging towards the release they
+	// already pin, which is what makes the behind set empty.
+	h.versionIs(
+		delivery.ComponentState{
+			Component: "todo-api", State: delivery.ComponentStateConverging,
+			DesiredSHA: testMergeSHA, Pinned: "release-todo-api",
+		},
+		delivery.ComponentState{
+			Component: "todo-webapp", State: delivery.ComponentStateConverging,
+			DesiredSHA: testMergeSHA, Pinned: "release-todo-webapp",
+		},
+	)
+	h.wavesAre(nil, temporal.NewNonRetryableApplicationError(
+		"deployment: hard dependency cycle among components todo-api needs [todo-webapp]; todo-webapp needs [todo-api]",
+		errTypePermanentDeploy, nil))
+	h.deployMintsAre([]int{testRepairIssue})
+	h.merges(1)
+
+	h.run(delivery.RunKindDev, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonDeployBudget)
+	require.Equal(t, 1, h.deployMintCount(), "a failure that names nobody files nothing and wedges the run")
+	require.ElementsMatch(t, []string{"todo-api", "todo-webapp"},
+		delivery.TargetNames(h.deployMints[0].Failed),
+		"with nothing behind, the attribution falls back to every component that is not serving")
 }
 
 // A plan that could not be READ is a blip, not an answer, and must keep the

--- a/services/aep-api/internal/delivery/run/workflow_test.go
+++ b/services/aep-api/internal/delivery/run/workflow_test.go
@@ -81,8 +81,8 @@ type harness struct {
 	// deploys records every promote the loop asked for, and deployMints every
 	// deploy-fix filing. wavePlans records every ordering request, so a test can
 	// assert the stage planned before it wrote.
-	deploys     []DeployCycleInput
-	wavePlans   []DeployCycleInput
+	deploys     []PromoteInput
+	wavePlans   []PlanDeployInput
 	deployMints []MintDeployFixIssuesInput
 	// traitSyncs records every managed-API trait convergence the loop asked for,
 	// so a test can assert WHEN it fires rather than merely that it was wired.
@@ -119,6 +119,23 @@ type harness struct {
 	// gateChecks counts the deploy gate's reads, so a test can assert the gate
 	// was consulted (or deliberately was not, on a cycle that promotes nothing).
 	gateChecks int
+
+	// The VERSION STATE model: what the cluster would answer ReadVersionState.
+	//
+	// Derived rather than pinned, because the loop now reads the same world
+	// twice — once to decide what to promote, once at the boundary to decide
+	// whether the version may be delivered — and a static answer could only be
+	// right for one of them. buildStates is what the test already pinned
+	// (a component green at the merge SHA is BEHIND until something promotes it,
+	// a red one is UNBUILT), and promoted is what the loop actually wrote. So a
+	// test describes builds and deployments as before, and the version state
+	// follows from them the way it follows from the cluster.
+	seenBuilds []CycleBuildState
+	promoted   map[string]string
+	// versionOverride, when set, replaces the derived model — for the tests that
+	// are ABOUT a state the loop's own actions cannot produce, such as a
+	// component nothing ever bound.
+	versionOverride *delivery.VersionState
 }
 
 // newHarness registers the activities whose behaviour never varies — the
@@ -127,7 +144,7 @@ type harness struct {
 func newHarness(t *testing.T) *harness {
 	t.Helper()
 	var ts testsuite.WorkflowTestSuite
-	h := &harness{env: ts.NewTestWorkflowEnvironment(), set: map[string]bool{}}
+	h := &harness{env: ts.NewTestWorkflowEnvironment(), set: map[string]bool{}, promoted: map[string]string{}}
 	var acts *Activities
 	h.acts = acts
 
@@ -151,12 +168,13 @@ func newHarness(t *testing.T) *harness {
 	h.env.RegisterActivity(acts.ProvisionGates)
 	h.env.RegisterActivity(acts.PlanMilestone)
 	h.env.RegisterActivity(acts.PlanDeployWaves)
-	h.env.RegisterActivity(acts.DeployCycle)
-	h.env.RegisterActivity(acts.PollCycleDeployments)
+	h.env.RegisterActivity(acts.PromoteWave)
+	h.env.RegisterActivity(acts.PollDeployments)
 	h.env.RegisterActivity(acts.MintDeployFixIssues)
 	h.env.RegisterActivity(acts.HaltUnfinishedWork)
 	h.env.RegisterActivity(acts.CloseCancelledWork)
 	h.env.RegisterActivity(acts.CheckDeployReadiness)
+	h.env.RegisterActivity(acts.ReadVersionState)
 
 	h.env.OnActivity(acts.SetRunState, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -328,50 +346,202 @@ func (h *harness) planCounts() (gates, plans int) {
 // the harness consumes expectations in registration order.
 func (h *harness) deployIs(err error) {
 	h.set["deploy"] = true
-	h.env.OnActivity(h.acts.DeployCycle, mock.Anything, mock.Anything).
+	h.env.OnActivity(h.acts.PromoteWave, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
+			in := args.Get(1).(PromoteInput)
 			h.mu.Lock()
 			defer h.mu.Unlock()
-			h.deploys = append(h.deploys, args.Get(1).(DeployCycleInput))
+			h.deploys = append(h.deploys, in)
+			if err != nil {
+				return // a failed promote wrote nothing
+			}
+			for _, t := range in.Targets {
+				if t.CommitSHA == "" {
+					continue // a converge moves no pin
+				}
+				h.promoted[t.Component] = t.CommitSHA
+			}
 		}).Return([]delivery.ComponentDeploy(nil), err)
 }
 
-// wavesAre pins the deploy order the planner answers.
+// versionIs pins the version state outright, replacing the derived model. For
+// the cases the loop's own actions cannot produce — a component whose binding
+// nothing ever wrote, above all, which is the failure the delivery gate exists
+// to catch.
+func (h *harness) versionIs(components ...delivery.ComponentState) {
+	h.set["version"] = true
+	st := delivery.VersionState{Components: components}
+	h.mu.Lock()
+	h.versionOverride = &st
+	h.mu.Unlock()
+}
+
+// versionState is what ReadVersionState answers: the override if a test pinned
+// one, otherwise the model derived from the builds it pinned and the promotes
+// the loop made.
+//
+// A component is SERVING once the loop promoted it at the commit its newest
+// green build was cut from — which is exactly when the real read would say so,
+// because the stage does not leave the promote until the binding is Ready.
+func (h *harness) versionState() delivery.VersionState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.versionOverride != nil {
+		return *h.versionOverride
+	}
+	desired := map[string]string{}
+	var order []string
+	for _, st := range h.seenBuilds {
+		for _, name := range st.Components {
+			if _, seen := desired[name]; !seen {
+				order = append(order, name)
+			}
+			desired[name] = testMergeSHA
+		}
+		for _, name := range st.Red {
+			if _, seen := desired[name]; !seen {
+				order = append(order, name)
+			}
+			// A red build is a component with no release to pin. The next state
+			// in the queue may report it green, which overwrites this.
+			desired[name] = ""
+		}
+	}
+	out := delivery.VersionState{}
+	for _, name := range order {
+		st := delivery.ComponentState{Component: name, DesiredSHA: desired[name]}
+		switch {
+		case desired[name] == "":
+			st.State = delivery.ComponentStateUnbuilt
+		case h.promoted[name] == desired[name]:
+			st.State, st.Ready = delivery.ComponentStateServing, true
+		default:
+			st.State = delivery.ComponentStateBehind
+		}
+		out.Components = append(out.Components, st)
+	}
+	return out
+}
+
+// wavesAre pins the levels the planner answers, by name. Each named component
+// is promoted at the commit the version state says it is behind by, so a test
+// describes the ORDER and the model supplies the commits.
 func (h *harness) wavesAre(waves [][]string, err error) {
 	h.set["waves"] = true
 	h.env.OnActivity(h.acts.PlanDeployWaves, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			h.mu.Lock()
-			defer h.mu.Unlock()
-			h.wavePlans = append(h.wavePlans, args.Get(1).(DeployCycleInput))
-		}).Return(waves, err)
-}
-
-// wavesAreOneWave is the default: whatever the cycle built, promoted together —
-// what a project with no hard wiring edges gets.
-//
-// Derived from the REQUEST rather than hardcoded, so a test that changes which
-// components its builds report cannot end up silently planning a different set
-// than the one being deployed.
-func (h *harness) wavesAreOneWave() {
-	h.set["waves"] = true
-	h.env.OnActivity(h.acts.PlanDeployWaves, mock.Anything, mock.Anything).
-		Return(func(_ context.Context, in DeployCycleInput) ([][]string, error) {
+		Return(func(_ context.Context, in PlanDeployInput) (delivery.DeployPlan, error) {
 			h.mu.Lock()
 			defer h.mu.Unlock()
 			h.wavePlans = append(h.wavePlans, in)
-			if len(in.Components) == 0 {
-				return nil, nil
+			if err != nil {
+				return delivery.DeployPlan{}, err
 			}
-			return [][]string{in.Components}, nil
+			return planFor(in.Version, waves), nil
 		})
+}
+
+// wavesAreOneWave is the default: everything the version is behind by,
+// promoted together — what a project with no hard wiring edges gets.
+//
+// Derived from the STATE rather than hardcoded, so a test that changes which
+// components its builds report cannot end up planning a different set than the
+// one the loop would promote.
+func (h *harness) wavesAreOneWave() {
+	h.set["waves"] = true
+	h.env.OnActivity(h.acts.PlanDeployWaves, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, in PlanDeployInput) (delivery.DeployPlan, error) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			h.wavePlans = append(h.wavePlans, in)
+			return planFor(in.Version, nil), nil
+		})
+}
+
+// planIsHolding pins a planner that refuses to promote the named components,
+// however many cycles the run takes, and promotes everything else that is
+// behind. It is the one decision the derived plan cannot make on its own,
+// because it does not read a design.
+func (h *harness) planIsHolding(held ...string) {
+	h.set["waves"] = true
+	holds := make(map[string]bool, len(held))
+	for _, name := range held {
+		holds[name] = true
+	}
+	h.env.OnActivity(h.acts.PlanDeployWaves, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, in PlanDeployInput) (delivery.DeployPlan, error) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			h.wavePlans = append(h.wavePlans, in)
+			var promote []string
+			for _, c := range in.Version.Components {
+				if c.State == delivery.ComponentStateBehind && !holds[c.Component] {
+					promote = append(promote, c.Component)
+				}
+			}
+			plan := planFor(in.Version, [][]string{promote})
+			for i := range plan.Held {
+				plan.Held[i].WaitingOn = []string{"a provider that is not serving"}
+			}
+			return plan, nil
+		})
+}
+
+// planFor is the harness's stand-in for the real planner: it levels the behind
+// components the way the test asked (or all of them in one wave), pairs each
+// with the commit the state says it is behind by, and waits on everything it
+// promoted plus anything already converging.
+//
+// It deliberately does NOT hold anything. What a plan holds is the planner's
+// own decision, tested against real designs in projects/wiring_graph_test.go;
+// what these tests exercise is what the STAGE does with a plan.
+func planFor(version delivery.VersionState, levels [][]string) delivery.DeployPlan {
+	commits := map[string]string{}
+	var behind []string
+	plan := delivery.DeployPlan{}
+	for _, c := range version.Components {
+		switch c.State {
+		case delivery.ComponentStateBehind:
+			commits[c.Component] = c.DesiredSHA
+			behind = append(behind, c.Component)
+		case delivery.ComponentStateConverging:
+			plan.Waited = append(plan.Waited, c.Component)
+		}
+	}
+	if levels == nil && len(behind) > 0 {
+		levels = [][]string{behind}
+	}
+	placed := map[string]bool{}
+	for _, level := range levels {
+		var wave []delivery.DeployTarget
+		for _, name := range level {
+			if _, isBehind := commits[name]; !isBehind {
+				continue // already serving, or never built: not this pass's work
+			}
+			wave = append(wave, delivery.DeployTarget{Component: name, CommitSHA: commits[name]})
+			plan.Waited = append(plan.Waited, name)
+			placed[name] = true
+		}
+		if len(wave) > 0 {
+			plan.Waves = append(plan.Waves, wave)
+		}
+	}
+	// A behind component the levels did not name is HELD — which is how a test
+	// describes a plan that refuses to promote something.
+	for _, name := range behind {
+		if !placed[name] {
+			plan.Held = append(plan.Held, delivery.ComponentState{
+				Component: name, State: delivery.ComponentStateHeld, DesiredSHA: commits[name],
+			})
+		}
+	}
+	return plan
 }
 
 // deploymentsAre queues the readiness polls, in order; the last repeats.
 func (h *harness) deploymentsAre(states ...CycleDeployState) {
 	h.set["deployments"] = true
 	for i, st := range states {
-		call := h.env.OnActivity(h.acts.PollCycleDeployments, mock.Anything, mock.Anything).Return(st, nil)
+		call := h.env.OnActivity(h.acts.PollDeployments, mock.Anything, mock.Anything).Return(st, nil)
 		if i < len(states)-1 {
 			call.Once()
 		}
@@ -464,8 +634,18 @@ func (h *harness) milestoneIs(snaps ...MilestoneSnapshot) {
 // buildsAre queues the cycle-build polls, in order; the last repeats.
 func (h *harness) buildsAre(states ...CycleBuildState) {
 	h.set["builds"] = true
-	for i, s := range states {
-		call := h.env.OnActivity(h.acts.PollCycleBuilds, mock.Anything, mock.Anything).Return(s, nil)
+	for i, st := range states {
+		// Each answer is RECORDED as the loop consumes it, which is what makes the
+		// version model advance with the run: a component reported red in cycle
+		// one and green in cycle two is unbuilt while cycle one is deciding and
+		// behind once cycle two has seen its build. Deriving from the queue
+		// instead would let the first cycle see the second cycle's builds.
+		call := h.env.OnActivity(h.acts.PollCycleBuilds, mock.Anything, mock.Anything).
+			Run(func(mock.Arguments) {
+				h.mu.Lock()
+				defer h.mu.Unlock()
+				h.seenBuilds = append(h.seenBuilds, st)
+			}).Return(st, nil)
 		if i < len(states)-1 {
 			call.Once()
 		}
@@ -618,6 +798,16 @@ func (h *harness) applyDefaults() {
 	if !h.set["deployMint"] {
 		h.deployMintsAre([]int{testRepairIssue})
 	}
+	if !h.set["version"] {
+		h.set["version"] = true
+	}
+	// Always registered, override or not: the read is on the path of every dev
+	// run's delivery, and a mock the loop calls without an expectation fails the
+	// workflow rather than the assertion.
+	h.env.OnActivity(h.acts.ReadVersionState, mock.Anything, mock.Anything).
+		Return(func(context.Context, ProjectRef) (delivery.VersionState, error) {
+			return h.versionState(), nil
+		})
 	if !h.set["gate"] {
 		// An OPEN gate is the default: the project is configured, so every test
 		// that is not about the gate deploys exactly as it did before ADR-0023.
@@ -807,25 +997,98 @@ func TestBuildsGreen_DeploysBeforeSettling(t *testing.T) {
 	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
 	require.Equal(t, 2, h.deployCount(),
 		"one green cycle = one wave promoted, then one converge that promotes nothing")
-	require.Equal(t, []string{"order-service"}, h.deploys[0].Components,
-		"the deploy promotes the components the BUILD poll reported, not a re-derived set")
-	require.Equal(t, testMergeSHA, h.deploys[0].CommitSHA,
-		"the promote is pinned to the cycle's own merge commit")
+	require.Equal(t, []delivery.DeployTarget{{Component: "order-service", CommitSHA: testMergeSHA}},
+		h.deploys[0].Targets,
+		"the deploy promotes what the VERSION is behind by, each at its own newest green build")
 }
 
-// TestRedBuild_DoesNotDeploy: a component that did not build has no image to
-// promote, so the red cycle must not reach the deploy stage at all. The fix
-// cycle that follows passes through the green path and promotes then.
-func TestRedBuild_DoesNotDeploy(t *testing.T) {
+// TestDeliverVersion_RefusesAVersionThatIsNotServing reconstructs the incident
+// this gate was written for.
+//
+// A build's webapp went red while its api went green. The api was never
+// promoted — the deploy set was the cycle's path diff, and the fix cycle's diff
+// touched only the webapp — so when the milestone emptied the run settled
+// SUCCEEDED, minted the version's validation task and closed the increment with
+// an api nothing had ever bound. Every cycle had been green; nothing in the
+// sequence was a lie. The predicate was.
+//
+// The version is now READ at the boundary, and a component that is not serving
+// fails the run with a reason that names the class rather than delivering
+// software that is not running.
+func TestDeliverVersion_RefusesAVersionThatIsNotServing(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(workable(1, 1), MilestoneSnapshot{})
+	h.merges(1)
+	// The api built and is serving; the webapp has a green build and no binding.
+	// That is exactly what the cluster answered on 2026-09-01.
+	h.versionIs(
+		delivery.ComponentState{
+			Component: "onboarding-api", State: delivery.ComponentStateServing, Ready: true,
+		},
+		delivery.ComponentState{
+			Component: "onboarding-webapp", State: delivery.ComponentStateBehind,
+			DesiredSHA: testMergeSHA,
+		},
+	)
+
+	h.run(delivery.RunKindDev, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonVersionIncomplete)
+	h.env.AssertNotCalled(t, "EnsureValidationIssue", mock.Anything, mock.Anything)
+	require.Equal(t, 0, h.closed,
+		"and the milestone stays open: the way forward is more work in the same version")
+	require.Len(t, h.haltedWork(), 1,
+		"the failed settle halts what it could not finish, like every other failure")
+}
+
+// TestDeliverVersion_DeliversWhenEveryComponentServes is the other half of the
+// same predicate, and it asserts the READ rather than the outcome: the boundary
+// re-derives the version state instead of trusting the cycle that just ended,
+// because between the two the world may have moved.
+func TestDeliverVersion_DeliversWhenEveryComponentServes(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(workable(1, 1), MilestoneSnapshot{})
+	h.merges(1)
+	h.versionIs(delivery.ComponentState{
+		Component: "order-service", State: delivery.ComponentStateServing, Ready: true,
+	})
+	h.validationIs(77, delivery.ValidationVerdictPassed)
+
+	h.run(delivery.RunKindDev, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+	h.env.AssertCalled(t, "EnsureValidationIssue", mock.Anything, mock.Anything)
+	require.Empty(t, res.ValidationVerdict,
+		"a dev run delivers and never judges — the validation run owns the verdict")
+}
+
+// TestRedBuild_PromotesItsGreenSiblings is the incident, run forwards.
+//
+// Cycle one built two components: the api went green, the webapp went red. The
+// cycle is RED — the webapp's fix issue is the next cycle's work — and the api
+// is promoted anyway, in that same cycle. What this replaced returned at the red
+// verdict before the deploy stage, so the api's release was never cut; and
+// because the deploy set was the cycle's path diff, the fix cycle that followed
+// touched only the webapp and never mentioned the api again. The api was
+// stranded for the rest of the version's life.
+//
+// A red build cannot be helped by holding its siblings back, and the promotable
+// rule is what makes promoting them safe: only components whose hard providers
+// are serving or promoted ahead of them are written.
+func TestRedBuild_PromotesItsGreenSiblings(t *testing.T) {
 	h := newHarness(t)
 	h.milestoneIs(
-		workable(1, 1),
-		workable(1, 1),
-		MilestoneSnapshot{},
+		workable(1, 1),      // dispatch
+		workable(1, 1),      // the webapp's fix issue
+		MilestoneSnapshot{}, // delivered
 	)
 	h.buildsAre(
-		CycleBuildState{Expected: 1, Settled: 1, Red: []string{"order-service"}, Components: []string{"order-service"}},
-		CycleBuildState{Expected: 1, Settled: 1, Components: []string{"order-service"}},
+		CycleBuildState{Expected: 2, Settled: 2,
+			Components: []string{"onboarding-api", "onboarding-webapp"},
+			Red:        []string{"onboarding-webapp"}},
+		CycleBuildState{Expected: 1, Settled: 1, Components: []string{"onboarding-webapp"}},
 	)
 	h.merges(2)
 
@@ -833,11 +1096,97 @@ func TestRedBuild_DoesNotDeploy(t *testing.T) {
 	res := h.result(t)
 
 	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
-	require.Equal(t, 2, h.deployCount(),
-		"only the GREEN cycle deploys — its one wave and its converge, and nothing from the red one")
+	require.Equal(t, []string{delivery.CycleKindCoding, delivery.CycleKindFix}, h.dispatchKinds(),
+		"the red build still makes the next cycle a FIX cycle — the deploy does not launder the verdict")
+
+	first := h.deploys[0]
+	require.Equal(t, []string{"onboarding-api"}, delivery.TargetNames(first.Targets),
+		"the RED cycle promotes its green sibling; the webapp has no release to pin")
+	require.Equal(t, 0, h.deployMintCount(),
+		"a component with no image is not a deployment failure — its red build already filed its issue")
+
+	// And the fix cycle picks the webapp up, so the version ends serving both.
+	var promoted []string
+	for _, in := range h.deploys {
+		for _, target := range in.Targets {
+			if target.CommitSHA != "" {
+				promoted = append(promoted, target.Component)
+			}
+		}
+	}
+	require.ElementsMatch(t, []string{"onboarding-api", "onboarding-webapp"}, promoted,
+		"both components are serving by the time the version is delivered")
 }
 
-// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.
+// TestHeldComponent_IsNeitherPromotedNorBlamed is the objection, answered: A
+// needs B, A is green, B is red.
+//
+// A is HELD. Not promoted — a SPA published against an api with no address is a
+// blank page — and not waited on and not filed against either, which is the part
+// that is easy to get wrong: a deploy-fix issue would send an agent to debug a
+// deployment that is perfectly healthy and simply has not happened. B's red
+// build has its own issue, and the pass that finds B serving promotes A.
+//
+// Which components a plan holds is the planner's decision, tested against real
+// designs in projects. What this pins is the STAGE's treatment of one.
+func TestHeldComponent_IsNeitherPromotedNorBlamed(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(workable(1, 1), workable(1, 1), MilestoneSnapshot{})
+	h.buildsAre(
+		CycleBuildState{Expected: 2, Settled: 2,
+			Components: []string{"api", "web"}, Red: []string{"api"}},
+		CycleBuildState{Expected: 1, Settled: 1, Components: []string{"api"}},
+	)
+	// The planner refuses to promote the web app while its api is unbuilt.
+	h.planIsHolding("web")
+	h.merges(2)
+
+	h.run(delivery.RunKindDev, 0)
+	res := h.result(t)
+
+	// The version never serves the web app, so the run refuses to deliver it —
+	// loudly, rather than shipping a SPA with no backend.
+	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonVersionIncomplete)
+	for _, in := range h.deploys {
+		require.NotContains(t, delivery.TargetNames(in.Targets), "web",
+			"a held component is never written — not in a wave, and not in the converge either")
+	}
+	require.Equal(t, 0, h.deployMintCount(),
+		"held is not a deployment failure: filing one would send an agent after nothing")
+	require.Len(t, h.deploys, 2,
+		"cycle one wrote NOTHING — not a wave and not a converge either, because a pass that "+
+			"promotes nothing never consulted the deploy gate; cycle two promoted the api and converged it")
+}
+
+// TestReconcile_AServingVersionWritesNothing is the property that lets the
+// reconcile run on every cycle, red or green: re-running it against a version
+// that already serves what has been built promotes nothing, waits on nothing,
+// and never consults the deploy gate.
+//
+// It is also what keeps a converge/validation-shaped cycle — a merge that
+// rebuilt no component — from parking on a credential it will not use.
+func TestReconcile_AServingVersionWritesNothing(t *testing.T) {
+	h := newHarness(t)
+	h.milestoneIs(workable(1, 1), MilestoneSnapshot{})
+	h.merges(1)
+	h.versionIs(delivery.ComponentState{
+		Component: "order-service", State: delivery.ComponentStateServing, Ready: true,
+		Pinned: "release-order-service",
+	})
+
+	h.run(delivery.RunKindDev, 0)
+	res := h.result(t)
+
+	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
+	require.Empty(t, h.deploys, "nothing is behind, so nothing is written — not even a converge")
+	require.Empty(t, h.wavePlans, "and nothing is planned: the state alone answers it")
+	_, checks := h.parksOnValues()
+	require.Equal(t, 0, checks,
+		"a pass that writes nothing must not consult the deploy gate — a credential it will not use cannot park the run")
+	h.env.AssertNotCalled(t, "PollDeployments", mock.Anything, mock.Anything)
+}
+
+// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.// TestDeploy_PromotesWaveByWaveThenConverges pins the whole stage's shape.
 //
 // A web app reads its backend's address out of window._env_ at module load, and
 // that address exists only once the backend has a rendered binding — so the
@@ -861,19 +1210,23 @@ func TestDeploy_PromotesWaveByWaveThenConverges(t *testing.T) {
 
 	h.assertSettled(t, res, delivery.RunStateSucceeded, "")
 	require.Len(t, h.deploys, 3, "two waves promote, then one converge")
-	require.Equal(t, []string{"todo-api"}, h.deploys[0].Components,
+	require.Equal(t, []delivery.DeployTarget{{Component: "todo-api", CommitSHA: testMergeSHA}},
+		h.deploys[0].Targets,
 		"the provider goes first — its address is what the consumer's config carries")
-	require.Equal(t, []string{"todo-webapp"}, h.deploys[1].Components)
-	require.Equal(t, testMergeSHA, h.deploys[0].CommitSHA)
-	require.Equal(t, testMergeSHA, h.deploys[1].CommitSHA)
+	require.Equal(t, []delivery.DeployTarget{{Component: "todo-webapp", CommitSHA: testMergeSHA}},
+		h.deploys[1].Targets)
 
-	require.Equal(t, []string{"todo-api", "todo-webapp"}, h.deploys[2].Components,
+	require.Equal(t, []string{"todo-api", "todo-webapp"}, delivery.TargetNames(h.deploys[2].Targets),
 		"the converge re-asserts the whole set, not just the last wave")
-	require.Empty(t, h.deploys[2].CommitSHA,
-		"the converge promotes nothing: an empty commit is what keeps it from re-cutting a release")
+	for _, target := range h.deploys[2].Targets {
+		require.Empty(t, target.CommitSHA,
+			"the converge promotes nothing: an empty commit is what keeps it from re-cutting a release")
+	}
 
-	require.Len(t, h.wavePlans, 1, "the order is planned once per cycle, before anything is written")
-	require.Equal(t, []string{"todo-api", "todo-webapp"}, h.wavePlans[0].Components)
+	require.Len(t, h.wavePlans, 1, "the pass is planned once per cycle, before anything is written")
+	require.Equal(t, []string{"todo-api", "todo-webapp"},
+		behindNames(h.wavePlans[0].Version),
+		"the planner is handed the version's own state, not the cycle's path diff")
 }
 
 // A wave that cannot come up ends the stage there: the waves after it depend on
@@ -893,7 +1246,7 @@ func TestDeploy_FailedWaveRunsNoFurtherWaveOrConverge(t *testing.T) {
 
 	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonDeployBudget)
 	require.Len(t, h.deploys, 1, "the first wave failed; nothing downstream of it runs")
-	require.Equal(t, []string{"todo-api"}, h.deploys[0].Components)
+	require.Equal(t, []string{"todo-api"}, delivery.TargetNames(h.deploys[0].Targets))
 }
 
 // An order that cannot be satisfied has to arrive as a DEPLOY FAILURE, not as a
@@ -923,7 +1276,7 @@ func TestDeployOrderUnsatisfiable_SettlesAsADeployFailure(t *testing.T) {
 	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonDeployBudget)
 	require.Empty(t, h.deploys, "an unsatisfiable order promotes nothing")
 	require.Equal(t, 1, h.deployMintCount(), "the fix work is filed, not swallowed by a failed workflow")
-	require.ElementsMatch(t, []string{"web-a", "web-b"}, h.deployMints[0].Components,
+	require.ElementsMatch(t, []string{"web-a", "web-b"}, delivery.TargetNames(h.deployMints[0].Failed),
 		"a cycle is nobody's individual fault — every component in it is named")
 	require.Contains(t, h.deployMints[0].Reasons["web-a"], "hard dependency cycle",
 		"the cause reaches the issue body rather than only the workflow history")
@@ -985,7 +1338,7 @@ func TestDeployFailed_BecomesTheNextCyclesWork(t *testing.T) {
 	require.Equal(t, []string{delivery.CycleKindCoding, delivery.CycleKindFix}, h.dispatchKinds(),
 		"a failed deployment recovers through an ordinary fix cycle")
 	require.Equal(t, 1, h.deployMintCount(), "the supervisor files the deploy-fix work itself")
-	require.Equal(t, []string{"order-service"}, h.deployMints[0].Components)
+	require.Equal(t, []string{"order-service"}, delivery.TargetNames(h.deployMints[0].Failed))
 	require.Equal(t, "RenderingFailed", h.deployMints[0].Reasons["order-service"],
 		"OpenChoreo's own reason reaches the issue body")
 }
@@ -1027,7 +1380,7 @@ func TestValidationRun_BuildsAndDeploysNothing(t *testing.T) {
 	require.Equal(t, 0, h.deployCount(), "a validation run promotes nothing")
 	h.env.AssertNotCalled(t, "PollCycleBuilds", mock.Anything, mock.Anything)
 	h.env.AssertNotCalled(t, "PlanDeployWaves", mock.Anything, mock.Anything)
-	h.env.AssertNotCalled(t, "PollCycleDeployments", mock.Anything, mock.Anything)
+	h.env.AssertNotCalled(t, "PollDeployments", mock.Anything, mock.Anything)
 	// And it never polls a working set: it has none, which is why it does not
 	// share the cycle-boundary loop at all.
 	h.env.AssertNotCalled(t, "PollMilestone", mock.Anything, mock.Anything)
@@ -1059,7 +1412,7 @@ func TestDeployNeverReady_ExpiresIntoADeployFailure(t *testing.T) {
 	h.assertSettled(t, res, delivery.RunStateFailed, delivery.RunReasonDeployBudget)
 	require.Positive(t, h.deployMintCount(),
 		"the expiry files fix work rather than hanging the run")
-	require.Equal(t, []string{"order-service"}, h.deployMints[0].Components,
+	require.Equal(t, []string{"order-service"}, delivery.TargetNames(h.deployMints[0].Failed),
 		"the components that never came up are the ones named")
 }
 

--- a/services/aep-api/internal/delivery/run_status.go
+++ b/services/aep-api/internal/delivery/run_status.go
@@ -137,6 +137,16 @@ type RunStatus struct {
 	// "delivered, not yet judged".
 	ValidationIssue   int    `json:"validationIssue,omitempty"`
 	ValidationVerdict string `json:"validationVerdict,omitempty"`
+
+	// Version is the last VersionState the run read: every component in the
+	// design, with what it should be serving and what it is (ADR-0026).
+	//
+	// Live status rather than a column, because it is a fact about the WORLD and
+	// not about the run — the next read may differ, and the run row must not
+	// carry a stale copy of something a reader can ask the cluster for. What
+	// outlives the run is the terminal reason `version-incomplete`, plus the
+	// settle log naming the components that were not serving.
+	Version VersionState `json:"version,omitzero"`
 }
 
 // Run phases — where a cycle is. They are a read-model label only: no platform

--- a/services/aep-api/internal/delivery/version_state.go
+++ b/services/aep-api/internal/delivery/version_state.go
@@ -88,6 +88,15 @@ type ComponentState struct {
 	// Pinned is the release the binding pins, "" when there is no binding.
 	Pinned string `json:"pinned,omitempty"`
 	Ready  bool   `json:"ready"`
+	// Undeploy is a binding somebody took out of the environment on purpose.
+	//
+	// Such a component reads as `serving` — nothing is owed, and promoting over a
+	// deliberate withdrawal would be the platform overruling the person who asked
+	// for it — but it is NOT a satisfied hard provider: it has no active release,
+	// so it has no address for a consumer's start-up config to carry. The two
+	// facts are separate for exactly that reason, and a planner that could not
+	// tell them apart would publish a web app against a backend nobody is running.
+	Undeploy bool `json:"undeploy,omitempty"`
 	// Reason is OpenChoreo's own Ready reason, verbatim. Carried for the log and
 	// the issue body; never branched on here.
 	Reason string `json:"reason,omitempty"`
@@ -134,6 +143,16 @@ func (v VersionState) NotServing() []ComponentState {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Component < out[j].Component })
 	return out
+}
+
+// ServesConsumers reports whether this component's address exists for a hard
+// consumer to be composed against: serving, and not deliberately withdrawn.
+//
+// Deliberately narrower than `State == serving`, which answers "does the version
+// owe this component anything". An undeployed component owes nothing and offers
+// nothing, and only the planner cares about the difference.
+func (c ComponentState) ServesConsumers() bool {
+	return c.State == ComponentStateServing && !c.Undeploy
 }
 
 // ServingCount is how many of the version's components are serving, out of how

--- a/services/aep-api/internal/delivery/version_state.go
+++ b/services/aep-api/internal/delivery/version_state.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package delivery
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/wso2/aep/aep-api/internal/platform/k8sname"
+)
+
+// The VERSION's deploy state: what each of a version's components should be
+// serving, what it is serving, and the difference between those two (ADR-0026).
+//
+// It lives at the delivery ROOT for the same reason the build fan-out naming
+// does. Two peer packages have to agree on it exactly — the RUN SUPERVISOR
+// classifies and decides, `projects` orders and writes — and they may not
+// import each other. A second spelling of "behind" would let the planner and
+// the promoter disagree about which components a pass owns, which is the class
+// of bug this whole model exists to remove.
+//
+// The deploy set used to be the cycle's path diff: whichever components the
+// merge happened to touch. That made "what is serving" a function of which
+// files a fix edited rather than of what has been built, so a component whose
+// build went green in a cycle a SIBLING failed was never promoted by any later
+// cycle either — its files had stopped changing. The states below replace that
+// with a difference between desired and actual, re-derived from ground truth on
+// every pass.
+
+// Component deploy states. Exactly one holds per component per read.
+const (
+	// ComponentStateServing — the binding pins the release of the component's
+	// newest succeeded build, and OpenChoreo reports it Ready. This is the only
+	// state that satisfies a hard consumer, and the only one serving(V) accepts.
+	ComponentStateServing = "serving"
+	// ComponentStateBehind — a succeeded build exists whose release is not what
+	// the binding pins (including a component with no binding at all). The ONLY
+	// state a reconcile writes to.
+	ComponentStateBehind = "behind"
+	// ComponentStateConverging — the binding pins the right release and has not
+	// reported Ready yet.
+	//
+	// It covers a binding that will NEVER be ready as well as one that is thirty
+	// seconds away: the two are indistinguishable from a pin, and the readiness
+	// poll is what separates them — a terminal Ready reason arrives as a deploy
+	// failure within one tick of the wait. Classifying on the pin alone is what
+	// keeps this function pure.
+	ComponentStateConverging = "converging"
+	// ComponentStateHeld — behind, but a hard provider is not serving and is not
+	// being promoted in this pass. Not a failure: the provider's own state has
+	// its own work (a fix issue, or an open development issue), and this
+	// component is promoted by the first pass that finds its providers serving.
+	ComponentStateHeld = "held"
+	// ComponentStateUnbuilt — no succeeded build at any commit, so there is
+	// nothing to promote. Not a failure either: a red build already minted its
+	// fix issue, and a component nobody has written yet has its development
+	// issue open.
+	ComponentStateUnbuilt = "unbuilt"
+)
+
+// ComponentState is one component's desired state, its actual state, and the
+// verdict comparing them.
+type ComponentState struct {
+	Component string `json:"component"`
+	State     string `json:"state"`
+	// DesiredSHA is the commit of the component's newest SUCCEEDED build, ""
+	// when it has none. Newest succeeded rather than newest: a component whose
+	// re-trigger failed is still built, at the commit that worked.
+	DesiredSHA string `json:"desiredSha,omitempty"`
+	// DesiredRelease is the release DesiredSHA names — carried rather than
+	// recomposed at every comparison site, because it is the value the binding's
+	// pin is compared against.
+	DesiredRelease string `json:"desiredRelease,omitempty"`
+	// Pinned is the release the binding pins, "" when there is no binding.
+	Pinned string `json:"pinned,omitempty"`
+	Ready  bool   `json:"ready"`
+	// Reason is OpenChoreo's own Ready reason, verbatim. Carried for the log and
+	// the issue body; never branched on here.
+	Reason string `json:"reason,omitempty"`
+	// WaitingOn names the hard providers holding this component back. Set only
+	// on a held component, by the planner that decided it.
+	WaitingOn []string `json:"waitingOn,omitempty"`
+}
+
+// VersionState is every component in the design, classified.
+//
+// Every component, not the cycle's: a version is delivered when everything the
+// design declares is serving, so a state that only described what one merge
+// touched could never answer that question.
+type VersionState struct {
+	Components []ComponentState `json:"components"`
+}
+
+// Serving reports whether every component in the design is serving — the
+// predicate a version's delivery and its validation both wait on.
+//
+// An EMPTY state is serving, and deliberately: a project with no design has no
+// component that could fail to serve, and a plane with no OpenChoreo behind it
+// reads every component as ready for the same reason DeployCycle degrades to a
+// no-op. Refusing to deliver in either case would fail runs over a gate that
+// has nothing to gate.
+func (v VersionState) Serving() bool {
+	for _, c := range v.Components {
+		if c.State != ComponentStateServing {
+			return false
+		}
+	}
+	return true
+}
+
+// NotServing lists the components that are not serving, with their state — what
+// the `version-incomplete` settle names, and what the console shows beside a
+// partially serving version. Sorted, so two reads of the same world read alike.
+func (v VersionState) NotServing() []ComponentState {
+	out := make([]ComponentState, 0, len(v.Components))
+	for _, c := range v.Components {
+		if c.State != ComponentStateServing {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Component < out[j].Component })
+	return out
+}
+
+// ServingCount is how many of the version's components are serving, out of how
+// many the design declares.
+func (v VersionState) ServingCount() (serving, total int) {
+	for _, c := range v.Components {
+		if c.State == ComponentStateServing {
+			serving++
+		}
+	}
+	return serving, len(v.Components)
+}
+
+// Describe renders the non-serving components as `component=state` pairs, for a
+// log line and for the run's live status. It names the state rather than the
+// release, because which of the five a component is in is the actionable fact.
+func (v VersionState) Describe() string {
+	off := v.NotServing()
+	parts := make([]string, 0, len(off))
+	for _, c := range off {
+		part := c.Component + "=" + c.State
+		if len(c.WaitingOn) > 0 {
+			part += " (waiting on " + strings.Join(c.WaitingOn, ", ") + ")"
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// DeployTarget is one component's promote: the component, and the commit whose
+// release is to be pinned.
+//
+// The commit is PER COMPONENT, which is the whole difference from the deploy
+// this replaced. One commit for a whole list is only right when the list is
+// what a single merge built; a reconcile promotes each component at its own
+// newest green build, which is a different commit per component in exactly the
+// case that motivated the change.
+//
+// An EMPTY CommitSHA is a CONVERGE: re-assert the wiring at whatever release is
+// already serving, without moving the pin (see ConvergeTargets).
+type DeployTarget struct {
+	Component string `json:"component"`
+	CommitSHA string `json:"commitSha,omitempty"`
+}
+
+// ConvergeTargets turns component names into converge targets — no commit, so
+// nothing is re-cut and no component's live release can move.
+func ConvergeTargets(components []string) []DeployTarget {
+	out := make([]DeployTarget, 0, len(components))
+	for _, name := range components {
+		out = append(out, DeployTarget{Component: name})
+	}
+	return out
+}
+
+// TargetNames lists the components a target set addresses, in order.
+func TargetNames(targets []DeployTarget) []string {
+	out := make([]string, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, t.Component)
+	}
+	return out
+}
+
+// DeployPlan is what one reconcile pass will do: the waves to promote, the
+// components to wait on, and the ones it deliberately leaves alone.
+type DeployPlan struct {
+	// Waves are the promotes, in order: every component in a wave has each of
+	// its hard providers serving already or promoted in an earlier wave.
+	Waves [][]DeployTarget `json:"waves,omitempty"`
+	// Waited is what the readiness poll waits for: everything promoted, plus the
+	// components already converging towards the release they pin.
+	//
+	// Held and unbuilt components are never here. The stage has ONE deadline,
+	// and spending it on a binding this pass did not write — or on a component
+	// that has no binding to wait for — would settle `deploy-budget` on a run
+	// whose only problem is work somebody still has to do.
+	Waited []string `json:"waited,omitempty"`
+	// Held is the behind components this pass refused to promote, each carrying
+	// the providers it is waiting on. Reported for the log and the run's status;
+	// nothing waits on it and nothing is filed against it.
+	Held []ComponentState `json:"held,omitempty"`
+}
+
+// Writes reports whether the plan promotes anything. A plan that writes nothing
+// starts no deadline — a fully serving version must reconcile in one read.
+func (p DeployPlan) Writes() bool {
+	for _, wave := range p.Waves {
+		if len(wave) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ReleaseNameFor names the release a component's deployment pins at a commit.
+//
+// Derived from the commit rather than server-generated so the whole deploy is
+// idempotent: the same cycle re-running its deploy activity cuts the same
+// release name, which OpenChoreo answers with a 409 the client treats as
+// success. Bounded through k8sname for the same reason build run names are — a
+// name one character over the label budget is accepted and then never renders.
+//
+// It lives HERE, beside BuildRunName, because two packages compose it and must
+// compose it identically: `projects` writes the name into the binding, and the
+// supervisor recomposes it from a build's commit to ask whether the binding
+// pins the release it should. The name is not parseable back into a commit —
+// k8sname.Bounded truncates a long readable head and appends a digest — so
+// composing the desired name and comparing is the only sound direction.
+func ReleaseNameFor(projectID, componentName, commitSHA string) string {
+	return k8sname.Bounded(k8sname.MaxLabelValueLen,
+		k8sname.Capped(projectID, releaseNameProjectWidth),
+		k8sname.Capped(componentName, releaseNameComponentWidth),
+		k8sname.Whole(ShortSHA(commitSHA)),
+	)
+}
+
+// Widths of the readable head of a release name. The commit is never truncated
+// — matching a release to the commit it froze is the main reason anyone reads
+// one of these names.
+const (
+	releaseNameProjectWidth   = 18
+	releaseNameComponentWidth = 18
+)

--- a/services/aep-api/internal/delivery/version_state_test.go
+++ b/services/aep-api/internal/delivery/version_state_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package delivery
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// RunStatus is the QueryRunStatus payload, so its wire shape is a contract with
+// the console. Version carries `omitzero` — the module's one use of it — and
+// that option is the difference between a status that stays exactly as it was
+// for every run that never deploys and one that grows an empty `version` object
+// on all of them. A silently-ignored tag would look identical in the source, so
+// it is asserted rather than assumed.
+func TestRunStatusVersion_OmittedWhenZeroAndCarriedWhenRead(t *testing.T) {
+	raw, err := json.Marshal(RunStatus{RunID: "run-1", State: RunStateWaiting})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "version") {
+		t.Errorf("a run that has read no version state still serves a `version` key: %s", raw)
+	}
+
+	raw, err = json.Marshal(RunStatus{
+		RunID: "run-1",
+		State: RunStateRunning,
+		Version: VersionState{Components: []ComponentState{{
+			Component: "onboarding-api", State: ComponentStateBehind, DesiredSHA: "aaa1",
+		}, {
+			Component: "onboarding-webapp", State: ComponentStateHeld,
+			WaitingOn: []string{"onboarding-api"},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back RunStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Version.Components) != 2 {
+		t.Fatalf("the version state did not survive the round trip: %s", raw)
+	}
+	if back.Version.Components[0].DesiredSHA != "aaa1" ||
+		back.Version.Components[1].State != ComponentStateHeld ||
+		len(back.Version.Components[1].WaitingOn) != 1 {
+		t.Errorf("a component's state lost a field on the wire: %+v", back.Version.Components)
+	}
+	// The whole point of serving it: a reader can say what is not serving and
+	// what each held component waits on, without asking the cluster.
+	if got := back.Version.Describe(); got != "onboarding-api=behind, onboarding-webapp=held (waiting on onboarding-api)" {
+		t.Errorf("Describe() = %q", got)
+	}
+}

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -53,7 +53,7 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
 | `runAbandoner` (`SetRunAbandoner`) | needs | `delivery` — ends the supervisors of a deleted project's live runs, wired at the root (nil is a no-op) |
 | per-project agent usage (`UsageService`) | needs | `delivery` — the agent-usage ledger, keyed by lifetime (`contracts.UsageScope`) |
 | OC `Project`/`Component`/`ReleaseBinding` CRUD | needs | `openchoreo` client — OC is the store |
-| `Deployer` · `DeploymentReader` | offers | `delivery/run` — promote a cycle's built components and read back whether they are serving. The supervisor owns the ORDER and the verdict; this domain owns the OpenChoreo writes, which is what keeps a cluster client out of the run loop |
+| `Deployer` · `DeploymentReader` | offers | `delivery/run` — plan a reconcile pass over the version's state, promote each target at its OWN commit, and read back whether components are serving. The supervisor owns the verdict and what to do with a held component; this domain owns the plan and the OpenChoreo writes, which is what keeps a cluster client out of the run loop |
 | `BindingConverger` (`Converge`) | offers | the config slice — an env-var edit pushes onto the live binding through the deploy path rather than patching a field of it, so the two can never write different desired states onto one object |
 | `ComponentEnvVarReader` · `RuntimeFileProvider` | needs | the config slice and `dependencies/runtimeconfig` — the two projections whose values ride the binding's workload overrides. Both are declared consumer-side and both distinguish "no values" from "cannot compute yet": an unready projection leaves its field UNMANAGED rather than writing an empty one over the user's values |
 | CRT catalog · binding patcher · `ThunderApplicationReader` | needs | after OC Ready, a web-app whose platform-resource CRT carries `ConsumerURLEnvConfig` stays pending until the ThunderApplication CR has the SPA callback. Wired via `SetResourceCatalog` / `SetResourceClient` / `SetThunderApplicationReader`. Any nil (or a nil store) skips the wait, so OC-only `DeploymentState` tests stay green. Service components never enter it. This domain consumes `ThunderApplicationView`; it does not GET Kubernetes |
@@ -110,7 +110,14 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
   yet — writing one with no release pinned produces an object OpenChoreo cannot render. The deploy stage's
   own last pass is a converge for the same reason: it finishes wiring that only became knowable once
   everything was up, and re-promoting to do it would re-cut a release OpenChoreo then refuses.
-- **The deploy ORDER is the design's hard wiring edges** (`wiring_graph.go` over `spec.HardConfigEdges`).
+- **The deploy PLAN is over the version's state, ordered by the design's hard wiring edges**
+  (`wiring_graph.go` over `spec.HardConfigEdges`, ADR-0026). `deploymentWaves` takes what each
+  component should be serving against what it is, promotes only the behind ones whose hard providers
+  are serving or promoted ahead of them, and returns the rest as HELD with the providers each waits
+  on. The edges are read over the whole design: a provider with no serving release is a real
+  unsatisfied edge, not an assumed-satisfied one. The fixpoint is not one pass — a consumer waiting on
+  a provider that is itself held has to fall out too, or it ships against a config its provider could
+  not fill.
   A provider whose address the platform stamps into a consumer's start-up config deploys first, so the
   consumer is never published with a config nothing could fill. What flows back from consumer to provider
   (CORS origins, an OIDC callback) orders nothing and is written by the converge. A cycle among hard edges

--- a/services/aep-api/internal/projects/deployment_cascade_test.go
+++ b/services/aep-api/internal/projects/deployment_cascade_test.go
@@ -112,7 +112,7 @@ func TestDeployment_DeleteCascade_EmptyArgsRejected(t *testing.T) {
 // deployed that was never promoted.
 func TestDeploy_RejectsUnconfiguredService(t *testing.T) {
 	var svc *DeploymentService
-	if _, err := svc.Deploy(context.Background(), "o", "p", []string{"c"}, "sha"); err == nil {
+	if _, err := svc.Deploy(context.Background(), "o", "p", promoting("sha", "c")); err == nil {
 		t.Fatal("want error from an unconfigured deployment service, got nil")
 	}
 }

--- a/services/aep-api/internal/projects/deployment_service.go
+++ b/services/aep-api/internal/projects/deployment_service.go
@@ -117,15 +117,22 @@ func (s *DeploymentService) SetAPIGatewayHost(host string) {
 	}
 }
 
-// Deploy promotes each named component at the given commit and reports what
-// happened per component.
+// Deploy promotes each target at ITS OWN commit and reports what happened per
+// component.
+//
+// The commit is per target rather than per call, and that is the difference the
+// reconcile needed: one commit for a whole list is only right when the list is
+// what a single merge built, and a pass that promotes each component at its own
+// newest green build has a different commit for each of them (ADR-0026). An
+// empty commit on a target is a CONVERGE — the wiring is re-asserted at
+// whatever release is already pinned.
 //
 // It never returns early on one component's failure: a project's components are
 // independent deployments, and stopping at the first would leave the rest of a
 // version undeployed for a reason that has nothing to do with them. Failures
 // ride the returned outcomes AND the joined error, so the supervisor can both
 // see which component failed and know that the pass did not fully succeed.
-func (s *DeploymentService) Deploy(ctx context.Context, orgID, projectID string, components []string, commitSHA string) ([]delivery.ComponentDeploy, error) {
+func (s *DeploymentService) Deploy(ctx context.Context, orgID, projectID string, targets []delivery.DeployTarget) ([]delivery.ComponentDeploy, error) {
 	if s == nil || s.components == nil || s.store == nil {
 		return nil, fmt.Errorf("deployment: not configured")
 	}
@@ -144,47 +151,47 @@ func (s *DeploymentService) Deploy(ctx context.Context, orgID, projectID string,
 	// component would issue the same reads N times for the same answer.
 	issuers := s.resolveIssuers(ctx, orgID, design)
 
-	out := make([]delivery.ComponentDeploy, 0, len(components))
+	out := make([]delivery.ComponentDeploy, 0, len(targets))
 	var failures []error
-	for _, name := range components {
-		outcome, derr := s.deployOne(ctx, orgID, projectID, name, commitSHA, design, issuers)
+	for _, t := range targets {
+		outcome, derr := s.deployOne(ctx, orgID, projectID, t.Component, t.CommitSHA, design, issuers)
 		out = append(out, outcome)
 		if derr != nil {
-			failures = append(failures, fmt.Errorf("component %q: %w", name, derr))
+			failures = append(failures, fmt.Errorf("component %q: %w", t.Component, derr))
 		}
 	}
 	return out, errors.Join(failures...)
 }
 
-// PlanDeploymentWaves orders a deploy set by the design's hard wiring edges —
-// the deploy stage's plan (see wiring_graph.go for what the order means).
+// PlanDeploymentWaves plans one reconcile pass over the version's state: what
+// to promote, in what order, what to wait for and what to hold
+// (see wiring_graph.go for what the plan means).
 //
-// It lives on the service because the order and the writes it orders are read
+// It lives on the service because the plan and the writes it orders are read
 // off the same artefact by the same reader — not the same READ: the plan reads
 // the design once and each Deploy reads it again, so a design edit landing
-// mid-stage is seen by the writes and not by the order. That window is
+// mid-stage is seen by the writes and not by the plan. That window is
 // deliberately left open. Closing it would mean pinning a design revision
-// through the whole stage, and the failure it would prevent (a component added
-// to the design between the plan and the promote) cannot happen from here — the
-// deploy set comes from the cycle's builds, which were cut from one commit.
+// through the whole stage, and a component added to the design between the plan
+// and the promote is behind with no build, which the next pass classifies as
+// unbuilt and leaves alone.
 //
-// A project with no design yet is one wave, which is the same answer Deploy
-// gives it — nothing to order by.
-func (s *DeploymentService) PlanDeploymentWaves(ctx context.Context, orgID, projectID string, components []string) ([][]string, error) {
-	if s == nil || len(components) == 0 {
-		return nil, nil
+// A project with no design yet gets no ordering — every behind component in one
+// wave — which is the same answer Deploy gives it: the design is the ordering
+// input, not the deploy's permission.
+func (s *DeploymentService) PlanDeploymentWaves(ctx context.Context, orgID, projectID string,
+	state delivery.VersionState) (delivery.DeployPlan, error) {
+	if s == nil || len(state.Components) == 0 {
+		return delivery.DeployPlan{}, nil
 	}
 	if s.store == nil {
-		return nil, fmt.Errorf("deployment: not configured")
+		return delivery.DeployPlan{}, fmt.Errorf("deployment: not configured")
 	}
 	design, err := s.store.ReadDesign(ctx, orgID, projectID)
-	if err != nil {
-		if spec.IsNotFound(err) {
-			return [][]string{components}, nil
-		}
-		return nil, fmt.Errorf("deployment: read design: %w", err)
+	if err != nil && !spec.IsNotFound(err) {
+		return delivery.DeployPlan{}, fmt.Errorf("deployment: read design: %w", err)
 	}
-	return deploymentWaves(design, components)
+	return deploymentWaves(design, state)
 }
 
 // Converge re-asserts the wiring of components that are already deployed,
@@ -216,7 +223,7 @@ func (s *DeploymentService) Converge(ctx context.Context, orgID, projectID strin
 	if len(live) == 0 {
 		return nil
 	}
-	_, err := s.Deploy(ctx, orgID, projectID, live, "")
+	_, err := s.Deploy(ctx, orgID, projectID, delivery.ConvergeTargets(live))
 	return err
 }
 
@@ -244,7 +251,7 @@ func (s *DeploymentService) deployOne(ctx context.Context, orgID, projectID, com
 	// must not be able to move which release is serving.
 	var releaseName string
 	if commitSHA != "" {
-		releaseName = ReleaseNameFor(projectID, componentName, commitSHA)
+		releaseName = delivery.ReleaseNameFor(projectID, componentName, commitSHA)
 		if _, err := s.components.EnsureRelease(ctx, orgID, projectID, componentName, releaseName); err != nil {
 			return outcome, fmt.Errorf("cut release: %w", permanentIfMissing(err))
 		}
@@ -314,11 +321,16 @@ func componentDeployFrom(name string, summary *openchoreo.ReleaseBindingSummary)
 		return out // no binding admitted yet — pending
 	}
 	out.Reason = summary.ReadyReason
+	// The PIN, carried on every read and not only on a write. It is what lets
+	// the supervisor tell a component serving its newest build from one serving
+	// an older release perfectly happily — Ready says only that whatever is
+	// pinned came up.
+	out.Release = summary.ReleaseName
 	switch {
 	case summary.Undeploy:
 		// Deliberately not deployed. Ready is meaningless here, and treating it
 		// as pending would hang the poll on a component nobody is deploying.
-		out.Ready = true
+		out.Ready, out.Undeploy = true, true
 	case strings.EqualFold(summary.ReadyStatus, "True"):
 		out.Ready = true
 	case strings.EqualFold(summary.ReadyStatus, "False") && terminalDeployReason(summary.ReadyReason):
@@ -351,29 +363,6 @@ func terminalDeployReason(reason string) bool {
 	}
 	return false
 }
-
-// ReleaseNameFor names the release a component's deployment pins at a commit.
-//
-// Derived from the commit rather than server-generated so the whole deploy is
-// idempotent: the same cycle re-running its deploy activity cuts the same
-// release name, which OpenChoreo answers with a 409 the client treats as
-// success. Bounded through k8sname for the same reason build run names are — a
-// name one character over the label budget is accepted and then never renders.
-func ReleaseNameFor(projectID, componentName, commitSHA string) string {
-	return k8sname.Bounded(k8sname.MaxLabelValueLen,
-		k8sname.Capped(projectID, releaseNameProjectWidth),
-		k8sname.Capped(componentName, releaseNameComponentWidth),
-		k8sname.Whole(delivery.ShortSHA(commitSHA)),
-	)
-}
-
-// Widths of the readable head of a release name. The commit is never truncated
-// — matching a release to the commit it froze is the main reason anyone reads
-// one of these names.
-const (
-	releaseNameProjectWidth   = 18
-	releaseNameComponentWidth = 18
-)
 
 // envVarsFor reads the user's component config. A read failure leaves the field
 // UNMANAGED rather than empty: writing an empty list would delete env vars the

--- a/services/aep-api/internal/projects/deployment_service_test.go
+++ b/services/aep-api/internal/projects/deployment_service_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo/mocks"
+	"github.com/wso2/aep/aep-api/internal/delivery"
 	"github.com/wso2/aep/aep-api/internal/spec"
 	"github.com/wso2/aep/aep-api/internal/spec/artifactstest"
 )
@@ -102,6 +103,18 @@ func plainServiceMd(name string) string {
 	return traitServiceJSON(name, "")
 }
 
+// promoting is one promote's targets: the same commit for each named component,
+// which is what a cycle's own deploy looked like before the reconcile made the
+// commit per component. The per-component case is covered where it matters — in
+// the wave planner, which is what pairs a component with its own build.
+func promoting(commitSHA string, components ...string) []delivery.DeployTarget {
+	out := make([]delivery.DeployTarget, 0, len(components))
+	for _, name := range components {
+		out = append(out, delivery.DeployTarget{Component: name, CommitSHA: commitSHA})
+	}
+	return out
+}
+
 // webAppMd renders a web-application component design.json (canonical type:
 // spec.ComponentTypeWebApplication — OpenChoreo's own term).
 func webAppMd(name string) string {
@@ -135,7 +148,7 @@ func TestDeploy_BindingCarriesPinAndTraitConfigTogether(t *testing.T) {
 	oc := ocDeployments(map[string]string{})
 	svc := NewDeploymentService(oc, traitStoreWith(files))
 
-	out, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api"}, "abc123def456")
+	out, err := svc.Deploy(context.Background(), "acme", "proj", promoting("abc123def456", "api"))
 	if err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
@@ -173,18 +186,18 @@ func TestDeploy_ReleaseNameIsDerivedFromTheCommit(t *testing.T) {
 	oc := ocDeployments(map[string]string{})
 	svc := NewDeploymentService(oc, traitStoreWith(files))
 
-	first, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api"}, "abc123def456")
+	first, err := svc.Deploy(context.Background(), "acme", "proj", promoting("abc123def456", "api"))
 	if err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
-	second, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api"}, "abc123def456")
+	second, err := svc.Deploy(context.Background(), "acme", "proj", promoting("abc123def456", "api"))
 	if err != nil {
 		t.Fatalf("Deploy (retry): %v", err)
 	}
 	if first[0].Release != second[0].Release {
 		t.Errorf("same commit produced two release names: %q vs %q", first[0].Release, second[0].Release)
 	}
-	if first[0].Release != ReleaseNameFor("proj", "api", "abc123def456") {
+	if first[0].Release != delivery.ReleaseNameFor("proj", "api", "abc123def456") {
 		t.Errorf("release %q is not the derived name", first[0].Release)
 	}
 }
@@ -194,15 +207,15 @@ func TestDeploy_ReleaseNameIsDerivedFromTheCommit(t *testing.T) {
 func TestDeploy_ProtectedAPIUsesTraitDefaultCORS(t *testing.T) {
 	t.Parallel()
 	files := map[string]string{
-		spec.DesignRootFile:           traitRootMd(),
-		"components/api/design.json":  endUserServiceMd("api"),
-		"components/s2s/design.json":  serviceToServiceMd("s2s"),
-		"components/web/design.json":  webAppMd("web"),
+		spec.DesignRootFile:          traitRootMd(),
+		"components/api/design.json": endUserServiceMd("api"),
+		"components/s2s/design.json": serviceToServiceMd("s2s"),
+		"components/web/design.json": webAppMd("web"),
 	}
 	oc := ocDeployments(map[string]string{"web": "http://web.local/app/"})
 	svc := NewDeploymentService(oc, traitStoreWith(files))
 
-	if _, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api", "s2s"}, "abc123def456"); err != nil {
+	if _, err := svc.Deploy(context.Background(), "acme", "proj", promoting("abc123def456", "api", "s2s")); err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
 	for _, c := range oc.ListDeploymentsCalls() {
@@ -260,7 +273,7 @@ func TestDeploy_PerComponentFailureContinuesThenSurfaces(t *testing.T) {
 	}
 	svc := NewDeploymentService(oc, traitStoreWith(files))
 
-	out, err := svc.Deploy(context.Background(), "acme", "proj", []string{"api", "two"}, "abc123def456")
+	out, err := svc.Deploy(context.Background(), "acme", "proj", promoting("abc123def456", "api", "two"))
 	if err == nil {
 		t.Fatal("want the failure surfaced, got nil")
 	}
@@ -396,4 +409,3 @@ func TestDeploymentState_FreshBindingIsPendingNotFailed(t *testing.T) {
 		}
 	}
 }
-

--- a/services/aep-api/internal/projects/wiring_graph.go
+++ b/services/aep-api/internal/projects/wiring_graph.go
@@ -26,20 +26,35 @@ import (
 	"github.com/wso2/aep/aep-api/internal/spec"
 )
 
-// deploymentWaves orders one deploy set into the levels it can be promoted in:
-// every component in wave N has each of its hard providers in some earlier wave.
+// deploymentWaves plans one reconcile pass: which components to promote, in
+// which order, which to wait on, and which to leave alone (ADR-0026).
 //
-// The deploy stage walks these in order and waits for each wave to serve before
-// starting the next, which is what makes a hard edge (spec.HardConfigEdges) mean
-// what it says — the provider has an address by the time the consumer's config
-// is composed. Promoting the whole set at once instead publishes the consumer
-// with a config nothing could have filled, which for a web app is a blank page
+// WAVES, because every component in wave N has each of its hard providers in
+// some earlier one. The stage waits for each wave to serve before starting the
+// next, which is what makes a hard edge (spec.HardConfigEdges) mean what it
+// says — the provider has an address by the time the consumer's config is
+// composed. Promoting the whole set at once instead publishes the consumer with
+// a config nothing could have filled, which for a web app is a blank page
 // served to anyone who visits during the repair.
 //
-// Only edges INSIDE the set constrain anything. A provider that is not being
-// deployed by this cycle is already deployed — its address exists — so waiting
-// on it would be waiting on something that has already happened. This is what
-// keeps the ordinary case (a cycle that touched one component) a single wave.
+// PROMOTABLE is the rule that replaced "everything the cycle built". A
+// component is promoted when it is BEHIND and every hard provider is either
+// serving already or being promoted in this same pass:
+//
+//	promotable(c) = behind(c) ∧ ∀p ∈ providers(c): serving(p) ∨ promotable(p)
+//
+// Anything else behind is HELD, carrying the providers it waits on. That is the
+// answer to "A needs B; A is green, B is red — deploy A?": no, and not as a
+// special case. It is also why the edges are read over the WHOLE design rather
+// than over the set being deployed: the incident this replaced promoted a web
+// app with no api behind it precisely because the only edges considered were
+// the ones inside a two-file diff, so a provider with no release at all was an
+// assumed-satisfied edge instead of an unsatisfied one.
+//
+// Held is not a failure and is never waited on: the provider's own state has
+// its own work — a red build's fix issue, an unwritten component's development
+// issue — and this component is promoted by the first pass that finds its
+// providers serving.
 //
 // The set is addressed in OpenChoreo's k8s-shaped names, because that is what
 // the run loop carries and what the deployer writes; the design graph is keyed
@@ -51,42 +66,162 @@ import (
 // the supervisor files it as a deploy failure on the first attempt rather than
 // retrying an unsatisfiable order forever. Soft edges are absent from this graph
 // by construction and may cycle freely — CORS always does.
-func deploymentWaves(design *spec.DesignFile, components []string) ([][]string, error) {
-	if len(components) == 0 {
-		return nil, nil
+func deploymentWaves(design *spec.DesignFile, state delivery.VersionState) (delivery.DeployPlan, error) {
+	byName := make(map[string]delivery.ComponentState, len(state.Components))
+	var behind []string
+	for _, c := range state.Components {
+		byName[c.Component] = c
+		if c.State == delivery.ComponentStateBehind {
+			behind = append(behind, c.Component)
+		}
 	}
-	if design == nil {
-		// No design to order by. One wave preserves today's behaviour rather than
-		// refusing to deploy: the design is the ordering input, not the deploy's.
-		return [][]string{components}, nil
+	plan := delivery.DeployPlan{Waited: waitedOn(state)}
+	if len(behind) == 0 {
+		return plan, nil
 	}
 
-	inSet := make(map[string]struct{}, len(components))
-	for _, name := range components {
-		inSet[name] = struct{}{}
-	}
-
-	// consumer -> providers, both k8s-shaped and both known to be in the set.
-	// Translating here is what makes the design graph and the deploy set talk
-	// about the same components: the design names them as the architect wrote
-	// them, the run loop carries what OpenChoreo is addressed by, and an untranslated
-	// comparison would quietly find no edges at all — every component in wave one,
-	// which is the exact behaviour the waves exist to replace.
-	edges := make(map[string][]string, len(components))
+	// consumer -> hard providers, k8s-shaped, restricted to components the
+	// version state knows about. Translating here is what makes the design graph
+	// and the deploy set talk about the same components: the design names them as
+	// the architect wrote them, the run loop carries what OpenChoreo is addressed
+	// by, and an untranslated comparison would quietly find no edges at all —
+	// every component in wave one, which is the exact behaviour the waves exist
+	// to replace.
+	//
+	// A nil design yields no edges, which is the same answer it gave before: the
+	// design is the ordering input, not the deploy's permission.
+	providers := make(map[string][]string, len(state.Components))
 	for consumer, deps := range spec.HardConfigEdges(design) {
 		c := k8sname.ToK8sName(consumer)
-		if _, ok := inSet[c]; !ok {
+		if _, known := byName[c]; !known {
 			continue
 		}
 		for _, dep := range deps {
 			p := k8sname.ToK8sName(dep)
-			if _, ok := inSet[p]; !ok || p == c {
+			if _, known := byName[p]; !known || p == c {
 				continue
 			}
-			edges[c] = append(edges[c], p)
+			providers[c] = append(providers[c], p)
 		}
 	}
-	return wavesFromEdges(components, edges)
+
+	promotable, held := promotableSet(behind, providers, byName)
+	plan.Held = held
+	if len(promotable) == 0 {
+		return plan, nil
+	}
+	// Only edges INSIDE the promoted set order anything. A provider that is
+	// serving already has an address, so waiting on it would be waiting on
+	// something that has happened — and by the rule above, a provider that is
+	// neither serving nor promoted here means its consumer is held, not ordered.
+	promoting := make(map[string]struct{}, len(promotable))
+	for _, name := range promotable {
+		promoting[name] = struct{}{}
+	}
+	ordered := make(map[string][]string, len(promotable))
+	for _, c := range promotable {
+		for _, p := range providers[c] {
+			if _, alsoPromoting := promoting[p]; alsoPromoting {
+				ordered[c] = append(ordered[c], p)
+			}
+		}
+	}
+	waves, err := wavesFromEdges(promotable, ordered)
+	if err != nil {
+		return delivery.DeployPlan{}, err
+	}
+	for _, wave := range waves {
+		targets := make([]delivery.DeployTarget, 0, len(wave))
+		for _, name := range wave {
+			targets = append(targets, delivery.DeployTarget{
+				Component: name, CommitSHA: byName[name].DesiredSHA,
+			})
+			plan.Waited = append(plan.Waited, name)
+		}
+		plan.Waves = append(plan.Waves, targets)
+	}
+	sort.Strings(plan.Waited)
+	return plan, nil
+}
+
+// promotableSet is the fixpoint behind the promotable rule: drop every behind
+// component whose hard providers cannot be met, then drop the ones that were
+// only waiting on THOSE, until nothing more falls out.
+//
+// One pass is not enough, and the case that proves it is a chain: a web app
+// waiting on an api waiting on an unbuilt service. A single pass would hold the
+// api and promote the web app into a config its api could not fill.
+//
+// A provider is met when it is SERVING or when it is being promoted in this
+// pass. Any other state — unbuilt, held, or converging towards a release it has
+// not reached — is a real unsatisfied edge: the stage's premise is that a
+// provider's address exists by the time the consumer's config is composed, and
+// only a serving release proves that. A converging provider therefore costs its
+// consumer one cycle, which is the conservative direction.
+func promotableSet(behind []string, providers map[string][]string,
+	byName map[string]delivery.ComponentState) (promotable []string, held []delivery.ComponentState) {
+	candidates := make(map[string]struct{}, len(behind))
+	for _, name := range behind {
+		candidates[name] = struct{}{}
+	}
+	waiting := map[string][]string{}
+	for {
+		var dropped []string
+		for _, name := range behind {
+			if _, still := candidates[name]; !still {
+				continue
+			}
+			var unmet []string
+			for _, p := range providers[name] {
+				if byName[p].State == delivery.ComponentStateServing {
+					continue
+				}
+				if _, promoting := candidates[p]; promoting {
+					continue
+				}
+				unmet = append(unmet, p)
+			}
+			if len(unmet) > 0 {
+				dropped = append(dropped, name)
+				waiting[name] = unmet
+			}
+		}
+		if len(dropped) == 0 {
+			break
+		}
+		for _, name := range dropped {
+			delete(candidates, name)
+		}
+	}
+	// Input order is preserved so the plan is stable across attempts; a deploy
+	// order that reshuffles between retries is needlessly hard to read in a log.
+	for _, name := range behind {
+		if _, ok := candidates[name]; ok {
+			promotable = append(promotable, name)
+			continue
+		}
+		st := byName[name]
+		st.State, st.WaitingOn = delivery.ComponentStateHeld, waiting[name]
+		held = append(held, st)
+	}
+	return promotable, held
+}
+
+// waitedOn is the components already converging towards the release they pin —
+// what a pass waits for besides its own promotes.
+//
+// Behind, held and unbuilt components are deliberately absent. The stage has ONE
+// deadline, and spending it on a binding this pass did not write, or on a
+// component with no binding at all, would settle `deploy-budget` on a run whose
+// only problem is work somebody still has to do.
+func waitedOn(state delivery.VersionState) []string {
+	var out []string
+	for _, c := range state.Components {
+		if c.State == delivery.ComponentStateConverging {
+			out = append(out, c.Component)
+		}
+	}
+	return out
 }
 
 // wavesFromEdges is the ordering itself: Kahn's algorithm over consumer ->

--- a/services/aep-api/internal/projects/wiring_graph.go
+++ b/services/aep-api/internal/projects/wiring_graph.go
@@ -110,8 +110,8 @@ func deploymentWaves(design *spec.DesignFile, state delivery.VersionState) (deli
 	if len(promotable) == 0 {
 		return plan, nil
 	}
-	// Only edges INSIDE the promoted set order anything. A provider that is
-	// serving already has an address, so waiting on it would be waiting on
+	// Only edges INSIDE the promoted set order anything. A provider that already
+	// serves its consumers has an address, so waiting on it would be waiting on
 	// something that has happened — and by the rule above, a provider that is
 	// neither serving nor promoted here means its consumer is held, not ordered.
 	promoting := make(map[string]struct{}, len(promotable))
@@ -173,7 +173,11 @@ func promotableSet(behind []string, providers map[string][]string,
 			}
 			var unmet []string
 			for _, p := range providers[name] {
-				if byName[p].State == delivery.ComponentStateServing {
+				// ServesConsumers, not `State == serving`: a component somebody
+				// UNDEPLOYED on purpose owes the version nothing and so reads as
+				// serving, but it has no active release and therefore no address
+				// for this component's start-up config to carry.
+				if byName[p].ServesConsumers() {
 					continue
 				}
 				if _, promoting := candidates[p]; promoting {

--- a/services/aep-api/internal/projects/wiring_graph_test.go
+++ b/services/aep-api/internal/projects/wiring_graph_test.go
@@ -52,68 +52,210 @@ func wiringDeps(names []string) []spec.Dependency {
 	return out
 }
 
+// The version states the plan is computed over. A behind component's desired
+// commit is derived from its name so a wrong pairing is visible in a failure
+// message rather than being a plausible-looking sha.
+func wiringBehind(name string) delivery.ComponentState {
+	return delivery.ComponentState{
+		Component: name, State: delivery.ComponentStateBehind, DesiredSHA: "sha-" + name,
+	}
+}
+
+func wiringServing(name string) delivery.ComponentState {
+	return delivery.ComponentState{
+		Component: name, State: delivery.ComponentStateServing,
+		DesiredSHA: "sha-" + name, Pinned: "release-" + name, Ready: true,
+	}
+}
+
+func wiringUnbuilt(name string) delivery.ComponentState {
+	return delivery.ComponentState{Component: name, State: delivery.ComponentStateUnbuilt}
+}
+
+func wiringConverging(name string) delivery.ComponentState {
+	return delivery.ComponentState{
+		Component: name, State: delivery.ComponentStateConverging,
+		DesiredSHA: "sha-" + name, Pinned: "release-" + name,
+	}
+}
+
+func versionOf(states ...delivery.ComponentState) delivery.VersionState {
+	return delivery.VersionState{Components: states}
+}
+
+// waveNames renders a plan's waves as names, and asserts in passing that every
+// target carries its OWN commit — the whole point of the target type.
+func waveNames(t *testing.T, plan delivery.DeployPlan) [][]string {
+	t.Helper()
+	var out [][]string
+	for _, wave := range plan.Waves {
+		names := make([]string, 0, len(wave))
+		for _, target := range wave {
+			if target.CommitSHA != "sha-"+target.Component {
+				t.Errorf("target %q promotes at %q, not its own newest green build",
+					target.Component, target.CommitSHA)
+			}
+			names = append(names, target.Component)
+		}
+		out = append(out, names)
+	}
+	return out
+}
+
+// heldOn renders the held set as `component→providers` pairs.
+func heldOn(plan delivery.DeployPlan) map[string][]string {
+	if len(plan.Held) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(plan.Held))
+	for _, c := range plan.Held {
+		out[c.Component] = c.WaitingOn
+	}
+	return out
+}
+
 func TestDeploymentWaves(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name       string
 		design     *spec.DesignFile
-		components []string
+		version    delivery.VersionState
 		want       [][]string
+		wantHeld   map[string][]string
+		wantWaited []string
 	}{{
 		// The case that blanked a page: promoted together, the SPA composes its
 		// config while its backend has no address. The provider goes first.
 		name:       "a SPA waits for the backend whose address it carries",
 		design:     designWith(wiringWebApp("todo-webapp", "todo-api"), wiringService("todo-api")),
-		components: []string{"todo-api", "todo-webapp"},
+		version:    versionOf(wiringBehind("todo-api"), wiringBehind("todo-webapp")),
 		want:       [][]string{{"todo-api"}, {"todo-webapp"}},
+		wantWaited: []string{"todo-api", "todo-webapp"},
 	}, {
-		// Order in the SET must not decide the order of the DEPLOY, or the plan
-		// would depend on however the build fan-out happened to list things.
+		// Order in the STATE must not decide the order of the DEPLOY, or the plan
+		// would depend on however the read happened to list things.
 		name:       "the consumer listed first still deploys second",
 		design:     designWith(wiringWebApp("todo-webapp", "todo-api"), wiringService("todo-api")),
-		components: []string{"todo-webapp", "todo-api"},
+		version:    versionOf(wiringBehind("todo-webapp"), wiringBehind("todo-api")),
 		want:       [][]string{{"todo-api"}, {"todo-webapp"}},
+		wantWaited: []string{"todo-api", "todo-webapp"},
 	}, {
 		name:       "no hard edges is one wave — the ordinary case pays nothing",
 		design:     designWith(wiringService("orders"), wiringService("payments")),
-		components: []string{"orders", "payments"},
+		version:    versionOf(wiringBehind("orders"), wiringBehind("payments")),
 		want:       [][]string{{"orders", "payments"}},
+		wantWaited: []string{"orders", "payments"},
 	}, {
-		// A provider outside the set is already deployed, so its address already
-		// exists. Waiting on it would be waiting for something that has happened.
-		name:       "a provider outside the deploy set does not split the wave",
+		// A provider that is already SERVING has an address, so waiting on it
+		// would be waiting for something that has happened.
+		name:       "a serving provider does not split the wave",
 		design:     designWith(wiringWebApp("todo-webapp", "todo-api"), wiringService("todo-api")),
-		components: []string{"todo-webapp"},
+		version:    versionOf(wiringServing("todo-api"), wiringBehind("todo-webapp")),
 		want:       [][]string{{"todo-webapp"}},
+		wantWaited: []string{"todo-webapp"},
 	}, {
 		name: "independent components share a wave; only the dependent one waits",
 		design: designWith(wiringWebApp("web", "api"), wiringService("api"),
 			wiringService("worker")),
-		components: []string{"api", "web", "worker"},
+		version:    versionOf(wiringBehind("api"), wiringBehind("web"), wiringBehind("worker")),
 		want:       [][]string{{"api", "worker"}, {"web"}},
+		wantWaited: []string{"api", "web", "worker"},
 	}, {
 		name:       "no design is one wave rather than a refusal",
 		design:     nil,
-		components: []string{"api", "web"},
+		version:    versionOf(wiringBehind("api"), wiringBehind("web")),
 		want:       [][]string{{"api", "web"}},
+		wantWaited: []string{"api", "web"},
 	}, {
-		name:       "an empty set plans nothing",
-		design:     designWith(wiringService("api")),
-		components: nil,
-		want:       nil,
+		name:    "an empty state plans nothing",
+		design:  designWith(wiringService("api")),
+		version: delivery.VersionState{},
+	}, {
+		// THE INCIDENT. The webapp's build went red, the api's went green: the api
+		// is promoted on its own, in the same cycle, rather than waiting for a
+		// later cycle whose diff would never mention it again.
+		name:       "a green provider is promoted while its consumer is unbuilt",
+		design:     designWith(wiringWebApp("onboarding-webapp", "onboarding-api"), wiringService("onboarding-api")),
+		version:    versionOf(wiringBehind("onboarding-api"), wiringUnbuilt("onboarding-webapp")),
+		want:       [][]string{{"onboarding-api"}},
+		wantWaited: []string{"onboarding-api"},
+	}, {
+		// THE OBJECTION, and the answer: A needs B, A is green, B is red. A is
+		// HELD — not promoted, not waited on, not a deploy failure — because a
+		// SPA published against an api with no address is a blank page.
+		name:     "a green consumer is held when its provider is unbuilt",
+		design:   designWith(wiringWebApp("web", "api"), wiringService("api")),
+		version:  versionOf(wiringBehind("web"), wiringUnbuilt("api")),
+		wantHeld: map[string][]string{"web": {"api"}},
+	}, {
+		// A provider still rolling out has a binding but has not been observed
+		// serving, and the wave rule's whole premise is that a provider serves
+		// before its consumer is composed. The consumer costs one cycle, which is
+		// the conservative direction; the provider is waited on either way.
+		name:       "a converging provider holds its consumer and is waited on",
+		design:     designWith(wiringWebApp("web", "api"), wiringService("api")),
+		version:    versionOf(wiringConverging("api"), wiringBehind("web")),
+		wantHeld:   map[string][]string{"web": {"api"}},
+		wantWaited: []string{"api"},
+	}, {
+		// The idempotence that lets this run on every cycle: nothing behind means
+		// nothing written and nothing waited on.
+		name:    "a fully serving version plans no writes at all",
+		design:  designWith(wiringWebApp("web", "api"), wiringService("api")),
+		version: versionOf(wiringServing("api"), wiringServing("web")),
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := deploymentWaves(tc.design, tc.components)
+			plan, err := deploymentWaves(tc.design, tc.version)
 			if err != nil {
 				t.Fatalf("deploymentWaves: %v", err)
 			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("deploymentWaves() = %v, want %v", got, tc.want)
+			if got := waveNames(t, plan); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("waves = %v, want %v", got, tc.want)
+			}
+			if got := heldOn(plan); !reflect.DeepEqual(got, tc.wantHeld) {
+				t.Errorf("held = %v, want %v", got, tc.wantHeld)
+			}
+			if !reflect.DeepEqual(plan.Waited, tc.wantWaited) {
+				t.Errorf("waited = %v, want %v", plan.Waited, tc.wantWaited)
 			}
 		})
+	}
+}
+
+// One pass of the promotable rule is not enough, and this is the case that
+// proves it: a consumer waiting on a provider that is ITSELF held has to fall
+// out too, or it ships against a config its provider could not fill.
+//
+// Asserted on the edges rather than through a design, for the same reason the
+// cycle refusal below is: today's edge rule gives hard providers only to a web
+// app, and only for its sibling SERVICES, so a three-deep chain cannot be
+// expressed as a design at all. The fixpoint is the graph's own invariant and
+// has to hold for whatever edge kind is added next.
+func TestPromotableSet_AHeldProviderHoldsItsOwnConsumer(t *testing.T) {
+	t.Parallel()
+	behind := []string{"web", "api"}
+	providers := map[string][]string{"web": {"api"}, "api": {"worker"}}
+	byName := map[string]delivery.ComponentState{
+		"web": wiringBehind("web"), "api": wiringBehind("api"), "worker": wiringUnbuilt("worker"),
+	}
+
+	promotable, held := promotableSet(behind, providers, byName)
+	if len(promotable) != 0 {
+		t.Errorf("promoted %v; a consumer whose provider is held must not be written", promotable)
+	}
+	got := map[string][]string{}
+	for _, c := range held {
+		if c.State != delivery.ComponentStateHeld {
+			t.Errorf("%s is in the held set with state %q", c.Component, c.State)
+		}
+		got[c.Component] = c.WaitingOn
+	}
+	want := map[string][]string{"web": {"api"}, "api": {"worker"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("held = %v, want %v", got, want)
 	}
 }
 
@@ -128,13 +270,13 @@ func TestDeploymentWaves_MatchesComponentsByK8sName(t *testing.T) {
 			Dependencies: wiringDeps([]string{"Todo API"})},
 		spec.DesignComponent{Name: "Todo API", ComponentType: spec.ComponentTypeService},
 	)
-	got, err := deploymentWaves(design, []string{"todo-web-app", "todo-api"})
+	plan, err := deploymentWaves(design, versionOf(wiringBehind("todo-web-app"), wiringBehind("todo-api")))
 	if err != nil {
 		t.Fatalf("deploymentWaves: %v", err)
 	}
 	want := [][]string{{"todo-api"}, {"todo-web-app"}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("deploymentWaves() = %v, want %v", got, want)
+	if got := waveNames(t, plan); !reflect.DeepEqual(got, want) {
+		t.Errorf("waves = %v, want %v", got, want)
 	}
 }
 
@@ -149,13 +291,14 @@ func TestPlanDeploymentWaves_OrdersFromTheStoredDesign(t *testing.T) {
 	}
 	svc := NewDeploymentService(&mocks.ComponentClientMock{}, traitStoreWith(files))
 
-	got, err := svc.PlanDeploymentWaves(context.Background(), "acme", "proj", []string{"web", "api"})
+	plan, err := svc.PlanDeploymentWaves(context.Background(), "acme", "proj",
+		versionOf(wiringBehind("web"), wiringBehind("api")))
 	if err != nil {
 		t.Fatalf("PlanDeploymentWaves: %v", err)
 	}
 	want := [][]string{{"api"}, {"web"}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("PlanDeploymentWaves() = %v, want %v — the SPA must wait for the backend it carries", got, want)
+	if got := waveNames(t, plan); !reflect.DeepEqual(got, want) {
+		t.Errorf("waves = %v, want %v — the SPA must wait for the backend it carries", got, want)
 	}
 }
 
@@ -171,13 +314,14 @@ func TestPlanDeploymentWaves_NoDesignIsOneWave(t *testing.T) {
 			},
 		}))
 
-	got, err := svc.PlanDeploymentWaves(context.Background(), "acme", "proj", []string{"api", "web"})
+	plan, err := svc.PlanDeploymentWaves(context.Background(), "acme", "proj",
+		versionOf(wiringBehind("api"), wiringBehind("web")))
 	if err != nil {
 		t.Fatalf("PlanDeploymentWaves with no design: %v", err)
 	}
 	want := [][]string{{"api", "web"}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("PlanDeploymentWaves() = %v, want %v", got, want)
+	if got := waveNames(t, plan); !reflect.DeepEqual(got, want) {
+		t.Errorf("waves = %v, want %v", got, want)
 	}
 }
 

--- a/services/aep-api/internal/projects/wiring_graph_test.go
+++ b/services/aep-api/internal/projects/wiring_graph_test.go
@@ -68,6 +68,14 @@ func wiringServing(name string) delivery.ComponentState {
 	}
 }
 
+// wiringWithdrawn is a component somebody undeployed on purpose: it reads as
+// serving (the version owes it nothing) but offers no address.
+func wiringWithdrawn(name string) delivery.ComponentState {
+	st := wiringServing(name)
+	st.Undeploy = true
+	return st
+}
+
 func wiringUnbuilt(name string) delivery.ComponentState {
 	return delivery.ComponentState{Component: name, State: delivery.ComponentStateUnbuilt}
 }
@@ -197,6 +205,17 @@ func TestDeploymentWaves(t *testing.T) {
 		version:    versionOf(wiringConverging("api"), wiringBehind("web")),
 		wantHeld:   map[string][]string{"web": {"api"}},
 		wantWaited: []string{"api"},
+	}, {
+		// A provider somebody UNDEPLOYED is not a satisfied hard edge. It reads
+		// as serving — nothing is owed and nothing may promote over the decision
+		// — but it has no active release, so it has no address for the web app's
+		// start-up config to carry. Promoting the consumer anyway is the blank
+		// page, reached through the one state that says "serving" and means
+		// "nothing is running".
+		name:     "an undeployed provider does not satisfy its consumer",
+		design:   designWith(wiringWebApp("web", "api"), wiringService("api")),
+		version:  versionOf(wiringWithdrawn("api"), wiringBehind("web")),
+		wantHeld: map[string][]string{"web": {"api"}},
 	}, {
 		// The idempotence that lets this run on every cycle: nothing behind means
 		// nothing written and nothing waited on.


### PR DESCRIPTION
## The version that shipped without running

Project `track-each-hire7321`, version `v1`, two components. Cycle one merged both; the API's build went green and the web app's went red, so the supervisor returned at the red verdict **before** its deploy stage. Cycle two merged the fix — two files, both under the web app — so the merge's path diff named the web app alone. The milestone emptied, the run settled **succeeded**, minted the version's validation task and closed the increment.

The API was never promoted. No `ComponentRelease`, no `ReleaseBinding`, no pod; its image had existed since cycle one. Every cycle was correct on its own terms. The predicate was not:

```
"deployed-green" was inferred from   the working set is empty
                                   ∧ the last cycle ended green
```

Neither conjunct is a statement about a component the cycles never touched, so neither could contradict it. Two shapes combined: the deploy set was the cycle's **path diff**, so *what is serving* was a function of which files a fix happened to edit; and a **red build returned before the deploy stage**, so the one cycle that could have promoted the API never reached the promote.

## What changes

**The deploy stage reconciles the VERSION, on every cycle, red or green** (ADR-0026).

```
desired(c)  the release the component's newest SUCCEEDED build would cut
actual(c)   the release its ReleaseBinding pins, and whether that is Ready
```

| state | condition | the pass |
|---|---|---|
| `serving` | pinned = desired, Ready | nothing owed |
| `behind` | pinned ≠ desired (incl. no binding) | the only state written to |
| `converging` | pinned = desired, not Ready yet | waited on |
| `held` | behind, a hard provider not serving | left alone, named |
| `unbuilt` | no succeeded build at any commit | left alone |

**Promotable, not green** — the answer to *"A needs B; A is green, B is red — deploy A?"*:

```
promotable(c) = behind(c) ∧ ∀p ∈ HardConfigEdges[c]: serving(p) ∨ promotable(p)
```

A fixpoint, not one pass: a consumer waiting on a provider that is itself held falls out too. The edges are read over the **whole design**, which is what makes a provider with no serving release an unsatisfied edge instead of the assumed-satisfied one ADR-0019 flagged as *"an assumption, not a proof"*. `held` and `unbuilt` are not failures and are never waited on or filed against — before this, neither state could be named at all.

**Delivery asserts what it used to infer.** The cycle boundary re-reads the version state and requires every design component serving before minting the validation task; anything else settles **`version-incomplete`**, naming what was not. By the invariants above it should be unreachable — which is exactly why it must be loud rather than silent.

**Idempotent by construction:** a fully serving version reconciles in one read and zero writes — no plan, no deadline, no deploy gate. That is what lets it run every cycle.

## Recomposition, not new machinery

Every read was already a port; two were one field short.

- `ReleaseBindingSummary` gains **`ReleaseName`** — without the pin, `behind` and `converging` cannot be told apart.
- `BuildRunInfo` gains **`CommitSHA` + `StartedAt`**, read off the WorkflowRun's own spec, never parsed out of its name (`k8sname.Bounded` truncates a long readable head, so parsing is sound for some projects and silently wrong for others).
- `ReleaseNameFor` moves to `delivery` beside `BuildRunName`: the writer and the reader must compose that name identically.
- `awaitBuilds` answers a cycle verdict and nothing else. `PollCycleBuilds` stays diff-scoped and SHA-scoped, which is right for that verdict.
- New activity `ReadVersionState`; `PlanDeployWaves` takes the state and returns waves + held + waited; `DeployCycle` → `PromoteWave` (per-component commits); `PollCycleDeployments` → `PollDeployments`.
- The deploy-fix issue's dedupe key becomes per component `(component, commit)`, because one pass can promote two components at two different commits.

## Proof on the live cluster

A two-component project (`task-api` service + `task-web` web app hard-depending on it) built end to end on the local k3d cluster with the rebuilt `aep-api`.

**1 — v1 built and delivered.** The reconcile classified the whole design, ordered by the hard edge, promoted each at its own commit, converged commitless, then the boundary asserted serving before delivery:

```
run: version state read   serving=0 components=2 notServing="task-api=behind, task-web=behind"
run: deploy pass planned  waves=[["task-api"],["task-web"]] waiting=[task-api,task-web] held=[]
deployment: release pinned  task-api → …-task-api-c19b5e10bf3c-f16ea25c
deployment: release pinned  task-web → …-task-web-c19b5e10bf3c-14741265
deployment: release pinned  task-api release=""      ← converge, no pin moved
deployment: release pinned  task-web release=""
run: version state read   serving=2 components=2 notServing=""      ← the delivery gate
version deployed-green; filed its validation task (#4)  → run succeeded
```

Console: *2 of 2 components ready*.

**2 — the incident reproduced.** Deleting `task-api`'s ReleaseBinding **and** its ComponentRelease left a green build with nothing running — byte-for-byte the state `v1` shipped in. Console: *1 of 2 components ready · task-api "Not deployed"*.

**3 — the fix (the decisive test).** An armed bug against **`task-web` only** → a task run whose PR touched only the web app:

```
run: version state read   serving=0 components=2 notServing="task-api=behind, task-web=behind"
run: deploy pass planned  waves=[["task-api"],["task-web"]] held=[]
deployment: release pinned  task-api → …-c19b5e10bf3c-f16ea25c   ← the OLD commit, re-promoted
deployment: release pinned  task-web → …-97414c666e68-fc8e9be6   ← the new commit
```

`task-api` was picked up at a commit **no PR in that cycle touched**, and both were promoted at different commits in one pass. Console back to *2 of 2*. Under the old deploy set (`[task-web]`) the API stays unbound and the run settles *succeeded* — that contrast is the whole point.

**4 — held + the gate.** Deleting `task-api`'s binding, release **and** its WorkflowRuns made it `unbuilt`; a dev run then worked an armed `development` issue on the web app:

```
run: version state read   serving=0 components=2 notServing="task-api=unbuilt, task-web=behind"
run: deploy pass planned  waves=[] waiting=null held=["task-web waiting on task-api"]
some components are held behind a provider that is not serving  held=["task-web waiting on task-api"]
run: version state read   serving=0 components=2 notServing="task-api=unbuilt, task-web=behind"
ERROR the milestone has no work left and the version is not serving  notServing="task-api=unbuilt, task-web=behind"
→ run settled FAILED · version-incomplete
```

The web app was **not** published against an API with no address, **zero** deploy-fix issues were filed against it, and the run refused to call the version delivered. The console renders `Failed · version-incomplete`.

## Tests

- `classifyComponentState` table-driven over (desired, pinned, ready, undeploy), including *newest build red, older green → serving at the older release* and *a failed binding at the right release is still converging*.
- `ReadVersionState` activity: the three-port composition, asserting the deployment read is asked about every **design** component, sorted.
- Planner over real designs: the promotable rule, the held set with what each waits on, a converging provider holding its consumer, a fully serving version planning no writes, the fixpoint (`promotableSet`), and the unchanged hard-cycle refusal.
- Workflow, on the Temporal test harness: the incident replayed (empty working set + a component behind → `version-incomplete`, no validation task, milestone left open); a red build promoting its green siblings; a held component neither promoted nor blamed and a pass that writes nothing consulting no gate; a fully serving version making zero promotes and starting no timer; per-component commits through the waves and the commitless converge.

The workflow harness now derives the version state from the builds a test pins and the promotes the loop makes, so a test describes builds and deployments as before and the state follows the way it follows from the cluster.

## Gates

`go build`, `go vet`, `golangci-lint` (0 issues), `deadcode-check`, and the `aep-api` test suite are green. One unrelated pre-existing flake fails intermittently: `internal/platform/gitfs/reaper TestMaintainReposSlowGitCompletes` races git's auto-gc in its own setup (`want >1000 loose, got 0 / 130 / 515` across runs) and that package has no path to any file this PR touches.

## Cost accepted

`ReadVersionState` is a new activity call ahead of existing ones in two places, and three deploy activities are renamed — not replay-safe. A dev or task run inside its deploy stage when the worker restarts fails on non-determinism; runs that have not reached deploy replay unchanged. ADR-0019 took the identical edit at the identical cost and deliberately did not reach for `workflow.GetVersion`, which would keep the diff-scoped promote alive for old histories. **Deploy this when no dev or task run is inside its deploy stage, and cancel the ones that are.**

## Not done, deliberately

Undeploy semantics; address allocation (ADR-0019's stands); promotion outside a run (`ConvergeWatcher` still only re-asserts bindings that exist); and the no-cycles ending (`onEmptyWorkingSet` case 1) stays ungated — it dispatched nothing, so it claims to have delivered nothing, and widening the gate there would fail rebuilds of versions whose work is all closed.

No console change was needed: the Development column already accounts for every design component, which is how the unbound API surfaced as *1 of 2 components ready* in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
