### PR TITLE
chore(makefile): replace dev-cluster/deploy-local with run/run-watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ LICENSE_HEADER := .github/license-header.txt
 LICENSE_MATCH = grep -E '\.(go|ts|tsx|sh)$$|(^|/)Dockerfile$$' | \
 	grep -vE '\.gen\.(go|ts)$$|_mock\.go$$|/mocks/|/node_modules/|/dist/|/generated/|(^|/)\.(agents|claude)/'
 
-.PHONY: install gen build dev test lint eval-ui typecheck license license-check tools clean eval cover build-runner workflow-skill deadcode-ts deadcode-ts-check setup-local dev-cluster deploy-local bal-library-tool
+.PHONY: install gen build dev test lint eval-ui typecheck license license-check tools clean eval cover build-runner workflow-skill deadcode-ts deadcode-ts-check setup-local run run-watch bal-library-tool
 
 install:
 	$(PNPM) install
@@ -167,16 +167,20 @@ workflow-skill:
 setup-local:
 	bash deployments/scripts/setup-local.sh
 
-# Inner dev loop: build images, load into k3d, deploy via Helm, watch for changes.
+# Inner dev loop: build images, load into k3d, deploy via Helm.
 # Console: http://console.openchoreo.localhost:8080
 # Per-developer overrides (smee webhook, etc.): copy skaffold/helm-values.yaml.example
 # to skaffold/helm-values.yaml (git-ignored) and fill in your values.
-dev-cluster:
-	skaffold dev --kube-context k3d-openchoreo -f skaffold.yaml
+#
+# Default (dev-cluster): manual trigger — builds and deploys once, then waits
+# for Enter before rebuilding.
+# Watch mode (dev-cluster-watch): rebuilds automatically on every file change.
+# Only the artifact whose files changed is rebuilt.
+run:
+	skaffold dev --kube-context k3d-openchoreo --trigger=manual
 
-# One-shot build + deploy (no watch). Useful for CI smoke tests or resetting state.
-deploy-local:
-	skaffold run --kube-context k3d-openchoreo -f skaffold.yaml
+run-watch:
+	skaffold dev --kube-context k3d-openchoreo
 
 clean:
 	$(TURBO) run build --force >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Replaces the stale `dev-cluster` and `deploy-local` Makefile targets with two cleaner skaffold targets:

- **`make run`** — builds and deploys once, then waits for Enter before rebuilding (`--trigger=manual`). Default for day-to-day use.
- **`make run-watch`** — rebuilds and redeploys automatically on file change. Per-artifact scoping ensures only the changed service rebuilds.

The old `deploy-local` (`skaffold run`) is removed — `make run` covers that use case and keeps the process alive for logs/port-forwards.

## Test plan

- [ ] `make run` builds all images, deploys, then waits for Enter before any rebuild
- [ ] `make run-watch` rebuilds only the affected artifact on file change

🤖 Generated with [Claude Code](https://claude.com/claude-code)