### PR TITLE
A validation report is an accumulation, not one all-or-nothing run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,16 @@ build: gen
 dev:
 	$(TURBO) run dev
 
+# `skills/` is not a pnpm workspace and deliberately isn't one — nothing in this
+# repo imports it (see knip.jsonc). Its payload still carries logic worth
+# pinning: the report generator the validation agent invokes decides a run's
+# verdict. Its tests run from here rather than nowhere, guarded on a match
+# because `node --test` with no arguments discovers the whole tree instead.
 test: gen
 	$(TURBO) run test
 	@for d in $(GO_MODULE_DIRS); do echo ">> go test $$d"; ( cd "$$d" && go test ./... ); done
+	@files=$$(find $(ROOT)/skills -name '*.test.mjs' | sort); \
+	  if [ -n "$$files" ]; then echo ">> node --test skills"; node --test $$files; fi
 
 # Local coverage summary — coverage is not gated in CI. Go: the aep-api module's fast-lane
 # cover target (-short, no Docker). TS: @aep/agents via node:test's

--- a/packages/progress-view/src/format.ts
+++ b/packages/progress-view/src/format.ts
@@ -123,6 +123,19 @@ export function formatOutcome(e: ProgressLineView | undefined): OutcomeView {
   const duration = e.durationMs && e.durationMs >= SLOW_CALL_MS ? formatDuration(e.durationMs) : "";
   if (e.ok !== false) return { detail: "", duration, tone: "muted" };
 
+  // A SEVERED call is not a failure and must not be called one. The command
+  // blew its timeout and was detached, so it neither succeeded nor failed — it
+  // has no outcome yet, and it may still be running. Saying "failed" would name
+  // a defect that did not happen, on the one line a reader consults to tell
+  // those apart. Warned rather than errored for the same reason.
+  if (e.status === "severed") {
+    return {
+      detail: e.summary ? `severed · ${e.summary}` : "severed",
+      duration,
+      tone: "warn",
+    };
+  }
+
   // A failure always speaks. `exit N` is the honest per-step signal — it names
   // THIS command as what broke. Tools that are not a shell report no code at
   // all, and inventing one would be worse than the bare word: "failed" is

--- a/packages/progress-view/test/format.test.ts
+++ b/packages/progress-view/test/format.test.ts
@@ -62,6 +62,29 @@ test("a progress_item is row state, never a row", () => {
   );
 });
 
