### PR TITLE
Make Oxygen UI the organization's design system, keeping Astryx available

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -139,13 +139,13 @@ changing a web-app skill:
 grep -rniE 'astryx|@astryxdesign|\boxygen\b|@wso2/oxygen' skills/ --include='*.md'
 ```
 
-Only `skills/organization/SKILL.md`, `skills/oxygen-ui-design-system/**`,
-`skills/astryx-design-system/**` and this file should match. A hit anywhere
-else — especially in `architecture`, which is `kind: platform` and read-only in
-the console — means an org can no longer swap its design system without a
-platform change.
+Four paths may match, plus the one exception below: `skills/organization/SKILL.md`,
+`skills/oxygen-ui-design-system/**`, `skills/astryx-design-system/**` and this
+file. A hit anywhere else — especially in `architecture`, which is
+`kind: platform` and read-only in the console — means an org can no longer swap
+its design system without a platform change.
 
-One documented exception: `skills/wireframes/SKILL.md` says the wireframe
+The exception: `skills/wireframes/SKILL.md` says the wireframe
 compiler renders with an "Oxygen UI palette" and applies "the Oxygen theme".
 That is the **compiler's** drawing style for a `.excalidraw` picture, not the
 app's UI toolkit, and it does not follow the org's design system — swapping

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -43,8 +43,8 @@ An absent kind means `org`, which is a real decision, not a default to lean on:
   `aep-validation`, `mock-verification`) and the browser CLIs they drive
   (`playwright-cli`, `agent-browser`).
 - **`org`** — the org-visible stack skills (`go`, `ballerina`, `react-webapp`,
-  `astryx-design-system`, `api-management`, `thunder-authentication`). Editable
-  and deletable by an org.
+  `oxygen-ui-design-system`, `astryx-design-system`, `api-management`,
+  `thunder-authentication`). Editable and deletable by an org.
 
 Kind decides console visibility and who may edit a skill, and nothing else. It is
 `audience` that decides who may *read* one, and the two are independent — a skill
@@ -84,9 +84,13 @@ one was `go`'s, and it was invisible for as long as `go` was preloaded regardles
 A web app's UI toolkit is an **organization** decision, and nothing in this
 library hardcodes one. Two edits change it, both in places an org may edit:
 
-1. Add the new design-system skill — author `skills/<name>/SKILL.md`, or import
-   it through Settings → Skills. Delete `astryx-design-system` if the org does
-   not want it available.
+1. Make sure a skill for the design system exists — author
+   `skills/<name>/SKILL.md`, or import it through Settings → Skills. The
+   library ships two: `oxygen-ui-design-system` (WSO2 Oxygen UI, the default
+   `organization` names) and `astryx-design-system` (kept available, named by
+   nothing). Delete the one an org does not want offered at all, or switch it
+   off in Settings → Skills — availability is the org's manifest flag
+   (ADR-0015), not something a library file can set.
 2. Point the **UI design system** section of `organization` at its name.
 
 `architecture` reads the name out of that section rather than holding one of its
@@ -97,7 +101,13 @@ per-flow eager skill), so the name is always in context when a component's
 the pin follows the org's choice with **no platform-skill edit** —
 `architecture` is `kind: platform` and read-only in the console, which is exactly
 why the name cannot live there. An empty section means web-app builds carry only
-the stack skills. `astryx-design-system` is the shipped default, nothing more.
+the stack skills. A design-system skill this section does not name is never
+**pinned**, so no build is steered by it — but it is still seeded **enabled**
+(ADR-0015: an absent manifest entry means enabled) and still copied into every
+project mirror, where a coding agent can load it by name. Withholding it as
+well is the org's toggle at Settings → Skills, and **no file in this library
+can pre-set it**: `reconcileEmbedded` only carries a `Disabled` flag forward
+from the org's own repo and never originates one.
 
 A design-system skill must declare four things to work in that slot:
 
@@ -105,7 +115,10 @@ A design-system skill must declare four things to work in that slot:
   system is built against, not designed with; `[coding]` is what puts it in the
   project mirror, and `org` is what lets an org edit or delete it.
 - **A `## Verify` section** naming the one command `react-webapp`'s verify
-  sequence should run for it, or nothing if it has none.
+  sequence should run for it, or nothing if it has none. A command that is a
+  script the skill ships (`oxygen-ui-design-system/scripts/verify.mjs`) rides
+  the mirror like any aux file and is pinned by a `*.test.mjs` beside it, which
+  `make test` runs.
 - **Which of its own defaults the platform overrides.** Every vendor's
   quickstart assumes a project it scaffolded itself; `react-webapp`'s deployment
   facts (no `base`, the platform's own nginx assets, `window._env_`, one
@@ -115,7 +128,7 @@ A design-system skill must declare four things to work in that slot:
   layer (`openapi-fetch` + the committed `src/generated/` client) stays
   `react-webapp`'s.
 
-Only `organization` and the design-system skill itself may name a design system.
+Only `organization` and a design-system skill itself may name a design system.
 A vendor name anywhere else in this library is a defect — it is the thing that
 would make a swap need more than the two edits above. That includes
 `references/*.md`: a mirror copies a skill's whole directory, so a vendor name in
@@ -123,13 +136,22 @@ a reference reaches a coding session exactly as a body would. Check it before
 changing a web-app skill:
 
 ```bash
-grep -rniE 'astryx|@astryxdesign' skills/ --include='*.md'
+grep -rniE 'astryx|@astryxdesign|\boxygen\b|@wso2/oxygen' skills/ --include='*.md'
 ```
 
-Only `skills/organization/SKILL.md`, `skills/astryx-design-system/**` and this
-file should match. A hit anywhere else — especially in `architecture`, which is
-`kind: platform` and read-only in the console — means an org can no longer swap
-its design system without a platform change.
+Only `skills/organization/SKILL.md`, `skills/oxygen-ui-design-system/**`,
+`skills/astryx-design-system/**` and this file should match. A hit anywhere
+else — especially in `architecture`, which is `kind: platform` and read-only in
+the console — means an org can no longer swap its design system without a
+platform change.
+
+One documented exception: `skills/wireframes/SKILL.md` says the wireframe
+compiler renders with an "Oxygen UI palette" and applies "the Oxygen theme".
+That is the **compiler's** drawing style for a `.excalidraw` picture, not the
+app's UI toolkit, and it does not follow the org's design system — swapping
+the design system does not restyle a wireframe. Keep it that way: do not
+couple the two, and do not let the name spread from there into anything a
+build reads.
 
 ## Who owns what
 

--- a/skills/astryx-design-system/SKILL.md
+++ b/skills/astryx-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: astryx-design-system
-description: Astryx (`@astryxdesign/core`) — this organization's web-app design system, covering its Theme + StyleX wiring, the organization's settled brand colors, and the CLI you confirm every component's props against before writing JSX. Apply to all UI work in a `web-application` that pins it — pages, layouts, forms, tables, dialogs, nav, theming — even when the task never names Astryx.
+description: Astryx (`@astryxdesign/core`) — a web-app design system this library keeps available, covering its Theme + StyleX wiring, the organization's settled brand colors, and the CLI you confirm every component's props against before writing JSX. Apply to all UI work in a `web-application` that pins it — pages, layouts, forms, tables, dialogs, nav, theming — even when the task never names Astryx.
 metadata:
   aep:
     kind: org

--- a/skills/organization/SKILL.md
+++ b/skills/organization/SKILL.md
@@ -28,7 +28,7 @@ Thunder is available as a dependency.
 
 ## UI design system
 
-`astryx-design-system`
+`oxygen-ui-design-system`
 
 That is the name of a skill in this library, and it is the single authority for
 this organization's web-app UI — components, layout, styling, theming, and the

--- a/skills/oxygen-ui-design-system/SKILL.md
+++ b/skills/oxygen-ui-design-system/SKILL.md
@@ -1,0 +1,375 @@
+---
+name: oxygen-ui-design-system
+description: Oxygen UI (`@wso2/oxygen-ui`) — this organization's web-app design system, covering its provider + router wiring, the organization's settled brand colors, the composite components a page is built from, and the verify step a web-app build owes it. Apply to all UI work in a `web-application` that pins it — pages, layouts, forms, tables, dialogs, nav, theming — even when the task never names Oxygen.
+metadata:
+  aep:
+    kind: org
+    audience: [coding]
+---
+
+# Oxygen UI Design System
+
+Oxygen UI (`@wso2/oxygen-ui`, https://github.com/wso2/oxygen-ui) is **this
+organization's** UI toolkit — WSO2's React component library on Material UI
+v7, with the Oxygen theme already applied to every export. Components, layout,
+icons, and styling all come from it. Never raw HTML styling, never another
+component library, never an invented component prop.
+
+You are here because the component you are building pinned this skill, so the
+whole of it is yours — theming included. The organization's colors are settled
+in Brand colors below; nobody is interviewed about them, at design time or any
+other time.
+
+`react-webapp` owns the app: layout, config, verify sequence, Dockerfile, nginx.
+This skill owns what goes **inside** `src/` — the UI. Where the two appear to
+disagree, `react-webapp` wins; the conflicts worth naming are listed under
+Platform constraints below.
+
+## Correctness through the installed types, not memory
+
+Everything `@wso2/oxygen-ui` exports is typed, and the types describe the
+*installed* version — a guessed prop is never right by comparison. The
+discipline: **before writing JSX for a component you have not confirmed this
+session, read its API, then write the JSX** — never the reverse. Two places to
+read, in this order:
+
+1. **The installed package's own docs**, which ship inside it and are matched
+   to the version this app installed:
+   `node_modules/@wso2/oxygen-ui/.claude/components.md` (every composite
+   component's props and sub-components), `patterns.md` (whole screens), and
+   `theming.md`. This skill does not carry a second copy of them on purpose —
+   a copy here would ride the org's library while the real API rides the
+   package, and the two would drift with nothing to catch it.
+2. **The `.d.ts`**, for anything the prose does not settle or contradicts:
+   `node_modules/@wso2/oxygen-ui/dist/components/<Name>/<Name>.d.ts`. The types
+   are generated from the code, so they are the last word — see Known errors
+   in the package's docs below.
+
+### Known errors in the package's docs
+
+Three snippets in the package's `.claude/*.md` do not compile against the code
+they ship with — verified with `tsc` against 0.13.1. The `.d.ts` is right and
+the prose is wrong. `references/app-structure.md` beside this skill carries a
+corrected scaffold.
+
+| The docs show | It actually is |
+|---|---|
+| `<Footer companyName="WSO2 LLC" />` | `Footer` takes children: `<Footer><Footer.Copyright>© WSO2 LLC</Footer.Copyright></Footer>` |
+| `DashboardIcon` | not an export — the lucide name is `LayoutDashboard` |
+| `GoogleIcon` | not an export — the brand icons carry no `Icon` suffix, so it is `Google` |
+
+A snippet that fails `tsc` is a doc bug, not a version you are missing — read
+the `.d.ts` and follow it.
+
+Plain MUI components (`Button`, `TextField`, `Dialog`, `Chip`, `Grid`, …) keep
+MUI v7's API; they are re-exported from `@wso2/oxygen-ui` unchanged except for
+the theme.
+
+**Violating the letter of this rule is violating the spirit of it.** "It's just a
+placeholder page," "the app doesn't have Oxygen wired up yet," and "this screen
+is throwaway" are reasons to wire Oxygen up *faster*, not reasons to skip it — a
+page built in raw `<div>`s is what deploys, because there is no human code-review
+gate between your PR and the dev environment.
+
+## Setup
+
+`react-webapp` scaffolds the app. Add Oxygen to it, from the App Path:
+
+```bash
+# 1. React exactly at the version Oxygen's peer dependency names — a newer
+#    19.x fails `npm install` with ERESOLVE, and forcing past that ships two Reacts
+REACT_VER=$(npm view @wso2/oxygen-ui@latest peerDependencies.react)
+npm install react@"$REACT_VER" react-dom@"$REACT_VER"
+# 2. Oxygen itself, its icon set, and the router its app shell is built around
+npm install @wso2/oxygen-ui@latest @wso2/oxygen-ui-icons-react@latest react-router
+# optional, only if a screen draws a chart
+npm install @wso2/oxygen-ui-charts-react@latest
+```
+
+**Never install `@mui/*`, `@emotion/*`, or `lucide-react` yourself.**
+`@wso2/oxygen-ui` bundles MUI, MUI X and Emotion as its own dependencies, and
+`@wso2/oxygen-ui-icons-react` brings lucide; a second copy
+in `package.json` gives the app two Emotion caches and two MUI runtimes, and
+the theme silently stops reaching half the tree. The package README's install
+line that names `@mui/material` predates this and is wrong for the version you
+install. Verify below fails on any of them.
+
+Wire the provider once, outermost, in `main.tsx` — then the router, then the
+app. Oxygen bundles its font (Inter Variable) and applies its theme
+globally from the provider; there is no stylesheet to import or link:
+
+```tsx
+// src/main.tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
+import { OxygenUIThemeProvider, OxygenTheme } from '@wso2/oxygen-ui';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <OxygenUIThemeProvider theme={OxygenTheme}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </OxygenUIThemeProvider>
+  </StrictMode>,
+);
+```
+
+`OxygenTheme` is the stock theme, and the fallback. It is what a project gets
+when this organization has not set brand colors — see the next section. Then
+lay the app out per `references/app-structure.md`: `src/config/appRoutes.tsx`
+(routes grouped under layouts), `src/layouts/AppLayout.tsx` (the `AppShell`),
+`src/pages/*.tsx` (each `PageContent` > `PageTitle` > content).
+
+## Brand colors
+
+A web app is themed at its FIRST build, and retrofitting a theme means revisiting
+every screen — so the colors cannot be a per-build decision. They are an
+**organization** decision, settled once in the section below, exactly like the
+language a service is written in.
+
+**Never ask anyone for them.** Not at design time, not at coding time, not once
+per project. The answer is either set below or it is the stock theme, and both
+are complete answers — a question about theming is a defect, not diligence.
+
+### The organization's colors
+
+- Accent (buttons, links, focus): _not set — use the stock theme_
+- Neutral (backgrounds, surfaces): _not set — use the stock theme_
+
+To brand every web app this organization builds, an org edits those two lines to
+hex values (Settings → Skills), e.g.:
+
+```markdown
+- Accent (buttons, links, focus): #f5c518
+- Neutral (backgrounds, surfaces): #0a0a0a
+```
+
+HEX only, never color words: "black and yellow" does not say WHICH yellow, and
+this file is the whole of what a build sees. The edit reaches every subsequent
+build in the org with no conversation involved.
+
+A per-project override still wins, **per value, not per section**: a hex under
+the `## Brand colors` heading in the project's `specs/requirements/prd.md`
+overrides the same line here, and a line that heading omits still comes from
+this section. That heading is there for a project whose colors someone stated
+outright — it is not something to solicit, and a half-filled one is not a
+reason to drop the organization's other color.
+
+### At build time — derive the theme
+
+Resolve each of the two colors before you wire the theme, independently: the
+project's `## Brand colors` line in `specs/requirements/prd.md` if it has one,
+otherwise the line in The organization's colors above. **A color neither one
+sets is not chosen** — leave that part of the theme stock and never invent
+one, whether that leaves you with two brand colors, one, or none. One brand
+color plus one stock color is a valid outcome; a guessed hex is not.
+
+With colors, a brand theme is a **theme of your own derived from the stock
+one** — not hand-written colors sprinkled over components. Painting components
+brand colors through `sx` violates "colors are tokens" and leaves every
+unstyled surface off-brand. `createOxygenTheme` deep-merges overrides onto the
+Oxygen base and returns a ready theme; there is no compile step and nothing
+generated to commit:
+
+```ts
+// src/theme.ts
+import { createOxygenTheme } from '@wso2/oxygen-ui';
+
+export const brandTheme = createOxygenTheme({
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: { main: '#f5c518' },                        // accent
+      },
+    },
+    dark: {
+      palette: {
+        primary: { main: '#f5c518' },                        // accent
+        background: { default: '#0a0a0a', paper: '#161616' }, // neutral, as a ramp
+      },
+    },
+  },
+});
+```
+
+```tsx
+// src/main.tsx — the only change from Setup
+import { brandTheme } from './theme';
+// <OxygenUIThemeProvider theme={brandTheme}>
+```
+
+What each color becomes:
+
+| Color | Set it on |
+|---|---|
+| Accent | `palette.primary.main` in **both** color schemes. MUI derives `light`, `dark`, and the text that sits on the accent (`contrastText`) from it, so set only `main`; check the result reads in both modes and darken the light-scheme `main` if a pale hue fails contrast on white. |
+| Neutral | `palette.background.default` and `palette.background.paper` in the color scheme the hex belongs to — a dark hex goes on `dark`, a light one on `light` — as a ramp: `default` the brand value, `paper` a step lighter (dark) or the brand value with `default` a step darker (light). Leave the other scheme's background stock; never put a dark neutral on the light scheme. |
+
+Keep the hue, move the lightness: contrast is not negotiable to match a brand.
+Omit a key rather than guess it — an override you do not write is the stock
+value, which is the correct answer for a color nobody set.
+
+## Verify
+
+This skill's step in `react-webapp`'s verify sequence — after `npm install`,
+before `npx tsc --noEmit`, from the App Path:
+
+```bash
+node "$AEP_SKILLS_DIR/oxygen-ui-design-system/scripts/verify.mjs"
+```
+
+If `$AEP_SKILLS_DIR` is unset, the script is `scripts/verify.mjs` next to this
+skill's `SKILL.md` (the BFF mirrors that directory to
+`.claude/skills/oxygen-ui-design-system/` at the repo root). A non-zero exit
+fails verification like any other step in that sequence, and every failure
+line names its fix. It is there because Oxygen's wiring faults — a second MUI
+or Emotion installed beside the bundled one, an import that bypasses
+`@wso2/oxygen-ui`, a root not wrapped in `OxygenUIThemeProvider`, a React that
+is not the exact version Oxygen's peer dependency names — type-check and build
+perfectly clean, then render an unthemed or broken page in the cluster: cheap
+to fix here, expensive to debug after the Docker build.
+
+## Platform constraints that override this system's defaults
+
+Five places where Oxygen's own defaults and docs do not fit this platform. Each
+is a runtime, build, or guidance failure, not a style preference:
+
+1. **Never run `npx @wso2/oxygen-ui init` (or `update`).** That CLI writes
+   `CLAUDE.md`, `AGENTS.md`, `.claude/oxygen-ui/` and `.claude/skills/` into the
+   repo root. Guidance reaches you as skills, so a committed agent file is a
+   second authority that nothing updates — it is stale the moment this skill
+   changes, and it lands in a directory the platform owns. The same docs are
+   already in the installed package (see Correctness above); read them there.
+2. **Never install the peer set Oxygen's README lists** (`@mui/material`,
+   `@emotion/*`, `@mui/x-*`). They are bundled — Setup above.
+3. **Never set `base` in `vite.config.ts`**, and never give `BrowserRouter` a
+   `basename`, whatever a sample shows. Each web app is served at its own
+   gateway host root; a `base` 404s every asset and the page renders blank
+   (`react-webapp`, Served at host root).
+4. **`index.html` gets no extra tags.** Its only `<script>` rules are
+   `react-webapp`'s: the synchronous `env-config.js` tag first, the module
+   bundle second. Oxygen bundles its font, so no `<link>` for Inter or a
+   stylesheet, and no script tag around those two — it risks
+   `window._env_` being unset when the first module evaluates.
+5. **Theme values are not runtime config.** Colors come from `src/theme.ts` at
+   build time. `window._env_` carries only what the **browser** needs — OIDC
+   config and flags — so do not plumb a theme value through it.
+
+Oxygen replaces hand-written UI, not the platform's data layer: `openapi-fetch`
+and the committed `src/generated/` client stay exactly as `react-webapp`
+specifies. "Install no other library" above is about UI and styling.
+
+## Critical rules
+
+1. **Import everything from `@wso2/oxygen-ui`** — never from `@mui/material`,
+   `@mui/x-*`, Tailwind, Chakra, Ant Design, Bootstrap, or a hand-rolled
+   component. The package re-exports the entire MUI API with the theme applied.
+2. **Icons come from `@wso2/oxygen-ui-icons-react`**, never `lucide-react`. It
+   re-exports all of lucide plus the brand icons `WSO2`, `GitHub`, `GitLab`,
+   `Bitbucket`, `Google`, `Facebook`, `MCP`, `Lambda`. Two rules the compiler
+   enforces and memory does not:
+   - **A lucide icon works bare or `Icon`-suffixed** (`Pencil` and `PencilIcon`
+     both resolve). Prefer the bare name for consistency, but neither is an
+     error — what fails is a name lucide does not have, like `DashboardIcon`
+     for `LayoutDashboard`. Check it at https://lucide.dev/icons/.
+   - **A brand icon has no `Icon` alias and is cased exactly as listed** —
+     `Google` not `GoogleIcon`, `GitHub` not `Github`.
+
+   Size with the `size` prop: `<Search size={18} />`.
+3. **MUI X is namespaced**: `DataGrid.DataGrid`, `DatePickers.DatePicker`,
+   `TreeView.SimpleTreeView` — import the namespace from `@wso2/oxygen-ui`.
+4. **Confirm a composite component's API before using it** — the package's
+   `.claude/components.md`, then the installed `.d.ts`; don't guess a
+   sub-component or prop.
+5. **Colors and spacing are theme tokens through `sx`, never literals.**
+   `p: 2`, `gap: 2`, `bgcolor: 'background.paper'`, `color: 'text.secondary'`,
+   `borderColor: 'divider'` — no hex, no rgb, no raw px. Brand colors live in
+   `src/theme.ts` (above), never in a component.
+6. **Layout is `Stack`/`Box`/`Grid` from `@wso2/oxygen-ui`** — never a raw
+   `<div>`/`<span>` for spacing or arrangement, and never `style={{…}}`.
+7. **Page-level structure follows a precedent, not intuition.** Every page is
+   `PageContent` > `PageTitle` (`PageTitle.Header`, `.SubHeader`, `.Actions`,
+   `.BackButton`) > content, inside the `AppShell` of `AppLayout`. Before
+   composing a listing, detail, dashboard, settings, or login screen, find it in
+   the package's `.claude/patterns.md` and match its composition.
+8. **Navigation goes through `react-router`**: `Sidebar.Item link={<Link to="…" />}`,
+   `useNavigate()` for actions, never a hardcoded `<a href>`.
+9. **Dense data is rows, not cards.** Use `ListingTable` for lists of records
+   (`variant="card"` when each row wants breathing room); `Card` is for widgets,
+   galleries, or grouped settings — not one card per record.
+
+## Reach for these components (not raw MUI, never raw HTML)
+
+| If you're about to build… | Use instead |
+|---|---|
+| Page shell with top bar + side nav | `AppShell` > `AppShell.Navbar` (`Header`), `AppShell.Sidebar` (`Sidebar`), `AppShell.Main`, `AppShell.Footer` (`Footer`) |
+| A page heading / page body wrapper | `PageTitle` (`.Header`, `.SubHeader`, `.Actions`, `.BackButton`, `.Avatar`) / `PageContent` |
+| A data table / list of records | `ListingTable` (`.Container`, `.Toolbar`, `.Head`, `.Body`, `.Row`, `.Cell`, `.RowActions`, `.EmptyState`, `.Footer`) |
+| A form with grouped fields | `Form.Section` + `Form.Stack` (fields are plain `TextField`, `Select`, `Checkbox`, `Switch`) |
+| A multi-step flow / wizard | `Form.Wizard` |
+| A user avatar + account menu | `UserMenu` (`.Trigger`, `.Header`, `.Item`, `.Divider`, `.Logout`) |
+| A KPI / metric tile | `StatCard` (`value`, `label`, `icon`) |
+| Breadcrumbs / search / rich select | `AppBreadcrumbs` / `SearchBar` / `ComplexSelect` |
+| Notifications | `NotificationPanel` (in `AppShell.NotificationPanel`) / `NotificationBanner` |
+| A modal / confirmation dialog | `Dialog` + `DialogTitle` + `DialogContent` + `DialogActions` |
+| Status / count / label chip | `Chip` (`color="success"` etc.), `Badge` |
+| Light/dark toggle, theme picker | `ColorSchemeToggle`, `ThemeSwitcher` |
+| Login / unauthenticated page | `Layout.Content` + `ParticleBackground` (`references/app-structure.md`, GateLayout) |
+| Date/time entry | `DatePickers.DatePicker`, `DatePickers.DateTimePicker` |
+| A chart | `@wso2/oxygen-ui-charts-react` |
+
+## Implementing a wireframe with Oxygen
+
+`wireframes/references/implementing.md` says what each DSL line must become;
+this is what it becomes here:
+
+| DSL | Oxygen |
+|---|---|
+| `navbar "…"` / `sidebar "…"` | the `AppLayout` shell — `Header` in `AppShell.Navbar`, `Sidebar.Item`s in `AppShell.Sidebar`, identical on every screen of a role |
+| `heading` | `PageTitle.Header` (screen title) or `Typography variant="h5"/"h6"` (section) |
+| `text`, `link`, `breadcrumb` | `Typography`, `Link` (react-router `Link` as `component`), `AppBreadcrumbs` |
+| `card "Label \| Value \| Caption"` | `StatCard` |
+| `table "A \| B \| C"` + `row` | `ListingTable` with exactly those columns; `ListingTable.EmptyState` for no rows |
+| `list`, `tabs`, `badge`, `progress`, `avatar`, `chart`, `image` | `List`, `Tabs`, `Chip`, `LinearProgress`, `Avatar`, a charts-react chart, `ColorSchemeImage` |
+| `input`, `textarea`, `select`, `search`, `checkbox`, `radio`, `toggle` | `TextField`, `TextField multiline`, `Select`/`ComplexSelect`, `SearchBar`, `Checkbox`, `RadioGroup`, `Switch` — inside `Form.Section`/`Form.Stack` |
+| `button "X" primary` / `danger` | `Button variant="contained"` / `Button color="error"`; every other button `variant="outlined"` or `"text"` |
+| `row`, `split N/M` | `Stack direction="row"` / `Grid` with `size={{ md: N }}` and `size={{ md: M }}` |
+| a `variant` (`danger`, `success`, …) | the palette's matching status color: `color="error"`, `"success"`, `"warning"`, `"info"` |
+
+## Pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `npm install` fails with `ERESOLVE` on `react` | Oxygen's peer dependency is an exact React version and the scaffold installed a newer one | Install `react`/`react-dom` at exactly `npm view @wso2/oxygen-ui@latest peerDependencies.react`; never `--force` or `--legacy-peer-deps` past it |
+| Components render in stock Material blue, not the Oxygen theme | `OxygenUIThemeProvider` missing, or not outermost in `main.tsx` | Wrap the root exactly as Setup shows; Verify fails on this |
+| Theme applies to some components and not others; console warns about multiple Emotion/MUI instances | `@mui/material` or `@emotion/*` installed beside Oxygen's bundled copy, or imported directly | Remove them from `package.json` and every import; import from `@wso2/oxygen-ui` only |
+| `Cannot find module 'lucide-react'` or an icon import fails | Icons imported from the wrong package, or a made-up name | Import the bare lucide name from `@wso2/oxygen-ui-icons-react`; check the name at lucide.dev |
+| `DataGrid is not a component` / `DatePicker is not exported` | Namespace used as a component | `DataGrid.DataGrid`, `DatePickers.DatePicker` |
+| Page renders blank in the cluster, every asset 404s | `base` in `vite.config.ts` or `basename` on the router, copied from a sample | Remove both — served at host root (`react-webapp`) |
+| A sub-component or prop "does not exist" | Answered from memory | Read the package's `.claude/components.md`, then the installed `.d.ts` — the installed types reflect the installed version, training data doesn't |
+| Every record in a list is its own `Card` | Defaulted to a card grid instead of checking data density | `ListingTable` for records; `Card` for widgets and galleries |
+| Brand colors are set, deployed app is stock-themed | Colors read but never put in `src/theme.ts`, or the provider still gets `OxygenTheme` | Derive `brandTheme` with `createOxygenTheme` and pass it to the provider |
+| The user gave brand colors in chat, the build ignored them | A coding run never sees a conversation — colors reach it only from this skill or the project's `specs/requirements/prd.md` | Set them in The organization's colors (Settings → Skills) for the whole org, or under `## Brand colors` in the project's `specs/requirements/prd.md` for one project; an answer that is not in a file did not happen |
+| Brand accent is unreadable in one mode | One `primary.main` for a pale hue used in both color schemes | Darken the light scheme's `main`; keep the hue, move the lightness |
+
+## Red flags — stop and use Oxygen
+
+- About to write `<div style={{...}}>`, a `className` with a stylesheet, or a
+  raw `<button>`/`<table>`/`<input>` for layout, color, spacing, or a control
+- About to `npm install` `@mui/*`, `@emotion/*`, `lucide-react`, or any other
+  component or styling library
+- About to run `npx @wso2/oxygen-ui init`
+- About to write JSX for a form, list, card, dialog, nav, or page header from
+  scratch instead of from the Reach-for table and the package's `.claude/patterns.md`
+- Thinking "it's just a placeholder" or "Oxygen isn't set up in this app yet"
+- Using a sub-component or prop without having confirmed it in
+  the package's `.claude/components.md` or the installed `.d.ts`
+- About to satisfy a brand-color requirement by styling components instead of
+  deriving a theme — or about to ignore one because no stock theme matches
+- About to ask which theme or colors to use — that is settled in Brand colors,
+  and "not set" means the stock theme, not an open question
+
+All of these mean: stop, open the reference, and use what it documents.

--- a/skills/oxygen-ui-design-system/references/app-structure.md
+++ b/skills/oxygen-ui-design-system/references/app-structure.md
@@ -93,25 +93,23 @@ parent route whose `element` is a layout that renders `<Outlet/>`).
 ```tsx
 // src/App.tsx
 import { Route, Routes } from 'react-router';
-import appRoutes from './config/appRoutes';
+import appRoutes, { type AppRoute } from './config/appRoutes';
+
+// Recursive, because `AppRoute.children` is: a renderer that walks only one
+// level type-checks against a grandchild route and then never renders it.
+// The branch is required — `RouteProps` is a union, and an index route may
+// not carry children, so passing both fails to compile.
+function renderRoute(route: AppRoute, key: string) {
+  if (route.index) return <Route key={key} index element={route.element} />;
+  return (
+    <Route key={key} path={route.path} element={route.element}>
+      {route.children?.map((child, i) => renderRoute(child, child.path ?? `index-${i}`))}
+    </Route>
+  );
+}
 
 export default function App() {
-  return (
-    <Routes>
-      {appRoutes.map((route) => (
-        <Route key={route.path ?? 'layout'} path={route.path} element={route.element}>
-          {route.children?.map((child, i) => (
-            <Route
-              key={child.path ?? `index-${i}`}
-              index={child.index}
-              path={child.path}
-              element={child.element}
-            />
-          ))}
-        </Route>
-      ))}
-    </Routes>
-  );
+  return <Routes>{appRoutes.map((route, i) => renderRoute(route, route.path ?? `layout-${i}`))}</Routes>;
 }
 ```
 

--- a/skills/oxygen-ui-design-system/references/app-structure.md
+++ b/skills/oxygen-ui-design-system/references/app-structure.md
@@ -1,0 +1,331 @@
+# Oxygen UI — App Structure & Setup
+
+The canonical structure, mirroring Oxygen's own sample app. It sits inside the layout
+`react-webapp` prescribes (`src/env.ts`, `src/generated/`, `src/api.ts`, `mock/`, `nginx/` are
+that skill's and stay as it says); this file adds `config/`, `layouts/` and `pages/`. Use this when scaffolding a
+new app or adding pages/layouts to an existing one. Stack: **React 19 + Vite + react-router
+v7 + @wso2/oxygen-ui**.
+
+## Table of contents
+- [Dependencies](#dependencies)
+- [File layout](#file-layout)
+- [main.tsx — provider + router](#maintsx)
+- [App.tsx + appRoutes](#approutes)
+- [Layouts](#layouts)
+- [Pages](#pages)
+- [Icons](#icons)
+
+---
+
+## Dependencies
+
+`react-webapp` scaffolds the app; the install commands are in `SKILL.md`, Setup
+(React pinned to the exact version Oxygen's peer dependency names, then
+`@wso2/oxygen-ui`, `@wso2/oxygen-ui-icons-react`, `react-router`). Oxygen bundles MUI,
+MUI X, Emotion and lucide as its own dependencies — **never install `@mui/*`,
+`@emotion/*` or `lucide-react`** (a second copy breaks theming at runtime).
+
+---
+
+## File layout
+
+```
+src/
+├── main.tsx                # OxygenUIThemeProvider + Router + <App/>
+├── App.tsx                 # maps appRoutes -> <Routes>/<Route>
+├── config/
+│   └── appRoutes.tsx       # routes grouped under layouts
+├── layouts/
+│   ├── AppLayout.tsx       # signed-in app shell (AppShell/Header/Sidebar)
+│   ├── GateLayout.tsx      # login / unauthenticated
+│   └── DefaultLayout.tsx   # standalone pages (home, error)
+└── pages/
+    ├── Projects.tsx        # PageContent > PageTitle > content
+    └── ...
+```
+
+---
+
+## main.tsx
+
+Wrap the root once in `OxygenUIThemeProvider`, then the router, then `<App/>`. Use a single
+`theme` for one theme, or `themes={[…]}` + `initialTheme` to allow theme switching.
+
+```tsx
+import {
+  OxygenUIThemeProvider,
+  OxygenTheme,
+  AcrylicOrangeTheme,
+  WSO2Theme,
+} from '@wso2/oxygen-ui';
+import { BrowserRouter } from 'react-router';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <OxygenUIThemeProvider
+      themes={[
+        { key: 'default', label: 'Default', theme: OxygenTheme },
+        { key: 'orange', label: 'Acrylic Orange', theme: AcrylicOrangeTheme },
+        { key: 'wso2', label: 'WSO2', theme: WSO2Theme },
+      ]}
+      initialTheme="default"
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </OxygenUIThemeProvider>
+  </StrictMode>,
+);
+```
+
+Single-theme variant: `<OxygenUIThemeProvider theme={OxygenTheme}>`.
+
+---
+
+## appRoutes
+
+`App.tsx` maps a route config to react-router. Routes are grouped under **layouts** (a
+parent route whose `element` is a layout that renders `<Outlet/>`).
+
+```tsx
+// src/App.tsx
+import { Route, Routes } from 'react-router';
+import appRoutes from './config/appRoutes';
+
+export default function App() {
+  return (
+    <Routes>
+      {appRoutes.map((route) => (
+        <Route key={route.path ?? 'layout'} path={route.path} element={route.element}>
+          {route.children?.map((child, i) => (
+            <Route
+              key={child.path ?? `index-${i}`}
+              index={child.index}
+              path={child.path}
+              element={child.element}
+            />
+          ))}
+        </Route>
+      ))}
+    </Routes>
+  );
+}
+```
+
+```tsx
+// src/config/appRoutes.tsx
+import { type RouteProps, Navigate } from 'react-router';
+import AppLayout from '../layouts/AppLayout';
+import GateLayout from '../layouts/GateLayout';
+import LoginPage from '../pages/LoginPage';
+import HomePage from '../pages/HomePage';
+import Projects from '../pages/Projects';
+import SettingsPage from '../pages/SettingsPage';
+
+export interface AppRoute extends Omit<RouteProps, 'children'> {
+  children?: AppRoute[];
+  label?: string;
+}
+
+const appRoutes: AppRoute[] = [
+  { path: '/', element: <Navigate to="/login" replace /> },
+  {
+    element: <GateLayout />,
+    children: [{ path: '/login', element: <LoginPage />, label: 'Login' }],
+  },
+  {
+    element: <AppLayout />,
+    children: [
+      { path: '/home', element: <HomePage />, label: 'Home' },
+      { path: '/projects', element: <Projects />, label: 'Projects' },
+      { path: '/settings', element: <SettingsPage />, label: 'Settings' },
+    ],
+  },
+];
+
+export default appRoutes;
+```
+
+---
+
+## Layouts
+
+### AppLayout — the signed-in app shell
+
+`AppShell` is a compound component: `AppShell.Navbar` (a `Header`), `AppShell.Sidebar` (a
+`Sidebar`), `AppShell.Main` (renders the routed page via `<Outlet/>`), and
+`AppShell.Footer`. Sidebar items navigate with `link={<Link to="…" />}`.
+
+```tsx
+import {
+  AppShell, Header, Sidebar, Footer, UserMenu, ColorSchemeToggle, Divider,
+} from '@wso2/oxygen-ui';
+import { Home, FolderOpen, Settings, LogOut, User } from '@wso2/oxygen-ui-icons-react';
+import { Outlet, Link, useLocation } from 'react-router';
+import type { JSX } from 'react';
+
+export default function AppLayout(): JSX.Element {
+  const { pathname } = useLocation();
+  const active = pathname.includes('/settings') ? 'settings'
+    : pathname.includes('/projects') ? 'projects' : 'home';
+
+  return (
+    <AppShell>
+      <AppShell.Navbar>
+        <Header>
+          <Header.Toggle />
+          <Header.Brand>
+            <Header.BrandTitle>Console</Header.BrandTitle>
+          </Header.Brand>
+          <Header.Spacer />
+          <Header.Actions>
+            <ColorSchemeToggle />
+            <Divider orientation="vertical" flexItem sx={{ mx: 2 }} />
+            <UserMenu>
+              <UserMenu.Trigger name="Jane Doe" />
+              <UserMenu.Header name="Jane Doe" email="jane@example.com" />
+              <UserMenu.Item icon={<User />} label="Profile" onClick={() => {}} />
+              <UserMenu.Item icon={<LogOut />} label="Sign out" onClick={() => {}} />
+            </UserMenu>
+          </Header.Actions>
+        </Header>
+      </AppShell.Navbar>
+
+      <AppShell.Sidebar>
+        <Sidebar activeItem={active}>
+          <Sidebar.Nav>
+            <Sidebar.Category>
+              <Sidebar.Item id="home" link={<Link to="/home" />}>
+                <Sidebar.ItemIcon><Home /></Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>Home</Sidebar.ItemLabel>
+              </Sidebar.Item>
+              <Sidebar.Item id="projects" link={<Link to="/projects" />}>
+                <Sidebar.ItemIcon><FolderOpen /></Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>Projects</Sidebar.ItemLabel>
+              </Sidebar.Item>
+              <Sidebar.Item id="settings" link={<Link to="/settings" />}>
+                <Sidebar.ItemIcon><Settings /></Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>Settings</Sidebar.ItemLabel>
+              </Sidebar.Item>
+            </Sidebar.Category>
+          </Sidebar.Nav>
+        </Sidebar>
+      </AppShell.Sidebar>
+
+      <AppShell.Main>
+        <Outlet />
+      </AppShell.Main>
+
+      <AppShell.Footer>
+        <Footer><Footer.Copyright>© WSO2 LLC</Footer.Copyright></Footer>
+      </AppShell.Footer>
+    </AppShell>
+  );
+}
+```
+
+### GateLayout — login / unauthenticated
+
+```tsx
+import { Outlet } from 'react-router';
+import { Box, ColorSchemeToggle, Layout, ParticleBackground, Stack, ThemeSwitcher } from '@wso2/oxygen-ui';
+
+export default function GateLayout() {
+  return (
+    <Layout.Content>
+      <ParticleBackground opacity={0.5} />
+      <Box sx={{ height: '100%' }}>
+        <Stack direction="row" spacing={2} sx={{ position: 'fixed', top: '3.7rem', left: '8rem', zIndex: 2 }}>
+          <ThemeSwitcher />
+          <ColorSchemeToggle />
+        </Stack>
+        <Outlet />
+      </Box>
+    </Layout.Content>
+  );
+}
+```
+
+`DefaultLayout` is the same shape without `ParticleBackground` — for standalone pages
+(home, error).
+
+---
+
+## Pages
+
+**Every page returns `PageContent` > `PageTitle` > content.** Use a `ListingTable` for list
+views, a `Grid` of `Card`s for galleries, `Form.*` for forms.
+
+```tsx
+import {
+  Box, Button, Card, CardContent, Chip, Grid, IconButton, InputAdornment,
+  PageContent, PageTitle, TextField, Typography,
+} from '@wso2/oxygen-ui';
+import { Search, Plus, MoreVertical, Folder } from '@wso2/oxygen-ui-icons-react';
+import { useState, type JSX } from 'react';
+
+export default function Projects(): JSX.Element {
+  const [query, setQuery] = useState('');
+
+  return (
+    <PageContent>
+      <PageTitle>
+        <PageTitle.Header>Projects</PageTitle.Header>
+        <PageTitle.SubHeader>Manage your projects and workflows</PageTitle.SubHeader>
+      </PageTitle>
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+        <TextField
+          placeholder="Search projects"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          slotProps={{ input: { startAdornment: (
+            <InputAdornment position="start"><Search size={18} /></InputAdornment>
+          ) } }}
+        />
+        <Button variant="contained" startIcon={<Plus size={18} />}>New project</Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {projects.map((p) => (
+          <Grid key={p.id} size={{ xs: 12, sm: 6, md: 4 }}>
+            <Card onClick={() => {/* navigate */}}>
+              <CardContent>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Folder size={20} />
+                  <IconButton size="small"><MoreVertical size={18} /></IconButton>
+                </Box>
+                <Typography variant="h6" sx={{ mt: 1 }}>{p.name}</Typography>
+                <Chip label={p.status} color="success" size="small" sx={{ mt: 1 }} />
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </PageContent>
+  );
+}
+```
+
+For a **list/table page**, swap the `Grid` for a `ListingTable` (see
+`references/components.md` for the full `ListingTable.*` API).
+
+---
+
+## Icons
+
+Import from `@wso2/oxygen-ui-icons-react` using **bare lucide names** (the convention the
+sample app uses), plus WSO2 brand icons:
+
+```tsx
+import { Home, Settings, Search, Plus, Trash2, Pencil, Users, Bell, FolderOpen } from '@wso2/oxygen-ui-icons-react';
+import { WSO2, GitHub, Google } from '@wso2/oxygen-ui-icons-react';
+```
+
+Sizing: `<Search size={18} />`. A lucide name resolves bare or `Icon`-suffixed (`Pencil`
+and `PencilIcon` both work); a name lucide does not have (`DashboardIcon`) does not. Brand
+icons carry no `Icon` suffix and are cased as listed (`GitHub`, `Google`). Browse real names
+at https://lucide.dev/icons/.

--- a/skills/oxygen-ui-design-system/scripts/verify.mjs
+++ b/skills/oxygen-ui-design-system/scripts/verify.mjs
@@ -83,10 +83,41 @@ function scannedFiles(appDir) {
   return [...sourceFiles(path.join(appDir, "src")), ...configs];
 }
 
-/** `{ value }` on success, `{ error }` on a missing or malformed file — never throws. */
+/**
+ * Source with comments blanked out. The import scan runs over this, because
+ * this skill spends paragraphs telling people NOT to import `@mui/material` —
+ * so a comment repeating that advice is likely, and matching it would fail a
+ * correct app. The `[^:]` guard keeps `https://` out of the line-comment rule.
+ */
+const stripComments = (text) => text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+/** A JSX element for `name`, not a mention of it in an import or a string. */
+const rendersElement = (src, name) => new RegExp(`<\\s*${name}[\\s>]`).test(src);
+
+/**
+ * Whether the provider actually ENCLOSES the app. `main.tsx` importing the
+ * symbol, or rendering it somewhere off the root, both leave the deployed page
+ * unthemed while reading as wired.
+ */
+function providerWrapsRoot(text) {
+  const src = stripComments(text);
+  if (!rendersElement(src, "OxygenUIThemeProvider")) return false;
+  const root = src.indexOf(".render(");
+  return root === -1 ? true : rendersElement(src.slice(root), "OxygenUIThemeProvider");
+}
+
+/**
+ * `{ value }` for a JSON OBJECT, `{ error }` for anything else — never throws.
+ * A bare `null` parses fine and would then throw on the first field read,
+ * killing the run before a single FAIL row is printed.
+ */
 function tryReadJSON(p) {
   try {
-    return { value: JSON.parse(readFileSync(p, "utf8")) };
+    const value = JSON.parse(readFileSync(p, "utf8"));
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return { error: `expected a JSON object, got ${Array.isArray(value) ? "an array" : String(value)}` };
+    }
+    return { value };
   } catch (e) {
     return { error: e.message };
   }
