### PR TITLE
fix(skaffold): switch remote-worker to custom builder

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -60,19 +60,15 @@ build:
             - tsconfig.base.json
     - image: ghcr.io/wso2/aep/remote-worker
       context: runners/remote-worker
-      docker:
-        dockerfile: Dockerfile
-        cliFlags:
-          - "--build-context=skills=./skills"
-          - "--build-context=bal-library-tool=./packages/bal-library-tool"
-          - "--secret=id=packagePAT,env=PACKAGE_PAT"
-      dependencies:
-        paths:
-          - runners/remote-worker/**
-          - skills/**
-        ignore:
-          - runners/remote-worker/node_modules/**
-          - runners/remote-worker/dist/**
+      custom:
+        buildCommand: docker build -f Dockerfile --build-context skills=../skills --build-context bal-library-tool=../packages/bal-library-tool --secret id=packagePAT,env=PACKAGE_PAT -t $IMAGE .
+        dependencies:
+          paths:
+            - runners/remote-worker/**
+            - skills/**
+          ignore:
+            - runners/remote-worker/node_modules/**
+            - runners/remote-worker/dist/**
     - image: ghcr.io/wso2/aep/thunder-app-operator
       context: deployments/single-cluster/resource-types/thunder-app/operator
       docker:


### PR DESCRIPTION
## Summary

- `dependencies.paths` is only valid on `custom:` and `buildpack:` artifact builders in Skaffold v4beta11 — using it on a `docker:` artifact causes a parse error (`field dependencies not found in type v4beta11.Artifact`) and `skaffold dev` fails to start
- Switches `remote-worker` from `docker:` to `custom:` builder, which supports `dependencies.paths` for per-artifact file-watch scoping
- Restores the `--build-context bal-library-tool` and `--secret packagePAT` flags that are required by the remote-worker Dockerfile but couldn't coexist with `dependencies:` on the `docker:` builder

## Test plan

- [ ] `skaffold dev` parses and starts without errors
- [ ] A change to `runners/remote-worker/` triggers only the remote-worker image rebuild
- [ ] A change to `skills/` triggers only the remote-worker image rebuild
- [ ] A change to an unrelated service (e.g. `apps/console/`) does not trigger a remote-worker rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)