### PR TITLE
A walk posts a numbered plan and a line per item; a deleted account leaves its roles first

### DIFF
--- a/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
+++ b/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
@@ -171,28 +171,30 @@ That narrows decisions 3 and 4: the boundary is still the component rather than
 the issue, but the DSL alone draws it, and `specs/requirements/` is no longer a
 walk input or a checklist source. Everything else above stands.
 
-## Amendment 2026-09-04 — one checklist, and the mechanics in a script
+## Amendment 2026-09-04 — a numbered plan, a line per item, and the server in a script
 
-The walk reported through three surfaces: a checklist comment before the
-browser opened, a status-line comment per settled line, and a report comment at
-the end, each with its own shape. They collapse into **one comment, edited in
-place**: the checklist is written once from the DSL, its first line is derived
-from its marks (`<p> pass, <f> fixed, <o> open, <t> outside, <u> to walk`), and
-the same comment is re-published as lines settle. The newest comment on the
-issue stays the checklist, so the status line ADR-0010 describes is its first
-line, and the pull request quotes that same line at the end.
+The walk's progress is three comment shapes: a **plan** posted before the
+browser opens, one numbered item per screen and per once-per-app check; **one
+line per item** as it settles (`n/N Screen: done | fixed | open | outside —
+detail`); and a **closing line** with the counts. The newest comment is where
+the walk is, which is the status line ADR-0010 asks for; an item with no line
+is a screen never reached; the closing line is what the pull request quotes.
+This replaces the marked checklist block and its separate status-line shapes.
+It posts more comments per web-app issue than ADR-0010's two to four — one per
+item — and takes a legible history over a quiet thread on purpose. Where the
+lines go is the dispatch prompt's to say, per mode (a `gh issue comment` on the
+platform, a section of `issues/<n>.md` in the playground), so the skill names
+no `gh` and ships byte-identical, as ADR-0010's decision 7 requires.
 
-The mechanics moved out of the skill text into `scripts/walk.sh` beside it
-(`up`, `restart`, `post`, `down`), reached through `$AEP_SKILLS_DIR` the way
+The dev server moved out of the skill text into `scripts/walk.sh` beside it
+(`up`, `restart`, `down`), reached through `$AEP_SKILLS_DIR` the way
 `aep-validation` reaches its report generator. The text had carried a
 process-group launcher, a port-collision rule and a stop sequence that every
 walk re-typed; the one walk that improvised instead leaked four dev servers
-into its memory limit. The script reaps by process group, searches for a free
-port so two walks in one wave do not collide, closes the browser on `down`,
-and holds the create-or-edit branch of the issue comment, so the same skill
-text serves a playground session whose prompt names no issue. The runner
-image also gains `procps` as a backstop for an agent that reaches for `pkill`
-outside the procedure. This reverses the earlier call to keep the skill
+into its memory limit. The script reaps by process group, takes a free port so
+two walks in one wave cannot collide, and closes the browser on `down`. The
+runner image also gains `procps` as a backstop for an agent that reaches for
+`pkill` outside the procedure. This reverses the earlier call to keep the skill
 text-only, on the measured cost of that choice.
 
 ## Consequences

--- a/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
+++ b/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
@@ -171,6 +171,30 @@ That narrows decisions 3 and 4: the boundary is still the component rather than
 the issue, but the DSL alone draws it, and `specs/requirements/` is no longer a
 walk input or a checklist source. Everything else above stands.
 
+## Amendment 2026-09-04 — one checklist, and the mechanics in a script
+
+The walk reported through three surfaces: a checklist comment before the
+browser opened, a status-line comment per settled line, and a report comment at
+the end, each with its own shape. They collapse into **one comment, edited in
+place**: the checklist is written once from the DSL, its first line is derived
+from its marks (`<p> pass, <f> fixed, <o> open, <t> outside, <u> to walk`), and
+the same comment is re-published as lines settle. The newest comment on the
+issue stays the checklist, so the status line ADR-0010 describes is its first
+line, and the pull request quotes that same line at the end.
+
+The mechanics moved out of the skill text into `scripts/walk.sh` beside it
+(`up`, `restart`, `post`, `down`), reached through `$AEP_SKILLS_DIR` the way
+`aep-validation` reaches its report generator. The text had carried a
+process-group launcher, a port-collision rule and a stop sequence that every
+walk re-typed; the one walk that improvised instead leaked four dev servers
+into its memory limit. The script reaps by process group, searches for a free
+port so two walks in one wave do not collide, closes the browser on `down`,
+and holds the create-or-edit branch of the issue comment, so the same skill
+text serves a playground session whose prompt names no issue. The runner
+image also gains `procps` as a backstop for an agent that reaches for `pkill`
+outside the procedure. This reverses the earlier call to keep the skill
+text-only, on the measured cost of that choice.
+
 ## Consequences
 
 - A `web-application` costs two dispatches where a service costs one, and the

--- a/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
+++ b/docs/decisions/ADR-0025-a-web-application-is-verified-before-it-is-committed.md
@@ -191,8 +191,10 @@ The dev server moved out of the skill text into `scripts/walk.sh` beside it
 `aep-validation` reaches its report generator. The text had carried a
 process-group launcher, a port-collision rule and a stop sequence that every
 walk re-typed; the one walk that improvised instead leaked four dev servers
-into its memory limit. The script reaps by process group, takes a free port so
-two walks in one wave cannot collide, and closes the browser on `down`. The
+into its memory limit. The script reaps by process group, searches for a free
+port and moves on when a launch loses the bind to a sibling walk in the same
+instant, keys its state on the App Path so same-named apps stay apart, and
+closes the browser on `down`. The
 runner image also gains `procps` as a backstop for an agent that reaches for
 `pkill` outside the procedure. This reverses the earlier call to keep the skill
 text-only, on the measured cost of that choice.

--- a/playground/AGENTS.md
+++ b/playground/AGENTS.md
@@ -52,16 +52,16 @@ a fixture like that is yours alone — author it by copying the `specs/` +
 
 **A `web-application` costs an extra round.** Its build is followed by mock
 verification: a subagent stands the app up in mock mode, walks every flow its
