### PR TITLE
fix: teach the flow diagram grammar instead of just refusing it

### DIFF
--- a/evals/spec-agents/eval-reviews/lunch-coordinator-2026-09-01T07-53-15-585Z.md
+++ b/evals/spec-agents/eval-reviews/lunch-coordinator-2026-09-01T07-53-15-585Z.md
@@ -1,0 +1,41 @@
+# Eval review — requirements-section / lunch-coordinator
+
+- Run: 2026-09-01T07:53:15.585Z
+- Transcript: playground/.projects/spec-agent-evals/req-lunch-coordinator.transcript.md
+- Raw trace: playground/.projects/spec-agent-evals/req-lunch-coordinator.trace.json
+
+## requirements — REVIEW (69)
+
+Structural 100%:
+- [x] prd.md exists
+- [x] substantial (≥800 chars)
+- [x] structured (≥3 headings)
+- [x] interview happened
+- [x] interview finished within cap
+
+Rubric judge 38%:
+- [ ] (w2) Google-workspace sign-in captured; no separate registration flow invented
+  - Artifact states 'Team members sign in via SSO through Thunder, the platform IDP (org default).' This invents a specific SSO provider ('Thunder') rather than capturing Google-workspace sign-in as required, and does not mention Google Workspace at all.
+- [x] (w2) Daily order round lifecycle: open (restaurant + cutoff) -> teammates add own items -> lock at cutoff
+  - 'any team member can open a daily lunch order for a chosen restaurant with a cutoff time. Teammates add their own items (with price) before the cutoff. Once the cutoff passes, the opener sees one consolidated summary...' and 'an order to stop accepting changes automatically once its cutoff time passes.'
+- [ ] (w1) Consolidated order view grouped by item with per-person cost totals
+  - Artifact describes the consolidated summary as 'every item, grouped by person, with per-person and total cost' — this groups by person, not by item as required by the rubric, so the specific grouping structure is not correctly captured.
+- [x] (w1) Payment explicitly out of scope beyond tracking who owes what
+  - 'Payment processing, splitting bills, or any money actually changing hands in-app — the app only totals what each person owes.'
+- [ ] (w1) Slack notifications at round open and cutoff; no email flows invented
+  - No Slack notifications are mentioned anywhere; instead the artifact explicitly states 'There is no reminder or notification before a cutoff in v1 — team members are responsible for checking the app' and lists 'Reminders or notifications ahead of a cutoff' as Out of Scope, directly contradicting the required Slack notification feature.
+- [ ] (w1) Mobile-browser support noted
+  - No mention of mobile-browser support anywhere in the document; the app is only described as 'A web app' with no note about mobile browser compatibility.
+
+Inventions flagged (unscored — human call):
+- SSO via a specific named IDP 'Thunder' (org default) — not Google-workspace sign-in as implied by the rubric, and not mentioned in the interview.
+- Viewing past daily orders / order history (User Story 7) — not derivable from rubric or interview decisions.
+- Consolidated view grouped by person rather than by item — a structural deviation not supported by rubric or interview.
+
+## Human verdict
+
+- [ ] Agree with the bands above
+- [ ] Override: <section> should be <band> because …
+
+Notes:
+

--- a/packages/agent-stream/src/design-diagrams.ts
+++ b/packages/agent-stream/src/design-diagrams.ts
@@ -126,7 +126,7 @@ const OPENERS = /^(alt|opt|loop|par|critical|break|rect|box)(\s|$)/;
 // wants one-word ids with the label carried by `as`, so the error must
 // TEACH that — a generic "not a sequence statement" earns a byte-identical
 // retry (seen live: attempt two of a rejected flow was unchanged).
-const SPACED_DECLARE_RE = /^(?:create\s+)?(?:participant|actor)\s+\S+(\s+\S+)+$/;
+const SPACED_DECLARE_RE = /^((?:create\s+)?(?:participant|actor))\s+\S+(?:\s+\S+)+$/;
 const SPACED_MESSAGE_RE = new RegExp(`^(.+?)\\s*(?:${ARROWS})\\s*[+-]?\\s*(.+?)\\s*:`);
 const CONTINUERS = /^(else|and|option)(\s|$)/;
 
