### PR TITLE
fix(skaffold): use workspace root context for remote-worker artifact

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -59,9 +59,9 @@ build:
             - pnpm-lock.yaml
             - tsconfig.base.json
     - image: ghcr.io/wso2/aep/remote-worker
-      context: runners/remote-worker
+      context: .
       custom:
-        buildCommand: docker build -f Dockerfile --build-context skills=../skills --build-context bal-library-tool=../packages/bal-library-tool --secret id=packagePAT,env=PACKAGE_PAT -t $IMAGE .
+        buildCommand: docker build -f runners/remote-worker/Dockerfile --build-context skills=./skills --build-context bal-library-tool=./packages/bal-library-tool --secret id=packagePAT,env=PACKAGE_PAT -t $IMAGE runners/remote-worker
         dependencies:
           paths:
             - runners/remote-worker/**/*


### PR DESCRIPTION
## Summary

- Custom builder `dependencies.paths` are resolved relative to the artifact's `context` directory, not the workspace root
- With `context: runners/remote-worker`, the path `runners/remote-worker/**/*` expanded to `runners/remote-worker/runners/remote-worker/**/*` (double-prefixed), which matched nothing — causing `getting dependencies for remote-worker: pattern did not match any file` on every `skaffold dev` run
- Fixes by switching to `context: .` (workspace root, consistent with all other custom artifacts) and correcting the `buildCommand` paths:
  - `-f runners/remote-worker/Dockerfile` (was `-f Dockerfile`, wrong from workspace root)
  - `--build-context skills=./skills` (was `../skills`, which resolved to `runners/skills/` — doesn't exist)
  - `--build-context bal-library-tool=./packages/bal-library-tool`
  - Primary build context `runners/remote-worker` passed explicitly (Docker uses this for `COPY . .` in the Dockerfile)

## Test plan

- [ ] `skaffold dev` starts without `pattern did not match any file` error for remote-worker
- [ ] Changing a file in `runners/remote-worker/src/` triggers only the remote-worker rebuild
- [ ] Changing a file in `skills/` triggers only the remote-worker rebuild
- [ ] Changing `apps/console/` does not trigger a remote-worker rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)