### PR TITLE
fix(runner): run the agent-browser smoke test only where a chromium can start

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,7 +7,8 @@
 # laptop, and no amd64 build of the runner image happened anywhere until the
 # release ran one.
 #
-# linux/amd64 for every image, because that is the half nothing else covers:
+# At least linux/amd64 for every image, because that is the half nothing else
+# covers:
 # arm64 is built by hand all day — `skaffold` and
 # `deployments/scripts/build-runner.sh` are plain host-arch `docker build`, so
 # every local bring-up on an Apple-silicon machine exercises it — while amd64 is
@@ -52,11 +53,14 @@ jobs:
   build:
     name: build changed images
     runs-on: ubuntu-latest
-    # remote-worker is the outlier — it compiles the `bal library` tool, installs
-    # a JDK and a chromium, smoke-tests the browser, and does half of that under
-    # emulation. The ceiling catches a wedged build rather than enforcing a
-    # budget.
-    timeout-minutes: 60
+    # A budget, not just a ceiling: the images build in sequence in one slot,
+    # and a shared-input change builds all seven. remote-worker is the outlier
+    # — it compiles the `bal library` tool, installs a JDK and a chromium,
+    # smoke-tests the browser, and does half of that under emulation; the
+    # release has measured its two-platform build at 28 min cold, and the other
+    # six follow it here rather than run beside it. Raise this rather than trim
+    # an image if a cold all-images run legitimately grows past it.
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: read
@@ -126,6 +130,7 @@ jobs:
           built=0
           for row in "${IMAGES[@]}"; do
             IFS='|' read -r name context dockerfile contexts platforms <<<"$row"
+            platforms=${platforms:-linux/amd64}
 
             selected=$ALL
             while IFS= read -r f; do
@@ -133,11 +138,11 @@ jobs:
             done <<<"$CHANGED"
             [ "$selected" = true ] || continue
 
-            echo "::group::$name (${platforms:-linux/amd64})"
+            echo "::group::$name ($platforms)"
             # Seeded, never empty: expanding an empty array under `set -u` is an
             # error on bash before 4.4, and this list is read by more shells than
             # the runner's.
-            cmd=(docker buildx build --platform "${platforms:-linux/amd64}" --file "$dockerfile")
+            cmd=(docker buildx build --platform "$platforms" --file "$dockerfile")
             for c in $contexts; do cmd+=(--build-context "$c"); done
             # --output type=cacheonly: build it, keep nothing. No tag to name and
             # no image to garbage-collect.

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,10 +7,21 @@
 # laptop, and no amd64 build of the runner image happened anywhere until the
 # release ran one.
 #
-# linux/amd64 ONLY, which is the half nothing else covers. arm64 is built by
-# hand all day — `skaffold` and `deployments/scripts/build-runner.sh` are plain
-# host-arch `docker build`, so every local bring-up on an Apple-silicon machine
-# exercises it. amd64 is built by no developer, no script and no other job.
+# linux/amd64 for every image, because that is the half nothing else covers:
+# arm64 is built by hand all day — `skaffold` and
+# `deployments/scripts/build-runner.sh` are plain host-arch `docker build`, so
+# every local bring-up on an Apple-silicon machine exercises it — while amd64 is
+# built by no developer, no script and no other job.
+#
+# remote-worker is built for BOTH platforms, which on this amd64 runner puts its
+# arm64 half under QEMU exactly as the release does. That emulated build is a
+# third mode no native build stands in for: a step that runs the target's own
+# binaries can pass natively and die under emulation — chromium does — and the
+# very next release after the `chrome-linux` fix failed that way. Only
+# remote-worker pays for it, being the one Dockerfile that launches programs
+# beyond a compiler at build time; the release has measured it at 28 min cold,
+# less against its buildcache. The other images stay amd64-only. A row's last
+# column opts an image in.
 #
 # ONE JOB, however many images a change touches: this runs on a runner pool
 # shared with the rest of the org, so the images are built in sequence inside a