+test("a severed call is not reported as a failure", () => {
+  // A command that blew its timeout was detached, so it neither succeeded nor
+  // failed — it has no outcome yet and may still be running. Calling it
+  // "failed" names a defect that did not happen, on the one line a reader
+  // consults to tell those apart.
+  const severed = formatOutcome({
+    kind: "tool_result",
+    ok: false,
+    status: "severed",
+    durationMs: 600_000,
+    summary: "the command hit its 600.0s timeout and was detached",
+  });
+  assert.equal(severed.detail, "severed · the command hit its 600.0s timeout and was detached");
+  assert.equal(severed.tone, "warn");
+  assert.doesNotMatch(severed.detail, /failed/);
+
+  // A real failure with no exit code still says so.
+  assert.equal(
+    formatOutcome({ kind: "tool_result", ok: false, summary: "File does not exist" }).detail,
+    "failed · File does not exist",
+  );
+});
+
 test("an outcome speaks only when it carries something the action didn't", () => {
   // A fast success: nothing to add. The next action appearing is the evidence.
   assert.deepEqual(formatOutcome({ kind: "tool_result", ok: true, durationMs: 40 }), {

--- a/runners/remote-worker/design/decisions/ADR-0009-a-run-reports-progress-per-item.md
+++ b/runners/remote-worker/design/decisions/ADR-0009-a-run-reports-progress-per-item.md
@@ -63,35 +63,43 @@ outlives it.
    re-runs the same shape. That deletes the socket, its listener, its lifecycle
    and its tests.
 
-   The RUN step is deliberately **not** changed to match, and making it per-spec
-   was tried and reverted. The suite runs serially against one shared deployed
-   environment (`fullyParallel: false, workers: 1`), so a spec that passes alone
-   can fail in sequence — `healing.md`'s data-collision class. Isolated probes
-   cannot find that, so replacing the integrated run with them moves the signal
-   past the heal budget, where it lands in `report.json` as a genuine failure and
-   mints a repair issue against code that is not broken. It also cost an extra
-   full pass of the suite on green runs while buying liveness only for
-   regression specs, which exist solely on re-validations.
+   The RUN step was deliberately not changed to match, on the grounds that the
+   integrated pass — the suite run serially against one shared deployed
+   environment — is the only thing that catches a spec depending on state
+   another spec left behind (`healing.md`'s data-collision class). That still
+   holds where the pass can happen. What ADR-0010 establishes is that on a suite
+   which has outgrown the command timeout it cannot happen at all, so it is now
+   attempted best-effort rather than required.
 
-5. **Only a COMPLETE run writes `results.json`.** The config chooses its own
-   reporters from whether the command narrows the suite: a narrowed run is a
-   probe and gets `line`, a complete run gets the JSON reporter the report
-   generator reads. Without this, every per-spec verification in steps 6 and 8
-   overwrites the whole suite's results with one criterion's — which today only
-   call ordering hides.
+5. **~~Only a COMPLETE run writes `results.json`.~~ Superseded by ADR-0010.**
 
-   Narrowing means a spec filter *or* one of Playwright's own flags — `--shard`,
-   `--grep`, `--last-failed`, `--only-changed`. `--shard` matters most: it looks
-   like the way to fit a big suite inside the command window, and treating it as
-   complete would write a third of the suite's results as if they were all of
-   it, reporting every unrun criterion as never checked.
+   > The config chooses its own reporters from whether the command narrows the
+   > suite: a narrowed run is a probe and gets `line`, a complete run gets the
+   > JSON reporter the report generator reads. Without this, every per-spec
+   > verification in steps 6 and 8 overwrites the whole suite's results with one
+   > criterion's.
+   >
+   > Narrowing means a spec filter *or* one of Playwright's own flags —
+   > `--shard`, `--grep`, `--last-failed`, `--only-changed`. `--shard` matters
+   > most: it looks like the way to fit a big suite inside the command window,
+   > and treating it as complete would write a third of the suite's results as
+   > if they were all of it.
+   >
+   > Inferred from the command rather than switched by a flag or an env var, for
+   > the same reason as decision 3: naming a spec is not optional, it is *how*
+   > you run one spec, so there is nothing for the agent to remember. The cost is
+   > that a narrowed authoritative run writes nothing; the generator then exits 2
+   > naming the missing file, which is why the skill forbids narrowing that one
+   > call — loudly wrong beats a partial report read as a whole one.
 
-   Inferred from the command rather than switched by a flag or an env var, for
-   the same reason as decision 3: naming a spec is not optional, it is *how* you
-   run one spec, so there is nothing for the agent to remember. The cost is that
-   a narrowed authoritative run writes nothing; the generator then exits 2 naming
-   the missing file, which is why the skill forbids narrowing that one call —
-   loudly wrong beats a partial report read as a whole one.
+   Kept verbatim above because what replaced it is only legible against it. It
+   was wrong in a way that cost a run: a suite that has outgrown the command
+   timeout **cannot** be run completely, so under this rule it had no path to a
+   report at all (issue #701). Results are now accumulated per run and merged,
+   with coverage verified against the specs on disk. The reasoning being
+   defended — a partial run silently recorded as the whole suite is worse than a
+   loud failure — still holds. The mistake was banning the partial run instead
+   of learning to detect it.
 
 6. **The live stream ends at `report.json`'s own words.** `pass` / `fail`, not
    `passed` / `failed`. The console overlays these statuses onto the same rows
@@ -108,9 +116,27 @@ outlives it.
 ## Rejected
 
 - **A durable store.** #307 added a `validation_criterion_statuses` table, an
-  ingest endpoint and a public GET. Unnecessary: the run-progress stream
-  replays the whole cycle log on reconnect, and the archive after the pod is
-  reaped, so a reload re-folds the same events.
+  ingest endpoint and a public GET, and this ADR rejected all of it on the
+  grounds that "the run-progress stream replays the whole cycle log on
+  reconnect, and the archive after the pod is reaped, so a reload re-folds the
+  same events."
+
+  **That premise is false, measured.** A poll returns at most
+  `defaultProgressLimit` = 200 events (`agent_progress.go`) drawn from the last
+  `logPageBytes` = 64 KiB of pod stdout (`cycle_log_source.go`); `sinceMillis
+  = 0` on a fresh attach means "everything in the current page", not "from the
+  start of the run". Older output is unrecoverable — it is not in the database,
+  not cached, and the archive is consulted only once live output is empty and
+  the pod terminal, itself capped at 20k lines and then cut to 199. So a page
+  opened 90 minutes into a 7200s validation cycle shows `Pending` for criteria
+  that already passed, and neither a refresh nor a reconnect recovers them.
+
+  Not building a store may still be the right call, but it is an **open gap**
+  rather than a justified rejection: the events are the only record, and they
+  are a sliding window. The durable artifact this wants already exists —
+  `tests/validation/report.json`, which is on the Files API read allow-list —
+  and what blocks reading it mid-run is that nothing records a head SHA for an
+  open cycle and the skill pushes only at step 10.
 - **Phase markers at the workflow's step boundaries.** A second claim about the
   same run, and wrong for most of it: `authoring.md` has the agent run tests all
   through the authoring step, so a marker reading "Authoring tests…" while rows

--- a/runners/remote-worker/design/decisions/ADR-0010-a-validation-report-is-an-accumulation.md
+++ b/runners/remote-worker/design/decisions/ADR-0010-a-validation-report-is-an-accumulation.md
@@ -1,0 +1,189 @@
+# ADR-0010 — A validation report is an accumulation, not one all-or-nothing run
+
+**Status:** Accepted
+
+## Context
+
+A validation run passed every acceptance criterion and delivered nothing — no
+push, no pull request — then died four hours later on `redispatch-budget` having
+spent $7.78 (issue #701).
+
+The agent did not stop because it thought it was finished. Its final suite run
+hit the 600s Bash ceiling: `durationMs: 597462`, `ok: true`, no output. Past the
+timeout the harness detaches the command and answers `code 0` with empty stdout,
+which is indistinguishable from a suite that completed. That destroyed
+`tests/e2e/test-results/results.json`, which makes report generation impossible,
+and `SKILL.md` is unconditional — *"Never open the PR without the report."* It
+complied and stopped.
+
+The trigger is arithmetic: 24 specs, subsets measured at 86–158s each, one
+sequential pass over the deployed system. The suite had outgrown the window, and
+criteria accumulate every milestone, so it was going to sever on every future
+run of that project.
+
+ADR-0009 decision 5 made this unrecoverable. It let only a complete, unnarrowed
+run write the report's input, so a suite that could not be run completely had no
+path to a report at all — sharding wrote nothing by design. The reasoning it was
+defending is sound: before it, a shard silently overwrote the whole suite's
+results with one batch's, and the report claimed most criteria were never
+checked. The mistake was **banning the partial run instead of learning to detect
+it.**
+
+The detector was already there. `generate-report.mjs` iterates the criteria
+**oracle** and looks up results, so the oracle is the denominator and Playwright
+only supplies numerators. The generator already knew which criteria had no
+result; it just could not tell two very different things apart, calling both
+`not_run`:
+
+| Criterion has… | Truth |
+|---|---|
+| no spec file on disk | legitimately never checked |
+| a spec file, no result anywhere | a run was missed or severed |
+
+## Decisions
+
+A **batch** below is one results file, written by one test run. The directory
+is `runs/` because a run is what produces one; the code and the report say
+`batch` because by the time the generator sees them they are inputs to a merge,
+and "run" is already this platform's word for something else.
+
+1. **Every run writes its own results file; the report is their merge.**
+   `test-results/runs/<ISO-stamp>.json`, the stamp computed once at config module
+   scope. Filename order is chronological, so `readdir().sort()` is the merge
+   order and the newest result for a criterion is simply the last one seen. No
+   single command has to cover the whole suite, which retires the ceiling as a
+   concern rather than moving it.
+
+2. **Coverage is verified, not assumed.** Every spec file on disk must APPEAR
+   in the merged runs, or the generator exits 2 naming the ones missing.
+   Appearing is the check, deliberately: a spec whose tests all skipped appears
+   and reports `not_run` honestly, which is the same thing a criterion with no
+   spec file reports. What cannot happen any more is a spec silently absent
+   because the run covering it never wrote anything. This is the compensating invariant for letting partial runs write,
+   and it is strictly stronger than what it replaces: ADR-0009 *assumed* one run
+   had covered everything and had no way to check.
+
+   A severed batch has written nothing *yet*, so its specs surface in exactly
+   that list — named and re-runnable. The agent never has to size a batch
+   correctly; getting it wrong costs an iteration instead of the cycle.
+
+   "Yet" is load-bearing: a call that blows its timeout is **detached, not
+   killed**, so it keeps running and its results may land minutes later. The
+   coverage list is therefore a snapshot, not a verdict on the batch, and both
+   the skill and the generator's message say to look again before re-running.
+
+   Coverage is matched by spec PATH, not by criterion id alone. Results
+   accumulate for the life of the run, so a batch recorded before a spec moved
+   would otherwise vouch for a file that has never been executed.
+
+3. **Merge per batch, then fold — never by concatenating `spec.tests[]`.**
+   `specOutcome` is fail-dominant and has no notion of time, so folding every
+   batch's tests into one array would let a failure that has since been healed
+   permanently outvote the pass that healed it. Two specs claiming one criterion
+   stays a hard error, but only **within** a batch — whether they sit in one
+   file or two, which the message distinguishes; across batches it is the same
+   spec run twice, which is the point.
+
+4. **The whole-suite run becomes best-effort, not required.** Attempt it: if it
+   lands it supersedes the per-spec results with one sequenced pass, which is the
+   only thing that catches a spec depending on state another spec left behind. If
+   it severs it costs nothing, because the per-spec results already cover every
+   authored spec — and being detached rather than killed, it may still deliver
+   its own results afterwards. Guessing its size wrong wastes minutes
+   instead of the report.
+
+5. **The authoring runs are the results.** `authoring.md` already requires every
+   spec to pass **alone, twice consecutively**, so those runs happen today and
+   their results were being thrown away. Keeping them adds no execution — it
+   stops a discard, and it is why decision 4 costs nothing.
+
+6. **A call that did not complete settles nothing.** `timedOutAfterMs` on the
+   SDK's Bash result is the flag for a severed call. The translator now withholds
+   the outcome for one, and renders it as severed rather than `ok`.
+
+   This was a live false-green: `ok: !isError` made a severed call look
+   successful, and `validationRunOutcome` painted `Passed` on every criterion it
+   was running — reachable on `healing.md`'s focused re-runs, i.e. on criteria
+   that had *just failed*. The feed had the same lie, contradicting the warning
+   `SKILL.md` prints in prose two paragraphs away.
+
+7. **The Bash ceiling is deliberately not raised.** It is configurable
+   (`BASH_MAX_TIMEOUT_MS`, unset in this repo, so 600s is a default rather than a
+   limit), and raising it was the obvious fix. It is also a treadmill: any value
+   is exceeded as criteria accumulate, so it only schedules the same incident
+   later. A number that has to be correct is the thing being removed.
+
+## Rejected
+
+- **Playwright's `blob` reporter plus `merge-reports`.** Both exist in the pinned
+  1.61.1, and neither survives contact with overlapping re-runs. The blob
+  reporter wipes its output directory on every invocation, so N sequential
+  batches into the default `blob-report/` leave one. The merger sets
+  `mergeTestCases: false` and compares an already-relative spec path against
+  `path.relative(rootDir, …)`, so the match always fails and overlapping specs
+  duplicate — which trips the duplicate-criterion check unconditionally. Its
+  contract is *disjoint shards*; re-running a spec is outside it. Merging the
+  JSON ourselves is less code, has no version coupling, and puts the tiebreaker
+  where it can be reasoned about.
+
+- **Cross-spec interference detection of its own.** Rotating spec order across
+  batches would surface state dependencies without any complete pass, at the cost
+  of multiplying runs — and a criterion that alternates pass/fail is what
+  `authoring.md` already calls a flake and refuses to ship. Interference rests on
+  the independence discipline that document already mandates (no ordering
+  dependencies, no state left behind, unique test data suffixed with a run
+  marker), plus decision 4's opportunistic pass. The full-suite run was only ever
+  an incidental check on that discipline.
+
+## Consequences
+
+- **A severed command is now visible as one.** It reports `ok: false` and says it
+  kept running in the background, so the feed stops agreeing with a lie the skill
+  warns about.
+- **The report carries provenance.** `batches[]` and a per-criterion `batch`,
+  because a green merged out of eleven runs and a green one run proved are
+  different claims and the report's whole value is being the authoritative record.
+- **The gates got wider coverage, not narrower.** The `// spec:` header check and
+  the locator lint are driven off the specs on disk rather than off whatever
+  appeared in the results — so a severed run can no longer make its own specs
+  skip a check, which is what happened before when they vanished from the tree.
+- **`generate-report.mjs` has tests.** `skills/` is not a pnpm workspace and
+  deliberately is not one, so they run from the root `Makefile`. The merge is the
+  one part of this script that can produce a wrong *verdict* rather than a loud
+  failure, and it was previously untested.
+
+- **`test-results/runs/` grows for the life of a run and is never pruned.** Safe
+  because `test-results/` is gitignored and a validation pod is one-shot, so the
+  directory begins empty and dies with the pod. A re-validation on a fresh clone
+  starts empty again. Nothing depends on that beyond this paragraph, which is
+  why it is written down.
+- **Backgrounding remains available but is not prescribed.** `run_in_background`
+  on Bash is un-hooked and a polling loop is permitted (the guard refuses only a
+  bare `sleep` of 25s or more as a command's first segment — `SKILL.md`'s claim
+  that sleep is blocked was wrong and is corrected). The skill does not offer it
+  as an alternative to covering the suite in pieces, because that would be both
+  halves of a choice the step already makes. It is the escape hatch if a single
+  spec ever outgrows the window, which batching cannot help with.
+
+## Deferred
+
+The corrected diagnosis on #701 asks for two changes this does not make, and
+they are deferred rather than rejected:
+
+- **Push and open the pull request before the repair loop.** *"the change that
+  prevents this run, not a defence-in-depth extra"* — had the PR existed before
+  the suite loop, a severed final run would have cost a stale report rather than
+  the whole cycle. `SKILL.md` step 10 still holds the only `git push`.
+- **Commit as the repair loop goes.** The failing run had one commit, of the
+  scaffold and test plan; every edit that made criteria pass was uncommitted, so
+  even recovering the pod's filesystem would not have recovered a green suite.
+
+Both are about *recovering* a run that ends early. This change is about a run
+being able to produce a report at all, and the two are separable — but neither
+is addressed here, and a reader should not infer otherwise from the fact that
+#701 is referenced.
+
+Related: ADR-0009 introduced the per-item progress this builds on; its decision 5
+is superseded here. #701 carries the diagnosis, and remains open for the runner
+post-condition it actually asks for — a run that exits 0 having delivered nothing
+should fail loudly, which nothing here addresses.

--- a/runners/remote-worker/src/lib/progress/from-sdk.test.ts
+++ b/runners/remote-worker/src/lib/progress/from-sdk.test.ts
@@ -968,3 +968,83 @@ test("from-sdk: a settled backgrounded fan-out does not poison the run's result"
 
   assert.deepEqual(translate({ type: "result", subtype: "success" }), [{ kind: "result", status: "success" }]);
 });
+
+// A command that blows its Bash timeout is auto-backgrounded and answers with
+// code 0, empty output and is_error false — indistinguishable, from here, from
+// a command that ran and succeeded. That cost a validation run its whole cycle
+// (#701): the feed called it a success and the per-criterion rows painted
+// `Passed` on criteria whose tests never finished.
+function bashCall(id: string, command: string): unknown {
+  return {
+    type: "assistant",
+    message: { content: [{ type: "tool_use", id, name: "Bash", input: { command } }] },
+  };
+}
+
+function bashResult(id: string, result: Record<string, unknown>): unknown {
+  return {
+    type: "user",
+    message: { content: [{ type: "tool_result", tool_use_id: id, content: "" }] },
+    tool_use_result: { stdout: "", stderr: "", interrupted: false, ...result },
+  };
+}
+
+test("from-sdk: a severed command is reported as severed, not as a success", () => {
+  const translate = createSdkTranslator();
+  translate(bashCall("toolu_run", "npm test --prefix tests/e2e"));
+  const out = translate(
+    bashResult("toolu_run", { timedOutAfterMs: 600_000, backgroundTaskId: "b3gnow81g" }),
+  );
+  const result = out.find((e) => e.kind === "tool_result");
+  assert.ok(result && result.kind === "tool_result");
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "severed");
+  assert.match(result.summary ?? "", /hit its 600\.0s timeout and was detached/);
+  // It says the command is still going, because it is — the point is that this
+  // call proved nothing, not that anything failed. @aep/progress-view reads the
+  // `severed` status so the feed does not print the word "failed".
+  assert.match(result.summary ?? "", /kept running in the background/);
+});
+
+test("from-sdk: a severed command settles no outcome", () => {
+  // The false-green: whatever folds outcomes into state must not be told this
+  // call succeeded. Validation's per-criterion rows are the consumer that was
+  // painting `Passed` from it.
+  const settled: [string, boolean][] = [];
+  const translate = createSdkTranslator({
+    onToolOutcome: (id, ok) => settled.push([id, ok]),
+  });
+  translate(bashCall("toolu_run", "npm test --prefix tests/e2e -- specs/AC-003-a.spec.ts"));
+  translate(bashResult("toolu_run", { timedOutAfterMs: 597_462, backgroundTaskId: "b3gnow81g" }));
+  assert.deepEqual(settled, []);
+});
+
+test("from-sdk: a deliberately backgrounded command settles no outcome either", () => {
+  // run_in_background is a launch, not a completion. Nothing was misled about
+  // it, so the feed line is left alone — but it cannot settle a result.
+  const settled: [string, boolean][] = [];
+  const translate = createSdkTranslator({
+    onToolOutcome: (id, ok) => settled.push([id, ok]),
+  });
+  translate(bashCall("toolu_bg", "npm test --prefix tests/e2e"));
+  const out = translate(bashResult("toolu_bg", { backgroundTaskId: "b3gnow81g" }));
+  assert.deepEqual(settled, []);
+  const result = out.find((e) => e.kind === "tool_result");
+  assert.ok(result && result.kind === "tool_result");
+  assert.equal(result.ok, true, "a launch did not fail");
+});
+
+test("from-sdk: an ordinary command still settles its outcome both ways", () => {
+  const settled: [string, boolean][] = [];
+  const translate = createSdkTranslator({
+    onToolOutcome: (id, ok) => settled.push([id, ok]),
+  });
+  translate(bashCall("toolu_ok", "npm test --prefix tests/e2e -- specs/AC-001-a.spec.ts"));
+  translate(bashResult("toolu_ok", { code: 0 }));
+  translate(bashCall("toolu_bad", "npm test --prefix tests/e2e -- specs/AC-002-a.spec.ts"));
+  translate({
+    type: "user",
+    message: { content: [{ type: "tool_result", tool_use_id: "toolu_bad", is_error: true, content: "Exit code 1" }] },
+  });
+  assert.deepEqual(settled, [["toolu_ok", true], ["toolu_bad", false]]);
+});

--- a/runners/remote-worker/src/lib/progress/from-sdk.ts
+++ b/runners/remote-worker/src/lib/progress/from-sdk.ts
@@ -356,6 +356,30 @@ function subagentTotals(result: unknown): {
   };
 }
 
+/**
+ * Whether a tool call came back WITHOUT having finished, and why.
+ *
+ * A command that blows its Bash timeout is auto-backgrounded, and what comes
+ * back is `code: 0`, empty output, and `is_error` false — indistinguishable
+ * from a command that ran and succeeded. That cost a validation run its whole
+ * cycle (#701): the final suite run was severed at the ceiling, the feed
+ * recorded it as a success, and the per-criterion rows painted `Passed` on
+ * criteria whose tests never completed.
+ *
+ * `timedOutAfterMs` is the SDK's own flag for exactly that case. A
+ * `backgroundTaskId` with no timeout is a deliberate `run_in_background`
+ * launch — also not a completion, but nobody was misled about it.
+ */
+function incompleteCall(result: unknown): { severedAfterMs?: number; backgrounded: boolean } {
+  if (!result || typeof result !== "object") return { backgrounded: false };
+  const r = result as Record<string, unknown>;
+  const severed = num(r.timedOutAfterMs);
+  return {
+    ...(severed ? { severedAfterMs: severed } : {}),
+    backgrounded: str(r.backgroundTaskId) !== "",
+  };
+}
+
 // parentOf reads the SDK's subagent discriminator: `parent_tool_use_id` is the
 // id of the fan-out tool call a message was forwarded from, and null on the
 // main conversation. "" means the main agent.
@@ -693,14 +717,37 @@ export function createSdkTranslator(opts?: SdkTranslatorOptions): SdkTranslator 
           }
           continue;
         }
-        onToolOutcome?.(tr.toolUseId, !tr.isError);
+        const incomplete = incompleteCall(m.tool_use_result);
+        // A call that has not finished settles nothing. Reporting its outcome
+        // would be inventing one: the command is still running, and a consumer
+        // that folds outcomes into state would record a result no run produced.
+        if (!incomplete.severedAfterMs && !incomplete.backgrounded) {
+          onToolOutcome?.(tr.toolUseId, !tr.isError);
+        }
+        // The severed case is the one the feed actively lied about, so it is the
+        // one overridden here. A deliberate background launch is left as it was:
+        // nothing failed, and nobody has been misled about it.
+        const severed = incomplete.severedAfterMs;
         events.push({
           kind: "tool_result",
-          ok: !tr.isError,
+          ok: severed ? false : !tr.isError,
           toolUseId: tr.toolUseId,
           ...(call ? { tool: call.tool, durationMs: Math.max(0, now() - call.startedAt) } : {}),
-          // Only failures carry their text — see ToolResultEvent's doc comment.
-          ...(tr.isError ? failureDetail(tr.content) : {}),
+          ...(severed
+            ? {
+                // `status` is the SDK's verdict word and already on the wire, so
+                // naming this one costs no schema move. @aep/progress-view reads
+                // it to say "severed" where it would otherwise say "failed" —
+                // which would name a defect that did not happen.
+                status: "severed",
+                summary:
+                  `the command hit its ${(severed / 1000).toFixed(1)}s timeout and was detached — ` +
+                  `it kept running in the background, so this call proved nothing`,
+              }
+            : // Only failures carry their text — see ToolResultEvent's doc comment.
+              tr.isError
+              ? failureDetail(tr.content)
+              : {}),
           ...who,
         });
       }

--- a/runners/remote-worker/src/lib/validation_progress.test.ts
+++ b/runners/remote-worker/src/lib/validation_progress.test.ts
@@ -276,3 +276,22 @@ test("validation-progress: a pass recorded through the tracker arms healing", ()
     );
   })();
 });