@@ -124,7 +155,7 @@ function verifyApp(appDir) {
   const offenders = [];
   for (const file of scannedFiles(appDir)) {
     const text = readFileSync(file, "utf8");
-    for (const m of text.matchAll(IMPORT_RE)) offenders.push(`${path.relative(appDir, file)} → ${m[1]}`);
+    for (const m of stripComments(text).matchAll(IMPORT_RE)) offenders.push(`${path.relative(appDir, file)} → ${m[1]}`);
   }
   rows.push({
     name: `src/ and the build config import nothing from ${BUNDLED_LABEL}`,
@@ -135,11 +166,11 @@ function verifyApp(appDir) {
   const main = ["src/main.tsx", "src/main.jsx", "src/main.ts", "src/main.js"].map((p) => path.join(appDir, p)).find(existsSync);
   rows.push({
     name: "src/main.tsx wraps the root in OxygenUIThemeProvider",
-    ok: main !== undefined && readFileSync(main, "utf8").includes("OxygenUIThemeProvider"),
+    ok: main !== undefined && providerWrapsRoot(readFileSync(main, "utf8")),
     fix:
       main === undefined
         ? "no src/main.tsx — scaffold per react-webapp, then wire the provider per SKILL.md Setup"
-        : "render <OxygenUIThemeProvider theme={…}> outermost in main.tsx (SKILL.md, Setup)",
+        : "render <OxygenUIThemeProvider theme={…}> around the app INSIDE createRoot(...).render(...) — importing it, or rendering it off the root, leaves the page unthemed (SKILL.md, Setup)",
   });
 
   const installedPath = path.join(appDir, "node_modules", OXYGEN, "package.json");

--- a/skills/oxygen-ui-design-system/scripts/verify.mjs
+++ b/skills/oxygen-ui-design-system/scripts/verify.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The design system's step in `react-webapp`'s verify sequence, run from the
+// App Path after `npm install` and before `npx tsc --noEmit`:
+//
+//   node scripts/verify.mjs [app-path]
+//
+// It checks the one class of fault `tsc` and `vite build` cannot see: Oxygen's
+// wiring. Each of these type-checks and builds clean, then renders an unthemed
+// or broken page in the cluster — a second MUI or Emotion installed beside the
+// copy Oxygen bundles (two Emotion caches, the theme reaches half the tree),
+// an import that bypasses `@wso2/oxygen-ui`, a root not wrapped in
+// `OxygenUIThemeProvider`, or a React that is not the exact version Oxygen's
+// peer dependency names (two Reacts, hooks throw at runtime). One line per
+// check; a failure names its fix; a non-zero exit fails verification like any
+// other step in the sequence.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const OXYGEN = "@wso2/oxygen-ui";
+const ICONS = "@wso2/oxygen-ui-icons-react";
+
+// Packages that already arrive with Oxygen — MUI, MUI X and Emotion as
+// dependencies of `@wso2/oxygen-ui`, lucide as one of
+// `@wso2/oxygen-ui-icons-react`. A direct copy of any of them duplicates a
+// runtime that must be a singleton, so this list is the one source for all
+// three ways the checks below use it: matching a dependency, matching an
+// import specifier, and naming itself in a failure line. A trailing "/"
+// means "this scope, any package under it".
+const BUNDLED = ["@mui/", "@emotion/", "lucide-react"];
+const BUNDLED_LABEL = BUNDLED.map((p) => (p.endsWith("/") ? `${p}*` : p)).join(", ");
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const SPECIFIER = BUNDLED.map((p) => (p.endsWith("/") ? `${escapeRe(p)}[^"']*` : `${escapeRe(p)}(?:\\/[^"']*)?`)).join("|");
+const IMPORT_RE = new RegExp(`(?:from\\s*|import\\s*\\(?\\s*|require\\s*\\(\\s*)["'](${SPECIFIER})["']`, "g");
+
+const SOURCE_EXT = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]);
+
+/** True when `dep` is one of the packages Oxygen already brings. */
+const isBundled = (dep) => BUNDLED.some((p) => (p.endsWith("/") ? dep.startsWith(p) : dep === p));
+
+/** Every source file under `dir`, depth-first; nothing under node_modules. */
+function sourceFiles(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules") continue;
+    const p = path.join(dir, name);
+    if (statSync(p).isDirectory()) sourceFiles(p, out);
+    else if (SOURCE_EXT.has(path.extname(name))) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * What an import scan covers: everything under `src/`, plus the build config
+ * at the app root. A `@emotion/*` pulled into `vite.config.ts` duplicates the
+ * runtime exactly as one in a page does, and it would otherwise go unseen.
+ */
+function scannedFiles(appDir) {
+  const configs = existsSync(appDir)
+    ? readdirSync(appDir)
+        .filter((n) => /\.config\.[cm]?[jt]s$/.test(n))
+        .map((n) => path.join(appDir, n))
+    : [];
+  return [...sourceFiles(path.join(appDir, "src")), ...configs];
+}
+
+/** `{ value }` on success, `{ error }` on a missing or malformed file — never throws. */
+function tryReadJSON(p) {
+  try {
+    return { value: JSON.parse(readFileSync(p, "utf8")) };
+  } catch (e) {
+    return { error: e.message };
+  }
+}
+
+/** The checks, as `{ name, ok, fix }` rows. */
+function verifyApp(appDir) {
+  const rows = [];
+  const pkgPath = path.join(appDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    return [{ name: "package.json present", ok: false, fix: `no package.json at ${appDir} — run from the App Path or pass it as the argument` }];
+  }
+  const pkgRead = tryReadJSON(pkgPath);
+  if (pkgRead.error) {
+    return [{ name: "package.json parses", ok: false, fix: `${pkgPath} is not valid JSON: ${pkgRead.error}` }];
+  }
+  const pkg = pkgRead.value;
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+
+  for (const name of [OXYGEN, ICONS]) {
+    rows.push({
+      name: `${name} is a dependency`,
+      ok: name in (pkg.dependencies ?? {}),
+      fix: `npm install ${name}@latest`,
+    });
+  }
+
+  const duplicated = Object.keys(deps).filter(isBundled);
+  rows.push({
+    name: `no ${BUNDLED_LABEL} installed directly`,
+    ok: duplicated.length === 0,
+    fix: `npm uninstall ${duplicated.join(" ")} — Oxygen and its icons package already bring them; a second copy breaks theming at runtime`,
+  });
+
+  const offenders = [];
+  for (const file of scannedFiles(appDir)) {
+    const text = readFileSync(file, "utf8");
+    for (const m of text.matchAll(IMPORT_RE)) offenders.push(`${path.relative(appDir, file)} → ${m[1]}`);
+  }
+  rows.push({
+    name: `src/ and the build config import nothing from ${BUNDLED_LABEL}`,
+    ok: offenders.length === 0,
+    fix: `import from ${OXYGEN} / ${ICONS} instead:\n    ${offenders.join("\n    ")}`,
+  });
+
+  const main = ["src/main.tsx", "src/main.jsx", "src/main.ts", "src/main.js"].map((p) => path.join(appDir, p)).find(existsSync);
+  rows.push({
+    name: "src/main.tsx wraps the root in OxygenUIThemeProvider",
+    ok: main !== undefined && readFileSync(main, "utf8").includes("OxygenUIThemeProvider"),
+    fix:
+      main === undefined
+        ? "no src/main.tsx — scaffold per react-webapp, then wire the provider per SKILL.md Setup"
+        : "render <OxygenUIThemeProvider theme={…}> outermost in main.tsx (SKILL.md, Setup)",
+  });
+
+  const installedPath = path.join(appDir, "node_modules", OXYGEN, "package.json");
+  const installed = existsSync(installedPath) ? tryReadJSON(installedPath) : { error: "not installed" };
+  if (installed.error) {
+    rows.push({ name: `${OXYGEN} is installed`, ok: false, fix: `npm install (this step runs after it) — ${installed.error}` });
+    return rows;
+  }
+  rows.push({ name: `${OXYGEN} is installed`, ok: true });
+
+  const peers = installed.value.peerDependencies ?? {};
+  for (const name of ["react", "react-dom"]) {
+    const want = peers[name];
+    if (!want || !/^\d+\.\d+\.\d+$/.test(want)) continue; // a range is npm's to enforce
+    const at = path.join(appDir, "node_modules", name, "package.json");
+    const read = existsSync(at) ? tryReadJSON(at) : { error: "not installed" };
+    rows.push({
+      name: `${name} is exactly ${want} (Oxygen's peer dependency)`,
+      ok: read.value?.version === want,
+      fix: `npm install ${name}@${want} — installed: ${read.value?.version ?? "none"}`,
+    });
+  }
+  return rows;
+}
+
+function main() {
+  const appDir = path.resolve(process.argv[2] ?? process.cwd());
+  const rows = verifyApp(appDir);
+  let failed = 0;
+  for (const r of rows) {
+    if (r.ok) {
+      console.log(`ok    ${r.name}`);
+    } else {
+      failed++;
+      console.log(`FAIL  ${r.name}\n  fix: ${r.fix}`);
+    }
+  }
+  console.log(failed === 0 ? `oxygen-ui-design-system verify: ok (${rows.length} checks)` : `oxygen-ui-design-system verify: ${failed} of ${rows.length} checks failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main();

--- a/skills/oxygen-ui-design-system/scripts/verify.test.mjs
+++ b/skills/oxygen-ui-design-system/scripts/verify.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// verify.mjs is the design system's one step in react-webapp's verify
+// sequence. Pinned here against a stand-in App Path: each fault it exists to
+// catch flips exactly one check, and a clean app passes every one.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT = path.join(import.meta.dirname, "verify.mjs");
+const REACT = "19.2.3";
+
+/** A stand-in App Path wired the way SKILL.md's Setup leaves it. */
+function fixtureApp({ deps = {}, main, src = {}, installed = true, reactInstalled = REACT, viteConfig } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), "oxygen-verify-"));
+  const write = (rel, text) => {
+    mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    writeFileSync(path.join(dir, rel), text);
+  };
+  write(
+    "package.json",
+    JSON.stringify({
+      dependencies: { "@wso2/oxygen-ui": "^0.13.1", "@wso2/oxygen-ui-icons-react": "^0.13.1", react: REACT, "react-dom": REACT, ...deps },
+    }),
+  );
+  write(
+    "src/main.tsx",
+    main ??
+      `import { OxygenUIThemeProvider, OxygenTheme } from '@wso2/oxygen-ui';
+createRoot(document.getElementById('root')!).render(<OxygenUIThemeProvider theme={OxygenTheme}><App /></OxygenUIThemeProvider>);`,
+  );
+  write("src/pages/Home.tsx", `import { Box } from '@wso2/oxygen-ui';\nimport { Search } from '@wso2/oxygen-ui-icons-react';\n`);
+  write("vite.config.ts", viteConfig ?? `import { defineConfig } from 'vite';\nexport default defineConfig({});\n`);
+  for (const [rel, text] of Object.entries(src)) write(rel, text);
+  if (installed) {
+    write(
+      "node_modules/@wso2/oxygen-ui/package.json",
+      JSON.stringify({ name: "@wso2/oxygen-ui", version: "0.13.1", peerDependencies: { react: REACT, "react-dom": REACT, "@wso2/oxygen-ui-icons-react": ">=0.1.0" } }),
+    );
+    write("node_modules/react/package.json", JSON.stringify({ name: "react", version: reactInstalled }));
+    write("node_modules/react-dom/package.json", JSON.stringify({ name: "react-dom", version: reactInstalled }));
+    // A stray import path under node_modules must never count as an offender.
+    write("node_modules/@wso2/oxygen-ui/dist/index.js", `export * from "@mui/material";`);
+  }
+  return dir;
+}
+
+function run(appDir, { cwd = appDir, args = [] } = {}) {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], { cwd, encoding: "utf8" });
+  return { status: r.status, out: r.stdout + r.stderr };
+}
+
+test("a correctly wired app passes every check", () => {
+  const { status, out } = run(fixtureApp());
+  assert.equal(status, 0, out);
+  assert.doesNotMatch(out, /^FAIL/m);
+  assert.match(out, /verify: ok \(\d+ checks\)/);
+});
+
+test("the App Path may be passed as the argument instead of being the cwd", () => {
+  const app = fixtureApp();
+  const { status, out } = run(app, { cwd: tmpdir(), args: [app] });
+  assert.equal(status, 0, out);
+});
+
+test("a direct @mui/material or @emotion dependency fails — they already arrive with Oxygen", () => {
+  const { status, out } = run(fixtureApp({ deps: { "@mui/material": "^7.0.0", "@emotion/react": "^11.0.0" } }));
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  no @mui\/\*, @emotion\/\*, lucide-react installed directly/);
+  assert.match(out, /npm uninstall @mui\/material @emotion\/react/);
+});
+
+test("a source import that bypasses @wso2/oxygen-ui fails and names the file", () => {
+  const { status, out } = run(
+    fixtureApp({
+      src: {
+        "src/pages/List.tsx": `import { Table } from '@mui/material';\nimport { Trash2 } from "lucide-react";\n`,
+        "src/lib/lazy.ts": `const m = await import('@mui/x-data-grid');\n`,
+      },
+    }),
+  );
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  src\/ and the build config import nothing from/);
+  assert.match(out, /src\/pages\/List\.tsx → @mui\/material/);
+  assert.match(out, /src\/pages\/List\.tsx → lucide-react/);
+  assert.match(out, /src\/lib\/lazy\.ts → @mui\/x-data-grid/);
+  // The one failing check is the only one: the rest of the wiring is fine.
+  assert.equal(out.match(/^FAIL/gm).length, 1);
+});
+
+test("a root not wrapped in OxygenUIThemeProvider fails", () => {
+  const { status, out } = run(fixtureApp({ main: `import App from './App';\ncreateRoot(document.getElementById('root')!).render(<App />);` }));
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  src\/main\.tsx wraps the root in OxygenUIThemeProvider/);
+});
+
+test("a missing Oxygen dependency fails with the install command", () => {
+  const dir = fixtureApp();
+  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ dependencies: { react: REACT, "react-dom": REACT } }));
+  const { status, out } = run(dir);
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  @wso2\/oxygen-ui is a dependency\n  fix: npm install @wso2\/oxygen-ui@latest/);
+  assert.match(out, /FAIL  @wso2\/oxygen-ui-icons-react is a dependency/);
+});
+
+test("React at a version other than Oxygen's exact peer fails — two Reacts at runtime", () => {
+  const { status, out } = run(fixtureApp({ reactInstalled: "19.3.0" }));
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  react is exactly 19\.2\.3 \(Oxygen's peer dependency\)\n  fix: npm install react@19\.2\.3 — installed: 19\.3\.0/);
+  assert.match(out, /FAIL  react-dom is exactly 19\.2\.3/);
+});
+
+test("before npm install the step fails on the missing package and says so", () => {
+  const { status, out } = run(fixtureApp({ installed: false }));
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  @wso2\/oxygen-ui is installed\n  fix: npm install/);
+  // The peer check needs the installed package, so it is not reported as a second failure.
+  assert.doesNotMatch(out, /is exactly/);
+});
+
+test("run outside an App Path, it says so instead of passing vacuously", () => {
+  const empty = mkdtempSync(path.join(tmpdir(), "oxygen-verify-empty-"));
+  const { status, out } = run(empty);
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  package\.json present/);
+});
+
+test("an import pulled into the build config is caught too, not just src/", () => {
+  const { status, out } = run(
+    fixtureApp({ viteConfig: `import emotion from '@emotion/babel-plugin';\nexport default { plugins: [emotion] };\n` }),
+  );
+  assert.equal(status, 1);
+  assert.match(out, /vite\.config\.ts → @emotion\/babel-plugin/);
+});
+
+test("a malformed package.json is a named failure, not a raw stack trace", () => {
+  const dir = fixtureApp();
+  writeFileSync(path.join(dir, "package.json"), "{ not json");
+  const { status, out } = run(dir);
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  package\.json parses/);
+  assert.doesNotMatch(out, /at \w+ \(/); // no stack frames
+});
+
+// The script is the App Path's verify step, and an App Path is a directory
+// name the platform does not choose. A path needing URL-escaping must not
+// turn every check into a silent pass.
+test("a path that needs escaping still runs the checks", () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "oxygen verify spaced-"));
+  const app = fixtureApp();
+  const script = path.join(parent, "verify.mjs");
+  writeFileSync(script, readFileSync(SCRIPT, "utf8"));
+  const r = spawnSync(process.execPath, [script, app], { encoding: "utf8" });
+  assert.match(r.stdout + r.stderr, /verify: ok \(\d+ checks\)/);
+  assert.equal(r.status, 0);
+});

--- a/skills/oxygen-ui-design-system/scripts/verify.test.mjs
+++ b/skills/oxygen-ui-design-system/scripts/verify.test.mjs
@@ -174,3 +174,70 @@ test("a path that needs escaping still runs the checks", () => {
   assert.match(r.stdout + r.stderr, /verify: ok \(\d+ checks\)/);
   assert.equal(r.status, 0);
 });
+
+// --- the checks must not be fooled, in either direction ---------------------
+
+// This skill spends paragraphs saying "never import @mui/material", so a
+// comment repeating that advice inside an app is likely. It must not fail one.
+test("a bundled package named in a comment is not an import", () => {
+  const { status, out } = run(
+    fixtureApp({
+      src: {
+        "src/pages/Note.tsx": `// never import { Table } from '@mui/material' — use ListingTable\n/* also not from '@emotion/react' */\nexport const n = 1;\n`,
+      },
+    }),
+  );
+  assert.equal(status, 0, out);
+  assert.doesNotMatch(out, /^FAIL/m);
+});
+
+test("a real import is still caught on a line that also carries a URL", () => {
+  const { status, out } = run(
+    fixtureApp({ src: { "src/pages/L.tsx": `import { Table } from '@mui/material'; // see https://mui.com/table\n` } }),
+  );
+  assert.equal(status, 1);
+  assert.match(out, /src\/pages\/L\.tsx → @mui\/material/);
+});
+
+// Importing the provider, or rendering it off the root, leaves the deployed
+// page unthemed while reading as wired.
+test("the provider imported but not wrapping the root fails", () => {
+  const { status, out } = run(
+    fixtureApp({
+      main: `import { OxygenUIThemeProvider } from '@wso2/oxygen-ui';\ncreateRoot(document.getElementById('root')!).render(<App />);`,
+    }),
+  );
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  src\/main\.tsx wraps the root in OxygenUIThemeProvider/);
+  assert.match(out, /INSIDE createRoot/);
+});
+
+test("the provider rendered off the root fails", () => {
+  const { status, out } = run(
+    fixtureApp({
+      main: `import { OxygenUIThemeProvider } from '@wso2/oxygen-ui';\nexport const Preview = () => <OxygenUIThemeProvider><Swatch /></OxygenUIThemeProvider>;\ncreateRoot(document.getElementById('root')!).render(<App />);`,
+    }),
+  );
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  src\/main\.tsx wraps the root in OxygenUIThemeProvider/);
+});
+
+// `JSON.parse("null")` succeeds, then every field read throws — which would
+// kill the run before a single row is printed.
+test("a package.json that is literally null is a named failure", () => {
+  const dir = fixtureApp();
+  writeFileSync(path.join(dir, "package.json"), "null");
+  const { status, out } = run(dir);
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  package\.json parses/);
+  assert.match(out, /expected a JSON object, got null/);
+});
+
+test("an installed Oxygen package.json that is null fails the install check, not the process", () => {
+  const dir = fixtureApp();
+  writeFileSync(path.join(dir, "node_modules/@wso2/oxygen-ui/package.json"), "null");
+  const { status, out } = run(dir);
+  assert.equal(status, 1);
+  assert.match(out, /FAIL  @wso2\/oxygen-ui is installed/);
+  assert.doesNotMatch(out, /at \w+ \(/); // no stack frames
+});


### PR DESCRIPTION
## Problem

The library shipped one design system, `astryx-design-system`, and `organization` named it. This org builds its own UI toolkit — [WSO2 Oxygen UI](https://github.com/wso2/oxygen-ui) (`@wso2/oxygen-ui`) — and every `web-application` the platform generates should be built with it.

## Changes

`skills/AGENTS.md` already documents what a swap costs: two edits, both in places an org may edit. This is those two edits, plus the skill the first one requires.

- **New `skills/oxygen-ui-design-system/`** — declares the four things "Swapping the UI design system" requires of the slot: `kind: org` + `audience: [coding]`, a `## Verify` command, the platform facts that override the vendor's own docs (no `base`, no extra `index.html` tags, never run `npx @wso2/oxygen-ui init`, never install the peer set its README lists), and its ownership boundary against `react-webapp` (Oxygen owns UI under `src/`; the `openapi-fetch` + `src/generated/` data layer stays `react-webapp`'s).
- **`organization`** — the **UI design system** section now names `oxygen-ui-design-system`. That one line is the switch: `architecture` reads the name from the Organization defaults block and pins it on every `web-application`, so no platform skill changed.
- **`astryx-design-system`** — kept, one line changed: its description no longer claims to be *this organization's* design system, because `organization` no longer names it.
- **`skills/AGENTS.md`** — records that the library now ships two design systems and which is the default, and widens the vendor-name guard.

## What "keep Astryx disabled" does and does not do

Worth being precise, because the library cannot do the whole of it.

Astryx is no longer **pinned**, so no build is steered by it — that half is done and it is the half that matters for output. But it is still seeded **enabled**: per `ADR-0015` an absent manifest entry means enabled, and `reconcileEmbedded` only carries a `Disabled` flag *forward* from an org's own repo, never originates one. So Astryx still lands in each project mirror and a coding agent could still load it by name.

**Turning it off is one toggle per org at Settings → Skills**, which is where ADR-0015 deliberately put availability. Nothing in this PR can pre-set it, and I did not try to fake it by narrowing `audience` — audience is visibility, not availability, and narrowing it would break any component that legitimately pinned Astryx. `skills/AGENTS.md` now states this outright rather than implying the skill is inert.

## Verify is a script, not a vendor CLI

`react-webapp`'s verify sequence reserves one slot for the design system, and Astryx fills it with `astryx doctor`. Oxygen ships no equivalent, so the skill ships `scripts/verify.mjs` — precedent: `mock-verification/scripts/walk.sh`, `aep-validation/scripts/generate-report.mjs`. It catches what `tsc` and `vite build` cannot, because these type-check and build perfectly clean and then render an unthemed or broken page in the cluster:

- a `@mui/*`, `@emotion/*` or `lucide-react` installed directly beside the copies Oxygen and its icons package already bring (two Emotion caches — the theme reaches half the tree)
- an import that bypasses `@wso2/oxygen-ui`, in `src/` **or in the build config**
- a root not wrapped in `OxygenUIThemeProvider`
- a React that is not the exact version Oxygen's peer dependency pins (two Reacts; hooks throw at runtime)

Each failure line names its fix. `scripts/verify.test.mjs` pins one fault per check (12 tests) and rides `make test` via the `skills/**/*.test.mjs` lane.

## The skill points at the package's docs instead of copying them

First draft vendored the package's `components.md` / `patterns.md` / `theming.md` (2,972 lines). Review caught that against `skills/AGENTS.md`, "Who owns what": *"A tool documents itself; a skill points at it … the two ship on different clocks … so a copy here goes stale with nothing to catch it."* It was already stale — the copy carried symbols 0.13.1 does not export.

Those three are gone. `@wso2/oxygen-ui` ships its own agent docs inside the package (`.claude/*.md`, guaranteed by its `files` field), so the skill points there and at the `.d.ts` for anything the prose does not settle. Only `references/app-structure.md` remains, because it is the platform-shaped scaffold rather than a vendor copy. This also matches `astryx-design-system`, which ships no references at all.

The skill does carry a short **Known errors in the package's docs** table, for three snippets that do not compile against the code they ship with — each confirmed with `tsc`, not asserted:

| The docs show | It actually is |
|---|---|
| `<Footer companyName="WSO2 LLC" />` | `Footer` takes children |
| `DashboardIcon` | not an export — `LayoutDashboard` |
| `GoogleIcon` | not an export — brand icons carry no `Icon` suffix |

## Verification

Proved against a **real app** scaffolded with the skill's own Setup commands and built:

```
verify.mjs        ok (8 checks)
npx tsc --noEmit  exit 0
npm run build     ✓ built
```

Negative cases behave: a stray `@mui/material` import in `src/`, and an `@emotion/*` pulled into `vite.config.ts`, each flip exactly one check and fail the step.

Every factual claim about icon names was settled by type-checking the names themselves rather than by reading docs — which is how the draft's inherited *"there is no `EditIcon`"* rule was caught and removed. lucide resolves bare **and** `Icon`-suffixed (`Pencil`, `PencilIcon`); only the brand icons have no alias.

Suites: `skills/**/*.test.mjs` 34/34, remote-worker 449/449, agents 347/347, playground 98/98.

`services/aep-api ./internal/spec` has one failure, `TestLoadEmbeddedLibrary`, that **fails identically on `upstream/main`**: `skills/agent-browser/SKILL.md` has an unquoted `description:` containing a colon, so `loadLibrary` cannot parse it and drops the skill from every org. Pre-existing and out of scope here — filed separately.

Vendor-name guard passes, with one exception now documented in `skills/AGENTS.md`: `wireframes` names Oxygen for the **wireframe compiler's** drawing palette, which is not the app's UI toolkit and does not follow the org's design system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