-wireframes draw with `agent-browser`, fixes what fails on the spot, and hands
-back one marked checklist (`skills/mock-verification`, whose `scripts/walk.sh`
-runs the server, and `react-webapp`'s `references/mock-mode.md` for the mock
-itself). In docker mode that is all
-inside the container. **In `--host` mode it is your machine**: the run binds a
-localhost port and drives a real browser under bypassPermissions. Nothing is
-installed — `agent-browser` and the browser are resolved off your `PATH`, the
-same way `playwright-cli` already is — but a run that dies badly can leave a
-`vite` process holding its port, and the next run's `--strictPort` will say so
-rather than quietly reading the old server.
+wireframes draw with `agent-browser`, fixes what fails on the spot, and posts
+its plan and one line per item into the issue file's `## Mock verification`
+section (`skills/mock-verification`, whose `scripts/walk.sh` runs the server,
+and `react-webapp`'s `references/mock-mode.md` for the mock itself). In docker
+mode that is all inside the container. **In `--host` mode it is your machine**:
+the run binds a localhost port and drives a real browser under
+bypassPermissions. Nothing is installed — `agent-browser` and the browser are
+resolved off your `PATH`, the same way `playwright-cli` already is — but a run
+that dies badly can leave a `vite` process holding its port, and the next run's
+`--strictPort` will say so rather than quietly reading the old server.
 
 That is the one part of the loop with no minimal fixture: a web app small enough
 to be fast still has screens to walk. Budget for it, or tune API-only changes on

--- a/playground/AGENTS.md
+++ b/playground/AGENTS.md
@@ -51,10 +51,11 @@ a fixture like that is yours alone — author it by copying the `specs/` +
 `issues/` shape of an existing project and stripping every dependency.
 
 **A `web-application` costs an extra round.** Its build is followed by mock
-verification: a subagent starts the app with `npm run dev:mock`, walks its
-stories with `agent-browser`, and reports a verdict per story, which the lead
-fixes and re-verifies (`skills/mock-verification`, and `react-webapp`'s
-`references/mock-mode.md` for the mock itself). In docker mode that is all
+verification: a subagent stands the app up in mock mode, walks every flow its
+wireframes draw with `agent-browser`, fixes what fails on the spot, and hands
+back one marked checklist (`skills/mock-verification`, whose `scripts/walk.sh`
+runs the server, and `react-webapp`'s `references/mock-mode.md` for the mock
+itself). In docker mode that is all
 inside the container. **In `--host` mode it is your machine**: the run binds a
 localhost port and drives a real browser under bypassPermissions. Nothing is
 installed — `agent-browser` and the browser are resolved off your `PATH`, the

--- a/runners/remote-worker/Dockerfile
+++ b/runners/remote-worker/Dockerfile
@@ -22,6 +22,10 @@
 # What each layer is for:
 #   - git / gh / curl / bash / python3 — workspace provisioning, the git
 #     credential helper + `gh` wrapper, and the agent's Bash tool.
+#   - procps (`ps`, `pkill`) — a backstop. The walk's own script reaps its dev
+#     server by process group and needs neither, but an agent improvising a
+#     cleanup reaches for `pkill` first, and on the image without it every such
+#     call was a silenced "command not found" that left the server running.
 #   - Go and Ballerina (pinned archives, not distro packages) + node/npm
 #     from the base — the agent's compile-level build verification
 #     (`go build`, `bal build`, `tsc --noEmit`, lockfile resolution) before
@@ -95,6 +99,7 @@ RUN apt-get update \
         curl \
         bash \
         python3 \
+        procps \
         unzip \
         ca-certificates \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/runners/remote-worker/src/lib/workflow_skill.test.ts
+++ b/runners/remote-worker/src/lib/workflow_skill.test.ts
@@ -87,6 +87,10 @@ const PLATFORM_ONLY = [
   // subagent are both overlaid away.
   "### The status line",
   "gh issue comment",
+  // The walk's prompt names the issue its checklist comment goes on; the
+  // playground has no issue, and `mock-verification` publishes nothing when the
+  // prompt names none.
+  "Walk <component> at <App Path> (issue #<N>).",
   // The invocation, not the words: local mode names `git push` too, in the
   // deny-list line that forbids it.
   "git push -u origin HEAD",
@@ -164,7 +168,7 @@ for (const rule of [
   // prompt. The procedure itself is `mock-verification`, asserted below.
   "**A `web-application` is finished by a walk, not a build.**",
   "dispatch **one more subagent**",
-  "Walk <component> at <App Path> (issue #<N>).",
+  "Walk <component> at <App Path>",
 ]) {
   test(`shared by both modes: ${rule.split("\n")[0]}`, () => {
     assert.ok(composed.github.includes(rule), `github mode lost: ${rule}`);
@@ -245,7 +249,14 @@ test("mock-verification walks and repairs a line at a time", () => {
     // The flow is the unit and the DSL the only map: the checklist is settled
     // from it before the browser opens, so an unreached screen is a visible gap.
     "## What you verify",
-    "## 1 · Checklist",
+    "## 1 · Stand it up",
+    "## 2 · Checklist",
+    // The mechanics — server, port, browser, the one issue comment — are the
+    // skill's script, reached through the runner-stamped path like
+    // aep-validation's report generator. The walker never re-derives them.
+    'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" up',
+    'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>',
+    'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" down',
     "**A line ends green.**",
     "**Three attempts on a line, then mark it `[ ]` and walk on.**",
     "**Repair the app, never the checklist.**",
@@ -253,10 +264,10 @@ test("mock-verification walks and repairs a line at a time", () => {
     // misread as a defect in a just-created record.
     "**Click between screens.**",
     "Make the mock agree with the app",
-    // The walk is a subagent's job, and a subagent now keeps its issue's status
-    // line current. So this skill bans the RECORD (git, commits, the PR) and
-    // defers where progress goes to the prompt — it ships byte-identical into a
-    // playground session, which has no issue to post on.
+    // The walk is a subagent's job. This skill bans the RECORD (git, commits,
+    // the PR) and publishes its one checklist comment only on the issue the
+    // prompt names — it ships byte-identical into a playground session, whose
+    // overlaid prompt names none.
     "The record belongs to the agent\n  that dispatched you",
   ]) {
     assert.ok(skill.includes(rule), `mock-verification lost: ${rule}`);
@@ -572,6 +583,7 @@ test("a skill's references, assets and scripts come along", async () => {
       path.join("react-webapp", "assets", "mock-browser.ts"),
       path.join("react-webapp", "assets", "mock-auth.ts"),
       path.join("mock-verification", "SKILL.md"),
+      path.join("mock-verification", "scripts", "walk.sh"),
       path.join("agent-browser", "SKILL.md"),
     ]) {
       assert.ok(fs.existsSync(path.join(skills, rel)), `mirror is missing ${rel}`);
@@ -585,7 +597,7 @@ test("a skill's references, assets and scripts come along", async () => {
 // mirror). `/app/plugin` was such a path, and it stopped existing when the plugin
 // did; the report generator was still being invoked through it.
 test("no library skill hardcodes a runner path", () => {
-  for (const skill of ["aep", "aep-validation", "playwright-cli"]) {
+  for (const skill of ["aep", "aep-validation", "playwright-cli", "mock-verification"]) {
     const body = fs.readFileSync(path.join(LIBRARY, skill, "SKILL.md"), "utf8");
     assert.ok(!body.includes("/app/plugin"), `${skill} names the retired /app/plugin`);
     assert.ok(

--- a/runners/remote-worker/src/lib/workflow_skill.test.ts
+++ b/runners/remote-worker/src/lib/workflow_skill.test.ts
@@ -87,10 +87,6 @@ const PLATFORM_ONLY = [
   // subagent are both overlaid away.
   "### The status line",
   "gh issue comment",
-  // The walk's prompt names the issue its checklist comment goes on; the
-  // playground has no issue, and `mock-verification` publishes nothing when the
-  // prompt names none.
-  "Walk <component> at <App Path> (issue #<N>).",
   // The invocation, not the words: local mode names `git push` too, in the
   // deny-list line that forbids it.
   "git push -u origin HEAD",
@@ -99,6 +95,9 @@ const PLATFORM_ONLY = [
 
 const LOCAL_ONLY = [
   "issues/<n>.md",
+  // The walk posts its progress where its prompt says: a GitHub comment on the
+  // platform, a section of the issue file here.
+  "under `## Mock verification`",
   "`## Progress`",
   ".aep-playground",
   "no git remote, no GitHub, and no PR",
@@ -240,34 +239,34 @@ for (const [file, rules] of Object.entries(REFERENCE_RULES)) {
 // failure at the line that found it, then re-walks that line before moving on.
 // A read-only verifier that only files a report is the shape this replaced, as
 // is batching every repair to the end — so the three properties that make one
-// fix-as-you-go agent safe are asserted here: the checklist is settled before
-// the browser opens, a line is not left behind until it passes, and one
-// stubborn defect cannot swallow the walk.
+// fix-as-you-go agent safe are asserted here: the plan is settled before the
+// browser opens, an item is not left behind until it passes, and one stubborn
+// defect cannot swallow the walk.
 test("mock-verification walks and repairs a line at a time", () => {
   const skill = fs.readFileSync(path.join(LIBRARY, "mock-verification", "SKILL.md"), "utf8");
   for (const rule of [
-    // The flow is the unit and the DSL the only map: the checklist is settled
-    // from it before the browser opens, so an unreached screen is a visible gap.
+    // The flow is the unit and the DSL the only map: the plan is settled from
+    // it before the browser opens, so an unreached screen is a visible gap.
     "## What you verify",
     "## 1 · Stand it up",
-    "## 2 · Checklist",
-    // The mechanics — server, port, browser, the one issue comment — are the
-    // skill's script, reached through the runner-stamped path like
-    // aep-validation's report generator. The walker never re-derives them.
+    "## 2 · Plan",
+    // The dev server — process group, free port, browser close — is the skill's
+    // script, reached through the runner-stamped path like aep-validation's
+    // report generator. The walker never re-derives it.
     'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" up',
-    'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>',
     'bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" down',
-    "**A line ends green.**",
-    "**Three attempts on a line, then mark it `[ ]` and walk on.**",
-    "**Repair the app, never the checklist.**",
+    // Progress is three fixed shapes; WHERE they go comes from the prompt, so
+    // the skill names no `gh` and ships byte-identical into the playground.
+    "## Progress",
+    "**An item ends green, and posted.**",
+    "**Three attempts on an item, then post it open and walk on.**",
+    "**Repair the app, never the plan.**",
     // Full page loads reset the mock's in-page state, which has twice been
     // misread as a defect in a just-created record.
     "**Click between screens.**",
     "Make the mock agree with the app",
     // The walk is a subagent's job. This skill bans the RECORD (git, commits,
-    // the PR) and publishes its one checklist comment only on the issue the
-    // prompt names — it ships byte-identical into a playground session, whose
-    // overlaid prompt names none.
+    // the PR) and defers where progress goes to the prompt (ADR-0010, 7).
     "The record belongs to the agent\n  that dispatched you",
   ]) {
     assert.ok(skill.includes(rule), `mock-verification lost: ${rule}`);

--- a/services/aep-api/internal/app/identity_adapters.go
+++ b/services/aep-api/internal/app/identity_adapters.go
@@ -98,6 +98,26 @@ func (d thunderDirectory) AddMembers(ctx context.Context, group identity.Directo
 	return toDirectoryGroup(g), nil
 }
 
+func (d thunderDirectory) RemoveMembers(ctx context.Context, group identity.DirectoryGroup, memberIDs []string) (identity.DirectoryGroup, error) {
+	g, err := d.c.RemoveGroupMembers(ctx, toThunderGroup(group), memberIDs)
+	if err != nil {
+		return identity.DirectoryGroup{}, err
+	}
+	return toDirectoryGroup(g), nil
+}
+
+func (d thunderDirectory) UserGroups(ctx context.Context, userID string) ([]identity.DirectoryGroup, error) {
+	groups, err := d.c.UserGroups(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]identity.DirectoryGroup, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, toDirectoryGroup(g))
+	}
+	return out, nil
+}
+
 func (d thunderDirectory) FindUserByUsername(ctx context.Context, username string) (*identity.DirectoryAccount, bool, error) {
 	u, found, err := d.c.FindUserByUsername(ctx, username)
 	if err != nil || !found {

--- a/services/aep-api/internal/clients/thundersvc/client.go
+++ b/services/aep-api/internal/clients/thundersvc/client.go
@@ -119,7 +119,22 @@ type Client interface {
 	// reading and writing under one lock. Destructive by construction — the
 	// write is a delete-and-recreate — so pass only a group the platform
 	// created. Returns the group's NEW id when members were added.
+	//
+	// Members already in the group that no longer exist on the directory are
+	// dropped rather than replayed; an account the CALLER asks to add that does
+	// not exist is an error raised before anything is written. Either way the
+	// group survives the call — see rewriteGroupMembers in directory.go.
 	AddGroupMembers(ctx context.Context, group Group, memberIDs []string) (Group, error)
+
+	// RemoveGroupMembers takes members out of a group, keeping everyone else.
+	// The un-enrol half of the pair: deleting an account without calling this
+	// first leaves the group pointing at an id that no longer resolves.
+	// Returns the group's NEW id when members were removed.
+	RemoveGroupMembers(ctx context.Context, group Group, memberIDs []string) (Group, error)
+
+	// UserGroups returns the groups an account belongs to. An account that is
+	// already gone reports no groups rather than an error.
+	UserGroups(ctx context.Context, userID string) ([]Group, error)
 
 	// FindUserByUsername returns the account with this exact username, and
 	// whether one exists.

--- a/services/aep-api/internal/clients/thundersvc/directory.go
+++ b/services/aep-api/internal/clients/thundersvc/directory.go
@@ -28,17 +28,44 @@ package thundersvc
 //  1. **Group membership can only be set when the group is CREATED.**
 //     `PUT /groups/{id}` accepts a `members` array, answers 200, and silently
 //     ignores it; there is no `POST/PUT/PATCH /groups/{id}/members` (404/405)
-//     and no SCIM surface. So adding a member to an existing group means
-//     delete-and-recreate with the merged list — see AddGroupMembers, and the
-//     ownership rule its doc comment names.
-//  2. **Passwords are write-only on read-back, but `PUT /users/{id}` echoes the
+//     and no SCIM surface. So changing the membership of an existing group
+//     means delete-and-recreate with the whole list — see rewriteGroupMembers,
+//     which is the only place in this file that does it.
+//
+//     Membership is READABLE from both ends, though: `/groups/{id}/members`
+//     lists a group's accounts and `/users/{id}/groups` lists an account's
+//     groups. The second one is what makes un-enrolling on delete possible at
+//     all (see UserGroups) — without it, removing an account from its roles
+//     would mean scanning every group in the directory.
+//
+//  2. **The directory has NO referential integrity between users and group
+//     membership.** `DELETE /users/{id}` leaves every group that account
+//     belonged to pointing at an id that no longer resolves, and a `POST
+//     /groups` carrying such an id is rejected WHOLESALE with
+//     `400 GRP-1007 Invalid user member ID` — which names no id, so the
+//     rejection does not say which member was the bad one.
+//
+//     Those two facts together are a data-loss machine, and it has fired: the
+//     only membership write is a delete-then-create, its payload is built from
+//     membership the directory itself corrupts, and the destructive half goes
+//     first. A group whose member list named a deleted account was DESTROYED
+//     by the next build that tried to enrol somebody into it, permanently,
+//     because the failure is deterministic and every retry repeated it.
+//     rewriteGroupMembers exists to make that outcome impossible: it proves
+//     every id resolves before it deletes anything, and it brings the group
+//     back — empty if it must — if the create fails anyway.
+//  3. **Passwords are write-only on read-back, but `PUT /users/{id}` echoes the
 //     submitted password in plaintext.** Same value the caller sent, so no new
 //     disclosure — but that response body must never reach a log or an error
 //     string. setUserAttributes is the one place that PUTs a user, and it
 //     deliberately does not read the body on success and does not interpolate
 //     it on failure.
-//  3. **There is no server-side user filter.** `GET /users?filter=…` is a 400,
-//     so finding a user by username is a bounded client-side scan.
+//  4. **There is no server-side filter, and the groups listing does not even
+//     REJECT one.** `GET /users?filter=…` is a 400, so finding a user by
+//     username is a bounded client-side scan. `GET /groups?userId=…` is worse:
+//     it answers 200 and silently returns every group, so a caller that
+//     believed it filtered would act on the whole directory. Nothing here
+//     passes a filter parameter to either.
 //
 // Requests here go through doJSON rather than the hand-rolled blocks the
 // application half of this client uses. That is deliberate scope control: the
@@ -51,6 +78,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -114,6 +142,11 @@ func (c *client) ListGroups(ctx context.Context) ([]Group, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getSystemToken: %w", err)
 	}
+	return c.listGroupsWith(ctx, token)
+}
+
+// listGroupsWith is ListGroups with a token the caller already holds.
+func (c *client) listGroupsWith(ctx context.Context, token string) ([]Group, error) {
 	var out []Group
 	for page := 0; page < maxDirectoryPages; page++ {
 		var body struct {
@@ -137,7 +170,18 @@ func (c *client) ListGroups(ctx context.Context) ([]Group, error) {
 // most one can match. The comparison is case-insensitive because the platform
 // treats two role names differing only in case as one role.
 func (c *client) FindGroupByName(ctx context.Context, name string) (*Group, bool, error) {
-	groups, err := c.ListGroups(ctx)
+	token, err := c.getSystemToken(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("getSystemToken: %w", err)
+	}
+	return c.findGroupByNameWith(ctx, token, name)
+}
+
+// findGroupByNameWith is FindGroupByName with a token the caller already holds.
+// rewriteGroupMembers needs it while holding the group lock, to ask the
+// directory what actually happened when a create reports failure.
+func (c *client) findGroupByNameWith(ctx context.Context, token, name string) (*Group, bool, error) {
+	groups, err := c.listGroupsWith(ctx, token)
 	if err != nil {
 		return nil, false, err
 	}
@@ -241,6 +285,12 @@ func (c *client) createGroupLocked(ctx context.Context, token, ou, name, descrip
 // membership write Thunder offers is a delete-and-recreate, so a no-op that
 // "wrote anyway" would change the group's id on every build for no reason.
 //
+// A member id the group ALREADY carries but that no longer resolves is dropped,
+// not replayed — see rewriteGroupMembers. A member id the CALLER asked to add
+// and that does not resolve is a different thing entirely: the caller wanted
+// somebody enrolled, so that is an error, and it is raised before anything is
+// written.
+//
 // Returns the group as it now stands — a DIFFERENT id when members were added.
 func (c *client) AddGroupMembers(ctx context.Context, group Group, memberIDs []string) (Group, error) {
 	token, err := c.getSystemToken(ctx)
@@ -265,23 +315,226 @@ func (c *client) AddGroupMembers(ctx context.Context, group Group, memberIDs []s
 		have[id] = true
 	}
 	union := append([]string(nil), existing...)
+	var added []string
 	for _, id := range memberIDs {
 		if !have[id] {
 			have[id] = true
 			union = append(union, id)
+			added = append(added, id)
 		}
 	}
-	if len(union) == len(existing) {
+	if len(added) == 0 {
 		return group, nil
 	}
-	if err := c.doJSON(ctx, token, http.MethodDelete, "/groups/"+url.PathEscape(group.ID), nil, nil); err != nil {
-		return Group{}, fmt.Errorf("add members to group %q: %w", group.Name, err)
-	}
-	recreated, err := c.createGroupLocked(ctx, token, ou, group.Name, group.Description, union)
+	return c.rewriteGroupMembers(ctx, token, ou, group, union, added)
+}
+
+// RemoveGroupMembers removes memberIDs from a group, keeping everyone else.
+//
+// This is the un-enrol half of the pair, and it exists so that deleting an
+// account can take that account out of its roles FIRST. Skipping it is what
+// leaves a group pointing at an id that no longer resolves — the state that
+// used to destroy the group on the next build (see the file header).
+//
+// Same lock, same read-modify-write, same no-op rule as AddGroupMembers: a
+// removal of somebody who is not a member writes nothing.
+func (c *client) RemoveGroupMembers(ctx context.Context, group Group, memberIDs []string) (Group, error) {
+	token, err := c.getSystemToken(ctx)
 	if err != nil {
-		return Group{}, fmt.Errorf("add members to group %q: recreate after delete: %w", group.Name, err)
+		return Group{}, fmt.Errorf("getSystemToken: %w", err)
 	}
-	return recreated, nil
+	ou := group.OUID
+	if ou == "" {
+		if ou, err = c.getDefaultOUID(ctx, token); err != nil {
+			return Group{}, err
+		}
+	}
+	c.lockGroup(group.Name)
+	defer c.unlockGroup(group.Name)
+
+	existing, err := c.groupMembersWith(ctx, token, group.ID)
+	if err != nil {
+		return Group{}, fmt.Errorf("read members of group %q: %w", group.Name, err)
+	}
+	drop := make(map[string]bool, len(memberIDs))
+	for _, id := range memberIDs {
+		drop[id] = true
+	}
+	remaining := make([]string, 0, len(existing))
+	for _, id := range existing {
+		if !drop[id] {
+			remaining = append(remaining, id)
+		}
+	}
+	if len(remaining) == len(existing) {
+		return group, nil
+	}
+	// Nothing is REQUIRED to resolve here. A removal only ever shrinks the
+	// membership, so the worst a dangling id among the survivors can do is get
+	// dropped too — which is the repair, not a loss.
+	return c.rewriteGroupMembers(ctx, token, ou, group, remaining, nil)
+}
+
+// rewriteGroupMembers replaces a group's membership with `want`, and is the ONE
+// place in this package that rewrites a group. Callers must hold the group's
+// lock.
+//
+// Thunder gives no atomic way to do this: the group is DELETED and created
+// again (file header, fact 1). That makes every membership write a potential
+// group-loss event, so the danger belongs to the operation rather than to any
+// caller — which is why the whole sequence, including what to do when it goes
+// wrong, lives here instead of being repeated at each call site.
+//
+// Two guarantees:
+//
+//   - **Nothing dead is ever written.** Every id in `want` is resolved against
+//     the directory BEFORE the delete. Ones that no longer exist are dropped
+//     and logged; ids in `require` — the ones a caller explicitly asked to add
+//     — must all resolve, and the write is abandoned with an error if any does
+//     not. This is the check whose absence destroyed nine role groups: the
+//     payload was built from membership the directory itself had corrupted.
+//
+//   - **The group always comes back.** If the create fails after the delete has
+//     committed, the same payload is tried once more (a transient failure must
+//     not cost the membership), and failing that the group is recreated EMPTY.
+//     The caller still gets an error — membership was lost, and the build
+//     should fail — but the role continues to exist, so the next build repairs
+//     it instead of finding a hole where a role used to be.
+func (c *client) rewriteGroupMembers(ctx context.Context, token, ou string, group Group, want, require []string) (Group, error) {
+	live, missing, err := c.resolveLiveUsers(ctx, token, want)
+	if err != nil {
+		// Nothing has been written. An unreadable directory is an ordinary
+		// error, and it must never become a delete.
+		return Group{}, fmt.Errorf("rewrite members of group %q: %w", group.Name, err)
+	}
+	if len(missing) > 0 {
+		gone := make(map[string]bool, len(missing))
+		for _, id := range missing {
+			gone[id] = true
+		}
+		var refused []string
+		for _, id := range require {
+			if gone[id] {
+				refused = append(refused, id)
+			}
+		}
+		if len(refused) > 0 {
+			return Group{}, fmt.Errorf(
+				"rewrite members of group %q: %d of the accounts to enrol do not exist on the directory: %s",
+				group.Name, len(refused), strings.Join(refused, ", "))
+		}
+		// Carried-over members only. Dropping them is the repair — replaying
+		// them is what the directory rejects — but say so, because a role
+		// quietly losing members is exactly the kind of thing nobody notices.
+		slog.WarnContext(ctx, "thunder: dropping group members that no longer exist on the directory",
+			"group", group.Name, "dropped", len(missing), "memberIDs", strings.Join(missing, ","),
+			"cause", "the identity provider does not remove a deleted account from its groups")
+	}
+
+	if err := c.doJSON(ctx, token, http.MethodDelete, "/groups/"+url.PathEscape(group.ID), nil, nil); err != nil {
+		return Group{}, fmt.Errorf("rewrite members of group %q: delete: %w", group.Name, err)
+	}
+
+	recreated, createErr := c.recreateGroup(ctx, token, ou, group, live)
+	if createErr == nil {
+		return recreated, nil
+	}
+	// One retry with the SAME payload. Past this point the group does not
+	// exist, so the choice is between trying again and giving up on the
+	// membership — and a blip must not cost the membership.
+	if recreated, err := c.recreateGroup(ctx, token, ou, group, live); err == nil {
+		return recreated, nil
+	}
+	// Last resort: the ROLE has to exist even if its membership does not.
+	if empty, err := c.recreateGroup(ctx, token, ou, group, nil); err == nil {
+		return Group{}, fmt.Errorf(
+			"rewrite members of group %q: recreate failed (%w); the group was restored EMPTY as %s "+
+				"and its members were lost — the next build re-enrols them",
+			group.Name, createErr, empty.ID)
+	}
+	return Group{}, fmt.Errorf(
+		"rewrite members of group %q: recreate after delete failed (%w) and so did the empty restore — "+
+			"THE GROUP NO LONGER EXISTS and must be recreated before this role can be used",
+		group.Name, createErr)
+}
+
+// recreateGroup creates the group and reconciles the one ambiguous outcome:
+// a create whose response was lost looks exactly like a create that failed, and
+// re-POSTing a name Thunder already holds is a 409 on the unique name. So a
+// failure is followed by asking the directory what is actually there. Without
+// this, a lost response would send rewriteGroupMembers down its compensation
+// path and report a group as gone while it sits there, correct and complete.
+func (c *client) recreateGroup(ctx context.Context, token, ou string, group Group, memberIDs []string) (Group, error) {
+	created, err := c.createGroupLocked(ctx, token, ou, group.Name, group.Description, memberIDs)
+	if err == nil {
+		return created, nil
+	}
+	if actual, found, ferr := c.findGroupByNameWith(ctx, token, group.Name); ferr == nil && found {
+		return *actual, nil
+	}
+	return Group{}, err
+}
+
+// resolveLiveUsers splits ids into the ones the directory still has and the
+// ones it does not, preserving the order of the input.
+//
+// It is one GET per id because there is no bulk or filtered read (file header,
+// fact 4). That is affordable here and nowhere else: this runs on the roles
+// ensure and the console's delete button, over groups holding single-digit
+// numbers of accounts — not on a request path.
+//
+// A 404 means gone. Any OTHER failure is returned as an error rather than
+// counted as gone, because treating an unreachable directory as "nobody
+// exists" would turn a network blip into a membership wipe.
+func (c *client) resolveLiveUsers(ctx context.Context, token string, ids []string) (live, missing []string, err error) {
+	for _, id := range ids {
+		lookupErr := c.doJSONNoEcho(ctx, token, http.MethodGet, "/users/"+url.PathEscape(id), nil, nil)
+		if lookupErr == nil {
+			live = append(live, id)
+			continue
+		}
+		var status *statusError
+		if errors.As(lookupErr, &status) && status.code == http.StatusNotFound {
+			missing = append(missing, id)
+			continue
+		}
+		return nil, nil, fmt.Errorf("resolve member: %w", lookupErr)
+	}
+	return live, missing, nil
+}
+
+// UserGroups returns the groups an account belongs to.
+//
+// `GET /users/{id}/groups` is the reverse of the membership read, and it is
+// what lets a delete un-enrol precisely instead of scanning the directory. An
+// account that is already gone answers 404, which is reported as "no groups"
+// so a retried delete does not fail on its own first step.
+func (c *client) UserGroups(ctx context.Context, userID string) ([]Group, error) {
+	token, err := c.getSystemToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getSystemToken: %w", err)
+	}
+	var out []Group
+	for page := 0; page < maxDirectoryPages; page++ {
+		var body struct {
+			TotalResults int     `json:"totalResults"`
+			Groups       []Group `json:"groups"`
+		}
+		path := fmt.Sprintf("/users/%s/groups?limit=%d&offset=%d",
+			url.PathEscape(userID), directoryPageSize, len(out))
+		if err := c.doJSON(ctx, token, http.MethodGet, path, nil, &body); err != nil {
+			var status *statusError
+			if errors.As(err, &status) && status.code == http.StatusNotFound {
+				return nil, nil
+			}
+			return nil, err
+		}
+		out = append(out, body.Groups...)
+		if !morePages(len(out), body.TotalResults, len(body.Groups)) {
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("thunder list groups of user: more than %d pages", maxDirectoryPages)
 }
 
 // userRecord is Thunder's wire shape for a person. `attributes` is an open map

--- a/services/aep-api/internal/clients/thundersvc/directory_test.go
+++ b/services/aep-api/internal/clients/thundersvc/directory_test.go
@@ -633,10 +633,31 @@ func TestCreateGroup_SendsAnEmptyMemberArrayNotNull(t *testing.T) {
 // -- AddGroupMembers ----------------------------------------------------------
 
 // addMembersStub answers the read-modify-write AddGroupMembers performs against
-// one group: the members read, the delete, and the recreate.
-func addMembersStub(t *testing.T, groupID string, existing []string, recreated Group, recreateStatus int) func(http.ResponseWriter, *http.Request, []byte) {
+// one group: the liveness resolution of every id it is about to write, the
+// members read, the delete, and the recreate.
+//
+// `live` is the set of ids the directory still HAS, and it is deliberately
+// separate from `existing` — the ids the group's member list names. A directory
+// where those two always agree cannot express the state this whole mechanism
+// exists to survive: a group naming an account that has been deleted. Pass an
+// id in `existing` but not in `live` to model exactly that.
+func addMembersStub(t *testing.T, groupID string, existing, live []string, recreated Group, recreateStatus int) func(http.ResponseWriter, *http.Request, []byte) {
+	has := make(map[string]bool, len(live))
+	for _, id := range live {
+		has[id] = true
+	}
 	return func(w http.ResponseWriter, r *http.Request, _ []byte) {
 		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			if !has[strings.TrimPrefix(r.URL.Path, "/users/")] {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": strings.TrimPrefix(r.URL.Path, "/users/")})
+		case r.Method == http.MethodGet && r.URL.Path == "/groups":
+			// The by-name re-read recreateGroup does after a failed create.
+			// This stub's group is gone by then, so the honest answer is empty.
+			_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": 0, "groups": []Group{}})
 		case r.Method == http.MethodGet && r.URL.Path == "/groups/"+groupID+"/members":
 			members := make([]map[string]string, 0, len(existing))
 			for _, id := range existing {
@@ -665,7 +686,7 @@ func TestAddGroupMembers_ReadsThenRecreatesWithTheUnion(t *testing.T) {
 	// create before the delete is a 409 on the unique name, and a recreate that
 	// forgot to read first would silently drop everyone already in the group.
 	recreated := Group{ID: "g-new", Name: "admin", Description: "the admins", OUID: "ou-1"}
-	stub := &directoryStub{handle: addMembersStub(t, "g-old", []string{"u-1"}, recreated, 0)}
+	stub := &directoryStub{handle: addMembersStub(t, "g-old", []string{"u-1"}, []string{"u-1", "u-2"}, recreated, 0)}
 	srv := stub.server(t)
 	defer srv.Close()
 
@@ -676,7 +697,12 @@ func TestAddGroupMembers_ReadsThenRecreatesWithTheUnion(t *testing.T) {
 	}
 
 	// The group already carries its OU, so no default-OU lookup is needed.
-	wantSeq(t, stub.seq(), "GET /groups/g-old/members", "DELETE /groups/g-old", "POST /groups")
+	// Every id is resolved BEFORE the delete: that ordering is the guarantee,
+	// because the delete cannot be undone and a rejected create is fatal.
+	wantSeq(t, stub.seq(),
+		"GET /groups/g-old/members",
+		"GET /users/u-1", "GET /users/u-2",
+		"DELETE /groups/g-old", "POST /groups")
 
 	var body struct {
 		Name        string `json:"name"`
@@ -708,7 +734,7 @@ func TestAddGroupMembers_NoOpWhenEveryMemberIsAlreadyPresent(t *testing.T) {
 	// The only membership write Thunder offers is a delete-and-recreate, which
 	// changes the group id. Doing that for nothing would churn the id on every
 	// build — and briefly leave the role absent for no reason at all.
-	stub := &directoryStub{handle: addMembersStub(t, "g-old", []string{"u-1", "u-2"}, Group{ID: "g-new"}, 0)}
+	stub := &directoryStub{handle: addMembersStub(t, "g-old", []string{"u-1", "u-2"}, []string{"u-1", "u-2"}, Group{ID: "g-new"}, 0)}
 	srv := stub.server(t)
 	defer srv.Close()
 
@@ -726,7 +752,7 @@ func TestAddGroupMembers_NoOpWhenEveryMemberIsAlreadyPresent(t *testing.T) {
 func TestAddGroupMembers_ResolvesDefaultOUWhenTheGroupHasNone(t *testing.T) {
 	stub := &directoryStub{
 		ouID:   "ou-default",
-		handle: addMembersStub(t, "g-old", []string{"u-1"}, Group{ID: "g-new"}, 0),
+		handle: addMembersStub(t, "g-old", []string{"u-1"}, []string{"u-1", "u-2"}, Group{ID: "g-new"}, 0),
 	}
 	srv := stub.server(t)
 	defer srv.Close()
@@ -738,6 +764,7 @@ func TestAddGroupMembers_ResolvesDefaultOUWhenTheGroupHasNone(t *testing.T) {
 	wantSeq(t, stub.seq(),
 		"GET /organization-units/tree/default",
 		"GET /groups/g-old/members",
+		"GET /users/u-1", "GET /users/u-2",
 		"DELETE /groups/g-old",
 		"POST /groups")
 
@@ -776,32 +803,76 @@ func TestAddGroupMembers_DoesNotDeleteWhenTheMembershipReadFails(t *testing.T) {
 	wantSeq(t, stub.seq(), "GET /groups/g-old/members")
 }
 
-func TestAddGroupMembers_RecreateFailureSaysTheGroupIsGone(t *testing.T) {
-	// The operation is not atomic: a failed recreate leaves the group deleted.
-	// The error has to say which group and that the delete already happened,
-	// because that is the difference between "nothing changed" and "the role
-	// no longer exists until the next build".
-	stub := &directoryStub{handle: addMembersStub(t, "g-old", []string{"u-1"}, Group{}, http.StatusInternalServerError)}
+func TestAddGroupMembers_RecreateFailureRestoresTheGroupEmpty(t *testing.T) {
+	// The operation is not atomic: once the delete has committed, a failed
+	// recreate would leave NO GROUP AT ALL — the role would simply cease to
+	// exist, and every project that declares it would fail at planning until
+	// somebody noticed. So the failure path is a ladder: retry the same
+	// payload once for a transient blip, then recreate the group EMPTY so the
+	// role survives. The caller still gets an error, because membership WAS
+	// lost and the build must not proceed as if a test user could sign in.
+	//
+	// This stub refuses any create carrying members and accepts an empty one,
+	// which is the shape of the real failure: Thunder rejects the whole POST
+	// for one bad member id.
+	var creates []int
+	stub := &directoryStub{handle: func(w http.ResponseWriter, r *http.Request, body []byte) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "u"})
+		case r.Method == http.MethodGet && r.URL.Path == "/groups/g-old/members":
+			_ = json.NewEncoder(w).Encode(memberPage([]map[string]string{{"id": "u-1", "type": "user"}}, 1))
+		case r.Method == http.MethodDelete && r.URL.Path == "/groups/g-old":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/groups":
+			_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": 0, "groups": []Group{}})
+		case r.Method == http.MethodPost && r.URL.Path == "/groups":
+			var req struct {
+				Members []struct{ ID string } `json:"members"`
+			}
+			_ = json.Unmarshal(body, &req)
+			creates = append(creates, len(req.Members))
+			if len(req.Members) > 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":"GRP-1007","message":"Invalid user member ID"}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(Group{ID: "g-restored", Name: "project-admin", OUID: "ou-1"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}}
 	srv := stub.server(t)
 	defer srv.Close()
 
 	old := Group{ID: "g-old", Name: "project-admin", OUID: "ou-1"}
 	got, err := newTestClient(srv.URL).AddGroupMembers(context.Background(), old, []string{"u-2"})
 	if err == nil {
-		t.Fatalf("want an error when the recreate fails, got group %+v", got)
+		t.Fatalf("want an error when the membership could not be written, got group %+v", got)
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "project-admin") {
-		t.Errorf("error should name the group, got %q", msg)
-	}
-	if !strings.Contains(msg, "after delete") {
-		t.Errorf("error should say the delete already happened, got %q", msg)
+	for _, want := range []string{"project-admin", "restored EMPTY", "g-restored"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q so the loss is actionable, got %q", want, msg)
+		}
 	}
 	if got != (Group{}) {
 		t.Errorf("want a zero Group alongside the error, got %+v", got)
 	}
-	// Prove the delete really did land — otherwise the message above is a lie.
-	wantSeq(t, stub.seq(), "GET /groups/g-old/members", "DELETE /groups/g-old", "POST /groups")
+	// Two attempts at the real payload, then the empty restore. The retry is
+	// what keeps a transient failure from costing the membership.
+	if len(creates) != 3 || creates[0] != 2 || creates[1] != 2 || creates[2] != 0 {
+		t.Errorf("create payload sizes = %v, want [2 2 0]: the payload twice, then empty", creates)
+	}
+	// The group EXISTS again when this returns. That is the guarantee.
+	if got := stub.snapshot(); len(got) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	last := stub.snapshot()[len(stub.snapshot())-1]
+	if last.Method != http.MethodPost || last.Path != "/groups" {
+		t.Errorf("last request was %s, want the restoring POST /groups", last)
+	}
 }
 
 // -- the lost update ----------------------------------------------------------
@@ -813,26 +884,72 @@ type storedGroup struct {
 	present            bool
 }
 
-// groupStore is a stateful Thunder group store for the read-modify-write race
-// test. It is keyed by NAME, and every id the group has ever had resolves to
-// the live record, so a caller holding a pre-recreate id still reads current
-// membership — that keeps the test about the lost update rather than about id
-// staleness. Recreating a name that is still present is a 409, as Thunder does.
+// groupStore is a stateful Thunder group store. It is keyed by NAME, and every
+// id the group has ever had resolves to the live record, so a caller holding a
+// pre-recreate id still reads current membership — that keeps the race test
+// about the lost update rather than about id staleness. Recreating a name that
+// is still present is a 409, as Thunder does.
+//
+// It also holds the USERS, and this is the part that matters most. Thunder
+// rejects a group create carrying a member id it does not have — the whole
+// POST, with `400 GRP-1007` — and it does NOT remove a deleted account from the
+// groups that name it. A double where group membership and the user store
+// cannot disagree makes that rejection unreachable, which is exactly why nine
+// role groups were destroyed in production by a code path this package's tests
+// covered. So membership here is just a list of ids, deleteUser leaves those
+// ids behind on purpose, and create validates against `users`.
 type groupStore struct {
 	mu        sync.Mutex
 	byName    map[string]*storedGroup
 	byID      map[string]*storedGroup
+	users     map[string]bool
 	next      int
 	readDelay time.Duration
 }
 
 func newGroupStore(name, id string, members []string, readDelay time.Duration) *groupStore {
 	g := &storedGroup{id: id, name: name, ou: "ou-1", members: members, present: true}
-	return &groupStore{
+	s := &groupStore{
 		byName:    map[string]*storedGroup{name: g},
 		byID:      map[string]*storedGroup{id: g},
+		users:     map[string]bool{},
 		readDelay: readDelay,
 	}
+	// Every seeded member exists to begin with; a test that wants a dangling
+	// one calls deleteUser, the way the platform's own delete used to.
+	for _, m := range members {
+		s.users[m] = true
+	}
+	return s
+}
+
+// addUser makes an account exist.
+func (s *groupStore) addUser(ids ...string) *groupStore {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ids {
+		s.users[id] = true
+	}
+	return s
+}
+
+// deleteUser removes an account WITHOUT touching the groups that name it —
+// Thunder has no referential integrity here, and reproducing that is the whole
+// point of this double.
+func (s *groupStore) deleteUser(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.users, id)
+}
+
+func (s *groupStore) groupNamed(name string) (storedGroup, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	g, ok := s.byName[name]
+	if !ok || !g.present {
+		return storedGroup{}, false
+	}
+	return *g, true
 }
 
 func (s *groupStore) membersOf(name string) []string {
@@ -848,6 +965,57 @@ func (s *groupStore) membersOf(name string) []string {
 func (s *groupStore) handle(t *testing.T) func(http.ResponseWriter, *http.Request, []byte) {
 	return func(w http.ResponseWriter, r *http.Request, body []byte) {
 		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/") &&
+			strings.HasSuffix(r.URL.Path, "/groups"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/users/"), "/groups")
+			s.mu.Lock()
+			if !s.users[id] {
+				s.mu.Unlock()
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			var out []Group
+			for _, g := range s.byName {
+				if !g.present {
+					continue
+				}
+				for _, m := range g.members {
+					if m == id {
+						out = append(out, Group{ID: g.id, Name: g.name, Description: g.desc, OUID: g.ou})
+						break
+					}
+				}
+			}
+			s.mu.Unlock()
+			sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+			_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": len(out), "groups": out})
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			s.mu.Lock()
+			exists := s.users[strings.TrimPrefix(r.URL.Path, "/users/")]
+			s.mu.Unlock()
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": strings.TrimPrefix(r.URL.Path, "/users/")})
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/users/"):
+			s.deleteUser(strings.TrimPrefix(r.URL.Path, "/users/"))
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/groups":
+			s.mu.Lock()
+			var out []Group
+			for _, g := range s.byName {
+				if g.present {
+					out = append(out, Group{ID: g.id, Name: g.name, Description: g.desc, OUID: g.ou})
+				}
+			}
+			s.mu.Unlock()
+			sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+			_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": len(out), "groups": out})
+
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/members"):
 			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/groups/"), "/members")
 			s.mu.Lock()
@@ -897,6 +1065,17 @@ func (s *groupStore) handle(t *testing.T) func(http.ResponseWriter, *http.Reques
 				t.Errorf("undecodable create body %q: %v", body, err)
 			}
 			s.mu.Lock()
+			// GRP-1007: one member id the directory does not have rejects the
+			// WHOLE create. This is the rejection that turns a delete-then-
+			// create into permanent group loss.
+			for _, m := range req.Members {
+				if !s.users[m.ID] {
+					s.mu.Unlock()
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"code":"GRP-1007","message":"Invalid user member ID"}`))
+					return
+				}
+			}
 			g, ok := s.byName[req.Name]
 			if !ok {
 				g = &storedGroup{name: req.Name}
@@ -934,6 +1113,9 @@ func TestAddGroupMembers_ConcurrentAddsDoNotLoseAMember(t *testing.T) {
 	// so moving it out must turn this red.
 	const goroutines = 6
 	store := newGroupStore("admin", "g-0", []string{"u-seed"}, 2*time.Millisecond)
+	for i := 0; i < goroutines; i++ {
+		store.addUser(fmt.Sprintf("u-%d", i))
+	}
 	stub := &directoryStub{handle: store.handle(t)}
 	srv := stub.server(t)
 	defer srv.Close()
@@ -1600,4 +1782,259 @@ func TestSetUserPassword_PreservesNonStringAttributes(t *testing.T) {
 	if attrs["password"] != "Aep1!new" {
 		t.Errorf("password not set: %+v", attrs)
 	}
+}
+
+// -- the dangling member ------------------------------------------------------
+//
+// These are the tests this package was missing. Every double it had modelled
+// group membership and the user store as one consistent thing, so the state
+// that destroyed nine role groups in production — a group naming an account the
+// directory no longer has — could not be expressed, and the failure it causes
+// could not be reached.
+
+func TestAddGroupMembers_DropsAMemberTheDirectoryNoLongerHas(t *testing.T) {
+	// The production incident, start to finish. A role group holds a test
+	// account; the account is deleted (which Thunder does NOT un-enrol); the
+	// next build enrols a fresh account into the same role.
+	//
+	// Replaying the dead id is what Thunder rejects, and the rejection lands
+	// after the delete has committed — so before this fix the group ceased to
+	// exist and the build failed at planning, permanently, on every retry.
+	store := newGroupStore("Manager", "g-0", []string{"test-manager-old"}, 0).addUser("test-manager-new")
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	store.deleteUser("test-manager-old") // the arming step
+
+	group := Group{ID: "g-0", Name: "Manager", Description: "approvers", OUID: "ou-1"}
+	got, err := newTestClient(srv.URL).AddGroupMembers(context.Background(), group, []string{"test-manager-new"})
+	if err != nil {
+		t.Fatalf("a dangling member must not fail the enrolment: %v", err)
+	}
+	if got.ID == "g-0" || got.ID == "" {
+		t.Errorf("returned id %q, want the id of the recreated group", got.ID)
+	}
+	live, ok := store.groupNamed("Manager")
+	if !ok {
+		t.Fatal("the group no longer exists — this is the production failure")
+	}
+	if strings.Join(sortedCopy(live.members), ",") != "test-manager-new" {
+		t.Errorf("membership = %v, want only the live account: the dead id must be dropped, not replayed", live.members)
+	}
+	if live.name != "Manager" || live.desc != "approvers" {
+		t.Errorf("recreated as %+v, want the name and description preserved", live)
+	}
+}
+
+func TestAddGroupMembers_RefusesAnAccountToEnrolThatDoesNotExist_BeforeWriting(t *testing.T) {
+	// A member the group already carries and a member the caller asks to add
+	// are not the same kind of thing. Dropping the first is the repair. Dropping
+	// the second would mean reporting success for an enrolment that did not
+	// happen — and the validation agent would then fail to sign in with a
+	// credential the gate published as working.
+	//
+	// So this is an error, and it has to be raised while the group is still
+	// intact: nothing may be deleted on behalf of a write that cannot succeed.
+	store := newGroupStore("Finance", "g-0", []string{"u-live"}, 0)
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	group := Group{ID: "g-0", Name: "Finance", OUID: "ou-1"}
+	got, err := newTestClient(srv.URL).AddGroupMembers(context.Background(), group, []string{"u-ghost"})
+	if err == nil {
+		t.Fatalf("want an error for an account that does not exist, got %+v", got)
+	}
+	if !strings.Contains(err.Error(), "u-ghost") {
+		t.Errorf("error must name the account that does not exist, got %q", err)
+	}
+	if got != (Group{}) {
+		t.Errorf("want a zero Group alongside the error, got %+v", got)
+	}
+	live, ok := store.groupNamed("Finance")
+	if !ok {
+		t.Fatal("the group was deleted for a write that could never have succeeded")
+	}
+	if live.id != "g-0" || strings.Join(live.members, ",") != "u-live" {
+		t.Errorf("group = %+v, want it untouched at g-0 with u-live", live)
+	}
+	for _, c := range stub.snapshot() {
+		if c.Method == http.MethodDelete || c.Method == http.MethodPost {
+			t.Errorf("nothing may be written before the ids are known good, got %s", c)
+		}
+	}
+}
+
+func TestAddGroupMembers_AnUnreadableDirectoryIsNotAnAbsentMember(t *testing.T) {
+	// A 404 means the account is gone. Anything else means we do not know, and
+	// guessing "gone" would let one bad response wipe a role's membership —
+	// the resolution would drop every id it could not read and then write the
+	// remainder. So a non-404 aborts, before the delete.
+	stub := &directoryStub{handle: func(w http.ResponseWriter, r *http.Request, _ []byte) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/groups/g-0/members":
+			_ = json.NewEncoder(w).Encode(memberPage([]map[string]string{{"id": "u-1", "type": "user"}}, 1))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/users/"):
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			t.Errorf("must not write when member liveness is unknown, got %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	group := Group{ID: "g-0", Name: "Employee", OUID: "ou-1"}
+	if _, err := newTestClient(srv.URL).AddGroupMembers(context.Background(), group, []string{"u-2"}); err == nil {
+		t.Fatal("want an error when the directory cannot be read")
+	}
+	for _, c := range stub.snapshot() {
+		if c.Method == http.MethodDelete {
+			t.Errorf("deleted the group on an unreadable directory: %s", c)
+		}
+	}
+}
+
+// -- RemoveGroupMembers -------------------------------------------------------
+
+func TestRemoveGroupMembers_KeepsEveryoneElse(t *testing.T) {
+	store := newGroupStore("Manager", "g-0", []string{"u-1", "u-2", "u-3"}, 0)
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	group := Group{ID: "g-0", Name: "Manager", Description: "approvers", OUID: "ou-1"}
+	got, err := newTestClient(srv.URL).RemoveGroupMembers(context.Background(), group, []string{"u-2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID == "g-0" {
+		t.Error("the id must change: the write is a delete-and-recreate")
+	}
+	live, _ := store.groupNamed("Manager")
+	if strings.Join(sortedCopy(live.members), ",") != "u-1,u-3" {
+		t.Errorf("membership = %v, want u-1 and u-3 kept", live.members)
+	}
+}
+
+func TestRemoveGroupMembers_NoOpWhenTheAccountIsNotAMember(t *testing.T) {
+	// Same reason as the add path: rewriting for nothing churns the group id,
+	// and every rewrite is a window in which the role does not exist.
+	store := newGroupStore("Manager", "g-0", []string{"u-1"}, 0)
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	group := Group{ID: "g-0", Name: "Manager", OUID: "ou-1"}
+	got, err := newTestClient(srv.URL).RemoveGroupMembers(context.Background(), group, []string{"u-9"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != group {
+		t.Errorf("returned %+v, want the group unchanged", got)
+	}
+	wantSeq(t, stub.seq(), "GET /groups/g-0/members")
+}
+
+func TestRemoveGroupMembers_AlsoRepairsADanglingSurvivor(t *testing.T) {
+	// Removing one account rewrites the whole group, so the ids that survive
+	// the removal go through the same liveness resolution. A dangling one among
+	// them is dropped — the repair, not a loss — which means an un-enrol can
+	// never be the thing that re-arms the group it is cleaning.
+	store := newGroupStore("Manager", "g-0", []string{"u-keep", "u-dead", "u-go"}, 0)
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+	store.deleteUser("u-dead")
+
+	group := Group{ID: "g-0", Name: "Manager", OUID: "ou-1"}
+	if _, err := newTestClient(srv.URL).RemoveGroupMembers(context.Background(), group, []string{"u-go"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	live, ok := store.groupNamed("Manager")
+	if !ok {
+		t.Fatal("the group no longer exists")
+	}
+	if strings.Join(sortedCopy(live.members), ",") != "u-keep" {
+		t.Errorf("membership = %v, want only u-keep", live.members)
+	}
+}
+
+// -- UserGroups ---------------------------------------------------------------
+
+func TestUserGroups_ReturnsTheGroupsTheAccountIsIn(t *testing.T) {
+	store := newGroupStore("Manager", "g-0", []string{"u-1"}, 0)
+	stub := &directoryStub{handle: store.handle(t)}
+	srv := stub.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	// A second group holding the same account, and a third that does not.
+	store.addUser("u-2")
+	if _, err := c.CreateGroup(context.Background(), "Employee", "", []string{"u-1"}); err != nil {
+		t.Fatalf("seed Employee: %v", err)
+	}
+	if _, err := c.CreateGroup(context.Background(), "Other", "", []string{"u-2"}); err != nil {
+		t.Fatalf("seed Other: %v", err)
+	}
+
+	groups, err := c.UserGroups(context.Background(), "u-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var names []string
+	for _, g := range groups {
+		names = append(names, g.Name)
+	}
+	if strings.Join(sortedCopy(names), ",") != "Employee,Manager" {
+		t.Errorf("groups = %v, want exactly the two the account is in", names)
+	}
+}
+
+func TestUserGroups_AnAccountThatIsAlreadyGoneHasNoGroups(t *testing.T) {
+	// The console can retry a delete, and the un-enrol step runs first. An
+	// account removed by an earlier attempt must not make the retry fail on its
+	// own opening move.
+	stub := &directoryStub{handle: func(w http.ResponseWriter, _ *http.Request, _ []byte) {
+		w.WriteHeader(http.StatusNotFound)
+	}}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	groups, err := newTestClient(srv.URL).UserGroups(context.Background(), "u-gone")
+	if err != nil {
+		t.Fatalf("a missing account must not be an error: %v", err)
+	}
+	if len(groups) != 0 {
+		t.Errorf("groups = %v, want none", groups)
+	}
+}
+
+func TestUserGroups_PagesOnWhatItReceived(t *testing.T) {
+	// Same cursor rule as every other listing here: advance by records
+	// RECEIVED, never by page × requested-limit, or a server that caps the
+	// limit silently truncates the answer. A truncated answer here means an
+	// un-enrol that misses a role and leaves the dangling member behind.
+	all := makeGroups(7)
+	const cap = 3
+	stub := &directoryStub{handle: func(w http.ResponseWriter, r *http.Request, _ []byte) {
+		if r.Method != http.MethodGet || r.URL.Path != "/users/u-1/groups" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			return
+		}
+		start, end := pageWindow(len(all), intQuery(t, r, "offset"), cap)
+		_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": len(all), "groups": all[start:end]})
+	}}
+	srv := stub.server(t)
+	defer srv.Close()
+
+	groups, err := newTestClient(srv.URL).UserGroups(context.Background(), "u-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != len(all) {
+		t.Fatalf("got %d groups, want all %d", len(groups), len(all))
+	}
+	wantPagingQueries(t, stub.snapshot(), 0, 3, 6)
 }

--- a/services/aep-api/internal/identity/fakes_test.go
+++ b/services/aep-api/internal/identity/fakes_test.go
@@ -31,7 +31,14 @@ package identity
 //   - membership is settable only at create, so AddMembers is a
 //     delete-and-recreate that hands back a NEW group id;
 //   - that recreate is skipped when every id is already in the group, which is
-//     what keeps an unchanged re-run from churning the group's identity.
+//     what keeps an unchanged re-run from churning the group's identity;
+//   - **the IdP has no referential integrity between accounts and group
+//     membership.** DeleteUser here leaves the member lists that name the
+//     account exactly as they were, and a create carrying an id no account
+//     has is REFUSED — both as the real one behaves. A fake where those two
+//     could not disagree is why a code path with tests to spare still
+//     destroyed nine role groups in production: the state that breaks it was
+//     unrepresentable, so no test could ask for it.
 
 import (
 	"context"
@@ -61,7 +68,7 @@ type dirCall struct {
 // (a lost lookup would be a real behaviour change) but they say nothing about
 // what the ensure did, so order and count assertions filter to these.
 var writeOps = map[string]bool{
-	"CreateGroup": true, "AddMembers": true, "DeleteGroup": true,
+	"CreateGroup": true, "AddMembers": true, "RemoveMembers": true, "DeleteGroup": true,
 	"CreateUser": true, "SetUserPassword": true, "DeleteUser": true,
 }
 
@@ -95,7 +102,8 @@ func newFakeDirectory() *fakeDirectory {
 }
 
 // seedGroup puts a group on the directory that the platform did not create —
-// the `Administrators` case.
+// the `Administrators` case. The member ids are taken as given: seeding one
+// that no account has is how a test asks for the dangling-member state.
 func (d *fakeDirectory) seedGroup(name string, memberIDs ...string) DirectoryGroup {
 	d.nextID++
 	g := DirectoryGroup{ID: fmt.Sprintf("grp-%d", d.nextID), Name: name, Description: "seeded"}
@@ -198,6 +206,13 @@ func (d *fakeDirectory) CreateGroup(_ context.Context, name, description string,
 	if _, exists := d.groups[strings.ToLower(name)]; exists {
 		return DirectoryGroup{}, fmt.Errorf("fake directory: group %q already exists", name)
 	}
+	// GRP-1007: the IdP rejects the whole create for one member it does not
+	// have. The client is expected to have resolved the ids first.
+	for _, id := range memberIDs {
+		if !d.hasAccountID(id) {
+			return DirectoryGroup{}, fmt.Errorf("fake directory: group %q: invalid user member id %q", name, id)
+		}
+	}
 	d.nextID++
 	g := DirectoryGroup{ID: fmt.Sprintf("grp-%d", d.nextID), Name: name, Description: description}
 	d.groups[strings.ToLower(name)] = g
@@ -229,6 +244,14 @@ func (d *fakeDirectory) AddMembers(_ context.Context, group DirectoryGroup, memb
 	if len(added) == 0 {
 		return group, nil
 	}
+	// An account to ENROL that the directory does not have is an error; a
+	// member the group merely carries and the directory has lost is dropped.
+	// The real client draws exactly this line — see rewriteGroupMembers.
+	for _, id := range added {
+		if !d.hasAccountID(id) {
+			return DirectoryGroup{}, fmt.Errorf("fake directory: group %q: invalid user member id %q", group.Name, id)
+		}
+	}
 	delete(d.members, group.ID)
 	d.nextID++
 	recreated := DirectoryGroup{
@@ -236,8 +259,91 @@ func (d *fakeDirectory) AddMembers(_ context.Context, group DirectoryGroup, memb
 		Description: group.Description, OUID: group.OUID,
 	}
 	d.groups[strings.ToLower(group.Name)] = recreated
-	d.members[recreated.ID] = append(append([]string(nil), existing...), added...)
+	d.members[recreated.ID] = append(d.liveMembers(existing), added...)
 	return recreated, nil
+}
+
+// hasAccountID reports whether any account on the directory has this id. The
+// port speaks ids and the accounts are keyed by username, so the reverse
+// lookup is what makes the referential rule checkable.
+func (d *fakeDirectory) hasAccountID(id string) bool {
+	for _, a := range d.users {
+		if a.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// liveMembers is the real client's guarantee, modelled: a member the directory
+// no longer has is dropped from a rewrite rather than replayed into it.
+func (d *fakeDirectory) liveMembers(ids []string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if d.hasAccountID(id) {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// RemoveMembers is the un-enrol half: the same delete-and-recreate, minus the
+// ids being removed, with a new group id when anything changed.
+func (d *fakeDirectory) RemoveMembers(_ context.Context, group DirectoryGroup, memberIDs []string) (DirectoryGroup, error) {
+	drop := map[string]bool{}
+	for _, id := range memberIDs {
+		drop[id] = true
+	}
+	existing := d.members[group.ID]
+	var remaining, removed []string
+	for _, id := range existing {
+		if drop[id] {
+			removed = append(removed, id)
+			continue
+		}
+		remaining = append(remaining, id)
+	}
+	d.record(dirCall{Op: "RemoveMembers", Target: group.Name, Members: removed, NoOp: len(removed) == 0})
+	if err := d.fail("RemoveMembers"); err != nil {
+		return DirectoryGroup{}, err
+	}
+	if len(removed) == 0 {
+		return group, nil
+	}
+	delete(d.members, group.ID)
+	d.nextID++
+	recreated := DirectoryGroup{
+		ID: fmt.Sprintf("grp-%d", d.nextID), Name: group.Name,
+		Description: group.Description, OUID: group.OUID,
+	}
+	d.groups[strings.ToLower(group.Name)] = recreated
+	// The survivors go through the same liveness filter a real rewrite applies.
+	d.members[recreated.ID] = d.liveMembers(remaining)
+	return recreated, nil
+}
+
+// UserGroups is the reverse membership read. An account the directory does not
+// have reports NO groups rather than an error — the real one 404s, and a
+// retried delete must not fail on its opening move.
+func (d *fakeDirectory) UserGroups(_ context.Context, userID string) ([]DirectoryGroup, error) {
+	d.record(dirCall{Op: "UserGroups", Target: userID})
+	if err := d.fail("UserGroups"); err != nil {
+		return nil, err
+	}
+	if !d.hasAccountID(userID) {
+		return nil, nil
+	}
+	var out []DirectoryGroup
+	for _, g := range d.groups {
+		for _, m := range d.members[g.ID] {
+			if m == userID {
+				out = append(out, g)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
 }
 
 func (d *fakeDirectory) DeleteGroup(_ context.Context, groupID string) error {

--- a/services/aep-api/internal/identity/panel.go
+++ b/services/aep-api/internal/identity/panel.go
@@ -301,10 +301,13 @@ func (s *PanelService) Rotate(ctx context.Context, orgID, projectID, username st
 
 // DeleteResult is what a delete did. RemainingReferences is how many OTHER
 // projects still referenced the account when it went — the honest warning the
-// shared directory makes necessary.
+// shared directory makes necessary. UnenrolledFrom names the roles the account
+// was taken out of on the way, which is the part of the work that is invisible
+// from the directory afterwards.
 type DeleteResult struct {
 	Username            string
 	RemainingReferences int
+	UnenrolledFrom      []string
 }
 
 // Delete removes the account from the directory and forgets the platform's
@@ -314,6 +317,27 @@ type DeleteResult struct {
 // them: dropping `Support Agent` because one test login went away would take the
 // role from every other project that names it, and from every real member of it.
 // The additive-only rule that governs the ensure governs this too.
+//
+// It DOES take the account out of its roles first, and that ordering is the
+// whole point. The identity provider has no referential integrity between
+// accounts and group membership: deleting an account leaves every group it
+// belonged to naming an id that no longer resolves, and the next build that
+// tries to enrol somebody into such a role used to DESTROY it — the write is a
+// delete-and-recreate, and the recreate is rejected wholesale for the dead
+// member. This function is where that corruption was introduced, so it is
+// where it has to stop.
+//
+// Un-enrol first, then delete. The failure modes are not symmetrical:
+//
+//   - un-enrol fails → nothing has happened, the account is still whole, and
+//     the caller can retry. So a failure here ABORTS the delete rather than
+//     pressing on: pressing on is precisely how the dangling member is made.
+//   - un-enrol succeeds, delete fails → a live account that holds no roles.
+//     Harmless and self-repairing, because the next ensure re-enrols it.
+//
+// Roles the platform does not own are un-enrolled from too. A group somebody
+// else made is not ours to curate, but an account being deleted must not be
+// left behind in it — that reference would be corruption the platform caused.
 func (s *PanelService) Delete(ctx context.Context, orgID, projectID, username string) (DeleteResult, error) {
 	owned, err := s.resolveOwned(ctx, orgID, projectID, username)
 	if err != nil {
@@ -336,6 +360,10 @@ func (s *PanelService) Delete(ctx context.Context, orgID, projectID, username st
 		slog.WarnContext(ctx, "roles panel: deleting a test account other projects still reference",
 			"org", orgID, "project", projectID, "username", owned.Username, "otherProjects", remaining)
 	}
+	unenrolled, err := s.unenrol(ctx, owned)
+	if err != nil {
+		return DeleteResult{}, err
+	}
 	if err := s.dir.DeleteUser(ctx, owned.ThunderUserID); err != nil {
 		return DeleteResult{}, fmt.Errorf("delete test user %q: %w", owned.Username, err)
 	}
@@ -345,7 +373,29 @@ func (s *PanelService) Delete(ctx context.Context, orgID, projectID, username st
 	if err := s.store.DeleteTestUser(ctx, owned.Username); err != nil {
 		return DeleteResult{}, err
 	}
-	return DeleteResult{Username: owned.Username, RemainingReferences: remaining}, nil
+	return DeleteResult{
+		Username:            owned.Username,
+		RemainingReferences: remaining,
+		UnenrolledFrom:      unenrolled,
+	}, nil
+}
+
+// unenrol takes an account out of every group it belongs to, and reports which
+// ones. See Delete for why this runs before the account is deleted and why a
+// failure here stops the delete.
+func (s *PanelService) unenrol(ctx context.Context, owned *TestUser) ([]string, error) {
+	groups, err := s.dir.UserGroups(ctx, owned.ThunderUserID)
+	if err != nil {
+		return nil, fmt.Errorf("read the roles of test user %q: %w", owned.Username, err)
+	}
+	out := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if _, err := s.dir.RemoveMembers(ctx, g, []string{owned.ThunderUserID}); err != nil {
+			return nil, fmt.Errorf("remove test user %q from role %q: %w", owned.Username, g.Name, err)
+		}
+		out = append(out, g.Name)
+	}
+	return out, nil
 }
 
 // resolveOwned applies BOTH fences and returns the platform's record of the

--- a/services/aep-api/internal/identity/ports.go
+++ b/services/aep-api/internal/identity/ports.go
@@ -38,7 +38,21 @@ type Directory interface {
 	// only membership write the IdP offers is a delete-and-recreate of the whole
 	// group. Destructive by construction: the ensure calls it ONLY for a group
 	// it owns. Returns the group's new identity.
+	//
+	// The implementation guarantees the group still exists when this returns,
+	// error or not, and never writes back a member the IdP no longer has.
 	AddMembers(ctx context.Context, group DirectoryGroup, memberIDs []string) (DirectoryGroup, error)
+
+	// RemoveMembers takes members out of a group, keeping everyone else, under
+	// the same lock and the same guarantee as AddMembers. Deleting an account
+	// without removing it from its groups first leaves the group pointing at an
+	// account that no longer exists — see PanelService.Delete.
+	RemoveMembers(ctx context.Context, group DirectoryGroup, memberIDs []string) (DirectoryGroup, error)
+
+	// UserGroups returns the groups an account belongs to, so a delete can
+	// un-enrol it from exactly those. An account that is already gone reports
+	// no groups rather than an error, which keeps a retried delete working.
+	UserGroups(ctx context.Context, userID string) ([]DirectoryGroup, error)
 
 	FindUserByUsername(ctx context.Context, username string) (*DirectoryAccount, bool, error)
 	CreateUser(ctx context.Context, username, email, password string) (DirectoryAccount, error)

--- a/services/aep-api/internal/identity/rolespanel/fakes_test.go
+++ b/services/aep-api/internal/identity/rolespanel/fakes_test.go
@@ -219,13 +219,23 @@ func (s *fakeStore) CountReferencing(_ context.Context, username string) (int, e
 // fakeDirectory is the identity provider. `deleted` records the user ids the
 // panel asked it to remove, which is how a test tells "the account is gone" from
 // "only our row is gone".
+//
+// `ops` records the ORDER of the mutating calls, because the delete path's
+// correctness is an ordering property: un-enrolling an account from its roles
+// after deleting it would leave every one of those groups naming an id that no
+// longer resolves — the state that destroys a role group on the next build. A
+// set of calls cannot express that; a sequence can.
 type fakeDirectory struct {
 	groups       map[string]identity.DirectoryGroup
 	members      map[string][]string
 	accounts     map[string]identity.DirectoryAccount
 	passwordsSet map[string]string
 	deleted      []string
+	ops          []string
 	err          error
+	// failRemoveMembers fails the un-enrol without failing anything else, so a
+	// test can prove the delete ABORTS rather than pressing on.
+	failRemoveMembers error
 }
 
 func newFakeDirectory() *fakeDirectory {
@@ -286,7 +296,47 @@ func (d *fakeDirectory) CreateGroup(_ context.Context, name, description string,
 
 func (d *fakeDirectory) AddMembers(_ context.Context, group identity.DirectoryGroup, memberIDs []string) (identity.DirectoryGroup, error) {
 	d.members[group.ID] = append(d.members[group.ID], memberIDs...)
+	d.ops = append(d.ops, "AddMembers:"+group.Name)
 	return group, nil
+}
+
+func (d *fakeDirectory) RemoveMembers(_ context.Context, group identity.DirectoryGroup, memberIDs []string) (identity.DirectoryGroup, error) {
+	d.ops = append(d.ops, "RemoveMembers:"+group.Name)
+	if d.failRemoveMembers != nil {
+		return identity.DirectoryGroup{}, d.failRemoveMembers
+	}
+	if d.err != nil {
+		return identity.DirectoryGroup{}, d.err
+	}
+	drop := map[string]bool{}
+	for _, id := range memberIDs {
+		drop[id] = true
+	}
+	var remaining []string
+	for _, id := range d.members[group.ID] {
+		if !drop[id] {
+			remaining = append(remaining, id)
+		}
+	}
+	d.members[group.ID] = remaining
+	return group, nil
+}
+
+func (d *fakeDirectory) UserGroups(_ context.Context, userID string) ([]identity.DirectoryGroup, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	var out []identity.DirectoryGroup
+	for _, g := range d.groups {
+		for _, m := range d.members[g.ID] {
+			if m == userID {
+				out = append(out, g)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
 }
 
 func (d *fakeDirectory) DeleteGroup(_ context.Context, groupID string) error {
@@ -323,7 +373,11 @@ func (d *fakeDirectory) SetUserPassword(_ context.Context, userID, password stri
 	return nil
 }
 
+// DeleteUser removes the account and, like the real identity provider, leaves
+// every group member list that names it untouched. Nothing here repairs that —
+// the panel has to have un-enrolled first.
 func (d *fakeDirectory) DeleteUser(_ context.Context, userID string) error {
+	d.ops = append(d.ops, "DeleteUser:"+userID)
 	if d.err != nil {
 		return d.err
 	}
@@ -334,6 +388,25 @@ func (d *fakeDirectory) DeleteUser(_ context.Context, userID string) error {
 	}
 	d.deleted = append(d.deleted, userID)
 	return nil
+}
+
+// danglingMembers is every member id across every group that no account has.
+// The invariant the delete path exists to preserve is that this stays empty.
+func (d *fakeDirectory) danglingMembers() []string {
+	have := map[string]bool{}
+	for _, a := range d.accounts {
+		have[a.ID] = true
+	}
+	var out []string
+	for _, g := range d.groups {
+		for _, m := range d.members[g.ID] {
+			if !have[m] {
+				out = append(out, g.Name+"/"+m)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 var _ identity.Directory = (*fakeDirectory)(nil)

--- a/services/aep-api/internal/identity/rolespanel/handler.go
+++ b/services/aep-api/internal/identity/rolespanel/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/identity"
@@ -96,6 +97,13 @@ func (h *Handler) DeleteTestUser(ctx context.Context, request gen.DeleteTestUser
 	// The status carries the shared-account warning: the role is untouched, and
 	// other projects may still be pointing at the account that just went away.
 	status := fmt.Sprintf("deleted test user %s; the role was left in place", out.Username)
+	// Say which roles it was taken out of. The account is gone by now, so this
+	// is the only place that fact is observable — and "removed from Manager"
+	// is what tells a reader why a role's member count just dropped.
+	if len(out.UnenrolledFrom) > 0 {
+		status = fmt.Sprintf("%s, after removing the account from %s",
+			status, strings.Join(out.UnenrolledFrom, ", "))
+	}
 	if out.RemainingReferences > 0 {
 		status = fmt.Sprintf("%s. WARNING: %d other project(s) still reference this account and their "+
 			"validation runs will no longer be able to sign in as it",

--- a/services/aep-api/internal/identity/rolespanel/rolespanel_component_test.go
+++ b/services/aep-api/internal/identity/rolespanel/rolespanel_component_test.go
@@ -436,6 +436,104 @@ func TestPanel_DeleteRemovesTheAccountNotTheRole(t *testing.T) {
 	}
 }
 
+// A delete has to take the account OUT of its roles before removing it, and
+// this is the test the incident asked for.
+//
+// The identity provider does not un-enrol a deleted account: the group goes on
+// naming an id that no longer resolves. Membership can only be written by
+// deleting the group and recreating it, and that recreate is rejected wholesale
+// for the dead member — so the next build that enrolled anybody into the role
+// DESTROYED it, after the delete had already committed, on every retry.
+//
+// Nine role groups went that way on the demo cluster. The fix is ordering, and
+// the assertion is the invariant: no group may name an account that is gone.
+func TestPanel_DeleteUnenrolsFromItsRolesBeforeRemovingTheAccount(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore().
+		withRole("Support Agent").
+		withOwnedUser("support-bot", "Support Agent", "Aep1!old").
+		withRef("acme", "helpdesk", "support-bot", "Support Agent")
+	dir := newFakeDirectory().
+		withGroup("Support Agent", "Handles tickets", "usr-support-bot", "usr-someone-else").
+		withGroup("Reporting", "Reads dashboards", "usr-support-bot").
+		withAccount("support-bot")
+	h := newPanel(t, dir, store)
+
+	resp := h.AsOrg("acme").Delete("/api/v1/projects/helpdesk/roles/test-users/support-bot")
+	if resp.Code != 200 {
+		t.Fatalf("delete: got %d body=%s", resp.Code, resp.Body.String())
+	}
+
+	// The invariant. A single dangling id here is a role group primed to be
+	// destroyed by the next build that touches it.
+	if got := dir.danglingMembers(); len(got) != 1 || got[0] != "Support Agent/usr-someone-else" {
+		t.Errorf("dangling members = %v, want only the pre-existing seed: the deleted account must be gone from every group", got)
+	}
+
+	// Un-enrol from EVERY role it held, not just the one the design named.
+	if len(dir.ops) != 3 ||
+		dir.ops[0] != "RemoveMembers:Reporting" ||
+		dir.ops[1] != "RemoveMembers:Support Agent" ||
+		dir.ops[2] != "DeleteUser:usr-support-bot" {
+		t.Fatalf("directory calls = %v, want both un-enrolments BEFORE the account delete", dir.ops)
+	}
+
+	// Everyone else in the shared role stays.
+	if got := dir.members["grp-Support Agent"]; len(got) != 1 || got[0] != "usr-someone-else" {
+		t.Errorf("Support Agent membership = %v, want the other member kept", got)
+	}
+	if _, gone := dir.groups["support agent"]; !gone {
+		t.Error("THE ROLE WAS DELETED — roles are shared and must be left standing")
+	}
+
+	// And the roles it left are named, because once the account is gone that
+	// fact is not observable from the directory any more.
+	var got gen.StatusMsg
+	if err := json.Unmarshal(resp.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v\n%s", err, resp.Body.String())
+	}
+	for _, want := range []string{"Reporting", "Support Agent"} {
+		if !strings.Contains(got.Status, want) {
+			t.Errorf("status must name the role the account was removed from (%s): %q", want, got.Status)
+		}
+	}
+}
+
+// An un-enrol that fails ABORTS the delete. The two orderings fail differently
+// and only one of them is recoverable: stopping here leaves a whole account
+// that can be deleted again, while pressing on would delete the account and
+// leave the group naming it — the corruption, made permanent, by the very
+// operation that was supposed to avoid it.
+func TestPanel_DeleteAbortsWhenTheAccountCannotBeUnenrolled(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore().
+		withRole("Support Agent").
+		withOwnedUser("support-bot", "Support Agent", "Aep1!old").
+		withRef("acme", "helpdesk", "support-bot", "Support Agent")
+	dir := newFakeDirectory().
+		withGroup("Support Agent", "Handles tickets", "usr-support-bot").
+		withAccount("support-bot")
+	dir.failRemoveMembers = errors.New("thunder POST /groups returned 500")
+	h := newPanel(t, dir, store)
+
+	resp := h.AsOrg("acme").Delete("/api/v1/projects/helpdesk/roles/test-users/support-bot")
+	if resp.Code < 500 {
+		t.Fatalf("want a server error when the un-enrol fails, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	if len(dir.deleted) != 0 {
+		t.Errorf("the account was deleted anyway (%v) — that is what leaves the group naming a dead id", dir.deleted)
+	}
+	if _, still := dir.accounts["support-bot"]; !still {
+		t.Error("the account must survive an aborted delete")
+	}
+	if _, still := store.testUsers["support-bot"]; !still {
+		t.Error("the platform's record must survive an aborted delete, or the account can never be deleted again")
+	}
+	if got := dir.danglingMembers(); len(got) != 0 {
+		t.Errorf("dangling members = %v, want none: an aborted delete must leave nothing behind", got)
+	}
+}
+
 // The account is shared, so a delete while other projects still reference it is
 // reported rather than done silently.
 func TestPanel_DeleteWarnsWhenOtherProjectsStillReference(t *testing.T) {

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -144,8 +144,9 @@ its design system without a platform change.
   an implementer. The lead reads it too, for inline work and for authoring
   `workload.yaml` (whose format is `references/workload-and-wiring.md`).
 - **The walk is split the same way.** `mock-verification` owns what a walk
-  verifies, the report shape and the walker's status lines; `aep` owns the
-  dispatch (a literal prompt the lead copies) and what becomes of the report;
+  verifies, the checklist that is its report, and the script that runs its
+  mechanics; `aep` owns the dispatch (a literal prompt the lead copies) and what
+  becomes of the report;
   the component contract and `react-webapp` say only that the walk exists and
   what the builder leaves for it. A second description of how to walk, in any
   of those, is a defect.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -144,9 +144,9 @@ its design system without a platform change.
   an implementer. The lead reads it too, for inline work and for authoring
   `workload.yaml` (whose format is `references/workload-and-wiring.md`).
 - **The walk is split the same way.** `mock-verification` owns what a walk
-  verifies, the checklist that is its report, and the script that runs its
-  mechanics; `aep` owns the dispatch (a literal prompt the lead copies) and what
-  becomes of the report;
+  verifies, the shapes its progress takes, and the script that runs its dev
+  server; `aep` owns the dispatch (a literal prompt the lead copies, carrying
+  where progress goes) and what becomes of the report;
   the component contract and `react-webapp` say only that the walk exists and
   what the builder leaves for it. A second description of how to walk, in any
   of those, is a defect.

--- a/skills/aep/SKILL.md
+++ b/skills/aep/SKILL.md
@@ -199,8 +199,7 @@ subagent you handed it to, keeps its status line current from start to done
    ```text
    Walk <component> at <App Path> (issue #<N>). Load `mock-verification` and
    `agent-browser`; the first is the whole procedure. Edit/Write only inside
-   <App Path>; never run `git`. Status line: <the gh issue comment command with #N filled in>.
-   Report back the skill's report block.
+   <App Path>; never run `git`. Report back the checklist, whole.
    ```
 
    The walk lands before the commit, so what it fixes ships with what it
@@ -260,8 +259,9 @@ gh issue comment <number> --body "<one line: what is happening on this issue now
 
 **Post when the one-line answer changes**, and always at both ends — when the
 work starts and when it stops. In between it changes when a component goes green
-and when its work is committed; a walk's own lines are the walker's
-(`mock-verification` fixes their shape). A stretch with no new answer is silence
+and when its work is committed. A walk's progress is the walker's:
+`mock-verification` keeps one checklist comment on the issue current, so its
+prompt carries only the issue number. A stretch with no new answer is silence
 telling the truth; a comment repeating the line already there is noise.
 
 Every tool call already reaches the run's progress feed, so this line carries the

--- a/skills/aep/SKILL.md
+++ b/skills/aep/SKILL.md
@@ -197,9 +197,10 @@ subagent you handed it to, keeps its status line current from start to done
    prompt, and nothing about how to walk:
 
    ```text
-   Walk <component> at <App Path> (issue #<N>). Load `mock-verification` and
+   Walk <component> at <App Path>. Load `mock-verification` and
    `agent-browser`; the first is the whole procedure. Edit/Write only inside
-   <App Path>; never run `git`. Report back the checklist, whole.
+   <App Path>; never run `git`. Progress: `gh issue comment <N> --body "<line>"`.
+   Report back the closing line and the numbered list.
    ```
 
    The walk lands before the commit, so what it fixes ships with what it
@@ -259,10 +260,10 @@ gh issue comment <number> --body "<one line: what is happening on this issue now
 
 **Post when the one-line answer changes**, and always at both ends — when the
 work starts and when it stops. In between it changes when a component goes green
-and when its work is committed. A walk's progress is the walker's:
-`mock-verification` keeps one checklist comment on the issue current, so its
-prompt carries only the issue number. A stretch with no new answer is silence
-telling the truth; a comment repeating the line already there is noise.
+and when its work is committed. A walk's progress is the walker's, posted with
+the command its prompt hands it; `mock-verification` fixes the shapes. A stretch
+with no new answer is silence telling the truth; a comment repeating the line
+already there is noise.
 
 Every tool call already reaches the run's progress feed, so this line carries the
 **shape** of the work rather than its steps — the component, and what is

--- a/skills/aep/overlays/local.md
+++ b/skills/aep/overlays/local.md
@@ -101,9 +101,9 @@ runtime relationship, not a build order — it never holds an issue back.
 <!-- drop-section: ### The status line -->
 
 <!-- replace-text -->
-   <App Path>; never run `git`. Status line: <the gh issue comment command with #N filled in>.
+   Walk <component> at <App Path> (issue #<N>). Load `mock-verification` and
 <!-- with -->
-   <App Path>; never run `git`.
+   Walk <component> at <App Path>. Load `mock-verification` and
 <!-- /replace-text -->
 
 <!-- replace-text -->

--- a/skills/aep/overlays/local.md
+++ b/skills/aep/overlays/local.md
@@ -101,9 +101,10 @@ runtime relationship, not a build order — it never holds an issue back.
 <!-- drop-section: ### The status line -->
 
 <!-- replace-text -->
-   Walk <component> at <App Path> (issue #<N>). Load `mock-verification` and
+   <App Path>; never run `git`. Progress: `gh issue comment <N> --body "<line>"`.
 <!-- with -->
-   Walk <component> at <App Path>. Load `mock-verification` and
+   <App Path> and `issues/<n>.md`; never run `git`. Progress: append the line
+   to `issues/<n>.md` under `## Mock verification`.
 <!-- /replace-text -->
 
 <!-- replace-text -->

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-browser
-description: The browser CLI a coding run drives a web page with — opening a URL, clicking through a screen, reading what actually rendered. Load before the first `agent-browser` command; `mock-verification` names it. For an e2e test suite against a deployed system, `playwright-cli` and `aep-validation` own that instead.
+description: The browser CLI a coding run drives a web page with — opening a URL, clicking through a screen, reading what actually rendered. Load before the first `agent-browser` command. For a web application this run built, load `mock-verification` first: that skill is the procedure, this one is only the tool. For an e2e test suite against a deployed system, `playwright-cli` and `aep-validation` own that instead.
 metadata:
   aep:
     kind: platform

--- a/skills/mock-verification/SKILL.md
+++ b/skills/mock-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mock-verification
-description: Smoke-walk a `web-application` in a real browser once it builds clean — stand it up in mock mode, walk every flow its wireframes draw, fix each failure where you find it, keep one checklist current on the issue. Required for every change to a webapp component. Judging a DEPLOYED system is `aep-validation`'s job instead.
+description: Smoke-walk a `web-application` in a real browser once it builds clean — stand it up in mock mode, walk every flow its wireframes draw, fix each failure where you find it, post progress item by item. Required for every change to a webapp component. Judging a DEPLOYED system is `aep-validation`'s job instead.
 metadata:
   aep:
     kind: platform
@@ -22,13 +22,6 @@ Your scope is the whole component: a cycle's regressions land in shared chrome
 and on pages nobody meant to touch, so every flow is walked, whichever issue
 built it.
 
-The mechanics — the dev server, the port, the browser, the issue comment — are
-one script, so you write none of them:
-
-```bash
-bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" <up | restart | post [issue#] | down>
-```
-
 ## What you verify
 
 ### The map
@@ -37,10 +30,10 @@ bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" <up | restart | post [i
 your working directory, one level above the App Path you edit in. A `flow`
 block is the unit: one role and the screens that role walks, entry screen
 first. Walk every flow under its role (`?role=<name>`) by clicking from its
-entry screen; a screen in no flow gets a block of its own, reached at its route.
-**The DSL is your only map**: you open a source file to repair, never to learn a
-route. A component with no `wireframes.dsl` gives you its registered routes
-instead, one flow per role.
+entry screen; a screen in no flow is reached at its route. **The DSL is your
+only map**: you open a source file to repair, never to learn a route. A
+component with no `wireframes.dsl` gives you its registered routes instead, one
+flow per role.
 
 ### Per screen
 
@@ -62,8 +55,8 @@ smoke.
 - **Session** (an auth dependency): `?auth=out` on one entry screen runs the
   app's own guard and `signIn()` brings you back; then **Sign out** where the
   navbar draws it leaves the screen through `signOut()`. The mock signs the
-  next load in again, so the session being gone is `[~]`; the click leaving the
-  page is not.
+  next load in again, so the session being gone is outside; the click leaving
+  the page is not.
 - **Probes**: submit one form empty; open one detail route with an id that does
   not exist. The wireframe draws the happy path; these are the two states it
   implies.
@@ -71,23 +64,48 @@ smoke.
   page that renders and throws is broken for whoever touches it next, and the
   error text is the finding.
 
-### Marks
+### Outcomes
 
-One line per screen and per once-per-app item. Unmarked, it is a line to walk.
-Walked, it carries exactly one of:
+Every item ends in exactly one:
+
+- **done** — what you did and what the page did back.
+- **fixed** — what was wrong; what you changed; what it does now, re-walked.
+- **open** — what happens, after three attempts.
+- **outside** — the truth lives outside the app: a computed total, a generated
+  checklist, a 403. The mock answers to `openapi.yaml`, so it proves the request
+  went out, never that the number is right; `aep-validation` judges that against
+  the deployed system.
+
+An unreachable screen is **open**, naming the navigation that failed, never
+**done** read off the source.
+
+## Progress
+
+Your prompt says where progress goes. Post there, in these three shapes and no
+other: the plan once, one line per item as it settles, the close once.
 
 ```text
-- [x] <Screen>: <one clause: what you did and what the page did back>
-- [x] <Screen>: FIXED <what was wrong>; <what you changed>. Re-walked: <what it does now>.
-- [ ] <Screen>: <what happens>. Tried <what>, 3 attempts. <what still happens>.
-- [~] <Screen>: <the truth that lives outside the app>
+Mock verification: <component> — <N> items
+1. <Screen> (<role>): <its controls>; -> <the screens its arrows name>
+2. <Screen>: ...
+<N-1>. Session
+<N>. Probes and Console
 ```
 
-`[~]` is what the mock or the gateway supplies — a computed total, a generated
-checklist, a 403. The mock answers to `openapi.yaml`, so it proves the request
-went out, never that the number is right; `aep-validation` judges that against
-the deployed system. An unreachable screen is a `[ ]` naming the navigation that
-failed, never an `[x]` read off the source.
+```text
+<n>/<N> <Screen>: done — <what you did and what the page did back>
+<n>/<N> <Screen>: fixed — <what was wrong>; <what you changed>; re-walked, <what it does now>
+<n>/<N> <Screen>: open — <what happens>, 3 attempts
+<n>/<N> <Screen>: outside — <the truth that lives outside the app>
+```
+
+```text
+Mock verification done: <component> — <N> items · <d> done, <f> fixed, <o> open (<n> <Screen>, ...)
+```
+
+The newest line is where the walk is, and that is what the person watching
+reads. An item with no line is a screen you never reached, and it stays visible
+as one.
 
 ## 1 · Stand it up
 
@@ -98,91 +116,66 @@ bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" up
 ```
 
 It starts `npm run dev:mock` on a free port, reaps a stale server from an
-earlier attempt first, and prints `READY <url> · checklist <file>`. The url is
-what you open (`?role=` and `?auth=out` go on it); the file is where the
-checklist goes. If it prints the log instead, that is your first finding: the
-harness is `react-webapp`'s `references/mock-mode.md`; fix it and run `up`
-again.
+earlier attempt first, and prints `READY <url>`. The url is what you open;
+`?role=` and `?auth=out` go on it. If it prints the log instead, that is your
+first finding: the harness is `react-webapp`'s `references/mock-mode.md`; fix
+it and run `up` again.
 
 **Done when:** `READY`.
 
-## 2 · Checklist
+## 2 · Plan
 
-Before the browser opens, write the checklist file from the map alone:
-
-```text
-Mock verification: <component>
-
-flow "<name>" (<role>)
-- <Screen>: <its controls>; -> <the screens its arrows name>
-- <Screen>: ...
-screens in no flow
-- <Screen>: <its controls>; -> <targets>
-once per app
-- Roles
-- Session
-- Probes
-- Console
-```
-
-Then publish it:
-
-```bash
-bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>
-```
-
-`post` rewrites the first line with the counts and posts the file as one
-comment on the issue your prompt names, editing that same comment on every
-later call. A prompt that names no issue: leave the number off, and the file is
-the report.
-
-This is your walk order and, marked up, your report: a screen you never reach
-is a line with no mark, where a list assembled as you go simply never mentions
-it. Posting it before the browser opens puts your coverage in front of the
+Before the browser opens, post the plan from the map alone: one numbered item
+per screen in each flow, in walking order under its role, then screens in no
+flow, then Roles (with `mock/roles.ts`), Session (with an auth dependency),
+and Probes and Console. Posting it first puts your coverage in front of the
 person watching while there is still time to say a screen is missing.
 
-**Done when:** every screen and flow in the map has a line, so does each
-once-per-app item, and `post` has run.
+**Done when:** every screen and flow in the map has a number, and the plan is
+posted.
 
 ## 3 · Walk
 
 Load `agent-browser` and follow it: open, snapshot, act on what the snapshot
 shows.
 
-**A line ends green.** Walk it; if it fails, fix it now, walk that same line
-again, and see it pass before the next. Every failure is yours, whichever issue
-put it there. **Repair the app, never the checklist.**
+**An item ends green, and posted.** Walk it; if it fails, fix it now, walk that
+same item again, and see it pass; then post its line, and only then open the
+next. A line posted at the end for an item settled an hour ago is a history,
+not progress. Every failure is yours, whichever issue put it there.
+**Repair the app, never the plan.**
 
-**Three attempts on a line, then mark it `[ ]` and walk on.** The screens
+**Three attempts on an item, then post it open and walk on.** The screens
 behind it are still unopened. A fix is the wiring a screen is missing; a defect
-that wants a redesign is a `[ ]` with its cause named.
+that wants a redesign is open with its cause named.
 
 **Click between screens.** Mock state lives in the page, so `open`, reload and
 back restore the seed data: a record you created a moment ago is gone, and that
 is the mock telling the truth, not the app. Spend full loads at the start of a
 block, where there is no state to lose — a role switch, `?auth=out`, an unknown
-id. The once-per-app lines are walked off the checklist like any other.
+id. The once-per-app items are walked off the plan like any other.
 
-**Mark the line as it settles, then `post`.** The comment's first line is what
-the person watching reads, and the counts are the progress. `restart` after a
-change to `vite.config.ts`, `mock/` or a dependency; everything else
-hot-reloads.
+`restart` after a change to `vite.config.ts`, `mock/` or a dependency;
+everything else hot-reloads.
 
-**Done when:** every line carries a mark.
+**Done when:** every number has its line, each posted before the next item was
+opened.
 
-## 4 · Report
+## 4 · Close
+
+Post the closing line, then:
 
 ```bash
-bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>
 bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" down
 ```
 
 `down` stops the server, closes the browser and confirms the port let go. Hand
-the checklist back to whoever dispatched you, whole: its first line is what the
-pull request quotes, and its `[ ]` lines are what the pull request carries.
+back to whoever dispatched you the closing line and the numbered list with each
+item's outcome: the closing line is what the pull request quotes, and the open
+items are what it carries.
 
-**Done when:** the last `post` is up, `down` printed `STOPPED`, and the
-checklist is in your reply.
+**Done when:** the close is posted, `down` printed `STOPPED`, and the list is
+in your reply.
 
 ## Never
 
@@ -192,5 +185,5 @@ checklist is in your reply.
   system too. A `501` is a handler you never wrote: write it against the
   contract.
 - **Run `git`, commit, or open a pull request.** The record belongs to the agent
-  that dispatched you. The checklist comment on your own issue is the only
+  that dispatched you. Progress, where your prompt says it goes, is the only
   writing you do outside the App Path.

--- a/skills/mock-verification/SKILL.md
+++ b/skills/mock-verification/SKILL.md
@@ -88,8 +88,9 @@ other: the plan once, one line per item as it settles, the close once.
 Mock verification: <component> — <N> items
 1. <Screen> (<role>): <its controls>; -> <the screens its arrows name>
 2. <Screen>: ...
-<N-1>. Session
-<N>. Probes and Console
+<N-2>. Session
+<N-1>. Probes
+<N>. Console
 ```
 
 ```text
@@ -100,7 +101,7 @@ Mock verification: <component> — <N> items
 ```
 
 ```text
-Mock verification done: <component> — <N> items · <d> done, <f> fixed, <o> open (<n> <Screen>, ...)
+Mock verification done: <component> — <N> items · <d> done, <f> fixed, <o> open (<n> <Screen>, ...), <t> outside
 ```
 
 The newest line is where the walk is, and that is what the person watching
@@ -128,7 +129,7 @@ it and run `up` again.
 Before the browser opens, post the plan from the map alone: one numbered item
 per screen in each flow, in walking order under its role, then screens in no
 flow, then Roles (with `mock/roles.ts`), Session (with an auth dependency),
-and Probes and Console. Posting it first puts your coverage in front of the
+Probes, and Console. Posting it first puts your coverage in front of the
 person watching while there is still time to say a screen is missing.
 
 **Done when:** every screen and flow in the map has a number, and the plan is

--- a/skills/mock-verification/SKILL.md
+++ b/skills/mock-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mock-verification
-description: Load once a `web-application` builds clean, to finish it — stand the app up in mock mode with no cluster behind it, smoke-walk every flow in a real browser, and fix each failure the moment you find it. Judging a DEPLOYED system against live infrastructure is `aep-validation`'s job instead.
+description: Smoke-walk a `web-application` in a real browser once it builds clean — stand it up in mock mode, walk every flow its wireframes draw, fix each failure where you find it, keep one checklist current on the issue. Required for every change to a webapp component. Judging a DEPLOYED system is `aep-validation`'s job instead.
 metadata:
   aep:
     kind: platform
@@ -13,92 +13,136 @@ A clean build says the code is well formed and nothing about what the screens
 do: a route the wireframe draws and the router never registered, a button wired
 to nothing, a form that flips a row and sends no request. So you open the app
 and use it. Mock mode stands it up on this machine with no cluster, no sibling
-service and no IDP (the harness is `react-webapp`'s `references/mock-mode.md`).
-You verify and repair in one pass, holding the component open.
+service and no IDP. You verify and repair in one pass.
 
-**This is a smoke walk: fast, breadth over depth.** You are looking for a screen
-that is missing, an arrow that goes nowhere, a control that does nothing, a
-request that never leaves the page. You are not judging data, layout or
-wording. Your scope is the whole component, every flow a user can walk and
-whichever issue built it: a cycle's regressions land in shared chrome and in
-pages nobody meant to touch, and breadth is what finds them.
+**This is a smoke walk: breadth over depth.** You are looking for a screen that
+is missing, an arrow that goes nowhere, a control that does nothing, a request
+that never leaves the page. Data, layout and wording are not your questions.
+Your scope is the whole component: a cycle's regressions land in shared chrome
+and on pages nobody meant to touch, so every flow is walked, whichever issue
+built it.
+
+The mechanics — the dev server, the port, the browser, the issue comment — are
+one script, so you write none of them:
+
+```bash
+bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" <up | restart | post [issue#] | down>
+```
 
 ## What you verify
 
-The unit is a **flow**: a `flow` block in
-`specs/design/components/<component>/wireframes.dsl`, one role and the screens
-that role walks, entry screen first. Walk every flow the file declares, under its
-role (`?role=<name>`), by clicking from its entry screen. A screen in no flow
-gets a block of its own. **The DSL is your only map**: you open a source file to
-repair, never to learn a route. A component with no `wireframes.dsl` gives you
-its routes instead, one flow per role the app registers.
+### The map
 
-Three questions per screen. Each is one action and one snapshot, with the first
-plausible input; a screen is answered in a handful of actions, and past that you
-are past the smoke.
+`specs/design/components/<component>/wireframes.dsl`, under the project root —
+your working directory, one level above the App Path you edit in. A `flow`
+block is the unit: one role and the screens that role walks, entry screen
+first. Walk every flow under its role (`?role=<name>`) by clicking from its
+entry screen; a screen in no flow gets a block of its own, reached at its route.
+**The DSL is your only map**: you open a source file to repair, never to learn a
+route. A component with no `wireframes.dsl` gives you its registered routes
+instead, one flow per role.
+
+### Per screen
+
+Three questions, each one action and one snapshot with the first plausible
+input. A screen is answered in a handful of actions; past that you are past the
+smoke.
 
 | | Question | Evidence |
 |---|---|---|
-| **Reach** | Did the arrow that names this screen bring you here, and does every `->` it draws land where it says? | the snapshot of the target |
+| **Reach** | Did the arrow that names this screen bring you here, and does every `->` it draws land where it says? | the target's snapshot |
 | **Act** | Does every drawn control change something visible when used? A create is in the next list, a filter narrows, a toggle flips a row. | the snapshot after the action |
 | **Request** | Did a change leave the page as the request the contract declares, with the status it declares? A row that flips and sends nothing is the one defect a build cannot see. | `agent-browser network requests` |
 
-Three guards and two probes, once each rather than per screen:
+### Once per app
 
 - **Roles** (`mock/roles.ts` exists): each flow's entry screen under its own
   role, and once under a role the DSL gives no flow there. Both directions are
   defects.
 - **Session** (an auth dependency): `?auth=out` on one entry screen runs the
-  app's own guard, and `signIn()` brings you back. Then click **Sign out** where
-  the navbar draws it: the app leaves the screen through `signOut()`. The mock
-  signs the next load in again, so whether the session is gone is `[~]`; the
-  click leaving the page is not.
-- **Console** (the CLI's own console verb, read before you stop): a page that
-  renders and throws is broken for whoever touches it next, and the error text
-  is the finding.
+  app's own guard and `signIn()` brings you back; then **Sign out** where the
+  navbar draws it leaves the screen through `signOut()`. The mock signs the
+  next load in again, so the session being gone is `[~]`; the click leaving the
+  page is not.
 - **Probes**: submit one form empty; open one detail route with an id that does
   not exist. The wireframe draws the happy path; these are the two states it
   implies.
+- **Console** (`agent-browser console`, read whole, once, before you stop): a
+  page that renders and throws is broken for whoever touches it next, and the
+  error text is the finding.
 
-Outside the walk, marked `[~]`: what the mock or the gateway supplies — a
-computed total, a generated checklist, a 403. The mock answers to
-`openapi.yaml`, so it can prove the request went out, never that the number is
-right. `aep-validation` judges that against the deployed system, and anything
-finer than obvious with it.
+### Marks
 
-## 1 · Checklist
+One line per screen and per once-per-app item. Unmarked, it is a line to walk.
+Walked, it carries exactly one of:
 
-Before the browser opens, write `/tmp/walk-<component>.md` from your map alone
-(the DSL, or the app's routes when there is none): one block per flow, one block
-`screens in no flow` when the map has any, one line per screen naming its
-controls and arrows, then one line each for Roles, Session, Probes and Console.
-It is your walk order, and filled in it is your report. A screen you never reach
-is then a line with no mark, where a list assembled as you go simply never
-mentions it.
+```text
+- [x] <Screen>: <one clause: what you did and what the page did back>
+- [x] <Screen>: FIXED <what was wrong>; <what you changed>. Re-walked: <what it does now>.
+- [ ] <Screen>: <what happens>. Tried <what>, 3 attempts. <what still happens>.
+- [~] <Screen>: <the truth that lives outside the app>
+```
 
-**Done when:** every screen and every flow in the map has a line, and so does
-each of Roles, Session, Probes and Console.
+`[~]` is what the mock or the gateway supplies — a computed total, a generated
+checklist, a 403. The mock answers to `openapi.yaml`, so it proves the request
+went out, never that the number is right; `aep-validation` judges that against
+the deployed system. An unreachable screen is a `[ ]` naming the navigation that
+failed, never an `[x]` read off the source.
 
-## 2 · Stand it up
+## 1 · Stand it up
 
 From the App Path:
 
 ```bash
-setsid --fork bash -c 'echo $$ > /tmp/mock-<component>.pgid; exec npm run dev:mock -- --port 5173 --strictPort' > /tmp/mock-<component>.log 2>&1 &
-for i in $(seq 1 30); do curl -sf http://localhost:5173/ >/dev/null && break; sleep 2; done
-curl -sf http://localhost:5173/ >/dev/null || tail -40 /tmp/mock-<component>.log
+bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" up
 ```
 
-Every part is load-bearing. `npm run` is three processes, so the process
-**group** is the only handle that reaps them all; `setsid --fork` makes one and
-the leader writes its own id (`$!` would name `setsid`, which has already
-exited). `--strictPort` keeps a browser at 5173 off a previous run's server: a
-refusal to bind means one is still up, so end it with
-`kill -- -"$(cat /tmp/mock-<component>.pgid)"` and start again. This machine has
-no `ps`, `pgrep`, `pkill` or `lsof`.
+It starts `npm run dev:mock` on a free port, reaps a stale server from an
+earlier attempt first, and prints `READY <url> · checklist <file>`. The url is
+what you open (`?role=` and `?auth=out` go on it); the file is where the
+checklist goes. If it prints the log instead, that is your first finding: the
+harness is `react-webapp`'s `references/mock-mode.md`; fix it and run `up`
+again.
 
-**Done when:** the URL answers and the log holds no error. If it will not start,
-that is the whole finding: fix it and start again.
+**Done when:** `READY`.
+
+## 2 · Checklist
+
+Before the browser opens, write the checklist file from the map alone:
+
+```text
+Mock verification: <component>
+
+flow "<name>" (<role>)
+- <Screen>: <its controls>; -> <the screens its arrows name>
+- <Screen>: ...
+screens in no flow
+- <Screen>: <its controls>; -> <targets>
+once per app
+- Roles
+- Session
+- Probes
+- Console
+```
+
+Then publish it:
+
+```bash
+bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>
+```
+
+`post` rewrites the first line with the counts and posts the file as one
+comment on the issue your prompt names, editing that same comment on every
+later call. A prompt that names no issue: leave the number off, and the file is
+the report.
+
+This is your walk order and, marked up, your report: a screen you never reach
+is a line with no mark, where a list assembled as you go simply never mentions
+it. Posting it before the browser opens puts your coverage in front of the
+person watching while there is still time to say a screen is missing.
+
+**Done when:** every screen and flow in the map has a line, so does each
+once-per-app item, and `post` has run.
 
 ## 3 · Walk
 
@@ -116,68 +160,29 @@ that wants a redesign is a `[ ]` with its cause named.
 **Click between screens.** Mock state lives in the page, so `open`, reload and
 back restore the seed data: a record you created a moment ago is gone, and that
 is the mock telling the truth, not the app. Spend full loads at the start of a
-block, where there is no state to lose: a role switch, `?auth=out`, an unknown
-id.
+block, where there is no state to lose — a role switch, `?auth=out`, an unknown
+id. The once-per-app lines are walked off the checklist like any other.
 
-**Roles, Session, Probes and Console are lines like any other** — walk them off
-the checklist, and spend their full loads at the start of a block.
-
-Restart the server after a change to `vite.config.ts`, `mock/` or a dependency;
-everything else hot-reloads. Post a status line when a line is fixed or given up
-(**Status line**).
+**Mark the line as it settles, then `post`.** The comment's first line is what
+the person watching reads, and the counts are the progress. `restart` after a
+change to `vite.config.ts`, `mock/` or a dependency; everything else
+hot-reloads.
 
 **Done when:** every line carries a mark.
 
 ## 4 · Report
 
-The checklist, filled in, in exactly this shape. It goes back to whoever
-dispatched you: its first line is what the status line and the pull request
-quote, and its `[ ]` lines are what the pull request carries.
-
-```text
-Mock verification: <component> · <N> screens, <M> flows · <p> pass, <f> fixed, <o> open
-
-flow "<name>" (<role>)
-- [x] <Screen>: <one clause: what you did and what the page did back>
-- [x] <Screen>: FIXED <what was wrong>; <what you changed>. Re-walked: <what it does now>.
-- [ ] <Screen>: <what happens>. Tried <what>, 3 attempts. <what still happens>.
-- [~] <Screen>: <the truth that lives outside the app>.
-screens in no flow
-- [x] <Screen>: <reached at its route under <role>; what you did and what the page did back>
-- [x] Roles: <role> on <route> bounced to <route>; <role> reached <screen>.
-- [x] Session: ?auth=out ran the guard, signIn() returned to <screen>; Sign out left <screen>.
-- [x] Probes: the empty <form> <what it did>; <detail route> with an unknown id <what it rendered>.
-- [x] Console: clean | <error text>.
-```
-
-A green line is one clause; only `FIXED`, `[ ]` and `[~]` lines carry more. An
-unreachable screen is a `[ ]` naming the navigation that failed, never an `[x]`
-read off the source.
-
-Then stop the server and confirm the port let go:
-
 ```bash
-kill -- -"$(cat /tmp/mock-<component>.pgid)"
-curl -sf http://localhost:5173/ >/dev/null && echo "STILL UP" || echo "STOPPED"
+bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" post <issue#>
+bash "$AEP_SKILLS_DIR/mock-verification/scripts/walk.sh" down
 ```
 
-**Done when:** every line carries one of the three marks and no dev server is
-left running.
+`down` stops the server, closes the browser and confirms the port let go. Hand
+the checklist back to whoever dispatched you, whole: its first line is what the
+pull request quotes, and its `[ ]` lines are what the pull request carries.
 
-## Status line
-
-A person watching the build reads these. Three shapes, and your prompt says
-where they go:
-
-```text
-Walking <component> in mock mode: <N> screens, <M> flows.
-<Screen>: <what the page did>. Fixed, re-walked green.
-<Screen>: <what the page did>. Open after 3 attempts.
-Walk done: <N> screens, <p> pass, <f> fixed, <o> open.
-```
-
-The first at the start, the middle two whenever a line is settled either way,
-the last at the end. A screen that passes is not news; the count at the end is.
+**Done when:** the last `post` is up, `down` printed `STOPPED`, and the
+checklist is in your reply.
 
 ## Never
 
@@ -186,6 +191,6 @@ the last at the end. A screen that passes is not news; the count at the end is.
   else. A handler bent until a screen passes hides the defect from the deployed
   system too. A `501` is a handler you never wrote: write it against the
   contract.
-- Run `git`, commit, or open a pull request. The record belongs to the agent
-  that dispatched you: hand it the report block above, and post progress only
-  where your prompt says to.
+- **Run `git`, commit, or open a pull request.** The record belongs to the agent
+  that dispatched you. The checklist comment on your own issue is the only
+  writing you do outside the App Path.

--- a/skills/mock-verification/scripts/walk.sh
+++ b/skills/mock-verification/scripts/walk.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# walk.sh — the mechanics of a mock-verification walk, so the walker writes none
+# of them. Run from the App Path.
+#
+#   walk.sh up               start `npm run dev:mock` on a free port
+#                            → READY <url> · checklist <file>
+#   walk.sh restart          stop the server and start it again (same browser)
+#   walk.sh post [<issue#>]  rewrite the checklist's first line with the counts;
+#                            with an issue, publish the file as ONE comment on
+#                            it, edited in place on every later call
+#   walk.sh down             stop the server, close the browser, confirm the
+#                            port let go → STOPPED
+#
+# State lives at /tmp/walk-<app>.* where <app> is the App Path's basename; the
+# checklist the walker writes is /tmp/walk-<app>.md and `up` prints that path.
+#
+# Why a script and not four lines in the skill: `npm run` is three processes and
+# the runner image has no `ps`/`pkill`, so the process GROUP is the only handle
+# that reaps them all — `set -m` makes the background job its own group leader,
+# which is why `$!` below is a group id, on Linux and on a macOS laptop alike.
+# Every walk used to re-derive that, and the one that did not leaked four dev
+# servers into a 3Gi cgroup. The port is searched rather than fixed so two
+# web-application walks in one wave do not fight over 5173; a stale server from
+# this app's earlier attempt is reaped before a new one starts.
+
+set -euo pipefail
+
+app=$(basename "$PWD")
+state="/tmp/walk-$app"
+checklist="$state.md"
+log="$state.log"
+pgid_file="$state.pgid"
+port_file="$state.port"
+comment_file="$state.comment"
+
+listening() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
+
+stop_server() {
+  [ -f "$pgid_file" ] || return 0
+  local pgid
+  pgid=$(cat "$pgid_file")
+  kill -TERM -- "-$pgid" 2>/dev/null || true
+  for _ in $(seq 1 20); do
+    kill -0 -- "-$pgid" 2>/dev/null || break
+    sleep 0.25
+  done
+  kill -KILL -- "-$pgid" 2>/dev/null || true
+  rm -f "$pgid_file"
+}
+
+start_server() {
+  stop_server
+  local port
+  for port in $(seq 5173 5199); do
+    listening "$port" || break
+  done
+  if listening "$port"; then
+    echo "no free port between 5173 and 5199" >&2
+    exit 1
+  fi
+  : > "$log"
+  # `</dev/null`: under job control a server that reads the terminal would be
+  # stopped with SIGTTIN; Vite reads stdin for its keyboard shortcuts.
+  bash -c 'set -m; npm run dev:mock -- --port "$1" --strictPort </dev/null >"$2" 2>&1 & echo $! > "$3"' \
+    _ "$port" "$log" "$pgid_file"
+  echo "$port" > "$port_file"
+  for _ in $(seq 1 60); do
+    if curl -sf "http://localhost:$port/" >/dev/null 2>&1; then
+      echo "READY http://localhost:$port · checklist $checklist"
+      return 0
+    fi
+    # The launcher died: stop waiting on a port nothing will ever answer.
+    kill -0 -- "-$(cat "$pgid_file")" 2>/dev/null || break
+    sleep 1
+  done
+  echo "dev:mock did not come up on port $port; log tail:" >&2
+  tail -40 "$log" >&2
+  stop_server
+  exit 1
+}
+
+# Rewrite line 1 from the marks. Whatever the walker wrote before the first
+# " · " is kept as the title; everything after it is derived, so the counts can
+# never disagree with the lines. A screen listed in two flows is two lines and
+# two walks, so it counts twice; the once-per-app block is not screens.
+recount() {
+  local tmp
+  tmp=$(mktemp)
+  awk '
+    NR == 1 { head = $0; sub(/ · .*$/, "", head); next }
+    /^flow "/ { flows++ }
+    /^once per app$/ { once = 1 }
+    /^- / {
+      if (!once) screens++
+      if ($0 ~ /^- \[x\] .*FIXED/) fixed++
+      else if ($0 ~ /^- \[x\]/) pass++
+      else if ($0 ~ /^- \[ \]/) open++
+      else if ($0 ~ /^- \[~\]/) outside++
+      else towalk++
+    }
+    { body[NR] = $0 }
+    END {
+      line = head " · " screens + 0 " screens, " flows + 0 " flows · " \
+             pass + 0 " pass, " fixed + 0 " fixed, " open + 0 " open, " outside + 0 " outside"
+      if (towalk) line = line ", " towalk " to walk"
+      print line
+      for (i = 2; i <= NR; i++) print body[i]
+    }' "$checklist" > "$tmp"
+  mv "$tmp" "$checklist"
+}
+
+post() {
+  local issue=${1:-}
+  if [ ! -f "$checklist" ]; then
+    echo "no checklist at $checklist — write it first" >&2
+    exit 1
+  fi
+  recount
+  if [ -z "$issue" ]; then
+    echo "recounted $checklist (no issue given, not published)"
+    head -1 "$checklist"
+    return 0
+  fi
+  if [ -f "$comment_file" ]; then
+    gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$(cat "$comment_file")" \
+      -F "body=@$checklist" > /dev/null
+  else
+    local url id
+    url=$(gh issue comment "$issue" --body-file "$checklist")
+    id=${url##*issuecomment-}
+    if [[ $id =~ ^[0-9]+$ ]]; then
+      echo "$id" > "$comment_file"
+    else
+      echo "could not read the comment id from '$url'; the next post will create a new comment" >&2
+    fi
+  fi
+  echo "published to #$issue: $(head -1 "$checklist")"
+}
+
+down() {
+  stop_server
+  if command -v agent-browser > /dev/null 2>&1; then
+    agent-browser close --all > /dev/null 2>&1 || true
+  fi
+  local port
+  port=$(cat "$port_file" 2>/dev/null || true)
+  if [ -n "$port" ]; then
+    for _ in $(seq 1 20); do
+      listening "$port" || break
+      sleep 0.25
+    done
+    if listening "$port"; then
+      echo "STILL UP on port $port" >&2
+      exit 1
+    fi
+  fi
+  rm -f "$port_file" "$log"
+  echo STOPPED
+}
+
+case "${1:-}" in
+  up | restart) start_server ;;
+  post) post "${2:-}" ;;
+  down) down ;;
+  *)
+    sed -n '18,27p' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/skills/mock-verification/scripts/walk.sh
+++ b/skills/mock-verification/scripts/walk.sh
@@ -15,20 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# walk.sh — the mechanics of a mock-verification walk, so the walker writes none
-# of them. Run from the App Path.
+# walk.sh — the dev server of a mock-verification walk, so the walker runs none
+# of its mechanics. Run from the App Path.
 #
-#   walk.sh up               start `npm run dev:mock` on a free port
-#                            → READY <url> · checklist <file>
-#   walk.sh restart          stop the server and start it again (same browser)
-#   walk.sh post [<issue#>]  rewrite the checklist's first line with the counts;
-#                            with an issue, publish the file as ONE comment on
-#                            it, edited in place on every later call
-#   walk.sh down             stop the server, close the browser, confirm the
-#                            port let go → STOPPED
+#   walk.sh up        start `npm run dev:mock` on a free port → READY <url>
+#   walk.sh restart   stop the server and start it again (same browser)
+#   walk.sh down      stop the server, close the browser, confirm the port let
+#                     go → STOPPED
 #
-# State lives at /tmp/walk-<app>.* where <app> is the App Path's basename; the
-# checklist the walker writes is /tmp/walk-<app>.md and `up` prints that path.
+# State lives at /tmp/walk-<app>.* where <app> is the App Path's basename.
 #
 # Why a script and not four lines in the skill: `npm run` is three processes and
 # the runner image has no `ps`/`pkill`, so the process GROUP is the only handle
@@ -43,11 +38,9 @@ set -euo pipefail
 
 app=$(basename "$PWD")
 state="/tmp/walk-$app"
-checklist="$state.md"
 log="$state.log"
 pgid_file="$state.pgid"
 port_file="$state.port"
-comment_file="$state.comment"
 
 listening() { (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; }
 
@@ -82,7 +75,7 @@ start_server() {
   echo "$port" > "$port_file"
   for _ in $(seq 1 60); do
     if curl -sf "http://localhost:$port/" >/dev/null 2>&1; then
-      echo "READY http://localhost:$port · checklist $checklist"
+      echo "READY http://localhost:$port"
       return 0
     fi
     # The launcher died: stop waiting on a port nothing will ever answer.
@@ -93,64 +86,6 @@ start_server() {
   tail -40 "$log" >&2
   stop_server
   exit 1
-}
-
-# Rewrite line 1 from the marks. Whatever the walker wrote before the first
-# " · " is kept as the title; everything after it is derived, so the counts can
-# never disagree with the lines. A screen listed in two flows is two lines and
-# two walks, so it counts twice; the once-per-app block is not screens.
-recount() {
-  local tmp
-  tmp=$(mktemp)
-  awk '
-    NR == 1 { head = $0; sub(/ · .*$/, "", head); next }
-    /^flow "/ { flows++ }
-    /^once per app$/ { once = 1 }
-    /^- / {
-      if (!once) screens++
-      if ($0 ~ /^- \[x\] .*FIXED/) fixed++
-      else if ($0 ~ /^- \[x\]/) pass++
-      else if ($0 ~ /^- \[ \]/) open++
-      else if ($0 ~ /^- \[~\]/) outside++
-      else towalk++
-    }
-    { body[NR] = $0 }
-    END {
-      line = head " · " screens + 0 " screens, " flows + 0 " flows · " \
-             pass + 0 " pass, " fixed + 0 " fixed, " open + 0 " open, " outside + 0 " outside"
-      if (towalk) line = line ", " towalk " to walk"
-      print line
-      for (i = 2; i <= NR; i++) print body[i]
-    }' "$checklist" > "$tmp"
-  mv "$tmp" "$checklist"
-}
-
-post() {
-  local issue=${1:-}
-  if [ ! -f "$checklist" ]; then
-    echo "no checklist at $checklist — write it first" >&2
-    exit 1
-  fi
-  recount
-  if [ -z "$issue" ]; then
-    echo "recounted $checklist (no issue given, not published)"
-    head -1 "$checklist"
-    return 0
-  fi
-  if [ -f "$comment_file" ]; then
-    gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$(cat "$comment_file")" \
-      -F "body=@$checklist" > /dev/null
-  else
-    local url id
-    url=$(gh issue comment "$issue" --body-file "$checklist")
-    id=${url##*issuecomment-}
-    if [[ $id =~ ^[0-9]+$ ]]; then
-      echo "$id" > "$comment_file"
-    else
-      echo "could not read the comment id from '$url'; the next post will create a new comment" >&2
-    fi
-  fi
-  echo "published to #$issue: $(head -1 "$checklist")"
 }
 
 down() {
@@ -176,10 +111,9 @@ down() {
 
 case "${1:-}" in
   up | restart) start_server ;;
-  post) post "${2:-}" ;;
   down) down ;;
   *)
-    sed -n '18,27p' "$0" >&2
+    sed -n '18,24p' "$0" >&2
     exit 2
     ;;
 esac

--- a/skills/mock-verification/scripts/walk.sh
+++ b/skills/mock-verification/scripts/walk.sh
@@ -23,7 +23,9 @@
 #   walk.sh down      stop the server, close the browser, confirm the port let
 #                     go → STOPPED
 #
-# State lives at /tmp/walk-<app>.* where <app> is the App Path's basename.
+# State lives at /tmp/walk-<app>.* where <app> is the App Path with its slashes
+# turned to underscores, so two apps with the same directory name under
+# different parents keep separate servers.
 #
 # Why a script and not four lines in the skill: `npm run` is three processes and
 # the runner image has no `ps`/`pkill`, so the process GROUP is the only handle
@@ -31,12 +33,14 @@
 # which is why `$!` below is a group id, on Linux and on a macOS laptop alike.
 # Every walk used to re-derive that, and the one that did not leaked four dev
 # servers into a 3Gi cgroup. The port is searched rather than fixed so two
-# web-application walks in one wave do not fight over 5173; a stale server from
-# this app's earlier attempt is reaped before a new one starts.
+# web-application walks in one wave do not fight over 5173 — and because two
+# `up` calls can still pick the same free port in the same instant, a launch
+# that dies on a bind collision moves to the next port by itself. A stale server
+# from this app's earlier attempt is reaped before a new one starts.
 
 set -euo pipefail
 
-app=$(basename "$PWD")
+app=$(printf '%s' "$PWD" | tr '/' '_')
 state="/tmp/walk-$app"
 log="$state.log"
 pgid_file="$state.pgid"
@@ -57,16 +61,10 @@ stop_server() {
   rm -f "$pgid_file"
 }
 
-start_server() {
-  stop_server
-  local port
-  for port in $(seq 5173 5199); do
-    listening "$port" || break
-  done
-  if listening "$port"; then
-    echo "no free port between 5173 and 5199" >&2
-    exit 1
-  fi
+# Launch on one port and wait for it. Returns 0 when the url answers, 2 when the
+# launcher died on a bind collision (the caller tries the next port), 1 otherwise.
+launch_on() {
+  local port=$1
   : > "$log"
   # `</dev/null`: under job control a server that reads the terminal would be
   # stopped with SIGTTIN; Vite reads stdin for its keyboard shortcuts.
@@ -75,16 +73,33 @@ start_server() {
   echo "$port" > "$port_file"
   for _ in $(seq 1 60); do
     if curl -sf "http://localhost:$port/" >/dev/null 2>&1; then
-      echo "READY http://localhost:$port"
       return 0
     fi
     # The launcher died: stop waiting on a port nothing will ever answer.
-    kill -0 -- "-$(cat "$pgid_file")" 2>/dev/null || break
+    if ! kill -0 -- "-$(cat "$pgid_file")" 2>/dev/null; then
+      rm -f "$pgid_file"
+      grep -qiE "EADDRINUSE|already in use" "$log" && return 2
+      return 1
+    fi
     sleep 1
   done
-  echo "dev:mock did not come up on port $port; log tail:" >&2
-  tail -40 "$log" >&2
+  return 1
+}
+
+start_server() {
   stop_server
+  local port rc
+  for port in $(seq 5173 5199); do
+    listening "$port" && continue
+    launch_on "$port" && { echo "READY http://localhost:$port"; return 0; }
+    rc=$?
+    [ "$rc" -eq 2 ] && continue
+    echo "dev:mock did not come up on port $port; log tail:" >&2
+    tail -40 "$log" >&2
+    stop_server
+    exit 1
+  done
+  echo "no free port between 5173 and 5199" >&2
   exit 1
 }
 

--- a/skills/mock-verification/scripts/walk.test.mjs
+++ b/skills/mock-verification/scripts/walk.test.mjs
@@ -17,9 +17,8 @@
  */
 
 // walk.sh owns the one thing the walker cannot see when it goes wrong — a dev
-// server it left behind — and the one line a pull request quotes. Both are
-// pinned here against a stand-in app whose `dev:mock` is a bare node listener,
-// and a stand-in `gh` that records what it was asked.
+// server it left behind. Pinned here against a stand-in app whose `dev:mock` is
+// a bare node listener.
 
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
@@ -46,23 +45,10 @@ function fixtureApp({ devMock = "node server.mjs" } = {}) {
   return dir;
 }
 
-// Stand-ins ahead of PATH for every run: a `gh` that logs its argv and answers
-// like the real one, and an `agent-browser` that does nothing — `down` closes
-// the browser, and a test must not close the one a developer is using.
+// A no-op `agent-browser` ahead of PATH: `down` closes the browser, and a test
+// must not close the one a developer is using.
 const BIN = mkdtempSync(path.join(tmpdir(), "walk-bin-"));
-const GH_LOG = path.join(BIN, "gh.log");
-writeFileSync(
-  path.join(BIN, "gh"),
-  `#!/usr/bin/env bash
-printf '%s\\n' "$*" >> "${GH_LOG}"
-case "$1" in
-  issue) echo "https://github.com/o/r/issues/$3#issuecomment-4242" ;;
-  api) echo "{}" ;;
-esac
-`,
-);
 writeFileSync(path.join(BIN, "agent-browser"), "#!/usr/bin/env bash\nexit 0\n");
-chmodSync(path.join(BIN, "gh"), 0o755);
 chmodSync(path.join(BIN, "agent-browser"), 0o755);
 
 function walk(cwd, args) {
@@ -83,7 +69,7 @@ after(() => {
 function track(dir) {
   cleanups.push(() => {
     walk(dir, ["down"]);
-    for (const ext of ["md", "log", "pgid", "port", "comment"]) rmSync(`${stateOf(dir)}.${ext}`, { force: true });
+    for (const ext of ["log", "pgid", "port"]) rmSync(`${stateOf(dir)}.${ext}`, { force: true });
     rmSync(dir, { recursive: true, force: true });
   });
   return dir;
@@ -106,9 +92,8 @@ test("up starts dev:mock on a free port and down leaves nothing listening", asyn
   const app = track(fixtureApp());
   const up = walk(app, ["up"]);
   assert.equal(up.status, 0, up.stderr);
-  const m = /^READY (http:\/\/localhost:(\d+)) · checklist (\S+)$/m.exec(up.stdout);
+  const m = /^READY (http:\/\/localhost:(\d+))$/m.exec(up.stdout);
   assert.ok(m, `unexpected READY line: ${up.stdout}`);
-  assert.equal(m[3], `${stateOf(app)}.md`, "up names the checklist path the walker writes");
   assert.ok(await isListening(Number(m[2])), "the url answers");
   assert.ok(existsSync(`${stateOf(app)}.pgid`), "the process group is recorded");
 
@@ -169,74 +154,6 @@ test("up fails fast, with the log, when dev:mock dies at once", () => {
   assert.match(up.stderr, /did not come up/);
   assert.match(up.stderr, /boom: no such mode/, "the log tail is in the output");
   assert.equal(existsSync(`${stateOf(app)}.pgid`), false, "nothing is left recorded as running");
-});
-
-const CHECKLIST = `Mock verification: todo-webapp · stale counts the walker typed
-
-flow "Approval queue" (Admin)
-- [x] AdminQueue: filtered by status; "Approve" moved the row to Done
-- [x] AuditDetail: FIXED back arrow went to /; now -> AdminQueue. Re-walked: lands on the queue.
-- [ ] AuditExport: "Export" does nothing. Tried wiring onClick, 3 attempts. Still no request.
-flow "My orders" (Customer)
-- [x] Orders: table -> OrderDetail
-- OrderDetail: "Cancel" button; -> Orders
-screens in no flow
-- [~] Settings: the 403 is the gateway's
-once per app
-- [x] Roles: Customer on /admin bounced to /orders
-- Session
-- Probes
-- [x] Console: clean
-`;
-
-test("post derives the first line from the marks and keeps the title", () => {
-  const app = track(fixtureApp());
-  writeFileSync(`${stateOf(app)}.md`, CHECKLIST);
-  const post = walk(app, ["post"]);
-  assert.equal(post.status, 0, post.stderr);
-  const lines = readFileSync(`${stateOf(app)}.md`, "utf8").split("\n");
-  assert.equal(
-    lines[0],
-    "Mock verification: todo-webapp · 6 screens, 2 flows · 4 pass, 1 fixed, 1 open, 1 outside, 3 to walk",
-  );
-  assert.equal(lines.length, CHECKLIST.split("\n").length, "only line 1 changed");
-  assert.match(post.stdout, /not published/);
-});
-
-test("post omits 'to walk' once every line is marked", () => {
-  const app = track(fixtureApp());
-  writeFileSync(`${stateOf(app)}.md`, CHECKLIST.replaceAll(/^- (?!\[)/gm, "- [x] "));
-  walk(app, ["post"]);
-  assert.equal(
-    readFileSync(`${stateOf(app)}.md`, "utf8").split("\n")[0],
-    "Mock verification: todo-webapp · 6 screens, 2 flows · 7 pass, 1 fixed, 1 open, 1 outside",
-  );
-});
-
-test("post creates one comment and edits that same comment afterwards", () => {
-  const app = track(fixtureApp());
-  writeFileSync(`${stateOf(app)}.md`, CHECKLIST);
-
-  const first = walk(app, ["post", "17"]);
-  assert.equal(first.status, 0, first.stderr);
-  assert.match(first.stdout, /^published to #17: Mock verification: todo-webapp · 6 screens/m);
-  assert.equal(readFileSync(`${stateOf(app)}.comment`, "utf8").trim(), "4242");
-
-  const second = walk(app, ["post", "17"]);
-  assert.equal(second.status, 0, second.stderr);
-
-  const calls = readFileSync(GH_LOG, "utf8").trim().split("\n");
-  assert.deepEqual(calls, [
-    `issue comment 17 --body-file ${stateOf(app)}.md`,
-    `api -X PATCH repos/{owner}/{repo}/issues/comments/4242 -F body=@${stateOf(app)}.md`,
-  ]);
-});
-
-test("post without a checklist is an error, not a silent no-op", () => {
-  const app = track(fixtureApp());
-  const post = walk(app, ["post", "17"]);
-  assert.notEqual(post.status, 0);
-  assert.match(post.stderr, /no checklist/);
 });
 
 test("an unknown verb prints the usage and exits 2", () => {

--- a/skills/mock-verification/scripts/walk.test.mjs
+++ b/skills/mock-verification/scripts/walk.test.mjs
@@ -22,7 +22,7 @@
 
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -30,16 +30,23 @@ import path from "node:path";
 
 const SCRIPT = path.join(import.meta.dirname, "walk.sh");
 
+// FAIL_PORT stands in for a bind collision: on that port the server dies the
+// way Vite does when another process won the port a moment earlier.
 const SERVER = `
 const i = process.argv.indexOf("--port");
 const port = Number(process.argv[i + 1]);
+if (String(port) === process.env.FAIL_PORT) {
+  console.error("Error: Port " + port + " is already in use");
+  process.exit(1);
+}
 import("node:http").then(({ createServer }) =>
   createServer((_, res) => res.end("ok")).listen(port));
 `;
 
-/** A stand-in App Path. Its basename is the walk's state key, so each test gets its own. */
-function fixtureApp({ devMock = "node server.mjs" } = {}) {
-  const dir = mkdtempSync(path.join(tmpdir(), "walk-app-"));
+/** A stand-in App Path. Its path is the walk's state key, so each test gets its own. */
+function fixtureApp({ devMock = "node server.mjs", parent = tmpdir(), name } = {}) {
+  const dir = name ? path.join(parent, name) : mkdtempSync(path.join(parent, "walk-app-"));
+  if (name) mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "package.json"), JSON.stringify({ scripts: { "dev:mock": devMock } }));
   writeFileSync(path.join(dir, "server.mjs"), SERVER);
   return dir;
@@ -51,16 +58,18 @@ const BIN = mkdtempSync(path.join(tmpdir(), "walk-bin-"));
 writeFileSync(path.join(BIN, "agent-browser"), "#!/usr/bin/env bash\nexit 0\n");
 chmodSync(path.join(BIN, "agent-browser"), 0o755);
 
-function walk(cwd, args) {
+function walk(cwd, args, env = {}) {
   return spawnSync("bash", [SCRIPT, ...args], {
     cwd,
     encoding: "utf8",
-    env: { ...process.env, PATH: `${BIN}:${process.env.PATH}` },
+    env: { ...process.env, ...env, PATH: `${BIN}:${process.env.PATH}` },
     timeout: 90_000,
   });
 }
 
-const stateOf = (dir) => `/tmp/walk-${path.basename(dir)}`;
+// The script keys state on bash's $PWD, which is the physical path — on macOS
+// mkdtemp hands back /var/… for what bash sees as /private/var/….
+const stateOf = (dir) => `/tmp/walk-${realpathSync(dir).replaceAll("/", "_")}`;
 const cleanups = [];
 after(() => {
   for (const fn of cleanups) fn();
@@ -143,6 +152,39 @@ test("a second up reaps the first server instead of leaking it", async () => {
   assert.notEqual(secondPgid, firstPgid, "a new process group");
   assert.equal(secondPort, firstPort, "the reaped server's port is free again");
   assert.equal(spawnSync("kill", ["-0", "--", `-${firstPgid}`]).status !== 0, true, "the first group is gone");
+});
+
+test("up moves to the next port when the launch loses a bind race", async () => {
+  const app = track(fixtureApp());
+  // Find the port a bare `up` would take, and make the server refuse exactly it.
+  let first = 5173;
+  for (; first < 5199; first++) {
+    const holder = await occupy(first).catch(() => undefined);
+    if (holder) {
+      holder.close();
+      break;
+    }
+  }
+  const up = walk(app, ["up"], { FAIL_PORT: String(first) });
+  assert.equal(up.status, 0, up.stderr);
+  const port = Number(/localhost:(\d+)/.exec(up.stdout)[1]);
+  assert.ok(port > first, `moved past the contested port ${first}, got ${port}`);
+  assert.ok(await isListening(port));
+});
+
+test("two apps with the same directory name keep separate servers", async () => {
+  const a = track(fixtureApp({ parent: mkdtempSync(path.join(tmpdir(), "walk-a-")), name: "web" }));
+  const b = track(fixtureApp({ parent: mkdtempSync(path.join(tmpdir(), "walk-b-")), name: "web" }));
+  assert.notEqual(stateOf(a), stateOf(b));
+  const upA = walk(a, ["up"]);
+  const upB = walk(b, ["up"]);
+  assert.equal(upA.status, 0, upA.stderr);
+  assert.equal(upB.status, 0, upB.stderr);
+  const portA = Number(/localhost:(\d+)/.exec(upA.stdout)[1]);
+  const portB = Number(/localhost:(\d+)/.exec(upB.stdout)[1]);
+  assert.notEqual(portA, portB);
+  assert.equal(walk(a, ["down"]).status, 0, "a's down");
+  assert.ok(await isListening(portB), "b's server survived a's down");
 });
 
 test("up fails fast, with the log, when dev:mock dies at once", () => {

--- a/skills/mock-verification/scripts/walk.test.mjs
+++ b/skills/mock-verification/scripts/walk.test.mjs
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// walk.sh owns the one thing the walker cannot see when it goes wrong — a dev
+// server it left behind — and the one line a pull request quotes. Both are
+// pinned here against a stand-in app whose `dev:mock` is a bare node listener,
+// and a stand-in `gh` that records what it was asked.
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT = path.join(import.meta.dirname, "walk.sh");
+
+const SERVER = `
+const i = process.argv.indexOf("--port");
+const port = Number(process.argv[i + 1]);
+import("node:http").then(({ createServer }) =>
+  createServer((_, res) => res.end("ok")).listen(port));
+`;
+
+/** A stand-in App Path. Its basename is the walk's state key, so each test gets its own. */
+function fixtureApp({ devMock = "node server.mjs" } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), "walk-app-"));
+  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ scripts: { "dev:mock": devMock } }));
+  writeFileSync(path.join(dir, "server.mjs"), SERVER);
+  return dir;
+}
+
+// Stand-ins ahead of PATH for every run: a `gh` that logs its argv and answers
+// like the real one, and an `agent-browser` that does nothing — `down` closes
+// the browser, and a test must not close the one a developer is using.
+const BIN = mkdtempSync(path.join(tmpdir(), "walk-bin-"));
+const GH_LOG = path.join(BIN, "gh.log");
+writeFileSync(
+  path.join(BIN, "gh"),
+  `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${GH_LOG}"
+case "$1" in
+  issue) echo "https://github.com/o/r/issues/$3#issuecomment-4242" ;;
+  api) echo "{}" ;;
+esac
+`,
+);
+writeFileSync(path.join(BIN, "agent-browser"), "#!/usr/bin/env bash\nexit 0\n");
+chmodSync(path.join(BIN, "gh"), 0o755);
+chmodSync(path.join(BIN, "agent-browser"), 0o755);
+
+function walk(cwd, args) {
+  return spawnSync("bash", [SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${BIN}:${process.env.PATH}` },
+    timeout: 90_000,
+  });
+}
+
+const stateOf = (dir) => `/tmp/walk-${path.basename(dir)}`;
+const cleanups = [];
+after(() => {
+  for (const fn of cleanups) fn();
+  rmSync(BIN, { recursive: true, force: true });
+});
+function track(dir) {
+  cleanups.push(() => {
+    walk(dir, ["down"]);
+    for (const ext of ["md", "log", "pgid", "port", "comment"]) rmSync(`${stateOf(dir)}.${ext}`, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return dir;
+}
+
+async function isListening(port) {
+  const res = await fetch(`http://localhost:${port}/`).catch(() => undefined);
+  return res?.ok === true;
+}
+
+function occupy(port) {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(port, "127.0.0.1", () => resolve(srv));
+  });
+}
+
+test("up starts dev:mock on a free port and down leaves nothing listening", async () => {
+  const app = track(fixtureApp());
+  const up = walk(app, ["up"]);
+  assert.equal(up.status, 0, up.stderr);
+  const m = /^READY (http:\/\/localhost:(\d+)) · checklist (\S+)$/m.exec(up.stdout);
+  assert.ok(m, `unexpected READY line: ${up.stdout}`);
+  assert.equal(m[3], `${stateOf(app)}.md`, "up names the checklist path the walker writes");
+  assert.ok(await isListening(Number(m[2])), "the url answers");
+  assert.ok(existsSync(`${stateOf(app)}.pgid`), "the process group is recorded");
+
+  const down = walk(app, ["down"]);
+  assert.equal(down.status, 0, down.stderr);
+  assert.match(down.stdout, /^STOPPED$/m);
+  assert.equal(await isListening(Number(m[2])), false, "the port let go");
+  assert.equal(existsSync(`${stateOf(app)}.pgid`), false);
+});
+
+test("up skips a port something else already holds", async () => {
+  const app = track(fixtureApp());
+  // Whatever is free first from 5173 is the port a bare `up` would take.
+  let taken = 5173;
+  let holder;
+  for (; taken < 5199; taken++) {
+    try {
+      holder = await occupy(taken);
+      break;
+    } catch {
+      /* in use by someone else — try the next */
+    }
+  }
+  try {
+    const up = walk(app, ["up"]);
+    assert.equal(up.status, 0, up.stderr);
+    const port = Number(/localhost:(\d+)/.exec(up.stdout)[1]);
+    assert.notEqual(port, taken, "the occupied port was not chosen");
+    assert.ok(port > taken);
+    assert.ok(await isListening(port));
+  } finally {
+    holder.close();
+  }
+});
+
+test("a second up reaps the first server instead of leaking it", async () => {
+  const app = track(fixtureApp());
+  const first = walk(app, ["up"]);
+  assert.equal(first.status, 0, first.stderr);
+  const firstPort = Number(/localhost:(\d+)/.exec(first.stdout)[1]);
+  const firstPgid = readFileSync(`${stateOf(app)}.pgid`, "utf8").trim();
+
+  const second = walk(app, ["restart"]);
+  assert.equal(second.status, 0, second.stderr);
+  const secondPort = Number(/localhost:(\d+)/.exec(second.stdout)[1]);
+  const secondPgid = readFileSync(`${stateOf(app)}.pgid`, "utf8").trim();
+  assert.notEqual(secondPgid, firstPgid, "a new process group");
+  assert.equal(secondPort, firstPort, "the reaped server's port is free again");
+  assert.equal(spawnSync("kill", ["-0", "--", `-${firstPgid}`]).status !== 0, true, "the first group is gone");
+});
+
+test("up fails fast, with the log, when dev:mock dies at once", () => {
+  const app = track(fixtureApp({ devMock: "node -e \"console.error('boom: no such mode'); process.exit(3)\"" }));
+  const started = Date.now();
+  const up = walk(app, ["up"]);
+  assert.notEqual(up.status, 0);
+  assert.ok(Date.now() - started < 20_000, "did not wait out the whole poll");
+  assert.match(up.stderr, /did not come up/);
+  assert.match(up.stderr, /boom: no such mode/, "the log tail is in the output");
+  assert.equal(existsSync(`${stateOf(app)}.pgid`), false, "nothing is left recorded as running");
+});
+
+const CHECKLIST = `Mock verification: todo-webapp · stale counts the walker typed
+
+flow "Approval queue" (Admin)
+- [x] AdminQueue: filtered by status; "Approve" moved the row to Done
+- [x] AuditDetail: FIXED back arrow went to /; now -> AdminQueue. Re-walked: lands on the queue.
+- [ ] AuditExport: "Export" does nothing. Tried wiring onClick, 3 attempts. Still no request.
+flow "My orders" (Customer)
+- [x] Orders: table -> OrderDetail
+- OrderDetail: "Cancel" button; -> Orders
+screens in no flow
+- [~] Settings: the 403 is the gateway's
+once per app
+- [x] Roles: Customer on /admin bounced to /orders
+- Session
+- Probes
+- [x] Console: clean
+`;
+
+test("post derives the first line from the marks and keeps the title", () => {
+  const app = track(fixtureApp());
+  writeFileSync(`${stateOf(app)}.md`, CHECKLIST);
+  const post = walk(app, ["post"]);
+  assert.equal(post.status, 0, post.stderr);
+  const lines = readFileSync(`${stateOf(app)}.md`, "utf8").split("\n");
+  assert.equal(
+    lines[0],
+    "Mock verification: todo-webapp · 6 screens, 2 flows · 4 pass, 1 fixed, 1 open, 1 outside, 3 to walk",
+  );
+  assert.equal(lines.length, CHECKLIST.split("\n").length, "only line 1 changed");
+  assert.match(post.stdout, /not published/);
+});
+
+test("post omits 'to walk' once every line is marked", () => {
+  const app = track(fixtureApp());
+  writeFileSync(`${stateOf(app)}.md`, CHECKLIST.replaceAll(/^- (?!\[)/gm, "- [x] "));
+  walk(app, ["post"]);
+  assert.equal(
+    readFileSync(`${stateOf(app)}.md`, "utf8").split("\n")[0],
+    "Mock verification: todo-webapp · 6 screens, 2 flows · 7 pass, 1 fixed, 1 open, 1 outside",
+  );
+});
+
+test("post creates one comment and edits that same comment afterwards", () => {
+  const app = track(fixtureApp());
+  writeFileSync(`${stateOf(app)}.md`, CHECKLIST);
+
+  const first = walk(app, ["post", "17"]);
+  assert.equal(first.status, 0, first.stderr);
+  assert.match(first.stdout, /^published to #17: Mock verification: todo-webapp · 6 screens/m);
+  assert.equal(readFileSync(`${stateOf(app)}.comment`, "utf8").trim(), "4242");
+
+  const second = walk(app, ["post", "17"]);
+  assert.equal(second.status, 0, second.stderr);
+
+  const calls = readFileSync(GH_LOG, "utf8").trim().split("\n");
+  assert.deepEqual(calls, [
+    `issue comment 17 --body-file ${stateOf(app)}.md`,
+    `api -X PATCH repos/{owner}/{repo}/issues/comments/4242 -F body=@${stateOf(app)}.md`,
+  ]);
+});
+
+test("post without a checklist is an error, not a silent no-op", () => {
+  const app = track(fixtureApp());
+  const post = walk(app, ["post", "17"]);
+  assert.notEqual(post.status, 0);
+  assert.match(post.stderr, /no checklist/);
+});
+
+test("an unknown verb prints the usage and exits 2", () => {
+  const app = track(fixtureApp());
+  const r = walk(app, ["sideways"]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /walk\.sh up/);
+});

--- a/skills/react-webapp/references/mock-mode.md
+++ b/skills/react-webapp/references/mock-mode.md
@@ -269,11 +269,10 @@ guard in `src/main.tsx` was written so the bundler could not prove the branch
 dead — production would then ship the mock, which is the one failure this whole
 arrangement exists to prevent.
 
-To drive it by hand:
-
-```bash
-npm run dev:mock -- --port 5173 --strictPort
-```
+You never start it. The walk (`mock-verification`) starts and stops the dev
+server through its own script, and a server you start here has nothing to reap
+it: the runner image has no `pkill`, and a stray `vite` stays in the pod's
+memory for the rest of the run.
 
 ## Pitfalls
 


### PR DESCRIPTION
Three commits: two that reshape how a mock-verification walk reports, and one
identity fix that has already destroyed role groups on the demo cluster.

## 1 · A deleted test account must not be left in its roles

Thunder keeps no referential integrity between accounts and group membership.
`DELETE /users/{id}` leaves every group the account belonged to naming an id
that no longer resolves, and `POST /groups` carrying such an id is rejected
wholesale with `400 GRP-1007`. Because membership can only be written by
deleting the group and recreating it, the next build that enrolled anybody into
that role **destroyed it** — deterministically, on every retry, after the
delete had already committed. Nine role groups went that way on the demo
cluster.

The corruption is introduced by the delete, so that is where it is stopped:

- `PanelService.Delete` un-enrols the account from every group it belongs to,
  owned or not, **before** removing it. A failure aborts the delete — nothing
  has happened yet and the caller can retry, where pressing on is precisely how
  the dangling member is made. `DeleteResult.UnenrolledFrom` names the roles and
  the handler says so in the status, because once the account is gone that fact
  is unobservable.
- `thundersvc` gains `UserGroups` (`GET /users/{id}/groups`; a 404 means no
  groups, so a retried delete does not fail on its first step) and
  `RemoveGroupMembers`.
- `rewriteGroupMembers` is now the one place that rewrites a group, and it makes
  the data-loss outcome impossible: every id is resolved against the directory
  before anything is deleted.

## 2–3 · A walk posts a numbered plan and a line per item

The walk used to report through three surfaces with three shapes (a checklist
comment, a status line per settled line, a report comment at the end). The first
commit collapsed them into one comment edited in place; the second replaces that
with a running thread, which is what the amendment to ADR-0025 now records:

- a **plan** posted before the browser opens, one numbered item per screen and
  per once-per-app check;
- **one line per item** as it settles — `n/N Screen: done | fixed | open |
  outside — detail`;
- a **closing line** with the counts, which is what the pull request quotes.

The newest comment is then where the walk is (the status line ADR-0010 asks
for), and an item with no line is a screen never reached. This posts more
comments per web-app issue than ADR-0010's two to four, and takes a legible
history over a quiet thread on purpose.

**Where** the lines go is the dispatch prompt's to say, per mode — a
`gh issue comment` on the platform, a section of `issues/<n>.md` in the
playground — so the skill names no `gh` and ships byte-identical into both, as
ADR-0010's decision 7 requires. That takes the `post` verb out of `walk.sh`,
which is now only the dev server: `up`, `restart`, `down`.

The script itself is the other half of these two commits. The skill text had
carried a process-group launcher, a port-collision rule and a stop sequence that
every walk re-typed; the one walk that improvised instead leaked four dev
servers into its memory limit. `walk.sh` reaps by process group, takes a free
port so two walks in one wave cannot collide, and closes the browser on `down`.
The runner image gains `procps` as a backstop for an agent that reaches for
`pkill` outside the procedure. `mock-mode.md` no longer hands out a bare
`npm run dev:mock`, because a server started outside the script has nothing to
reap it.

## Proof

```
$ node --test skills/mock-verification/scripts/walk.test.mjs
# tests 5
# pass 5
# fail 0

$ cd runners/remote-worker && npm test
# tests 449
# pass 449
# fail 0

$ cd runners/remote-worker && npm run typecheck
> tsc --noEmit          (clean)

$ cd services/aep-api && go vet ./internal/...
                        (clean)

$ go test -count=1 ./internal/clients/thundersvc/... ./internal/identity/...
ok  	github.com/wso2/aep/aep-api/internal/clients/thundersvc	0.925s
ok  	github.com/wso2/aep/aep-api/internal/identity	1.034s
ok  	github.com/wso2/aep/aep-api/internal/identity/rolespanel	1.685s

$ make license-check
                        (clean)
```

`walk.test.mjs` stands the script up against a fixture app whose `dev:mock` is a
bare node listener, and asserts what the walker cannot see when it goes wrong: a
free port is taken, the process group is recorded, a second `up` reaps the first
server instead of leaking it, `down` leaves nothing listening, and a `dev:mock`
that dies at once fails fast with its log rather than hanging on a port nothing
will answer. `workflow_skill.test.ts` pins the skill's rules and the local
overlay, so the platform/playground split above is enforced, not just intended.

The identity fakes now model the IdP's missing referential integrity — which is
what lets a test ask for the state that broke this — and the component tests
assert the ordering (a sequence, not a set), the invariant that no group may name
an account that is gone, and that an aborted un-enrol leaves the account, the
platform's row and the membership all intact.

**Not yet exercised on a real run.** The walk's new comment shapes are proven by
the skill/overlay tests and the script tests; a live web-app cycle posting them
is still pending.

## Docs

- `docs/decisions/ADR-0025` carries the amendment for the reporting shapes and
  the script, replacing the previous amendment.
- `skills/AGENTS.md` (the walk's ownership split), `playground/AGENTS.md` (where
  progress lands in `--host`/docker mode), `skills/aep/SKILL.md` + its local
  overlay (the dispatch prompt now carries the post command),
  `skills/react-webapp/references/mock-mode.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
