### PR TITLE
feat(console): test users are a count on the Deployments card and a table in a dialog

### DIFF
--- a/apps/console/PRD.md
+++ b/apps/console/PRD.md
@@ -297,8 +297,11 @@ here: they're the open `console` + `feature` issues.
   their URLs. Connections keep their Configure surface on a card under the
   ledger. A row is what the environment runs NOW — the platform keeps no
   deployment record, so the design's past deployments, Duration, Redeploy and
-  runtime log wait on a backend read. **No contract change** (ADR-0027,
-  amending ADR-0021)
+  runtime log wait on a backend read. The Development card names how many
+  **test users** the project has, one per role, and opens them in a dialog —
+  a table of username, masked password with reveal and copy, role, and the
+  cold-start account — so the card holds one height whatever the design
+  declares. **No contract change** (ADR-0027, amending ADR-0021)
 - Deployments page — one-story rail + environment panel: Development /
   Validation / Production as one numbered rail (Builds-spine vocabulary,
   ADR-0014) with a side panel (version, rollout, endpoints, production

--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -222,6 +222,17 @@ them (`24 / 24 passed`), the shared verdict word otherwise (*validating*,
 record, so there is no *Superseded* row and no Duration cell — saying either
 would be a guess. The card's age (*2h ago*) is the newest binding's stamp.
 
+**Test users are counted on the card and listed in a dialog.** The card says
+**`N accounts, one per role`** beside **View test users**, because the list
+grows with the design and the card must not. The dialog is titled **Test
+users** and says what they are — *Disposable accounts the platform created for
+this project's roles, so agents can sign in to the running app and check what
+each role can do. They are not real people.* Its columns are Username ·
+Password · Role · Cold start, and a password is **`**********`** until the eye
+beside it is pressed. The accounts are the project's own, one per role its
+security design declares; the Thunder Console link below the count is for
+**real** accounts, which is a different thing and says so.
+
 ### A task's row, on a build
 
 | Situation | Says |

--- a/apps/console/src/features/projects/components/DeploymentsPage.test.tsx
+++ b/apps/console/src/features/projects/components/DeploymentsPage.test.tsx
@@ -907,33 +907,37 @@ describe("DeploymentsPage — Test users", () => {
     expect(
       screen.getByText("Test users for agents on this environment"),
     ).toBeInTheDocument();
-    expect(screen.getByText("test-viewer")).toBeInTheDocument();
+    // The card carries the count; the accounts live in the dialog behind it,
+    // so a many-role app cannot grow this card past the ledger beside it.
+    expect(screen.getByText("1 account, one per role")).toBeInTheDocument();
+    expect(screen.queryByText("test-viewer")).not.toBeInTheDocument();
     const thunder = screen.getByRole("link", {
       name: "Open Thunder Console to add or remove real accounts",
     });
     expect(thunder).toHaveAttribute("href", THUNDER_CONSOLE_USERS);
     expect(thunder).toHaveAttribute("target", "_blank");
 
+    fireEvent.click(screen.getByRole("button", { name: "View test users" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("test-viewer")).toBeInTheDocument();
+
     fireEvent.click(
-      screen.getByRole("button", {
+      within(dialog).getByRole("button", {
         name: "Reveal the password for test-viewer",
       }),
     );
     expect(mockReveal).toHaveBeenCalledWith("test-viewer");
     await waitFor(() => {
-      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
+      expect(within(dialog).getByText(MOCK_PASSWORD)).toBeInTheDocument();
     });
     fireEvent.click(
-      screen.getByRole("button", { name: "Hide the password for test-viewer" }),
+      within(dialog).getByRole("button", {
+        name: "Hide the password for test-viewer",
+      }),
     );
     expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
-    // Masked, not gone — the line holds its place on the card.
-    expect(screen.getByText("**********")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    ).toBeInTheDocument();
+    // Masked, not gone — the row holds its place in the table.
+    expect(within(dialog).getByText("**********")).toBeInTheDocument();
   });
 
   it("keeps Thunder / Test users copy and omits Roles-gate and account actions", () => {

--- a/apps/console/src/features/projects/components/SignInPanel.test.tsx
+++ b/apps/console/src/features/projects/components/SignInPanel.test.tsx
@@ -17,12 +17,13 @@
  */
 
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { OxygenTheme, OxygenUIThemeProvider } from "@wso2/oxygen-ui";
 import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { PublishedTestUser } from "../lib/publishedTestUsers";
 import { SignInPanel } from "./SignInPanel";
+import { MASK } from "./TestUsersDialog";
 
 const THUNDER_URL = "http://localhost:8097";
 const THUNDER_CONSOLE_USERS = "http://localhost:8097/console/users";
@@ -58,15 +59,13 @@ describe("SignInPanel", () => {
   it("empty logins shows only the Thunder sentence", () => {
     renderPanel({ logins: [] });
 
-    expect(
-      screen.getByText(/Manage user accounts in/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Manage user accounts in/)).toBeInTheDocument();
     expect(
       screen.queryByText("Test users for agents on this environment"),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/test-/i)).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Reveal/i }),
+      screen.queryByRole("button", { name: "View test users" }),
     ).not.toBeInTheDocument();
 
     const link = screen.getByRole("link", {
@@ -76,178 +75,55 @@ describe("SignInPanel", () => {
     expect(link).toHaveAttribute("target", "_blank");
   });
 
-  it("one owned login shows caption, username, and Thunder sentence", () => {
+  it("says how many accounts there are and offers the dialog, listing none itself", () => {
     renderPanel({
       logins: [
         { username: "test-viewer", role: "Viewer", coldStart: true },
+        { username: "test-admin", role: "Admin", coldStart: false },
       ],
     });
 
     expect(
       screen.getByText("Test users for agents on this environment"),
     ).toBeInTheDocument();
-    expect(screen.getByText("test-viewer")).toBeInTheDocument();
+    expect(screen.getByText("2 accounts, one per role")).toBeInTheDocument();
     expect(
-      screen.getByText(/Manage user accounts in/),
+      screen.getByRole("button", { name: "View test users" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Test users/)).toHaveTextContent(
-      "Test users for agents on this environment",
-    );
-    expect(screen.queryByText(/Test users/)).not.toHaveTextContent(
-      /user accounts/,
-    );
+    // The card carries the COUNT and nothing else: the accounts themselves
+    // are what made it grow with the design.
+    expect(screen.queryByText("test-viewer")).not.toBeInTheDocument();
+    expect(screen.queryByText(MASK)).not.toBeInTheDocument();
+    expect(screen.getByText(/Manage user accounts in/)).toBeInTheDocument();
   });
 
-  it("keeps the masked password on screen, with both icons, before any reveal", () => {
+  it("counts one account without pluralising it", () => {
     renderPanel({
       logins: [{ username: "test-viewer", role: "Viewer", coldStart: true }],
     });
 
-    // The line is here from the start — the reader can see a password exists,
-    // and can copy it, without ever putting it on screen.
-    expect(screen.getByText("**********")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Copy the password for test-viewer" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("1 account, one per role")).toBeInTheDocument();
   });
 
-  it("the eye toggles visibility, and reads the secret only once", async () => {
-    const { revealPassword } = renderPanel({
-      logins: [
-        { username: "test-viewer", role: "Viewer", coldStart: true },
-      ],
-    });
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    );
-    expect(revealPassword).toHaveBeenCalledWith("test-viewer");
-
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
-    });
-    expect(screen.getByText(MOCK_PASSWORD)).toHaveAttribute(
-      "aria-live",
-      "polite",
-    );
-    expect(screen.queryByText("**********")).not.toBeInTheDocument();
-
-    // The same control hides it again — no separate Hide button.
-    const hide = screen.getByRole("button", {
-      name: "Hide the password for test-viewer",
-    });
-    fireEvent.click(hide);
-    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
-    expect(screen.getByText("**********")).toBeInTheDocument();
-
-    // Showing it again is a decision about this screen, not a reason to ask
-    // the sealed store for the secret a second time.
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    );
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
-    });
-    expect(revealPassword).toHaveBeenCalledTimes(1);
-  });
-
-  it("copies a password that was never put on screen", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-    renderPanel({
-      logins: [{ username: "test-viewer", role: "Viewer", coldStart: true }],
-    });
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Copy the password for test-viewer" }),
-    );
-
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(MOCK_PASSWORD);
-    });
-    // Copying does not reveal it.
-    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
-    expect(screen.getByText("**********")).toBeInTheDocument();
-  });
-
-  it("revealing one of two logins does not reveal the other", async () => {
+  it("opens the accounts in a dialog", () => {
     renderPanel({
       logins: [
         { username: "test-viewer", role: "Viewer", coldStart: true },
-        {
-          username: "test-compliance-admin",
-          role: "Compliance Admin",
-          coldStart: false,
-        },
+        { username: "test-admin", role: "Admin", coldStart: false },
       ],
     });
 
-    expect(screen.getByText("test-viewer")).toBeInTheDocument();
-    expect(screen.getByText("test-compliance-admin")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View test users" }));
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    );
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-compliance-admin",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: "Hide the password for test-viewer",
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryAllByText(MOCK_PASSWORD),
-    ).toHaveLength(1);
-    // The other row stays masked.
-    expect(screen.getAllByText("**********")).toHaveLength(1);
-  });
-
-  it("shows an error caption when revealPassword rejects", async () => {
-    renderPanel({
-      logins: [
-        { username: "test-viewer", role: "Viewer", coldStart: true },
-      ],
-      revealPassword: vi.fn(async () => {
-        throw new Error("sealed store unreachable");
-      }),
-    });
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("sealed store unreachable")).toBeInTheDocument();
-    });
-    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("test-viewer")).toBeInTheDocument();
+    expect(within(dialog).getByText("test-admin")).toBeInTheDocument();
   });
 
   it("does not render Add, Rotate, Delete, or Roles-gate copy", () => {
     renderPanel({
-      logins: [
-        { username: "test-viewer", role: "Viewer", coldStart: true },
-      ],
+      logins: [{ username: "test-viewer", role: "Viewer", coldStart: true }],
     });
 
     expect(screen.queryByText(/^Add$/i)).not.toBeInTheDocument();
@@ -256,37 +132,9 @@ describe("SignInPanel", () => {
     expect(screen.queryByText(/Roles gate/i)).not.toBeInTheDocument();
   });
 
-  it("role tooltip shows cold-start suffix or bare role name", async () => {
-    renderPanel({
-      logins: [
-        { username: "test-viewer", role: "Viewer", coldStart: true },
-        {
-          username: "test-compliance-admin",
-          role: "Compliance Admin",
-          coldStart: false,
-        },
-      ],
-    });
-
-    const coldStartUsername = screen.getByText("test-viewer");
-    fireEvent.mouseOver(coldStartUsername);
-    const coldTooltip = await screen.findByRole("tooltip");
-    expect(coldTooltip).toHaveTextContent("Viewer · cold start");
-    fireEvent.mouseLeave(coldStartUsername);
-    await waitFor(() => {
-      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-    });
-
-    const roleUsername = screen.getByText("test-compliance-admin");
-    fireEvent.mouseOver(roleUsername);
-    const roleTooltip = await screen.findByRole("tooltip");
-    expect(roleTooltip).toHaveTextContent("Compliance Admin");
-    expect(roleTooltip.textContent).toBe("Compliance Admin");
-  });
-
   it("pending load shows a caption and still links Thunder Console", () => {
     renderPanel({ loadState: "pending" });
-    expect(screen.getByText("Loading test users…")).toBeInTheDocument();
+    expect(screen.getByText("Loading test users\u2026")).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: "Open Thunder Console to add or remove real accounts",
@@ -302,32 +150,5 @@ describe("SignInPanel", () => {
         name: "Open Thunder Console to add or remove real accounts",
       }),
     ).toBeInTheDocument();
-  });
-
-  it("shows an error caption when clipboard write rejects", async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"));
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-    renderPanel({
-      logins: [{ username: "test-viewer", role: "Viewer", coldStart: true }],
-    });
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Reveal the password for test-viewer",
-      }),
-    );
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
-    });
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Copy the password for test-viewer",
-      }),
-    );
-    await waitFor(() => {
-      expect(screen.getByText("clipboard denied")).toBeInTheDocument();
-    });
   });
 });