+
+test("validation-progress: a run nobody settles leaves the criterion running", () => {
+  // What a SEVERED test command now produces. The translator withholds the
+  // outcome for a call that never finished (see from-sdk's incompleteCall), so
+  // no status arrives — and `running` is the honest resting place, because the
+  // command was auto-backgrounded and may still be executing.
+  //
+  // Before this, a severed call answered `ok: true` and painted `pass` on the
+  // criterion, which on a heal re-run means a criterion that was just failing.
+  const seen: ProgressItemUpdate[] = [];
+  const tracker = createValidationProgressTracker((u) => seen.push(u));
+  return tracker
+    .hook(preToolUse("Bash", { command: "npm test --prefix tests/e2e -- specs/AC-004-a.spec.ts" }, "toolu_sev"), undefined, {
+      signal: new AbortController().signal,
+    })
+    .then(() => {
+      assert.deepEqual(seen, [{ itemId: "AC-004-a", status: "running" }]);
+    });
+});

--- a/skills/aep-validation/SKILL.md
+++ b/skills/aep-validation/SKILL.md
@@ -247,7 +247,7 @@ tests/e2e/
 - `playwright.config.ts` is platform-owned too, and is the one scaffold
   file to re-copy from the template on EVERY run rather than skip when
   present. It carries the launch args that make deployed endpoints
-  reachable and the rule deciding which run may write `results.json`;
+  reachable and the per-run results layout the report generator merges;
   a repo scaffolded before either landed keeps the old behaviour
   silently, which is exactly the class of bug those two exist to fix.
 
