### PR TITLE
fix(aep-api): reap the git processes aep-api inherits as PID 1

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -50,12 +50,6 @@ services:
       additional_contexts:
         skills: ../skills
     container_name: aep-api
-    # aep-api is PID 1 here, and git orphans helpers (background `gc --auto`,
-    # remote helpers) that then re-parent to it. A Go binary never reaps
-    # children it did not spawn, so without an init they pile up as zombies
-    # (~6/min observed locally). tini as PID 1 reaps them; the app still gets
-    # its signals, so shutdown is unchanged.
-    init: true
     # Fast SYN-retransmit recovery for the local Colima env. Its docker-bridge
     # NAT intermittently drops a SYN under concurrent outbound bursts (the BFF's
     # parallel git fetches + GitHub API calls on a project page load); the kernel

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -50,6 +50,12 @@ services:
       additional_contexts:
         skills: ../skills
     container_name: aep-api
+    # aep-api is PID 1 here, and git orphans helpers (background `gc --auto`,
+    # remote helpers) that then re-parent to it. A Go binary never reaps
+    # children it did not spawn, so without an init they pile up as zombies
+    # (~6/min observed locally). tini as PID 1 reaps them; the app still gets
+    # its signals, so shutdown is unchanged.
+    init: true
     # Fast SYN-retransmit recovery for the local Colima env. Its docker-bridge
     # NAT intermittently drops a SYN under concurrent outbound bursts (the BFF's
     # parallel git fetches + GitHub API calls on a project page load); the kernel

--- a/services/aep-api/Dockerfile
+++ b/services/aep-api/Dockerfile
@@ -47,7 +47,7 @@ FROM alpine:3.21
 # shell out to the git CLI. GitHub REST remains only for repo admin, issues,
 # webhooks, and App installs. aep-api is the sole writer of the mount;
 # the agents service consumes read-only per-SHA snapshots from it.
-RUN apk add --no-cache git
+RUN apk add --no-cache git tini
 RUN addgroup -g 1000 appgroup && adduser -S -u 1000 -G appgroup appuser
 
 WORKDIR /app
@@ -63,4 +63,11 @@ USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["./aep-api"]
+# tini as PID 1, because aep-api would otherwise hold that slot itself. git
+# leaves helpers behind it (a background `gc --auto`, a remote helper outliving
+# the fetch that spawned it); an orphan re-parents to PID 1, and no process
+# implicitly reaps children it did not spawn, so they accumulate as zombies
+# (~6/min observed on a local stack). tini reaps them and forwards signals
+# through unchanged, so shutdown behaves as before. Here rather than on a
+# runtime flag so every path gets it (compose, skaffold/helm, cloud).
+ENTRYPOINT ["/sbin/tini", "--", "./aep-api"]


### PR DESCRIPTION
`aep-api` is PID 1 wherever it runs, and it never reaps the children it did not
spawn. On a local stack left up for a day and a half that had grown to **2512
zombie `git` processes**, climbing at roughly six a minute.

## Why it is not a missing `Wait()`

That is the first place to look, and it is clean. Every spawn site in
`services/aep-api/internal/platform/gitfs/engine.go` reaps what it starts: the
buffered path uses `cmd.Run()`, the streaming path pairs `Start()` with `Wait()`
after draining the pipe. Grepping the package for a `Start()` without a matching
`Wait()` returns nothing.

The zombies are not aep-api's own children. `git` leaves helpers behind it — a
background `gc --auto`, a remote helper outliving the fetch that spawned it. An
orphan re-parents to PID 1, and no process implicitly reaps children it did not
spawn, so each one stays a zombie for the life of the process.

## Why the image and not the compose file

The first commit here put `init: true` on the aep-api compose service. The
standards review caught that this fixes one deployment path and leaves the
others carrying the defect: the Dockerfile ends `ENTRYPOINT ["./aep-api"]` on a
bare alpine, and `deployments/helm-charts/platform/templates/aep-api/deployment.yaml`
sets neither an init wrapper nor `shareProcessNamespace`. The Skaffold/helm path
and any cloud release binding orphan git's helpers exactly as the local stack
does, and there the process is long-lived — the worse case, not the milder one.

So the second commit moves it into the image and takes `init: true` back out, as
a redundant second answer to a question the entrypoint now settles. tini reaps
orphans and forwards signals through unchanged, so shutdown behaves as before,
and the fix does not depend on finding every `git` invocation that might leave
something behind — including ones a future `git` version introduces.

## Proof

Rebuilt the image and recreated the container against the running local stack:

```
BEFORE
  PID1: /app/aep-api
  zombies: 2512

AFTER  (docker compose up -d aep-api)
  PID1: /sbin/tini
  zombies: 0

  PID   PPID  STAT COMMAND
      1     0 S    tini
      7     1 S    aep-api        # the app, reparented under the reaper
```

Then held at `zombies=0` across ten consecutive samples on a 30-second poll —
five minutes, every one of them zero. The pre-fix rate of roughly six a minute
would have put about thirty on the board in that window. Container came back
healthy, no change to startup or shutdown behaviour.

The built image carries tini 0.19.0 at `/sbin/tini`, and the entrypoint is
`["/sbin/tini","--","./aep-api"]`.

## Documentation

None needed, and I checked rather than assumed. `deployments/CHANGES.md` is a
frozen restoration log from 2026-05-17 that ~11 later commits to
`docker-compose.yml` left untouched, `deployments/README.md` documents no
per-service knobs (not even the adjacent `sysctls`), and AGENTS.md scopes
`design/` notes to shipped features rather than a one-line runtime change. The
rationale lives in the comment above the entrypoint, where the next reader of
that line will be.

## Scope

`pid_max` is 4194304, so this was never close to breaking anything — a leak
worth not having, not an outage averted. It surfaced while diagnosing unrelated
local CPU load; the far larger cause there was accumulated `dp-default-*`
namespaces, filed separately as #728.