--- a/apps/console/src/features/projects/components/SignInPanel.tsx
+++ b/apps/console/src/features/projects/components/SignInPanel.tsx
@@ -19,14 +19,12 @@
 import { useState } from "react";
 import {
   Box,
-  CircularProgress,
-  IconButton,
+  Button,
   Link as MuiLink,
   Stack,
-  Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Copy, ExternalLink, Eye, EyeOff } from "@wso2/oxygen-ui-icons-react";
+import { ExternalLink, Users } from "@wso2/oxygen-ui-icons-react";
 import { env } from "../../../config/env";
 import { thunderUsersConsoleHref } from "../../../config/thunderConsole";
 import {
@@ -37,146 +35,7 @@ import {
   publishedTestUsers,
   type PublishedTestUser,
 } from "../lib/publishedTestUsers";
-
-function copyText(value: string): Promise<void> {
-  if (!navigator.clipboard?.writeText) {
-    return Promise.reject(new Error("Clipboard is not available"));
-  }
-  return navigator.clipboard.writeText(value);
-}
-
-/** The password's placeholder while it is hidden. Fixed width, monospace, so
- *  revealing swaps the characters without moving the icons beside them. */
-const MASK = "**********";
-
-function LoginRow({
-  login,
-  revealPassword,
-}: {
-  login: PublishedTestUser;
-  revealPassword: (username: string) => Promise<string>;
-}) {
-  const [password, setPassword] = useState<string | null>(null);
-  const [shown, setShown] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  /**
-   * The password itself, read once and kept for the row's life.
-   *
-   * The eye toggles VISIBILITY, not another read: hiding a revealed password
-   * and showing it again is a decision about this screen, not a reason to ask
-   * the sealed store for a secret a second time. Copy shares the same path, so
-   * a reader can copy a password they never put on screen.
-   */
-  const ensurePassword = async (): Promise<string | null> => {
-    if (password !== null) return password;
-    setBusy(true);
-    setError(null);
-    try {
-      const value = await revealPassword(login.username);
-      setPassword(value);
-      return value;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      return null;
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const toggle = async () => {
-    if (shown) {
-      setShown(false);
-      return;
-    }
-    if ((await ensurePassword()) !== null) setShown(true);
-  };
-
-  const copy = async () => {
-    const value = await ensurePassword();
-    if (value === null) return;
-    setError(null);
-    try {
-      await copyText(value);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  };
-
-  return (
-    <Box>
-      <Tooltip title={login.coldStart ? `${login.role} · cold start` : login.role}>
-        <Typography
-          variant="body2"
-          sx={{ fontFamily: "monospace", minWidth: 0, width: "fit-content" }}
-        >
-          {login.username}
-        </Typography>
-      </Tooltip>
-      {/* The password line is ALWAYS here, masked until asked for. It used to
-          appear only after a reveal, which made the card grow by a row at the
-          moment of the click and left a reader with no sign that a password
-          existed at all until they had already fetched it. */}
-      <Stack
-        direction="row"
-        spacing={0.5}
-        sx={{ alignItems: "center", mt: 0.25 }}
-      >
-        <Typography
-          variant="body2"
-          aria-live="polite"
-          // The mask is decoration: its ten asterisks would be read out one by
-          // one, and the eye's accessible name already says whether the
-          // password is showing.
-          {...(shown && password !== null ? {} : { "aria-hidden": true })}
-          sx={{ fontFamily: "monospace", color: "text.secondary" }}
-        >
-          {shown && password !== null ? password : MASK}
-        </Typography>
-        <Tooltip title={shown ? "Hide password" : "Reveal password"}>
-          <span>
-            <IconButton
-              size="small"
-              disabled={busy}
-              aria-label={
-                shown
-                  ? `Hide the password for ${login.username}`
-                  : `Reveal the password for ${login.username}`
-              }
-              onClick={() => void toggle()}
-            >
-              {busy ? (
-                <CircularProgress size={12} color="inherit" />
-              ) : shown ? (
-                <EyeOff size={14} />
-              ) : (
-                <Eye size={14} />
-              )}
-            </IconButton>
-          </span>
-        </Tooltip>
-        <Tooltip title="Copy password">
-          <span>
-            <IconButton
-              size="small"
-              disabled={busy}
-              aria-label={`Copy the password for ${login.username}`}
-              onClick={() => void copy()}
-            >
-              <Copy size={14} />
-            </IconButton>
-          </span>
-        </Tooltip>
-      </Stack>
-      {error !== null && (
-        <Typography variant="caption" color="error">
-          {error}
-        </Typography>
-      )}
-    </Box>
-  );
-}
+import { TestUsersDialog } from "./TestUsersDialog";
 
 function ThunderSentence({ thunderUrl }: { thunderUrl: string }) {
   return (
@@ -220,6 +79,7 @@ export function SignInPanel({
   revealPassword: (username: string) => Promise<string>;
   loadState?: "ready" | "pending" | "error";
 }) {
+  const [open, setOpen] = useState(false);
   return (
     <Box>
       {loadState === "pending" && (
@@ -249,15 +109,35 @@ export function SignInPanel({
           >
             Test users for agents on this environment
           </Typography>
-          <Stack spacing={1} sx={{ mt: 1, mb: 1.5 }}>
-            {logins.map((login) => (
-              <LoginRow
-                key={login.username}
-                login={login}
-                revealPassword={revealPassword}
-              />
-            ))}
+          {/* One LINE, whatever the design declares. The accounts used to be
+              listed here, one two-line block per role, so a six-role app grew
+              this card past the ledger beside it (review on #714). The count
+              is the fact the card owes the reader; the accounts themselves are
+              a table, and a table belongs in a dialog. */}
+          <Stack
+            direction="row"
+            spacing={1.5}
+            sx={{ alignItems: "center", mt: 1, mb: 1.5 }}
+          >
+            <Typography variant="body2">
+              {logins.length} account{logins.length === 1 ? "" : "s"}, one per
+              role
+            </Typography>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Users size={14} aria-hidden />}
+              onClick={() => setOpen(true)}
+            >
+              View test users
+            </Button>
           </Stack>
+          <TestUsersDialog
+            open={open}
+            onClose={() => setOpen(false)}
+            logins={logins}
+            revealPassword={revealPassword}
+          />
         </>
       )}
       <ThunderSentence thunderUrl={thunderUrl} />

--- a/apps/console/src/features/projects/components/TestUsersDialog.test.tsx
+++ b/apps/console/src/features/projects/components/TestUsersDialog.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { OxygenTheme, OxygenUIThemeProvider } from "@wso2/oxygen-ui";
+import { describe, expect, it, vi } from "vitest";
+import type { PublishedTestUser } from "../lib/publishedTestUsers";
+import { MASK, TestUsersDialog } from "./TestUsersDialog";
+
+const MOCK_PASSWORD = "mocknotreal";
+
+const TWO: PublishedTestUser[] = [
+  { username: "test-viewer", role: "Viewer", coldStart: true },
+  { username: "test-compliance-admin", role: "Compliance Admin", coldStart: false },
+];
+
+function renderDialog(
+  over: {
+    logins?: readonly PublishedTestUser[];
+    revealPassword?: (username: string) => Promise<string>;
+    onClose?: () => void;
+  } = {},
+) {
+  const revealPassword = over.revealPassword ?? vi.fn(async () => MOCK_PASSWORD);
+  const onClose = over.onClose ?? vi.fn();
+  render(
+    <OxygenUIThemeProvider theme={OxygenTheme}>
+      <TestUsersDialog
+        open
+        onClose={onClose}
+        logins={over.logins ?? TWO}
+        revealPassword={revealPassword}
+      />
+    </OxygenUIThemeProvider>,
+  );
+  return { revealPassword, onClose };
+}
+
+/** The row a username sits in — every assertion about one account is scoped
+ *  to its row, so a two-account table cannot pass on the other one's cells. */
+function rowOf(username: string): HTMLElement {
+  const cell = screen.getByText(username);
+  const row = cell.closest("tr");
+  if (row === null) throw new Error(`no row for ${username}`);
+  return row;
+}
+
+describe("TestUsersDialog", () => {
+  it("gives every account its role, and marks the cold-start one", () => {
+    renderDialog();
+
+    // The role used to live in a tooltip on the username. It is a column now,
+    // which is the whole reason the table earns a dialog.
+    expect(within(rowOf("test-viewer")).getByText("Viewer")).toBeInTheDocument();
+    expect(within(rowOf("test-viewer")).getByText("Cold start")).toBeInTheDocument();
+    expect(
+      within(rowOf("test-compliance-admin")).getByText("Compliance Admin"),
+    ).toBeInTheDocument();
+    expect(
+      within(rowOf("test-compliance-admin")).queryByText("Cold start"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("masks every password, with both controls, before any reveal", () => {
+    renderDialog();
+
+    expect(screen.getAllByText(MASK)).toHaveLength(2);
+    expect(
+      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy the password for test-viewer" }),
+    ).toBeInTheDocument();
+  });
+
+  it("the eye toggles visibility, and reads the secret only once", async () => {
+    const { revealPassword } = renderDialog();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
+    );
+    expect(revealPassword).toHaveBeenCalledWith("test-viewer");
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
+    });
+    expect(screen.getByText(MOCK_PASSWORD)).toHaveAttribute("aria-live", "polite");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hide the password for test-viewer" }),
+    );
+    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
+
+    // Showing it again is a decision about this screen, not a reason to ask
+    // the sealed store for the secret a second time.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
+    });
+    expect(revealPassword).toHaveBeenCalledTimes(1);
+  });
+
+  it("revealing one account does not reveal another", async () => {
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_PASSWORD)).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(MOCK_PASSWORD)).toHaveLength(1);
+    expect(screen.getAllByText(MASK)).toHaveLength(1);
+    expect(
+      screen.getByRole("button", {
+        name: "Reveal the password for test-compliance-admin",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("copies a password that was never put on screen", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy the password for test-viewer" }),
+    );
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(MOCK_PASSWORD);
+    });
+    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
+  });
+
+  it("shows an error in the row when the reveal fails", async () => {
+    renderDialog({
+      revealPassword: vi.fn(async () => {
+        throw new Error("sealed store unreachable");
+      }),
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Reveal the password for test-viewer" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("sealed store unreachable")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(MOCK_PASSWORD)).not.toBeInTheDocument();
+    // The password stays masked; a failed read reveals nothing.
+    expect(screen.getAllByText(MASK)).toHaveLength(2);
+  });
+
+  it("shows an error in the row when the clipboard write fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy the password for test-viewer" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("clipboard denied")).toBeInTheDocument();
+    });
+  });
+
+  it("closes on the close button", () => {
+    const { onClose } = renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/console/src/features/projects/components/TestUsersDialog.tsx
+++ b/apps/console/src/features/projects/components/TestUsersDialog.tsx
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import {
+  Box,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  ListingTable,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Copy, Eye, EyeOff, X } from "@wso2/oxygen-ui-icons-react";
+import { StatusChip } from "../../../components/StatusChip";
+import type { PublishedTestUser } from "../lib/publishedTestUsers";
+
+/** The password's placeholder while it is hidden. Fixed width, monospace, so
+ *  revealing swaps the characters without moving the icons beside them. */
+export const MASK = "**********";
+
+function copyText(value: string): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    return Promise.reject(new Error("Clipboard is not available"));
+  }
+  return navigator.clipboard.writeText(value);
+}
+
+/**
+ * One account: its username, its masked password with the two controls, the
+ * role it holds, and whether it is the cold-start account.
+ *
+ * The reveal state is per row and lives here, so opening one password does not
+ * open the rest — the dialog can hold a dozen accounts and only the one asked
+ * for is ever on screen.
+ */
+function TestUserRow({
+  login,
+  revealPassword,
+}: {
+  login: PublishedTestUser;
+  revealPassword: (username: string) => Promise<string>;
+}) {
+  const [password, setPassword] = useState<string | null>(null);
+  const [shown, setShown] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * The password itself, read once and kept for the row's life.
+   *
+   * The eye toggles VISIBILITY, not another read: hiding a revealed password
+   * and showing it again is a decision about this screen, not a reason to ask
+   * the sealed store for a secret a second time. Copy shares the same path, so
+   * a reader can copy a password they never put on screen.
+   */
+  const ensurePassword = async (): Promise<string | null> => {
+    if (password !== null) return password;
+    setBusy(true);
+    setError(null);
+    try {
+      const value = await revealPassword(login.username);
+      setPassword(value);
+      return value;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggle = async () => {
+    if (shown) {
+      setShown(false);
+      return;
+    }
+    if ((await ensurePassword()) !== null) setShown(true);
+  };
+
+  const copy = async () => {
+    const value = await ensurePassword();
+    if (value === null) return;
+    setError(null);
+    try {
+      await copyText(value);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <ListingTable.Row>
+      <ListingTable.Cell>
+        <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+          {login.username}
+        </Typography>
+      </ListingTable.Cell>
+
+      <ListingTable.Cell>
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+          <Typography
+            variant="body2"
+            aria-live="polite"
+            // The mask is decoration: its ten asterisks would be read out one
+            // by one, and the eye's accessible name already says whether the
+            // password is showing.
+            {...(shown && password !== null ? {} : { "aria-hidden": true })}
+            sx={{ fontFamily: "monospace", color: "text.secondary" }}
+          >
+            {shown && password !== null ? password : MASK}
+          </Typography>
+          <Tooltip title={shown ? "Hide password" : "Reveal password"}>
+            <span>
+              <IconButton
+                size="small"
+                disabled={busy}
+                aria-label={
+                  shown
+                    ? `Hide the password for ${login.username}`
+                    : `Reveal the password for ${login.username}`
+                }
+                onClick={() => void toggle()}
+              >
+                {busy ? (
+                  <CircularProgress size={12} color="inherit" />
+                ) : shown ? (
+                  <EyeOff size={14} />
+                ) : (
+                  <Eye size={14} />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Copy password">
+            <span>
+              <IconButton
+                size="small"
+                disabled={busy}
+                aria-label={`Copy the password for ${login.username}`}
+                onClick={() => void copy()}
+              >
+                <Copy size={14} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+        {error !== null && (
+          <Typography variant="caption" color="error" sx={{ display: "block" }}>
+            {error}
+          </Typography>
+        )}
+      </ListingTable.Cell>
+
+      <ListingTable.Cell>
+        <Typography variant="body2">{login.role}</Typography>
+      </ListingTable.Cell>
+
+      <ListingTable.Cell>
+        {login.coldStart ? (
+          <Tooltip title="Served when a caller asks for credentials without naming a role">
+            <span>
+              <StatusChip label="Cold start" tone="info" appearance="soft" />
+            </span>
+          </Tooltip>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            —
+          </Typography>
+        )}
+      </ListingTable.Cell>
+    </ListingTable.Row>
+  );
+}
+
+/**
+ * The environment's test accounts, in a dialog.
+ *
+ * They live behind a button rather than on the Development card because the
+ * list is one account PER ROLE: an app with six roles pushed six two-line
+ * blocks into a card that sits beside the ledger, and the card grew with the
+ * design instead of holding its place (review on #714).
+ */
+export function TestUsersDialog({
+  open,
+  onClose,
+  logins,
+  revealPassword,
+}: {
+  open: boolean;
+  onClose: () => void;
+  logins: readonly PublishedTestUser[];
+  revealPassword: (username: string) => Promise<string>;
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ pr: 6 }}>
+        Test users
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          Disposable accounts the platform created for this project&apos;s
+          roles, so agents can sign in to the running app and check what each
+          role can do. They are not real people.
+        </Typography>
+        <IconButton
+          aria-label="Close"
+          onClick={onClose}
+          sx={{ position: "absolute", right: 12, top: 12 }}
+        >
+          <X size={18} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0 }}>
+        <ListingTable.Container sx={{ width: "100%" }}>
+          <ListingTable density="standard">
+            <ListingTable.Head>
+              <ListingTable.Row>
+                <ListingTable.Cell>Username</ListingTable.Cell>
+                <ListingTable.Cell sx={{ width: 260 }}>Password</ListingTable.Cell>
+                <ListingTable.Cell sx={{ width: 180 }}>Role</ListingTable.Cell>
+                <ListingTable.Cell sx={{ width: 130 }}>Cold start</ListingTable.Cell>
+              </ListingTable.Row>
+            </ListingTable.Head>
+            <ListingTable.Body>
+              {logins.map((login) => (
+                <TestUserRow
+                  key={login.username}
+                  login={login}
+                  revealPassword={revealPassword}
+                />
+              ))}
+            </ListingTable.Body>
+          </ListingTable>
+        </ListingTable.Container>
+        <Box sx={{ px: 2.25, py: 1.5 }}>
+          <Typography variant="caption" color="text.secondary">
+            The same logins are posted on this version&apos;s roles gate issue
+            when the build provisions them.
+          </Typography>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Follow-up to the review comment on [#714](https://github.com/wso2/labs-agentic-engineer/pull/714), which is merged and frozen: *"Could we display test users in a pop-up model? If this user app has multiple roles then the test user list will be longer."*

**Console only.** No contract change, no backend.

## The problem

The accounts were listed on the Development card, one two-line block per role — a username line and a masked password line. That is a list whose length is the design's to decide. A six-role app pushed six blocks into a card that sits beside the deployments ledger, so the card grew with the app instead of holding its place.

## What changed

The card now says **`N accounts, one per role`** beside a **View test users** button. The accounts are a table in a dialog, which is what the data always was:

| Column | Note |
|---|---|
| Username | monospace, as before |
| Password | `**********` until the eye beside it is pressed, with copy next to it |
| Role | was a tooltip on the username; it is a column now |
| Cold start | marked with a chip, instead of being a suffix inside that tooltip |

Behaviour carried over unchanged from #714:

- **The eye toggles visibility, and the sealed store is read once.** Hiding and showing again is a decision about the screen, not a reason to ask for the secret a second time.
- **Copy works without revealing**, so a password can reach the clipboard without ever being on screen.
- **Reveal state is per row**, so opening one password does not open the rest — which matters more here, where a dozen rows can be open at once.

The dialog also notes that the same logins are posted on the version's roles gate issue, which is the other place a reader meets them.

## Side effect worth naming

The Development card now holds one height whatever the design declares. That is a sturdier answer to the equal-height pair than the `height: 100%` stretch #714 added, which only made Production match whatever Development happened to grow to.

## Verification

- `pnpm --filter @aep/console test` — **139 files, 1755 tests, all passing.** 8 new on the dialog, 7 rewritten on the panel, 1 updated on the Deployments page.
- `typecheck` and `lint` clean.
- Walked in mock mode in both themes: the collapsed card, the dialog masked, and one password revealed. Screenshots to follow as attachments.

## Docs

PRD entry amended, and the lexicon gains the card's count wording, the dialog's title and description, and its columns.


https://github.com/user-attachments/assets/cc09a7b2-c2ea-4fc5-b7c5-1274c3f1a1ac



🤖 Generated with [Claude Code](https://claude.com/claude-code)