@@ -274,6 +274,11 @@ counts only after passing twice consecutively against the live app.
 - Spec naming (the report's join key — get this exactly right):
   - file: `tests/e2e/specs/<AC-ID>.spec.ts` (e.g. `AC-001-a.spec.ts`)
   - title: `test('<AC-ID>: <short form of the must>', ...)`
+- **Your solo runs are the results.** The independence check below — each
+  spec passing alone, twice consecutively — writes a results file under
+  `tests/e2e/test-results/runs/` every time, and the report merges them.
+  So the work of proving a spec is also the work of recording it; step 7
+  is not repeating it.
 - **Create the file before you explore for it.** For each criterion you
   are authoring fresh, write `tests/e2e/specs/<AC-ID>.spec.ts` with its
   `// spec:` header and nothing else, THEN explore, THEN fill in the
@@ -289,49 +294,57 @@ counts only after passing twice consecutively against the live app.
 
 ### 7. RUN
 
-The suite outlives the Bash tool's DEFAULT timeout (120s), so ask for the
-time up front — `timeout` is a parameter on the Bash call, max `600000`:
+Every run writes its **own** results file under
+`tests/e2e/test-results/runs/`, and the report is the merge of them —
+newest result per criterion wins. So no single command has to cover the
+whole suite, and nothing you have already proved is thrown away by a
+later call. In particular the solo runs from step 6 already count: each
+spec you authored has a result before you get here.
+
+Run the whole suite, and treat it as **best effort**:
 
 ```bash
-rm -f tests/e2e/test-results/results.json   # never read a previous run's verdict
-npm test --prefix tests/e2e                 # Bash timeout: 600000
+npm test --prefix tests/e2e   # Bash timeout: use the max your Bash tool states
 ```
 
+If it completes, it supersedes the per-spec results with one pass over
+the deployed system in sequence — which is the only thing that catches a
+spec depending on state another spec left behind. If it severs, it costs
+you nothing: step 6's results still cover every spec you authored. A
+severed call is detached rather than killed — it keeps running, so its
+results may still land in `runs/` minutes later, which is a bonus rather
+than something to wait on.
+
+Do **not** delete anything under `test-results/runs/` first. Those are the
+accumulated results; removing them is how you lose coverage you already
+have.
+
 Never `npx playwright test` from the repo root. It finds the specs and
-passes anyway, without loading the config — so no reporter, no
-`results.json`, and none of the launch args the endpoints need. Exit 0,
-nothing written.
+passes anyway, without loading the config — so no reporter, nothing
+written, and none of the launch args the endpoints need. Exit 0, nothing
+written.
 
-Two things about this step will mislead you if you let them:
+**A timed-out command still reports success.** Past the timeout the
+harness detaches the command and hands back an OK result with no output —
+identical, from where you sit, to a suite that finished. Never infer the
+run completed from the call returning; check whether a new file appeared
+under `test-results/runs/`.
 
-- **A timed-out command still reports success.** Past the timeout the
-  harness detaches the command and hands back an OK result with no
-  output — identical, from where you sit, to a suite that finished. So
-  never infer the run completed from the call returning. Confirm
-  `tests/e2e/test-results/results.json` exists and is NEWER than the moment you
-  started the run; if it is missing or stale, the run was severed and
-  its results do not exist.
-- **You cannot wait for a detached run.** `sleep` is blocked, and
-  `Monitor`/`TaskOutput` are not available to you, so a severed run is
-  unrecoverable — there is no way to attach to it or read its output
-  later. Getting the timeout right up front is the whole game.
+If the suite will not fit one call, **cover it in pieces** — that is what
+the merge is for:
 
-**Never narrow this call** — no spec filter, and none of `--shard`,
-`--grep`, `--last-failed`, `--only-changed`. The config decides which run
-may write `results.json` by whether the command narrows the suite: a
-complete run is this one, and anything narrower is a probe — a spec being
-checked while it is authored (step 6) or healed (step 8), neither of which
-may overwrite the report's input. A narrowed run therefore writes nothing,
-and `generate-report.mjs` exits 2 naming the missing file. That is
-deliberate: a run that loudly writes nothing beats one that quietly writes
-a third of the suite as if it were all of it.
+```bash
+npm test --prefix tests/e2e -- specs/AC-001-a.spec.ts specs/AC-001-b.spec.ts
+```
 
-If the suite genuinely cannot finish inside the window, say so in the plan
-and PR notes: that is a finding about the suite, not something to work
-around by merging batches by hand.
+You do not have to guess the right size. Run what you think fits, then
+let step 9 tell you what is still missing: the report generator names
+every spec on disk that has no result and refuses to emit until they all
+do. A batch that severs is a batch you re-run smaller — its specs show up
+in that list until its results land, if they ever do.
 
-The config writes `tests/e2e/test-results/results.json`. The run includes the
-regression set — that's free regression coverage, not an accident.
+The suite includes the regression set — that's free regression coverage,
+not an accident.
 
 ### 8. HEAL (bounded)
 
@@ -339,12 +352,15 @@ For failures, **Read `references/healing.md` now and follow it as the
 binding HEAL discipline** before touching any spec. Then: triage each
 one against the live app, repair only *brittleness* (locators, waits,
 setup), never weaken what a test asserts. Log each heal in
-`tests/e2e/heal-log.json`. When the budget is exhausted, finish with
-one final full run so `results.json` reflects the authoritative state —
-under the same timeout discipline as step 7, and under its no-sharding
-rule for the same reason: a run that names specs is read as a probe and
-writes no `results.json` at all. A final run that severs leaves you with
-no authoritative state, and a sharded one leaves you with none either.
+`tests/e2e/heal-log.json`.
+
+Re-run each healed spec on its own. That result is newer than the failure
+it replaces, so it supersedes it in the report — you do not need a
+closing full-suite run to make the repair count:
+
+```bash
+npm test --prefix tests/e2e -- specs/<AC-ID>.spec.ts
+```
 
 ### 9. REPORT
 
@@ -368,11 +384,25 @@ cp "$AEP_SKILLS_DIR/aep-validation/scripts/generate-report.mjs" \
 This writes `tests/validation/report.md` + `report.json`. It reads the
 criteria but never writes them — coverage is expressed by each criterion's
 pass/fail in the report, not by a flag in the criteria file. Exit code 2
-means a contract violation: spec titles that don't map to criterion ids
-(fix titles, re-run tests from step 7), a spec file missing its
-`// spec:` header (add the header, regenerate — no test re-run needed),
-or a pre-existing spec modified without a heal-log entry (record the
-heal per `references/healing.md`).
+means a contract violation:
+
+- **a spec on disk with no result** — the generator names every one of
+  them and refuses to emit. This is the ordinary loop, not a defect: run
+  exactly those specs and regenerate. A severed batch lands here, which is
+  how you find out which of its specs you still owe — though a severed
+  call is detached, not killed, so look at `runs/` once more before
+  re-running: its results may have arrived in the meantime.
+- spec titles that don't map to criterion ids (fix titles, re-run those
+  specs), or two spec files claiming one criterion inside a single run.
+- a spec file missing its `// spec:` header (add the header, regenerate
+  — no test re-run needed).
+- a pre-existing spec modified without a heal-log entry (record the heal
+  per `references/healing.md`).
+- results recorded under different `rootDir` values or by different
+  Playwright versions — those results describe two different checkouts.
+
+The generator IS the coverage check, so there is no separate command to
+run: generate, read what it names, cover that, generate again.
 
 **`tests/validation/report.json` is REQUIRED. Commit it with the tests.**
 