@@ -39,11 +50,12 @@ concurrency:
 
 jobs:
   build:
-    name: build changed images (linux/amd64)
+    name: build changed images
     runs-on: ubuntu-latest
     # remote-worker is the outlier — it compiles the `bal library` tool, installs
-    # a JDK and a chromium, and smoke-tests the browser. The ceiling catches a
-    # wedged build rather than enforcing a budget.
+    # a JDK and a chromium, smoke-tests the browser, and does half of that under
+    # emulation. The ceiling catches a wedged build rather than enforcing a
+    # budget.
     timeout-minutes: 60
     permissions:
       contents: read
@@ -75,17 +87,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # name | context | dockerfile | named contexts. Mirrors release.yml's
-          # matrix; an image added there belongs here too. An image is selected
-          # when its own directory — the Dockerfile's — changed.
+          # name | context | dockerfile | named contexts | platforms (empty =
+          # linux/amd64). Mirrors release.yml's matrix; an image added there
+          # belongs here too. An image is selected when its own directory — the
+          # Dockerfile's — changed.
           IMAGES=(
-            "remote-worker|runners/remote-worker|runners/remote-worker/Dockerfile|skills=skills bal-library-tool=packages/bal-library-tool"
-            "aep-api|services/aep-api|services/aep-api/Dockerfile|skills=skills"
-            "agents|.|services/agents/Dockerfile|"
-            "collab|.|services/collab/Dockerfile|"
-            "aep-mcp-server|.|services/aep-mcp-server/Dockerfile|"
-            "console|.|apps/console/Dockerfile|"
-            "thunder-app-operator|deployments/single-cluster/resource-types/thunder-app/operator|deployments/single-cluster/resource-types/thunder-app/operator/Dockerfile|"
+            "remote-worker|runners/remote-worker|runners/remote-worker/Dockerfile|skills=skills bal-library-tool=packages/bal-library-tool|linux/amd64,linux/arm64"
+            "aep-api|services/aep-api|services/aep-api/Dockerfile|skills=skills|"
+            "agents|.|services/agents/Dockerfile||"
+            "collab|.|services/collab/Dockerfile||"
+            "aep-mcp-server|.|services/aep-mcp-server/Dockerfile||"
+            "console|.|apps/console/Dockerfile||"
+            "thunder-app-operator|deployments/single-cluster/resource-types/thunder-app/operator|deployments/single-cluster/resource-types/thunder-app/operator/Dockerfile||"
           )
 
           # Inputs no single image owns: the four root manifests and `packages/`
@@ -112,7 +125,7 @@ jobs:
 
           built=0
           for row in "${IMAGES[@]}"; do
-            IFS='|' read -r name context dockerfile contexts <<<"$row"
+            IFS='|' read -r name context dockerfile contexts platforms <<<"$row"
 
             selected=$ALL
             while IFS= read -r f; do
@@ -120,11 +133,11 @@ jobs:
             done <<<"$CHANGED"
             [ "$selected" = true ] || continue
 
-            echo "::group::$name"
+            echo "::group::$name (${platforms:-linux/amd64})"
             # Seeded, never empty: expanding an empty array under `set -u` is an
             # error on bash before 4.4, and this list is read by more shells than
             # the runner's.
-            cmd=(docker buildx build --platform linux/amd64 --file "$dockerfile")
+            cmd=(docker buildx build --platform "${platforms:-linux/amd64}" --file "$dockerfile")
             for c in $contexts; do cmd+=(--build-context "$c"); done
             # --output type=cacheonly: build it, keep nothing. No tag to name and
             # no image to garbage-collect.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,15 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
-      # A CAP ON RUNNER SLOTS, not on the work. Seven images used to start at
-      # once; on a shared org runner pool that is seven slots held for the length
-      # of the longest build, and the release competes with every other repo in
-      # the org for them. Three at a time should cost little wall-clock: the
-      # critical path is remote-worker alone (~28 min), and the other six run two
-      # at a time beside it. Raise the cap if a release ever tails on the images.
-      max-parallel: 3
+      # No max-parallel: all seven start at once. GitHub already queues a job
+      # when the org's concurrency limit is reached, so a cap prevents no
+      # failure — it only stops the release using runners that are idle.
       matrix:
         include:
-          # DECLARED FIRST because this is the long pole and observed slot order
-          # follows declaration order — an ordering GitHub documents nowhere, so
-          # treat it as a hint, not a guarantee: the worst case is a longer run,
-          # never a wrong one.
+          # DECLARED FIRST so the long pole takes a slot in the first batch when
+          # the pool is short, rather than queueing behind six shorter builds.
+          # Slot order following declaration order is observed, not documented —
+          # a hint, so the worst case is a slower run, never a wrong one.
           #
           # One runner image serves both task kinds (implementation and
           # validation) — see runners/remote-worker/Dockerfile.
@@ -231,14 +227,11 @@ jobs:
           - \`ghcr.io/wso2/aep/thunder-app-operator:${{ inputs.version }}\`"
 
   # ─── CTL: build every binary, then cut the release ──────────────────────────
-  # ONE job for all five targets. aectl is pure Go built with CGO_ENABLED=0, so
-  # every target is a cross-compile from the same toolchain and the loop below
-  # needs one checkout and one Go setup where five matrix jobs each paid their
-  # own. The compile itself is not free — each GOOS/GOARCH gets its own build
-  # cache, so the five are ~22s apiece rather than one build plus four cheap
-  # ones (measured cold: 1m51s for the set) — but that is the same work the
-  # matrix did, minus four runners. Building in the job that also cuts the
-  # release removes the upload-artifact/download-artifact round trip, which
+  # ONE job for all five targets. aectl is pure Go with CGO_ENABLED=0, so every
+  # target cross-compiles from the same toolchain on one checkout and one Go
+  # setup. The compiles are not free — each GOOS/GOARCH has its own build cache,
+  # so it is ~22s apiece, 1m51s for the set measured cold — but that is the work
+  # the matrix did anyway, minus four runners and the artifact round trip that
   # existed only to hand the binaries to a sixth job.
   release-ctl:
     name: Build aectl + create CTL release
@@ -285,6 +278,10 @@ jobs:
           VERSION: ${{ inputs.version }}
           REPO: ${{ github.repository }}
         run: |
+          # Re-checked here, though the build step above already validated it:
+          # this is the step that cuts a public tag, and shellcheck cannot parse
+          # the multi-line --notes string as the script's opening command.
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]] || { echo "invalid version: $VERSION"; exit 1; }
           gh release create "ctl/v${VERSION}" \
             --title "AECTL v${VERSION}" \
             --notes "## AECTL v${VERSION}

--- a/docs/developer-guide/releasing.md
+++ b/docs/developer-guide/releasing.md
@@ -25,7 +25,12 @@ architecture-independent are pinned to `$BUILDPLATFORM` so they run once,
 natively, instead of under QEMU — read the note in `services/aep-api/Dockerfile`
 before removing a pin. `remote-worker` is the notable exception: it installs a
 per-arch Go toolchain, Ballerina, and Playwright browsers, so its arm64 half
-genuinely is emulated and it is the slowest job in the release.
+genuinely is emulated and it is the slowest job in the release. One consequence:
+chromium cannot run under QEMU, so the runner Dockerfile's browser smoke test
+runs only on native builds. The release asserts the arm64 image's browser
+launch nowhere; native arm64 builds (every Apple-silicon bring-up) do. The
+emulated arm64 build itself is exercised before a release by the `Images`
+workflow, which builds `remote-worker` for both platforms on its PR.
 
 Layer cache lives in GHCR under `ghcr.io/wso2/aep/buildcache/<image>` rather than
 the Actions cache, which is capped at 10 GB per repository and which CI's own

--- a/runners/remote-worker/Dockerfile
+++ b/runners/remote-worker/Dockerfile
@@ -222,6 +222,10 @@ RUN groupadd -r aep \
 # files (icudtl.dat, the .pak set, the crashpad handler) beside it.
 ARG AGENT_BROWSER_VERSION=0.35.2
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/share/aep-chromium/chrome
+# BuildKit predefines both; a stage has to redeclare them to read them in a RUN.
+# Equal on a native build, different on the emulated half of the release matrix.
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 RUN npm install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
     && test -d "$(npm root -g)/@playwright/test" \
     && CHROME="$(node -p "require(require.resolve('playwright-core', { paths: ['$(npm root -g)/@playwright/test'] })).chromium.executablePath()")" \
@@ -254,16 +258,30 @@ RUN npm install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
     # root and not for an unprivileged user is the class of bug ADR-0007
     # records. `su` without `-` keeps the environment, so the variable set
     # above is the one under test.
-    && printf '<h1>agent-browser-ok</h1>' > /tmp/ab-smoke.html \
-    && chmod a+r /tmp/ab-smoke.html \
-    && su aep -s /bin/bash -c 'set -e; \
-        export AGENT_BROWSER_ARGS=--no-sandbox; \
-        agent-browser open file:///tmp/ab-smoke.html; \
-        agent-browser get text h1 | grep agent-browser-ok; \
-        agent-browser close --all' \
-    # The smoke test leaves a state directory behind; a socket and pid file
-    # baked into the image would be stale in every pod started from it.
-    && rm -rf /tmp/ab-smoke.html /home/aep/.agent-browser
+    #
+    # NATIVE BUILDS ONLY. The release builds both platforms on one amd64
+    # runner, so its arm64 half runs under QEMU user-mode emulation, and
+    # chromium does not run there: the browser process dies at launch and the
+    # CLI reports "CDP response channel closed". Nothing about that half of the
+    # IMAGE is wrong — the same layer, built natively on an arm64 host, passes
+    # this test — so the launch is asserted wherever a chromium can start (the
+    # release's native half, every developer's host-arch `docker build`) and
+    # skipped where one cannot. The emulated half keeps everything above the
+    # `if`: the install, the symlink and the `test -x` need no browser process.
+    && if [ "$TARGETPLATFORM" = "$BUILDPLATFORM" ]; then \
+        printf '<h1>agent-browser-ok</h1>' > /tmp/ab-smoke.html \
+        && chmod a+r /tmp/ab-smoke.html \
+        && su aep -s /bin/bash -c 'set -e; \
+            export AGENT_BROWSER_ARGS=--no-sandbox; \
+            agent-browser open file:///tmp/ab-smoke.html; \
+            agent-browser get text h1 | grep agent-browser-ok; \
+            agent-browser close --all' \
+        # The smoke test leaves a state directory behind; a socket and pid file
+        # baked into the image would be stale in every pod started from it.
+        && rm -rf /tmp/ab-smoke.html /home/aep/.agent-browser; \
+    else \
+        echo "agent-browser smoke test skipped: ${TARGETPLATFORM} is being built on ${BUILDPLATFORM}, and chromium does not run under emulation"; \
+    fi
 
 WORKDIR /app
 

--- a/runners/remote-worker/Dockerfile
+++ b/runners/remote-worker/Dockerfile
@@ -264,10 +264,19 @@ RUN npm install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
     # chromium does not run there: the browser process dies at launch and the
     # CLI reports "CDP response channel closed". Nothing about that half of the
     # IMAGE is wrong — the same layer, built natively on an arm64 host, passes
-    # this test — so the launch is asserted wherever a chromium can start (the
-    # release's native half, every developer's host-arch `docker build`) and
-    # skipped where one cannot. The emulated half keeps everything above the
+    # this test — so the launch is asserted on every native build (the
+    # release's amd64 half, every developer's host-arch `docker build`) and
+    # skipped on any cross-platform one. The gate is the platform pair, not a
+    # probe for emulation, so a foreign-arch build that COULD launch (amd64
+    # under Rosetta on a Mac) skips it too; that costs nothing the native
+    # builds do not already cover. The skipped half keeps everything above the
     # `if`: the install, the symlink and the `test -x` need no browser process.
+    #
+    # The alternative is a release that builds its arm64 half on an arm64
+    # runner, where this test would run natively on both halves. That is a
+    # release-workflow change (per-platform jobs, a manifest merge) and is
+    # not what fixes this; the gate stays correct under it, since a native
+    # build takes the `then` branch.
     && if [ "$TARGETPLATFORM" = "$BUILDPLATFORM" ]; then \
         printf '<h1>agent-browser-ok</h1>' > /tmp/ab-smoke.html \
         && chmod a+r /tmp/ab-smoke.html \


### PR DESCRIPTION
## What failed

Release run [33752625851](https://github.com/wso2/labs-agentic-engineer/actions/runs/33752625851/job/100639466139), `Build + push remote-worker`, arm64 leg:

```
#42 [linux/arm64 stage-1  7/14] RUN npm install -g "agent-browser@0.35.2" ... su aep ... agent-browser open file:///tmp/ab-smoke.html ...
#42 46.21 ✗ CDP response channel closed
#42 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c ..." did not complete successfully: exit code: 1
```

The amd64 leg of the same layer passed. The release builds both platforms on one amd64 runner, so the arm64 half runs under QEMU user-mode emulation (`/dev/.buildkit_qemu_emulator` in the failing command), and chromium does not run under emulation: the browser process dies at launch, and the smoke test that opens and reads a page cannot complete. The image is not wrong on that half; the test was being run where its subject cannot execute.

## Fix

- `runners/remote-worker/Dockerfile`: redeclare `ARG BUILDPLATFORM` / `ARG TARGETPLATFORM` in the runner stage and run the browser round trip only when they are equal. The install, the symlink and the `test -x` stay unconditional. The cross-platform half logs that the launch was skipped and why.
- `.github/workflows/images.yml`: remote-worker is built for `linux/amd64,linux/arm64` on its PR, the release's exact shape, so the emulated leg is exercised before a release instead of only by one. Other images stay amd64-only via a new per-row `platforms` column (empty = amd64). Job timeout becomes a stated budget (90 min) now that a cold all-images run has a two-platform remote-worker at its front.
- `docs/developer-guide/releasing.md`: says what the release does and does not assert about the arm64 image's browser launch.
- `.github/workflows/release.yml`: drops `max-parallel: 3`. GitHub queues a job when the pool is full, so a cap protected nothing and could put the short builds on the critical path behind remote-worker.

## Proof

**This PR's own Images run** ([33754202370](https://github.com/wso2/labs-agentic-engineer/actions/runs/33754202370)), remote-worker built for both platforms on an amd64 runner, which is the release's failing shape:

```
#43 [linux/amd64 stage-1  7/14] RUN npm install -g "agent-browser@0.35.2" ...
#43 5.077 agent-browser-ok
#43 9.042 ✓ Closed session: default
#42 [linux/arm64 stage-1  7/14] RUN npm install -g "agent-browser@0.35.2" ...
#42 24.94 agent-browser smoke test skipped: linux/arm64 is being built on linux/amd64, and chromium does not run under emulation
```

**Native arm64**, real image built on an Apple-silicon host (builder `aep-multiarch`, `--platform linux/arm64`), the smoke test runs and passes, which is what the release's arm64 leg cannot do under QEMU:

```
#32 [stage-1  7/14] RUN npm install -g "agent-browser@0.35.2" ...
#32 7.007 ✓
#32 7.007   file:///tmp/ab-smoke.html
#32 7.019 agent-browser-ok
#32 7.124 ✓ Closed session: default
#32 DONE 7.3s
```

**Gating probe** (minimal Dockerfile, same `if`) on the same host, both directions:

```
=== linux/arm64 ===   target=linux/arm64 build=linux/arm64 uname=aarch64  -> NATIVE: smoke would run
=== linux/amd64 ===   target=linux/amd64 build=linux/arm64 uname=x86_64   -> EMULATED: smoke skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