@@ -202,12 +202,14 @@ function parseSequence(block: MermaidBlock): SequenceParse {
       participants.add(msg[4] as string);
       continue;
     }
-    if (SPACED_DECLARE_RE.test(text) && !/\sas\s/.test(text)) {
-      const words = text.replace(/^(?:create\s+)?(?:participant|actor)\s+/, "");
+    const spacedDecl = SPACED_DECLARE_RE.exec(text);
+    if (spacedDecl && !/\sas\s/.test(text)) {
+      const keyword = spacedDecl[1] as string;
+      const words = text.slice(keyword.length).trim();
       const oneWord = words.replace(/[^\p{L}\p{N}]+/gu, "");
       diagnostics.push({
         line,
-        message: `\`${text}\` — a name is ONE word; declare \`actor ${oneWord} as ${words}\` and use \`${oneWord}\` in every message`,
+        message: `\`${text}\` — a name is ONE word; declare \`${keyword} ${oneWord} as ${words}\` and use \`${oneWord}\` in every message`,
       });
       continue;
     }

--- a/packages/agent-stream/src/design-diagrams.ts
+++ b/packages/agent-stream/src/design-diagrams.ts
@@ -121,6 +121,13 @@ const MESSAGE_RE = new RegExp(`^(\\S+?)\\s*(${ARROWS})\\s*([+-])?\\s*(\\S+?)\\s*
 const DECLARE_RE = /^(?:create\s+)?(participant|actor)\s+([^\s:]+)(?:\s+as\s+(.+))?$/;
 const NOTE_RE = /^note\s+(?:left of|right of|over)\s+([^\s:,]+)(?:\s*,\s*([^\s:,]+))?\s*:/i;
 const OPENERS = /^(alt|opt|loop|par|critical|break|rect|box)(\s|$)/;
+// The two shapes the evidence says models actually write when a line fails:
+// a multi-word name in a declaration, or in a message endpoint. Mermaid
+// wants one-word ids with the label carried by `as`, so the error must
+// TEACH that — a generic "not a sequence statement" earns a byte-identical
+// retry (seen live: attempt two of a rejected flow was unchanged).
+const SPACED_DECLARE_RE = /^(?:create\s+)?(?:participant|actor)\s+\S+(\s+\S+)+$/;
+const SPACED_MESSAGE_RE = new RegExp(`^(.+?)\\s*(?:${ARROWS})\\s*[+-]?\\s*(.+?)\\s*:`);
 const CONTINUERS = /^(else|and|option)(\s|$)/;
 
 interface SequenceParse {
@@ -195,10 +202,26 @@ function parseSequence(block: MermaidBlock): SequenceParse {
       participants.add(msg[4] as string);
       continue;
     }
+    if (SPACED_DECLARE_RE.test(text) && !/\sas\s/.test(text)) {
+      const words = text.replace(/^(?:create\s+)?(?:participant|actor)\s+/, "");
+      const oneWord = words.replace(/[^\p{L}\p{N}]+/gu, "");
+      diagnostics.push({
+        line,
+        message: `\`${text}\` — a name is ONE word; declare \`actor ${oneWord} as ${words}\` and use \`${oneWord}\` in every message`,
+      });
+      continue;
+    }
+    const spaced = SPACED_MESSAGE_RE.exec(text);
+    if (spaced && (/\s/.test(spaced[1] as string) || /\s/.test(spaced[2] as string))) {
+      diagnostics.push({
+        line,
+        message: `\`${text}\` — a message's endpoints are one-word ids (\`WarehouseStaff->>ops-console: …\`); a multi-word name gets its words from the declaration's \`as\` alias, never from the message line`,
+      });
+      continue;
+    }
     diagnostics.push({
       line,
-      message:
-        "not a sequence statement — expected a participant/actor declaration, a message (A->>B: text), a Note, or an alt/opt/loop/par block",
+      message: `\`${text}\` is not a sequence statement — expected a participant/actor declaration, a message (A->>B: text), a Note, or an alt/opt/loop/par block`,
     });
   }
   if (!sawHeader) {
@@ -257,7 +280,7 @@ function parseEr(block: MermaidBlock): Diagnostic[] {
     if (RELATION_RE.test(text) || BARE_ENTITY_RE.test(text)) continue;
     diagnostics.push({
       line,
-      message: "not an ER statement — expected an entity block (NAME { … }) or a relation (A ||--o{ B : label)",
+      message: `\`${text}\` is not an ER statement — expected an entity block (NAME { … }) or a relation (A ||--o{ B : label)`,
     });
   }
   if (!sawHeader) diagnostics.push({ line: block.fenceLine, message: "the mermaid block is empty" });

--- a/packages/agent-stream/test/design-diagrams.test.ts
+++ b/packages/agent-stream/test/design-diagrams.test.ts
@@ -154,7 +154,7 @@ test("a sequence statement outside the subset is named by line", () => {
 `);
   const p = checkDesignDiagram(FLOW, bad, bundle());
   assert.equal(p?.code, "INVALID_DIAGRAM");
-  assert.match(p!.message, /line 8: not a sequence statement/);
+  assert.match(p!.message, /line 8: .* is not a sequence statement/);
 });
 
 test("an unclosed alt block is rejected at the line it opened", () => {
@@ -232,4 +232,29 @@ test("an unterminated mermaid fence is rejected at the line it opened", () => {
   const p = checkDesignDiagram(FLOW, bad, bundle());
   assert.equal(p?.code, "INVALID_DIAGRAM");
   assert.match(p!.message, /fence opened at line 3 is never closed/);
+});
+
+test("a multi-word declared name is taught the alias form, echoing the line", () => {
+  const bad = flow(`sequenceDiagram\n    actor Warehouse Staff\n    participant expense-api\n`);
+  const p = checkDesignDiagram(FLOW, bad, bundle());
+  assert.equal(p?.code, "INVALID_DIAGRAM");
+  assert.match(p!.message, /`actor Warehouse Staff` — a name is ONE word/);
+  assert.match(p!.message, /actor WarehouseStaff as Warehouse Staff/);
+});
+
+test("a multi-word message endpoint is taught the one-word-id rule", () => {
+  const bad = flow(`sequenceDiagram\n    actor Employee\n    Warehouse Staff->>expense-api: log parcel\n`);
+  const p = checkDesignDiagram(FLOW, bad, bundle());
+  assert.match(p!.message, /`Warehouse Staff->>expense-api: log parcel` — a message's endpoints are one-word ids/);
+});
+
+test("a generic unknown line is echoed back verbatim", () => {
+  const bad = flow(`sequenceDiagram\n    expense-api ==> expense-db: not an arrow\n`);
+  const p = checkDesignDiagram(FLOW, bad, bundle());
+  assert.match(p!.message, /`expense-api ==> expense-db: not an arrow`/);
+});
+
+test("the skill's worked example passes the gate as written", () => {
+  const example = `# Submit a claim\n\nAn Employee submits a claim; the Line Manager approves.\n\n\`\`\`mermaid\nsequenceDiagram\n    actor Employee\n    actor LineManager as Line Manager\n    participant expense-webapp\n    participant expense-api\n\n    Employee->>expense-webapp: submit claim (amount, receipt)\n    expense-webapp->>expense-api: create claim\n    alt no receipt\n        expense-api-->>expense-webapp: refused\n    else\n        expense-api-->>expense-webapp: created\n    end\n    LineManager->>expense-webapp: approve\n\`\`\`\n`;
+  assert.equal(checkDesignDiagram(FLOW, example, bundle()), null);
 });

--- a/packages/agent-stream/test/design-diagrams.test.ts
+++ b/packages/agent-stream/test/design-diagrams.test.ts
@@ -258,3 +258,11 @@ test("the skill's worked example passes the gate as written", () => {
   const example = `# Submit a claim\n\nAn Employee submits a claim; the Line Manager approves.\n\n\`\`\`mermaid\nsequenceDiagram\n    actor Employee\n    actor LineManager as Line Manager\n    participant expense-webapp\n    participant expense-api\n\n    Employee->>expense-webapp: submit claim (amount, receipt)\n    expense-webapp->>expense-api: create claim\n    alt no receipt\n        expense-api-->>expense-webapp: refused\n    else\n        expense-api-->>expense-webapp: created\n    end\n    LineManager->>expense-webapp: approve\n\`\`\`\n`;
   assert.equal(checkDesignDiagram(FLOW, example, bundle()), null);
 });
+
+test("the repair guidance keeps the declaration's own keyword", () => {
+  const bad = flow(`sequenceDiagram\n    participant Order Service\n`);
+  const p = checkDesignDiagram(FLOW, bad, bundle());
+  assert.match(p!.message, /declare `participant OrderService as Order Service`/);
+  const badCreate = flow(`sequenceDiagram\n    create participant Order Service\n`);
+  assert.match(checkDesignDiagram(FLOW, badCreate, bundle())!.message, /declare `create participant OrderService as Order Service`/);
+});

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -101,10 +101,32 @@ turn — apply them directly, and load one only if you find you do not have it.
    design.cell declares (a component, or a boundary external such as the
    identity server or a SaaS) or an actor from the PRD — never an invented
    name. No context/C1 diagram anywhere: the cell and the PRD carry that.
-   The platform judges both documents as you write them: a second diagram,
+   The shape is formulaic — write it like this, first try:
+
+   ```mermaid
+   sequenceDiagram
+       actor Employee
+       actor LineManager as Line Manager
+       participant expense-webapp
+       participant expense-api
+
+       Employee->>expense-webapp: submit claim (amount, receipt)
+       expense-webapp->>expense-api: create claim
+       alt no receipt
+           expense-api-->>expense-webapp: refused
+       else
+           expense-api-->>expense-webapp: created
+       end
+       LineManager->>expense-webapp: approve
+   ```
+
+   Names are ONE word. A multi-word PRD actor gets an alias — `actor
+   LineManager as Line Manager` — and every message uses the one-word id;
+   spaces in a declared name or a message endpoint are refused. The
+   platform judges both documents as you write them: a second diagram,
    a statement outside plain mermaid, or an unresolved participant is
-   refused (`INVALID_DIAGRAM`, `UNKNOWN_PARTICIPANT`) with the line and the
-   ids you may use — fix it and re-emit the whole file once.
+   refused (`INVALID_DIAGRAM`, `UNKNOWN_PARTICIPANT`) with the offending
+   line and the ids you may use — fix it and re-emit the whole file once.
 5. **Security design** (`security-design`) — `specs/design/security.json` when
    the design has sign-in or roles.
 6. **Per-component artifacts** — every `service` gets `openapi.yaml`


### PR DESCRIPTION
Follow-up to #689 (#687's diagram gate), from a live observation: sequence-diagram writes were rejected several times before the agent got them right.

## Diagnosis (from the parcel-forwarding chat log)

The model's first write used `actor Warehouse Staff` and `Warehouse Staff->>ops-console: …`. The gate's message — *"line 10: not a sequence statement"* — never said **why**, so the first retry was **byte-identical**; the third attempt converged on `actor WarehouseStaff as Warehouse Staff`, which is exactly mermaid's documented form (multi-word names require an alias; ids are single tokens). Meanwhile the design eval (same `claude-sonnet-5` as the stack) produces zero rejections on its scenario — the model knows mermaid; nothing taught it our (mermaid-documented) one-word-id rule, and the error didn't either.

## Fix

1. **Teaching errors** — every unknown line is echoed verbatim, and the two observed shapes get the correction outright: a multi-word declaration → ``actor WarehouseStaff as Warehouse Staff`` with "use the one-word id in every message"; a spaced message endpoint → the one-word-id rule. Red-capable tests for each.
2. **Worked example in the design skill** — the key-flows step now shows the 14-line formulaic shape (aliased multi-word PRD actor, cell-id participants, one `alt`). A test runs the example through the gate so skill and gate can never drift.
3. **Grammar unchanged** — strict one-word ids stay; they match mermaid's documented grammar, and the console render remains the backstop.

Verification: agent-stream 149/149, repo typecheck/lint green; a fresh design-eval run against the amended skill is attached in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018u1aUmh2d6k1VyhGAzEC28