--- a/skills/aep-validation/assets/playwright.config.template.ts
+++ b/skills/aep-validation/assets/playwright.config.template.ts
@@ -82,29 +82,25 @@ function hostResolverArgs(baseURL: string): string[] {
 
 const baseURL = primaryTarget();
 
-// Playwright's own ways of narrowing a run, beyond naming spec files. `--shard`
-// is the one that bites: it looks like the way to fit a big suite inside the
-// command window, and without it here a `--shard=1/3` would have been treated as
-// the authoritative pass and written a THIRD of the suite's results as if they
-// were all of it — every unrun criterion reported as never checked.
-const NARROWING_FLAGS = /^(?:--shard|--grep|--grep-invert|-g|--last-failed|--only-changed)(?:=|$)/;
-
-/**
- * Whether this run covers less than the whole suite.
- *
- * A partial run is a PROBE — one spec being checked on its own, a shard, a
- * grep — and no probe may write `test-results/results.json`, which is the
- * report generator's only input. Only a complete, unfiltered run may.
- *
- * Read off the command rather than switched by a flag or an env var: naming a
- * spec is not optional, it is how you run one spec, so there is nothing for a
- * caller to remember and nothing to forget.
- */
-function isPartialRun(): boolean {
-  return process.argv
-    .slice(2)
-    .some((a) => a.includes(".spec.") || NARROWING_FLAGS.test(a));
-}
+// Every run writes its OWN results file, and the report is the merge of them.
+//
+// One run used to have to cover the whole suite, because there was one file and
+// the last writer won. That made a run which could not finish in a single
+// command a run that could produce no report at all — 24 specs outgrew the Bash
+// timeout, the call was severed, and the criteria that had passed were lost with
+// it (issue #701). Nothing here caps how long a suite may take any more: it is
+// covered by however many calls it takes.
+//
+// The stamp is the merge order. ISO-8601 sorts lexicographically in time order,
+// so `readdir().sort()` is chronological and the newest result for a criterion
+// is simply the last one seen — which is what makes a heal's re-run supersede
+// the failure that prompted it.
+//
+// Computed once at module scope, deliberately. Playwright loads this config
+// twice — the CLI process, which constructs the reporters, and each worker,
+// which does not — so a per-evaluation stamp would differ between them
+// harmlessly, but a per-CALL one would not be stable within the run that uses it.
+const STAMP = new Date().toISOString().replace(/[:.]/g, "-");
 
 export default defineConfig({
   testDir: "./specs",
@@ -116,30 +112,11 @@ export default defineConfig({
   forbidOnly: true,
   timeout: 30_000,
   expect: { timeout: 10_000 },
-  // A PARTIAL run is a probe — one spec being checked on its own (how it is
-  // verified while authored and re-checked while healed), a shard, or a grep. A
-  // run that narrows nothing is the authoritative pass over the whole suite, and
-  // its `results.json` is the only thing the report generator reads. See
-  // isPartialRun above.
-  //
-  // Only the authoritative pass may write that file. Probes used to overwrite it
-  // with a single spec's results, which is invisible until the report claims one
-  // criterion was checked and the rest never ran.
-  //
-  // Inferred from the command rather than switched by a flag or an env var on
-  // purpose: naming a spec is not optional — it is how you run one spec — so
-  // there is nothing here for a caller to remember, and nothing to forget. The
-  // cost is that a SHARDED authoritative run reads as a probe and writes no
-  // report input at all; the generator then exits 2 naming the missing path,
-  // which is why the workflow runs the authoritative pass as one call.
-  //
-  // Playwright loads this config twice — once in the CLI process, which is where
-  // argv carries the filter and where reporters are constructed, and once per
-  // worker, where argv is empty. Only the first decides. Do not "simplify" this
-  // to a module-level constant computed somewhere the CLI process cannot see.
-  reporter: isPartialRun()
-    ? [["line"]]
-    : [["list"], ["json", { outputFile: "test-results/results.json" }]],
+  // Written per run, never shared. See STAMP above: the report generator merges
+  // this directory, so a narrowed run — one spec being verified while authored,
+  // a spec re-run while healed, a shard — contributes its results instead of
+  // overwriting everyone else's or being thrown away.
+  reporter: [["list"], ["json", { outputFile: `test-results/runs/${STAMP}.json` }]],
   outputDir: "test-results/artifacts",
   use: {
     baseURL,

--- a/skills/aep-validation/references/healing.md
+++ b/skills/aep-validation/references/healing.md
@@ -52,10 +52,12 @@ validation phase.
 
 - Max **2 heal attempts per criterion**; each followed by a focused
   re-run: `npm test --prefix tests/e2e -- specs/<AC-ID>.spec.ts`.
-- Max **2 focused re-run waves** after the initial full run.
-- Then **one final full run** (`npm test --prefix tests/e2e`) so
-  `tests/e2e/test-results/results.json` — the report's input — reflects the
-  authoritative end state.
+- Max **2 focused re-run waves**.
+- No closing full-suite run is required. Each run writes its own results
+  file under `tests/e2e/test-results/runs/` and the report takes the
+  newest per criterion, so a focused re-run supersedes the failure that
+  prompted it. Run the whole suite again if you want the sequenced pass
+  as well, not because the report needs it.
 - Still failing after the budget: leave it failing. In the plan/PR
   notes, mark it `genuine` or `unresolved (possibly brittle)`.
 

--- a/skills/aep-validation/scripts/generate-report.mjs
+++ b/skills/aep-validation/scripts/generate-report.mjs
@@ -34,7 +34,10 @@
 //   --issue <n>       validation issue number (required)
 //   --commit <sha>    commit under validation (default: "unknown")
 //   --criteria <p>    default specs/validation/validation-criteria.json (read-only)
-//   --results <p>     default tests/e2e/test-results/results.json
+//   --results <p>     default tests/e2e/test-results/runs (a DIRECTORY of
+//                     per-run result files, merged in filename order; a single
+//                     file is also accepted)
+//   --specs <dir>     default tests/e2e/specs
 //   --heal-log <p>    default tests/e2e/heal-log.json (optional file)
 //   --out <dir>       default tests/validation
 //
@@ -43,8 +46,18 @@
 //   <out>/report.md            human report incl. manual checklist
 //
 // Join key: every automated spec's title MUST start with "<AC-ID>: "
-// (e.g. "AC-001-a: shows a name text box"). Duplicate or unknown AC ids
-// are hard errors (exit 2) — fix the spec titles, then re-run.
+// (e.g. "AC-001-a: shows a name text box"). An unknown AC id, or two spec
+// FILES claiming one criterion inside a single run, are hard errors (exit 2)
+// — fix the spec titles, then re-run. The same criterion appearing across
+// SEVERAL runs is not an error: it is a spec that was run more than once, and
+// the newest result wins.
+//
+// Coverage is verified, not assumed. Every spec file on disk must APPEAR in
+// the merged runs — matched by path, so a stale result for the same criterion
+// under a different spec file does not count — and one that does not appear is
+// a hard error naming the specs still owed. Appearing is the check —
+// a spec whose tests all skipped appears, and reports `not_run` honestly,
+// which is also what a criterion with no spec file at all reports.
 //
 // Each mapped spec file must also carry a "// spec:" header comment
 // linking it to its test-plan section (hard error when absent — add the
@@ -53,16 +66,22 @@
 // getByLabel/...) survive UI change, raw CSS is what the healer ends
 // up fixing later.
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
-const AC_TITLE_RE = /^(AC-\d{3}-[a-z]):/;
+// One shape, three questions asked of it: a spec TITLE's prefix (the join key),
+// a spec PATH's basename, and a spec FILENAME on its own.
+const AC_ID = String.raw`AC-\d{3}-[a-z]`;
+const AC_TITLE_RE = new RegExp(`^(${AC_ID}):`);
+const AC_SPEC_PATH_RE = new RegExp(`(${AC_ID})\\.spec\\.[cm]?[tj]sx?$`);
+const AC_SPEC_FILE_RE = new RegExp(`^(${AC_ID})\\.spec\\.[cm]?[tj]sx?$`);
 
 function parseArgs(argv) {
   const args = {
     criteria: "specs/validation/validation-criteria.json",
-    results: "tests/e2e/test-results/results.json",
+    results: "tests/e2e/test-results/runs",
+    specs: "tests/e2e/specs",
     healLog: "tests/e2e/heal-log.json",
     out: "tests/validation",
     commit: "unknown",
@@ -77,6 +96,7 @@ function parseArgs(argv) {
       case "--commit": args.commit = val; break;
       case "--criteria": args.criteria = val; break;
       case "--results": args.results = val; break;
+      case "--specs": args.specs = val; break;
       case "--heal-log": args.healLog = val; break;
       case "--out": args.out = val; break;
       default: fail(`unknown flag: ${key}`);
@@ -93,6 +113,13 @@ function fail(msg) {
   process.exit(2);
 }
 
+// Several checks accumulate before any of them speaks, so the reader gets every
+// violation at once rather than one per re-run.
+function failAll(errors) {
+  for (const e of errors) console.error(`generate-report: ${e}`);
+  process.exit(2);
+}
+
 function readJson(p, what) {
   if (!existsSync(p)) fail(`${what} not found: ${p}`);
   try {
@@ -100,6 +127,30 @@ function readJson(p, what) {
   } catch (err) {
     fail(`${what} is not valid JSON (${p}): ${err.message}`);
   }
+}
+
+/**
+ * The per-run result files, in merge order.
+ *
+ * Every test run writes its own file (see the skill's playwright.config
+ * template), so the input is normally a directory of them. Filename order is
+ * the merge order and is chronological, because the names are ISO stamps —
+ * which is what makes the newest result for a criterion simply the last one
+ * seen.
+ *
+ * A single file is still accepted. That is what one complete run looks like,
+ * and what every report generated before batching read.
+ */
+function readResultBatches(p, what) {
+  if (!existsSync(p)) fail(`${what} not found: ${p}`);
+  if (!statSync(p).isDirectory()) {
+    return [{ name: path.basename(p), doc: readJson(p, what) }];
+  }
+  const files = readdirSync(p).filter((f) => f.endsWith(".json")).sort();
+  if (files.length === 0) {
+    fail(`${what} directory holds no .json files: ${p} — no test run has written results`);
+  }
+  return files.map((f) => ({ name: f, doc: readJson(path.join(p, f), `${what} (${f})`) }));
 }
 
 function stripAnsi(s) {
@@ -157,7 +208,7 @@ function main() {
   const args = parseArgs(process.argv);
 
   const criteriaDoc = readJson(args.criteria, "criteria file");
-  const results = readJson(args.results, "Playwright results");
+  const batches = readResultBatches(args.results, "Playwright results");
   const healEntries = existsSync(args.healLog)
     ? readJson(args.healLog, "heal log")
     : [];
@@ -173,34 +224,78 @@ function main() {
   }
   if (criteriaById.size === 0) fail("criteria file has no criteria");
 
-  // ---- index test results by AC id ---------------------------------------
-  const specs = [];
-  for (const suite of results.suites ?? []) collectSpecs(suite, specs);
+  // ---- one rootDir, one Playwright version -------------------------------
+  // Batches that disagree are describing two different checkouts, and the
+  // merge would be silently meaningless. Playwright's own merge-reports
+  // refuses the same way, for the same reason.
+  const rootDirs = new Set(batches.map((b) => b.doc.config?.rootDir).filter(Boolean));
+  if (rootDirs.size > 1) {
+    fail(`results were recorded under different rootDir values: ${[...rootDirs].sort().join(", ")}`);
+  }
+  const rootDir = [...rootDirs][0];
+  const versions = new Set(batches.map((b) => b.doc.config?.version).filter(Boolean));
+  if (versions.size > 1) {
+    fail(`results were recorded by different Playwright versions: ${[...versions].sort().join(", ")}`);
+  }
 
+  // ---- index test results by AC id, merging the batches ------------------
+  //
+  // Per batch, then fold — and the two-step matters. Folding every batch's raw
+  // `spec.tests[]` into one array and calling specOutcome once would be wrong:
+  // it is fail-dominant and time-blind, so a failure that has since been
+  // healed would outvote the pass that healed it, permanently.
+  //
+  // Later batches overwrite earlier ones because the batches are in time
+  // order, which is exactly how a heal's re-run supersedes the failure that
+  // prompted it.
   const resultByAc = new Map();
+  // How many mapped specs each batch contributed, for the report's provenance.
+  // Held beside the batches rather than written onto them: readResultBatches
+  // owns those objects, and a count derived here is this loop's fact.
+  const specsPerBatch = new Map();
+  const unmappedSeen = new Set();
   const unmappedTests = [];
   const errors = [];
-  for (const spec of specs) {
-    const m = AC_TITLE_RE.exec(spec.title ?? "");
-    if (!m) {
-      unmappedTests.push({ title: spec.title ?? "", file: spec.file ?? null });
-      continue;
+  for (const batch of batches) {
+    const specs = [];
+    for (const suite of batch.doc.suites ?? []) collectSpecs(suite, specs);
+    const inBatch = new Map();
+    for (const spec of specs) {
+      const m = AC_TITLE_RE.exec(spec.title ?? "");
+      if (!m) {
+        // Deduped across batches: the same unmapped spec reappears in every run
+        // that covered it, and one authoring mistake should be reported once.
+        const key = `${spec.title ?? ""}\u0000${spec.file ?? ""}`;
+        if (!unmappedSeen.has(key)) {
+          unmappedSeen.add(key);
+          unmappedTests.push({ title: spec.title ?? "", file: spec.file ?? null });
+        }
+        continue;
+      }
+      const acId = m[1];
+      // Two spec FILES claiming one criterion is an authoring bug and stays a
+      // hard error — but only WITHIN a batch. Across batches it is the same
+      // spec run twice, which is the entire point of merging them.
+      if (inBatch.has(acId)) {
+        const first = inBatch.get(acId).file;
+        errors.push(
+          `duplicate spec title prefix ${acId} within ${batch.name} — ` +
+            (first === (spec.file ?? null)
+              ? `two tests in ${first} claim it`
+              : `claimed by both ${first} and ${spec.file}`),
+        );
+        continue;
+      }
+      if (!criteriaById.has(acId)) {
+        errors.push(`spec title references unknown criterion ${acId} (${spec.file})`);
+        continue;
+      }
+      inBatch.set(acId, { ...specOutcome(spec), file: spec.file ?? null, batch: batch.name });
     }
-    const acId = m[1];
-    if (resultByAc.has(acId)) {
-      errors.push(`duplicate spec title prefix ${acId} (files: ${resultByAc.get(acId).file}, ${spec.file})`);
-      continue;
-    }
-    if (!criteriaById.has(acId)) {
-      errors.push(`spec title references unknown criterion ${acId} (${spec.file})`);
-      continue;
-    }
-    resultByAc.set(acId, { ...specOutcome(spec), file: spec.file ?? null });
+    specsPerBatch.set(batch.name, inBatch.size);
+    for (const [acId, r] of inBatch) resultByAc.set(acId, r);
   }
-  if (errors.length > 0) {
-    for (const e of errors) console.error(`generate-report: ${e}`);
-    process.exit(2);
-  }
+  if (errors.length > 0) failAll(errors);
 
   // Heal-log entries must join to criteria AND carry full provenance — reject
   // free-form shapes (an entry the report can't attribute, or a heal without
@@ -262,7 +357,7 @@ function main() {
       healCheckSkipped = true;
     } else {
       for (const p of modified) {
-        const m = /(AC-\d{3}-[a-z])\.spec\.[cm]?[tj]sx?$/.exec(p);
+        const m = AC_SPEC_PATH_RE.exec(p);
         if (!m) continue;
         if (!healByAc.has(m[1])) {
           errors.push(
@@ -274,16 +369,40 @@ function main() {
     }
   }
 
-  // ---- spec-file conventions (header hard-check, locator lint) -----------
-  // Reporter file paths are relative to the run's rootDir (usually the
-  // testDir, e.g. tests/e2e/specs), NOT the repo root — resolve against
-  // rootDir first, then the conventional layouts.
-  const rootDir = results.config?.rootDir;
+  // ---- specs on disk: coverage, header hard-check, locator lint ----------
+  //
+  // Driven by what is on DISK, not by what turned up in the results, and that
+  // inversion is the invariant that replaces "one run must have covered
+  // everything".
+  //
+  // A spec file that exists with no result means a run was missed or severed.
+  // That used to be indistinguishable from a criterion nobody wrote a test for
+  // — both landed as `not_run` — so a partial set of results could report most
+  // of the suite as never checked and look like a finished report. Now the
+  // first is a hard error naming the specs still owed, and only the second is a
+  // legitimate `not_run`.
+  //
+  // It also fixes what the two gates below could see. Scoped to the results, a
+  // severed run's specs vanished from the tree and their missing headers went
+  // unreported, so the report could exit 0 having skipped a check on exactly
+  // the specs whose run had failed.
+  // A missing specs directory degrades VISIBLY, never silently — the same rule
+  // the heal check above follows. Without it the coverage invariant, the header
+  // gate and the locator lint would all pass over an empty list and the report
+  // would look complete having checked nothing.
+  const specsDirMissing = !existsSync(args.specs);
+  const specFiles = specsDirMissing
+    ? []
+    : readdirSync(args.specs).filter((f) => AC_SPEC_FILE_RE.test(f)).sort();
+
+  // Reporter file paths are relative to the run's rootDir (usually the testDir,
+  // e.g. tests/e2e/specs), NOT the repo root — kept as the fallback for a
+  // criterion whose result names a spec that is no longer on disk.
   function resolveSpecPath(file) {
     const candidates = [];
     if (rootDir) candidates.push(path.resolve(rootDir, file));
     candidates.push(
-      path.resolve("tests/e2e/specs", file),
+      path.resolve(args.specs, file),
       path.resolve("tests/e2e", file),
     );
     for (const c of candidates) {
@@ -295,31 +414,62 @@ function main() {
   if (healCheckSkipped) {
     warnings.push("heal-visibility check skipped (no git origin ref available)");
   }
-  for (const [acId, r] of resultByAc) {
-    if (!r.file) continue;
-    const abs = resolveSpecPath(r.file);
-    if (!abs) {
-      warnings.push(`${acId}: spec file not found on disk (${r.file}) — header/locator checks skipped`);
+  if (specsDirMissing) {
+    warnings.push(
+      `coverage, header and locator checks skipped — no spec directory at ${args.specs}`,
+    );
+  }
+  const uncovered = [];
+  for (const f of specFiles) {
+    const acId = AC_SPEC_FILE_RE.exec(f)[1];
+    const repoPath = path.join(args.specs, f).split(path.sep).join("/");
+    if (!criteriaById.has(acId)) {
+      errors.push(`${repoPath} names criterion ${acId}, which the criteria file does not carry`);
       continue;
     }
-    r.repoPath = path.relative(process.cwd(), abs).split(path.sep).join("/");
-    const src = readFileSync(abs, "utf8");
+    // Matched by PATH, not by criterion id alone. A result carrying the same
+    // `AC-001-a:` title from a DIFFERENT spec file — a stale batch from before
+    // a rename, or a spec authored in the wrong directory — would otherwise
+    // satisfy coverage for a file that was never executed, and results
+    // accumulate across the whole run so a superseded path lingers.
+    //
+    // A result with no file at all is accepted: it cannot be verified either
+    // way, and refusing would invent a failure rather than find one.
+    const r = resultByAc.get(acId);
+    const ranThisFile = r ? (r.file ? resolveSpecPath(r.file) === path.resolve(args.specs, f) : true) : false;
+    if (ranThisFile) r.repoPath = repoPath;
+    else uncovered.push(f);
+
+    const src = readFileSync(path.join(args.specs, f), "utf8");
     const head = src.split("\n").slice(0, 10);
     if (!head.some((l) => l.startsWith("// spec:"))) {
       errors.push(
-        `${r.repoPath} is missing its "// spec:" header comment (link to the test-plan section for ${acId})`,
+        `${repoPath} is missing its "// spec:" header comment (link to the test-plan section for ${acId})`,
       );
     }
     if (/\.locator\(/.test(src)) {
       warnings.push(
-        `${acId}: raw locator() usage in ${r.repoPath} — prefer getByRole/getByLabel/getByPlaceholder`,
+        `${acId}: raw locator() usage in ${repoPath} — prefer getByRole/getByLabel/getByPlaceholder`,
       );
     }
   }
-  if (errors.length > 0) {
-    for (const e of errors) console.error(`generate-report: ${e}`);
-    process.exit(2);
+  if (uncovered.length > 0) {
+    errors.push(
+      `no test result for ${uncovered.length} spec(s) that exist on disk: ${uncovered.join(", ")} — ` +
+        `run them and regenerate. A run that was severed at its timeout keeps going in the ` +
+        `background, so its results may simply not have landed yet: check the runs directory ` +
+        `again before re-running`,
+    );
   }
+  // A result whose spec is gone from disk keeps the old resolution, so the
+  // report can still name the file the run actually executed.
+  for (const [acId, r] of resultByAc) {
+    if (r.repoPath || !r.file) continue;
+    const abs = resolveSpecPath(r.file);
+    if (abs) r.repoPath = path.relative(process.cwd(), abs).split(path.sep).join("/");
+    else warnings.push(`${acId}: spec file not found on disk (${r.file})`);
+  }
+  if (errors.length > 0) failAll(errors);
 
   // ---- build per-criterion rows ------------------------------------------
   const rows = [];
@@ -339,6 +489,7 @@ function main() {
         flaky: false,
         durationMs: 0,
         failure: null,
+        batch: null,
       };
       if (c.method === "e2e") {
         totals.e2e.total += 1;
@@ -352,6 +503,10 @@ function main() {
           row.flaky = r.flaky;
           row.durationMs = r.durationMs;
           row.failure = r.failure;
+          // Which run produced this. Without it a reader cannot tell a green
+          // merged out of eleven runs from a green one run proved, and the
+          // report's central claim is that it is the authoritative record.
+          row.batch = r.batch ?? null;
           if (r.status === "pass") totals.e2e.pass += 1;
           else if (r.status === "fail") totals.e2e.fail += 1;
           else totals.e2e.notRun += 1;
@@ -373,7 +528,10 @@ function main() {
     issue: args.issue,
     commit: args.commit,
     generatedAt: new Date().toISOString(),
-    playwrightVersion: results.config?.version ?? "unknown",
+    playwrightVersion: [...versions][0] ?? "unknown",
+    // Every run that contributed, in merge order. A criterion's `batch` names
+    // which of these its result came from.
+    batches: batches.map((b) => ({ file: b.name, specs: specsPerBatch.get(b.name) ?? 0 })),
     totals,
     criteria: rows,
     ...(warnings.length > 0 ? { warnings } : {}),

--- a/skills/aep-validation/scripts/generate-report.test.mjs
+++ b/skills/aep-validation/scripts/generate-report.test.mjs
@@ -1,0 +1,371 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The merge is the one part of this script that can produce a WRONG verdict
+// rather than a loud failure, so it is pinned here against fixtures.
+//
+// Driven as a subprocess, because the script owns its exit code — exit 2 is
+// half its contract and cannot be observed by importing it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT = path.join(import.meta.dirname, "generate-report.mjs");
+const ROOT_DIR = "/repo/tests/e2e/specs";
+
+/** One Playwright JSON reporter document covering the given specs. */
+function pwRun(specs, { rootDir = ROOT_DIR, version = "1.61.1" } = {}) {
+  return {
+    config: { rootDir, version },
+    suites: specs.map(({ id, status, file = `${id}.spec.ts` }) => ({
+      title: file,
+      file,
+      specs: [
+        {
+          title: `${id}: does the thing`,
+          file,
+          line: 3,
+          column: 1,
+          tests: [
+            {
+              status,
+              results: [
+                {
+                  duration: 10,
+                  ...(status === "unexpected" ? { error: { message: "boom" } } : {}),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })),
+  };
+}
+
+/**
+ * A throwaway project tree. `runs` is an ordered list, written under names that
+ * sort in the order given — which is what the merge reads as time order.
+ */
+function fixture({ criteria, runs = [], specFiles = {}, resultsAsFile = false }) {
+  const dir = mkdtempSync(path.join(tmpdir(), "genreport-"));
+  mkdirSync(path.join(dir, "specs/validation"), { recursive: true });
+  mkdirSync(path.join(dir, "tests/e2e/specs"), { recursive: true });
+  writeFileSync(
+    path.join(dir, "specs/validation/validation-criteria.json"),
+    JSON.stringify({
+      requirements: [{ id: "REQ-001", statement: "It works", criteria }],
+    }),
+  );
+  for (const [name, body] of Object.entries(specFiles)) {
+    writeFileSync(path.join(dir, "tests/e2e/specs", name), body);
+  }
+  let results;
+  if (resultsAsFile) {
+    results = "tests/e2e/test-results/results.json";
+    mkdirSync(path.join(dir, "tests/e2e/test-results"), { recursive: true });
+    writeFileSync(path.join(dir, results), JSON.stringify(runs[0]));
+  } else {
+    results = "tests/e2e/test-results/runs";
+    mkdirSync(path.join(dir, results), { recursive: true });
+    runs.forEach((doc, i) => {
+      writeFileSync(path.join(dir, results, `2026-09-02T00-00-0${i}-000Z.json`), JSON.stringify(doc));
+    });
+  }
+  return { dir, results };
+}
+
+function run({ dir, results }) {
+  const r = spawnSync(
+    process.execPath,
+    [SCRIPT, "--issue", "30", "--commit", "deadbeef", "--results", results, "--specs", "tests/e2e/specs"],
+    { cwd: dir, encoding: "utf8" },
+  );
+  let report = null;
+  try {
+    report = JSON.parse(readFileSync(path.join(dir, "tests/validation/report.json"), "utf8"));
+  } catch {
+    // exit 2 writes nothing, which is the point of several tests below
+  }
+  return { code: r.status, stderr: r.stderr, report };
+}
+
+const spec = (id) => `// spec: tests/validation/test-plan.md § ${id}\ntest('${id}: x', () => {});\n`;
+const e2e = (id) => ({ id, must: `${id} holds`, method: "e2e" });
+const statusOf = (report, id) => report.criteria.find((c) => c.id === id)?.status;
+
+// ---- the contract between the config and this script ---------------------
+
+test("generate-report: the config writes where this script reads", () => {
+  // Two files on opposite sides of a copy: the config template is scaffolded
+  // into the project repo and writes results; this script is invoked from
+  // $AEP_SKILLS_DIR and reads them. Nothing imports across that gap, so a
+  // renamed directory would break every validation run silently — the report
+  // would find an empty directory and say no run had written results.
+  //
+  // Pinned the same way services/aep-api pins ReportFilePath across its own
+  // split. If this fails, the two sides disagree about where results live.
+  const template = readFileSync(
+    path.join(import.meta.dirname, "../assets/playwright.config.template.ts"),
+    "utf8",
+  );
+  const outputFile = /outputFile:\s*`([^`]+)`/.exec(template)?.[1];
+  assert.ok(outputFile, "the template must configure a json reporter outputFile");
+  assert.match(outputFile, /^test-results\/runs\/\$\{STAMP\}\.json$/);
+
+  const script = readFileSync(SCRIPT, "utf8");
+  const defaultResults = /results:\s*"([^"]+)"/.exec(script)?.[1];
+  assert.equal(defaultResults, "tests/e2e/test-results/runs");
+
+  // The template's path is relative to tests/e2e (npm --prefix runs it there);
+  // this script's default is relative to the repo root. Same directory.
+  assert.equal(path.posix.join("tests/e2e", outputFile.replace("/${STAMP}.json", "")), defaultResults);
+});
+
+test("generate-report: the stamp sorts chronologically", () => {
+  // Merge order IS filename order, so the stamp must sort in time order or a
+  // heal's re-run stops superseding the failure it repaired. ISO-8601 with the
+  // colons and dot swapped for hyphens keeps that property.
+  const stamp = (iso) => iso.replace(/[:.]/g, "-");
+  const earlier = stamp("2026-09-02T08:10:59.240Z");
+  const later = stamp("2026-09-02T08:11:00.235Z");
+  assert.ok(earlier < later, `${earlier} must sort before ${later}`);
+  assert.ok(stamp("2026-09-02T09:00:00.000Z") > later);
+  // Across a midnight and a year boundary too.
+  assert.ok(stamp("2026-09-02T23:59:59.999Z") < stamp("2026-09-03T00:00:00.000Z"));
+  assert.ok(stamp("2026-12-31T23:59:59.999Z") < stamp("2027-01-01T00:00:00.000Z"));
+});
+
+// ---- the merge -----------------------------------------------------------
+
+test("generate-report: a later pass supersedes an earlier failure", () => {
+  // The heal loop's whole shape: a spec fails, is repaired, is re-run alone.
+  // Folding both runs' spec.tests[] together instead would keep the failure,
+  // because specOutcome is fail-dominant and has no notion of time.
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "unexpected" }]), pwRun([{ id: "AC-001-a", status: "expected" }])],
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(statusOf(report, "AC-001-a"), "pass");
+  assert.equal(report.totals.e2e.fail, 0);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: a later failure supersedes an earlier pass", () => {
+  // Newest-wins runs both ways: a whole-suite run that fails a spec which
+  // passed in isolation is a real finding, not noise to be outvoted.
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }]), pwRun([{ id: "AC-001-a", status: "unexpected" }])],
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(statusOf(report, "AC-001-a"), "fail");
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: the same criterion across batches is not a duplicate", () => {
+  // It used to be exit 2. Under merging it is a spec that ran more than once,
+  // which is the entire point.
+  const f = fixture({
+    criteria: [e2e("AC-001-a"), e2e("AC-002-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a"), "AC-002-a.spec.ts": spec("AC-002-a") },
+    runs: [
+      pwRun([{ id: "AC-001-a", status: "expected" }]),
+      pwRun([{ id: "AC-001-a", status: "expected" }, { id: "AC-002-a", status: "expected" }]),
+    ],
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(report.totals.e2e.pass, 2);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: two spec files claiming one criterion in ONE run still fails", () => {
+  // The authoring bug the old check existed for, which merging must not lose.
+  const doc = pwRun([{ id: "AC-001-a", status: "expected" }]);
+  doc.suites.push({
+    title: "copy.spec.ts",
+    file: "copy.spec.ts",
+    specs: [{ title: "AC-001-a: a second file", file: "copy.spec.ts", line: 3, column: 1, tests: [{ status: "expected", results: [{ duration: 1 }] }] }],
+  });
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [doc],
+  });
+  const { code, stderr } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /duplicate spec title prefix AC-001-a within/);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: batch provenance names which run answered each criterion", () => {
+  const f = fixture({
+    criteria: [e2e("AC-001-a"), e2e("AC-002-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a"), "AC-002-a.spec.ts": spec("AC-002-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }]), pwRun([{ id: "AC-002-a", status: "expected" }])],
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(report.batches.length, 2);
+  assert.deepEqual(report.batches.map((b) => b.specs), [1, 1]);
+  assert.notEqual(
+    report.criteria.find((c) => c.id === "AC-001-a").batch,
+    report.criteria.find((c) => c.id === "AC-002-a").batch,
+  );
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+// ---- the coverage invariant ---------------------------------------------
+
+test("generate-report: a spec on disk with no result anywhere is a hard error", () => {
+  // This is what replaces "one run must cover everything". A severed run
+  // writes nothing at all, so its specs land here — named, and re-runnable.
+  const f = fixture({
+    criteria: [e2e("AC-001-a"), e2e("AC-002-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a"), "AC-002-a.spec.ts": spec("AC-002-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }])],
+  });
+  const { code, stderr, report } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /no test result for 1 spec\(s\) that exist on disk: AC-002-a\.spec\.ts/);
+  assert.equal(report, null, "a refused report must not be written");
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: a result for the same criterion under a DIFFERENT file does not cover it", () => {
+  // Results accumulate across the whole run, so a batch recorded before a spec
+  // was moved lingers. Keying coverage on the criterion id alone would let that
+  // stale result vouch for a file that has never been executed.
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected", file: "old-layout/AC-001-a.spec.ts" }])],
+  });
+  const { code, stderr } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /no test result for 1 spec\(s\) that exist on disk: AC-001-a\.spec\.ts/);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: a criterion with no spec file at all is a legitimate not_run", () => {
+  // The other half of the split: nobody wrote a test for it, which is honest
+  // and must not be confused with a run that went missing.
+  const f = fixture({
+    criteria: [e2e("AC-001-a"), e2e("AC-009-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }])],
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(statusOf(report, "AC-009-a"), "not_run");
+  assert.equal(report.criteria.find((c) => c.id === "AC-009-a").batch, null);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: the header gate covers a spec absent from every result", () => {
+  // Scoped to the results, a severed run's specs vanished from the tree and
+  // their missing headers went unreported — the report exited 0 having
+  // skipped a check on exactly the specs whose run had failed.
+  const f = fixture({
+    criteria: [e2e("AC-001-a"), e2e("AC-002-a")],
+    specFiles: {
+      "AC-001-a.spec.ts": spec("AC-001-a"),
+      "AC-002-a.spec.ts": "test('AC-002-a: x', () => {});\n",
+    },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }])],
+  });
+  const { code, stderr } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /AC-002-a\.spec\.ts is missing its "\/\/ spec:" header/);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+// ---- config collapse and back-compat ------------------------------------
+
+test("generate-report: batches recorded under different rootDirs are refused", () => {
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [
+      pwRun([{ id: "AC-001-a", status: "expected" }]),
+      pwRun([{ id: "AC-001-a", status: "expected" }], { rootDir: "/elsewhere/specs" }),
+    ],
+  });
+  const { code, stderr } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /different rootDir values/);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: a single results FILE still works", () => {
+  // What one complete run looks like, and what every report written before
+  // batching read.
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }])],
+    resultsAsFile: true,
+  });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.equal(statusOf(report, "AC-001-a"), "pass");
+  assert.equal(report.batches.length, 1);
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: a missing specs directory degrades visibly, not silently", () => {
+  // Without the warning the coverage invariant, the header gate and the locator
+  // lint all pass over an empty list and the report looks complete having
+  // checked nothing — the same failure the heal check's `healCheckSkipped`
+  // warning exists to prevent, one hunk above it in the same file.
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: {},
+    runs: [pwRun([{ id: "AC-001-a", status: "expected" }])],
+  });
+  rmSync(path.join(f.dir, "tests/e2e/specs"), { recursive: true, force: true });
+  const { code, report } = run(f);
+  assert.equal(code, 0);
+  assert.ok(
+    (report.warnings ?? []).some((w) => /no spec directory at/.test(w)),
+    `expected a skipped-checks warning, got ${JSON.stringify(report.warnings)}`,
+  );
+  rmSync(f.dir, { recursive: true, force: true });
+});
+
+test("generate-report: an empty runs directory says no run has written results", () => {
+  const f = fixture({
+    criteria: [e2e("AC-001-a")],
+    specFiles: { "AC-001-a.spec.ts": spec("AC-001-a") },
+    runs: [],
+  });
+  const { code, stderr } = run(f);
+  assert.equal(code, 2);
+  assert.match(stderr, /holds no \.json files/);
+  rmSync(f.dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
References #701. **Does not close it** — see *What this does not do* below.

## The failure

A validation run passed every criterion, delivered nothing, and died four hours later on `redispatch-budget` having spent $7.78.

It did not stop because it thought it was finished. Its final suite run hit the 600s Bash ceiling — `durationMs: 597462` — and past the timeout the harness detaches the command and answers `code 0` with empty output, indistinguishable from a suite that completed. That destroyed `results.json`, which makes report generation impossible, and the skill is unconditional that no PR opens without one. It complied and stopped.

The trigger is arithmetic: 24 specs, subsets measured at 86–158s each, one sequential pass over a shared environment. The suite had outgrown the window, and criteria accumulate every milestone — so it was going to sever on every future run of that project.

**ADR-0009 decision 5 made that unrecoverable, and it was mine.** It let only a complete, unnarrowed run write the report's input, so a suite that cannot be run completely had no path to a report at all — sharding wrote nothing by design. What it defended is real: before it, a shard silently overwrote the whole suite's results with one batch's. The mistake was banning the partial run instead of learning to detect it.

## The fix

The detector was already there. `generate-report.mjs` iterates the criteria **oracle** and looks up results, so the oracle is the denominator and Playwright only supplies numerators. It already knew which criteria had no result — it just could not tell two different things apart, and called both `not_run`:

| Criterion has… | Truth |
|---|---|
| no spec file on disk | legitimately never checked |
| a spec file, no result anywhere | a run was missed or severed |

Split those and every run can safely write its own file. Each writes `test-results/runs/<ISO-stamp>.json`; the report merges them newest-per-criterion and **refuses to emit unless every spec on disk has a result**, naming the ones that don't. Coverage moves from *assumed* to *verified*, which is stronger than what it replaces — and no number has to be right, so the ceiling stops mattering.

`isPartialRun` and `NARROWING_FLAGS` are **deleted**, not patched. With per-run files there is nothing left to guard, which also removes the `--shard` hole found in review on #673.

## Proof of execution

The whole loop, real Playwright 1.61.1, using the committed config template and generator:

```
step 6  prove 3 specs alone         → 3 result files recorded
step 9  generate                    → generate-report: no test result for 1 spec(s)
                                      that exist on disk: AC-003-a.spec.ts —
                                      run them and regenerate
                                      exit 2
        cover it                    → AC-003-a  fail        (honest)
step 8  heal it, re-run only it
step 7  whole suite, best effort
        generate                    → e2e 4/4 passing

        AC-001-a  pass   from 08-25-33      ← the suite run superseded
        AC-001-b  pass   from 08-25-33         the per-spec results
        AC-002-a  pass   from 08-25-33
        AC-003-a  pass   from 08-25-33
        AC-004    manual from —
```

That `exit 2` is the design in one line: what killed the run in #701 — a severed batch leaving no results — now surfaces as a named, re-runnable list instead of an impossible report.

## Also fixes a live false-green

A severed call returns `is_error` false, so `from-sdk.ts` derived `ok: true` and `validationRunOutcome` painted **`Passed`** on every criterion that call was running — reachable on `healing.md`'s focused re-runs, which is to say on criteria that had *just failed*.

```
before   ↳ ok  597.5s                     and   AC-003-a  ✓ Passed
after    ✗ severed · the command hit its 597.5s timeout and was detached —
           it kept running in the background, so this call proved nothing
```

The SDK sets `timedOutAfterMs` for exactly that case. The translator now withholds the outcome for a call that never finished, which stops the feed agreeing with a lie `SKILL.md` warns about two paragraphs away. A deliberate `run_in_background` still renders as a success — nothing failed — but settles nothing either.

The wording mirror moves with it. `@aep/progress-view` rendered `ok:false` with no exit code as **"failed"**, so a severed call would have read `Bash failed` — naming a defect that did not happen, on the one line a reader consults to tell a break from a timeout. It now says `severed`, toned as a warning. No schema mirror was owed: `status` is the SDK's verdict word and already on the wire.

## Decisions worth arguing with

- **The Bash ceiling is deliberately not raised.** It is configurable (`BASH_MAX_TIMEOUT_MS`, unset here, so 600s is a default rather than a limit) and raising it was the obvious fix. It is also a treadmill — any value is exceeded as criteria accumulate, so it only schedules the same incident later.
- **The whole-suite run becomes best-effort.** If it lands it supersedes the per-spec results with one sequenced pass, which is the only thing catching a spec that depends on state another left behind. If it severs it costs nothing, because the authoring runs already cover every authored spec. Cross-spec interference otherwise rests on the independence discipline `authoring.md` already mandates.
- **Not via Playwright's `blob` + `merge-reports`.** Both exist in 1.61.1 and neither survives overlapping re-runs: the blob reporter wipes its output directory on every invocation, and the merger sets `mergeTestCases: false` with a path comparison that always fails, so overlapping specs duplicate and trip the duplicate-criterion check unconditionally. Its contract is disjoint shards.
- **`SKILL.md`'s claim that `sleep` is blocked was wrong.** The guard fires only on a bare `sleep` of 25s or more as a command's first segment, so a polling loop is available; it is now documented as the fallback alongside `run_in_background`.

## Review

`/code-review` ran against the merge base on both axes. Nine findings, all addressed in this branch:

- **the feed called a severed call "failed"**, contradicting this PR's own ADR and test — fixed via `status: "severed"` and a `@aep/progress-view` branch, with a test
- **`--specs` pointing nowhere degraded silently**: the coverage invariant, header gate and locator lint all passed over an empty list and the report looked complete having checked nothing. Now warns visibly, matching the heal check's own rule one hunk above it
- **the polling fallback could not work** — it waited for `runs/*.json` to be non-empty, which step 6 has already made true, so it returned instantly. The whole paragraph is cut instead: `skills/AGENTS.md` says never offer both halves of a choice, and covering the suite in pieces is the choice the step makes
- **`ADR-0009`'s superseded decision was deleted rather than annotated** — restored verbatim as a quote, since what replaced it is only legible against it
- the two asks in #701's corrected-diagnosis comment (push/PR before the repair loop, commit as the loop goes) were **silently dropped** — now an explicit *Deferred* section in ADR-0010
- **"the only legitimate `not_run`"** was untrue: a spec whose tests all skip produces one too. Coverage checks that a spec *appears*, and the docs now say so
- duplicated `AC-\d{3}-[a-z]` regex in three places, a duplicated error-exit block, and `batch.specCount =` mutating an object another function owns
- `batch` vs `run` used for one concept — ADR-0010 now defines the mapping in a line
- the duplicate-criterion error printed `(files: X, X)` when two tests in **one** file shared a prefix

## Gates

444 runner tests, 12 new generator fixture tests, 18 progress-view, 483 console, `tsc`, eslint, `make license-check`, `make deadcode-ts-check` — all green.

`generate-report.mjs` had **no tests** before this: the merge is the one part of it that can produce a wrong *verdict* rather than a loud failure. They run from the root `Makefile` rather than a workspace, because `knip.jsonc` deliberately keeps `skills/` out of one on the grounds nothing in the repo imports it.

## Docs

`ADR-0010` records the design. It supersedes `ADR-0009` decision 5, and corrects that ADR's rejection of a durable store: it claimed the progress stream *"replays the whole cycle log on reconnect"*, which is false — a poll returns at most 200 events drawn from the last 64 KiB of pod stdout, so a page opened 90 minutes into a run shows `Pending` for criteria that already passed. Recorded as a measured open gap rather than a justified rejection.

## What this does not do

> [!IMPORTANT]
> **#701 stays open.** Its acceptance criteria are about a runner post-condition — a run that exits 0 having delivered nothing must fail loudly, through the shared success path. Nothing here touches that. This removes the cause of *that particular* run and fixes the false-green found while diagnosing it.

Also out of scope, and worth their own issues: pushing and opening the PR before the repair loop (so a severed run leaves recoverable work), committing as the loop goes, the `-20`/`-21` seq collision in `agent_progress.go` that silently swallows *"logs no longer available"*, and the pod log being refetched in full from OpenChoreo every 2s per connected client.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
