### PR TITLE
Criteria pane: a glyph for the method, the verdict at the row's end

### DIFF
--- a/apps/console/design/lexicon.md
+++ b/apps/console/design/lexicon.md
@@ -836,21 +836,32 @@ readers never reach.
 
 | | |
 |---|---|
-| Description, under the heading | *Each criterion represents one thing your software must do, based on your requirements. After every deployment they are checked against the running software, and the results appear under Validations. To change one, ask the agent.* |
-| Checked by a test | **`AUTO`**, tooltip *Validated automatically by the agent.* |
-| Checked by a person | **`MANUAL`**, tooltip *Requires manual validation.* |
+| Description, under the heading | *Each criterion represents one thing your system must do, based on your requirements. After every deployment the ones that can be automated are checked against the deployed system, and the results appear under Validations. The rest you have to check yourself. To change one, ask the agent.* |
+| Checked by a test | the **agent glyph** — `Sparkles`, `primary.main` — tooltip *Validated automatically by the agent.* |
+| Checked by a person | the **person glyph** — `User`, `text.secondary` — tooltip *Requires manual validation.* |
 
-**`AUTO`, never `E2E`.** The stored value stays `e2e` — the validation runner,
-the report generator and the per-criterion spec path all key on it — so the badge
-carries a **display name** instead, the same split the run-state chips already
-draw. `E2E` was never a copy decision: it was agent-authored JSON rendered
-verbatim, which is how an unexpanded acronym reached the screen past naming rule
-4. The rule now has a place to bite, because the word is finally a string
-somebody wrote.
+**A glyph, never the word.** The stored value stays `e2e` — the validation
+runner, the report generator and the per-criterion spec path all key on it — and
+no row spells it out, because a row marks the method rather than naming it. That
+shuts naming rule 4's oldest hole here: `E2E` was never a copy decision, it was
+agent-authored JSON rendered verbatim, and an acronym can no longer reach a row
+even by accident. The display name **`auto`** survives where prose needs a word
+for the same thing — the Validations pending tile and its tally — and is not a
+row's vocabulary.
 
-**Every badge earns a tooltip, and only the two real methods get one.** A third
-value exists in older documents; it renders bare rather than being given an
-invented explanation.
+**The agent glyph is the console's own.** `Sparkles` at `primary.main` is what
+the agent chat, the "ask the agent" action and the nav already mean *the agent*
+by, so a row inherits a meaning the reader arrives with instead of teaching a
+new one.
+
+**Everything that is not `e2e` takes the person glyph.** A third method exists in
+older documents, and a criterion can arrive with no method at all. Neither is ever
+automated, so both fall to the person rather than rendering bare — the glyph is
+already claiming a human does the work, and one sentence is honest for all three.
+
+**The mark is the accessible name, not the tooltip.** A tooltip exists only while
+hovered, and `Tooltip` puts its title on a bare span where an aria-label is
+ignored, so the same sentence is repeated as visually-hidden text.
 
 **"Ask the agent", not an edit control.** There is no way to edit a criterion
 here, by design: they are written from the requirements alone and never from the
@@ -863,13 +874,12 @@ render the same pane, and Validations suppresses it — a reader there came for 
 results, so a sentence promising that results appear under Validations is
 redundant on the page holding them.
 
-**Unsettled: `deployment` or `build`.** This description says criteria are checked
-*after every deployment*; the **Validations** empty state says *"After a build,
-your software is checked against the validation criteria in your spec"*. Both name
-the same event. *Deployment* is the more accurate word, since validation runs
-against the deployed system and needs its resolved endpoints, but that empty state
-was out of scope when this pane was written. Whoever settles it changes both and
-deletes this note.
+**`deployment`, not `build`, and `the deployed system`, not `your software`.**
+Validation runs against a running instance and needs its resolved endpoints, so
+the event before it is a deployment; the **Validations** empty state says so too.
+The subject takes the platform's own noun, the one the agent's status line, the
+validation task's title and the `aep-validation` skill all already use — so the
+description and the run name the same thing the same way.
 
 ### What a criterion is doing, while a run is under way
 
@@ -884,11 +894,32 @@ The row now says what is happening to it. In the order a reader meets them:
 |---|---|
 | Nothing has happened to it yet | **`Pending`** |
 | The run has decided how it will check this one | **`Planned`** |
-| Driving the running software to learn how to check it | **`Exploring…`** |
+| Driving the deployed system to learn how to check it | **`Exploring…`** |
 | Writing its check | **`Authoring…`** |
 | Its check is running | **`Running…`** |
 | It worked, then broke — being repaired | **`Healing…`** |
-| Settled | **`Passed`** / **`Failed`**, unchanged |
+| Settled | **`Passed`** / **`Failed`** |
+| The last run has no row for it | **`No result`** |
+
+**`Passed` and `Failed` carry a mark; nothing else does.** They are the two
+answers a run produces, and as outlined chips they would otherwise differ by hue
+alone, which is nothing to a red/green colour-blind reader. Every other word in
+the table is the ABSENCE of an answer, so marking one would spend the distinction
+where it is not needed.
+
+**A trailing `*` qualifies the verdict.** A test that was flaky, or one the agent
+repaired, modifies the word beside it rather than earning a chip of its own; the
+tooltip says which applies. **`Failed*`** is a real row — a repair can leave a
+test still failing.
+
+**`No result` is about a run that finished without covering the row.** The
+criteria are read at the branch tip and the report at the merge commit of the
+attempt that wrote it, so a criterion authored or renamed since has no row in
+that report. Tooltip: *The last validation run produced no result for this
+criterion.* Neutral rather than a warning, because editing the spec after a run
+is the ordinary loop and colouring the expected state teaches the reader to
+discount the colour. It never appears while an attempt is in flight; such a row
+reads **`Pending`**, the run still being able to answer it.
 
 Above the rows, one line, and only while the run is under way. It is the newest
 comment on the run's validation issue, the same status line a dev cycle keeps on
@@ -1077,7 +1108,7 @@ five surfaces fill themselves.
 |---|---|---|
 | Builds | **No builds yet.** A build hands your design to coding agents, which write your components and open pull requests. | **Go to the spec** |
 | Deployments | **Nothing deployed yet.** Your components run here once they are built — each environment shows what is live and where to reach it. | — |
-| Validations *(never validated)* | **Nothing validated yet.** After a build, your software is checked against the **validation criteria** in your spec; results appear here. | — |
+| Validations *(never validated)* | **Nothing validated yet.** After a deployment, the deployed system is checked against the **validation criteria** in your spec. Results appear here. | — |
 | Validations *(version skipped)* | **This version was not validated** — it has no validation criteria, or it was an incident run, which gets no validation cycle. | — |
 | Components *(overview)* | **No components yet.** Components are the services and apps your design is made of — they appear as agents build them. | — |
 | Architecture *(overview)* | **No architecture yet.** Once the agent designs your app, its components and the connections between them are drawn here. | — |

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1812,6 +1812,20 @@ describe("SpecView validation criteria explanation", () => {
     expect(screen.getByText(/To change one, ask the agent/)).toBeInTheDocument();
   });
 
+  it("puts no status chip on the preview, for any method", () => {
+    // This pane has no run attached — it is a file preview of the oracle — so a
+    // chip here would name a run that does not exist. `manual` is the one that
+    // regressed: a rule giving manual criteria their final word was ranked above
+    // the has-a-run check, and stamped "Manual" onto every preview.
+    render(<SpecView projectName="proj1" />);
+
+    // The method BADGE still says manual (lowercase; the chip would capitalise).
+    expect(screen.getByText("manual")).toBeInTheDocument();
+    for (const chip of ["Manual", "Pending", "Passed", "Failed", "Planned"]) {
+      expect(screen.queryByText(chip)).not.toBeInTheDocument();
+    }
+  });
+
   it("names the methods without the e2e acronym", () => {
     render(<SpecView projectName="proj1" />);
 

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1832,8 +1832,9 @@ describe("SpecView validation criteria explanation", () => {
   });
 
   it("names no method at all — the glyph does it", () => {
-    // `e2e` is an acronym the console lexicon forbids, and it used to be spelled
-    // "auto" on a badge. Neither word is on the row now, so neither can leak.
+    // `e2e` is an acronym the console lexicon forbids, and "auto" is the word it
+    // is spelled as elsewhere. Neither belongs on a row, where the glyph carries
+    // the distinction, so neither may leak here.
     render(<SpecView projectName="proj1" />);
 
     for (const word of ["e2e", "auto", "manual"]) {

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1812,25 +1812,42 @@ describe("SpecView validation criteria explanation", () => {
     expect(screen.getByText(/To change one, ask the agent/)).toBeInTheDocument();
   });
 
-  it("puts no status chip on the preview, for any method", () => {
+  it("marks who checks each criterion, and never with a run signal", () => {
     // This pane has no run attached — it is a file preview of the oracle — so a
     // chip here would name a run that does not exist. `manual` is the one that
     // regressed: a rule giving manual criteria their final word was ranked above
     // the has-a-run check, and stamped "Manual" onto every preview.
     render(<SpecView projectName="proj1" />);
 
-    // The method BADGE still says manual (lowercase; the chip would capitalise).
-    expect(screen.getByText("manual")).toBeInTheDocument();
+    // Each row's mark is a glyph, so its phrase is what identifies it. The glyph
+    // carries no visible text of its own, which is why the phrase is also the
+    // accessible name.
+    expect(
+      screen.getByText("Validated automatically by the agent."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Requires manual validation.")).toBeInTheDocument();
     for (const chip of ["Manual", "Pending", "Passed", "Failed", "Planned"]) {
       expect(screen.queryByText(chip)).not.toBeInTheDocument();
     }
   });
 
-  it("names the methods without the e2e acronym", () => {
+  it("names no method at all — the glyph does it", () => {
+    // `e2e` is an acronym the console lexicon forbids, and it used to be spelled
+    // "auto" on a badge. Neither word is on the row now, so neither can leak.
     render(<SpecView projectName="proj1" />);
 
-    expect(screen.getByText("auto")).toBeInTheDocument();
-    expect(screen.getByText("manual")).toBeInTheDocument();
-    expect(screen.queryByText("e2e")).not.toBeInTheDocument();
+    for (const word of ["e2e", "auto", "manual"]) {
+      expect(screen.queryByText(word)).not.toBeInTheDocument();
+    }
+  });
+
+  it("shortens the ids, keeping the full one on hover", () => {
+    render(<SpecView projectName="proj1" />);
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+    expect(screen.queryByText("AC-001-a")).not.toBeInTheDocument();
+    expect(screen.queryByText("REQ-001")).not.toBeInTheDocument();
   });
 });

--- a/apps/console/src/features/spec/components/SpecView.test.tsx
+++ b/apps/console/src/features/spec/components/SpecView.test.tsx
@@ -1806,9 +1806,18 @@ describe("SpecView validation criteria explanation", () => {
     render(<SpecView projectName="proj1" />);
 
     expect(
-      screen.getByText(/Each criterion represents one thing your software must do/),
+      screen.getByText(/Each criterion represents one thing your system must do/),
     ).toBeInTheDocument();
     expect(screen.getByText(/based on your requirements/)).toBeInTheDocument();
+    // Both halves, because only the automatable ones are checked for the reader.
+    // Claiming all of them were is what this sentence used to do, above a list
+    // whose glyphs said otherwise.
+    expect(
+      screen.getByText(/the ones that can be automated are checked/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/The rest you have to check yourself/),
+    ).toBeInTheDocument();
     expect(screen.getByText(/To change one, ask the agent/)).toBeInTheDocument();
   });
 

--- a/apps/console/src/features/validation/components/PendingTile.tsx
+++ b/apps/console/src/features/validation/components/PendingTile.tsx
@@ -31,9 +31,8 @@ import type { StatusLine } from "../../tasks/lib/statusLine";
 // prose — otherwise nothing tells the reader that "auto" and "manual" are the two
 // halves this page is about to split the criteria into.
 //
-// It no longer echoes a badge on the rows below: those carry a glyph now, not a
-// word. So this is the only place the words appear, which is the argument for
-// marking them here rather than against it.
+// The rows below carry a glyph rather than a word, so this is the only place the
+// words appear — which is the argument for marking them, not against it.
 //
 // A wash and not a fill: a filled pill mid-sentence stops the line dead, while a
 // tint carries the mark and lets the words keep flowing. `text.primary` over an

--- a/apps/console/src/features/validation/components/PendingTile.tsx
+++ b/apps/console/src/features/validation/components/PendingTile.tsx
@@ -27,18 +27,21 @@ import { validationView } from "../../projects/lib/pipeline";
 import { FULL_WIDTH_ALERT_MESSAGE, LiveNote } from "./LiveNote";
 import type { StatusLine } from "../../tasks/lib/statusLine";
 
-// A method named inside a sentence: the badge's word, set the way the badge sets it
-// — same monospace, same weight, same tracking, same uppercase — so a reader
-// recognises it as the thing marking every row below.
+// A method named inside a sentence, marked as a term rather than left as ordinary
+// prose — otherwise nothing tells the reader that "auto" and "manual" are the two
+// halves this page is about to split the criteria into.
 //
-// What it does NOT take from the badge is the solid fill and the badge's padding. A
-// filled pill mid-sentence stops the line dead; a wash of the same colour carries the
-// identity while the words keep flowing. `text.primary` over an alpha fill rather
-// than the raw colour as text, so it holds in both themes — the idiom StatusChip's
-// soft tones and ValidationView's failure block both use.
+// It no longer echoes a badge on the rows below: those carry a glyph now, not a
+// word. So this is the only place the words appear, which is the argument for
+// marking them here rather than against it.
 //
-// Word and colour both come from the shared vocabulary (counts.ts), so renaming a
-// method or recolouring it carries the sentence along with the badges.
+// A wash and not a fill: a filled pill mid-sentence stops the line dead, while a
+// tint carries the mark and lets the words keep flowing. `text.primary` over an
+// alpha fill rather than the raw colour as text, so it holds in both themes — the
+// idiom StatusChip's soft tones and ValidationView's failure block both use.
+//
+// Word and colour both come from the shared vocabulary (counts.ts), so renaming or
+// recolouring a method carries this sentence and the tally below it along.
 function Method({ method }: { method: string }) {
   return (
     <Box
@@ -99,7 +102,7 @@ export function PendingTile({
   if (!view) return null;
 
   const manual = methods?.find((m) => m.method === "manual")?.count ?? 0;
-  // "12 auto · 3 manual" — the same words as the badges on the rows below, because
+  // "12 auto · 3 manual" — the same words as the sentence above, because
   // both read METHOD_LABEL.
   const counts = (methods ?? [])
     .map(({ method, count }) => `${count} ${METHOD_LABEL[method] ?? method}`)
@@ -117,9 +120,8 @@ export function PendingTile({
           NO_CRITERIA
         ) : (
           <>
-            {/* The two method words are the vocabulary of the badges on every row
-                below, so they are marked as terms rather than left as ordinary
-                prose — otherwise nothing connects the sentence to the list. */}
+            {/* The two words the tally beneath counts by, so they are marked as
+                terms rather than left as ordinary prose. */}
             <Method method="e2e" /> criteria are being validated end to end
             against the deployed system.
             {/* Only when there ARE manual criteria: this half is an instruction, and

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1176,11 +1176,10 @@ describe("ValidationPage lifecycle", () => {
   });
 });
 
-// The method badge is the reader's only signal for who checks a criterion, and it
-// used to render the wire value verbatim — `E2E`, an acronym the lexicon forbids
-// and nothing in the product expanded. The wire value cannot change (the runner,
-// the report generator and the tests/e2e/specs/<AC-ID>.spec.ts path all key on
-// it), so the display name is the thing under test here.
+// `e2e` is an acronym the console lexicon forbids and nothing in the product
+// expands, and it cannot change — the runner, the report generator and the
+// tests/e2e/specs/<AC-ID>.spec.ts path all key on it. So no surface may leak it,
+// which is part of what these assertions hold.
 describe("ValidationPage criterion rows", () => {
   function renderWithCriteria() {
     mockValidation = "passed";
@@ -1193,11 +1192,9 @@ describe("ValidationPage criterion rows", () => {
     renderPage(undefined);
   }
 
-  // One signal per row, and it is the verdict. A manual criterion used to carry
-  // TWO marks saying the same thing at opposite margins — a purple `manual` method
-  // badge on the left and a neutral "Manual" status chip on the right. The status
-  // chip is sufficient here, so the method mark is gone and the chip has moved into
-  // the column the badge used to hold.
+  // One signal per row, and on this page it is the verdict: the status chip already
+  // says "Manual", so a method mark beside it would say the same thing twice at
+  // opposite margins of one row.
   it("carries the verdict alone, with no method mark", () => {
     renderWithCriteria();
 

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -654,6 +654,12 @@ describe("ValidationPage lifecycle", () => {
     mockRun = run({});
     renderPage(undefined);
     expect(screen.getByText(/Nothing validated yet/)).toBeInTheDocument();
+    // The event is a DEPLOYMENT, not a build: validation drives a running
+    // instance and needs its resolved endpoints, so a build alone cannot trigger
+    // it. And it names the same subject the agent's own status line does.
+    expect(
+      screen.getByText(/After a deployment, the deployed system is checked/),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("run-feed")).not.toBeInTheDocument();
   });
 

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -263,6 +263,25 @@ const CRITERIA = JSON.stringify({
   ],
 });
 
+// The oracle after the spec moved on: AC-001-c is authored but absent from the
+// pinned REPORT below, which is what the page really sees whenever criteria are
+// edited after an attempt settled. The console reads the criteria at the branch tip
+// and the report at the merge commit of the attempt that wrote it.
+const CRITERIA_DRIFTED = JSON.stringify({
+  requirements: [
+    {
+      id: "REQ-001",
+      statement: "Shoppers can search the catalog.",
+      criteria: [
+        { id: "AC-001-a", must: "Search returns matches", method: "e2e" },
+        { id: "AC-001-b", must: "Category filter works", method: "e2e" },
+        { id: "AC-001-c", must: "An empty search explains itself", method: "e2e" },
+        { id: "AC-003-b", must: "Payment is encrypted", method: "manual" },
+      ],
+    },
+  ],
+});
+
 const REPORT = JSON.stringify({
   criteria: [
     { id: "AC-001-a", status: "pass" },
@@ -805,6 +824,52 @@ describe("ValidationPage lifecycle", () => {
   // The regression this replaced a default with: no state may FORCE a body, because
   // `?view=logs | absent` has no third value, so `onViewChange(undefined)` cannot
   // outrank a forced arm and the "View report" button silently does nothing.
+  // "Out of run" is a claim about a run that FINISHED without covering the row. A
+  // repeat attempt in flight may still answer it, so while one is running the row
+  // waits with everything else.
+  it("says a drifted criterion is pending while a repeat attempt runs", () => {
+    mockValidation = "running";
+    mockRun = {
+      ...run({
+        validation: {
+          verdict: "failed",
+          reportPath: "tests/validation/report.json",
+        },
+        cycles: [validationCycle],
+      }),
+      state: "running",
+    };
+    mockCriteria.data = { content: CRITERIA_DRIFTED };
+    mockReport.data = { content: REPORT };
+    renderPage(undefined);
+
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+    // The rows the pinned report DOES cover keep the last attempt's verdict, which
+    // is what makes widening the pending signal safe.
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  // The other side of the same gate: nothing is running, so the report's silence
+  // about this row is final.
+  it("says a drifted criterion is out of run once nothing is running", () => {
+    mockValidation = "failed";
+    mockRun = run({
+      validation: {
+        verdict: "failed",
+        reportPath: "tests/validation/report.json",
+      },
+      cycles: [validationCycle],
+    });
+    mockCriteria.data = { content: CRITERIA_DRIFTED };
+    mockReport.data = { content: REPORT };
+    renderPage(undefined);
+
+    expect(screen.getByText("Out of run")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+  });
+
   it("keeps the report/log toggle working while a repeat attempt runs", () => {
     mockValidation = "running";
     mockRun = {

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1192,22 +1192,22 @@ describe("ValidationPage criterion rows", () => {
     renderPage(undefined);
   }
 
-  // One signal per row, and on this page it is the verdict: the status chip already
-  // says "Manual", so a method mark beside it would say the same thing twice at
-  // opposite margins of one row.
-  it("carries the verdict alone, with no method mark", () => {
+  // Two marks answering two questions: the glyph says who checks the criterion,
+  // the chip says what the run made of it. Both belong on a results page — the
+  // reader still has to find their own work in it.
+  it("carries the verdict beside the method, and names neither in words", () => {
     renderWithCriteria();
 
     expect(screen.getByText("Passed")).toBeInTheDocument();
     expect(screen.getByText("Manual")).toBeInTheDocument();
-    // Neither the wire value, nor the word it was spelled as, nor the glyph's
-    // hover phrase — a page with results has no need to say who would have checked.
+    expect(
+      screen.getByText("Requires manual validation."),
+    ).toBeInTheDocument();
+    // The method is a glyph, never a word: neither the wire value nor the word it
+    // is spelled as elsewhere may reach a row.
     for (const word of ["e2e", "auto", "manual"]) {
       expect(screen.queryByText(word)).not.toBeInTheDocument();
     }
-    expect(
-      screen.queryByText("Validated automatically by the agent."),
-    ).not.toBeInTheDocument();
   });
 
   // The tile above already prints "N passed · M manual" and its method line. The

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1469,27 +1469,6 @@ describe("ValidationPage manual criteria ignore the live feed", () => {
     expect(screen.queryByText("Running…")).not.toBeInTheDocument();
   });
 
-  it("still says Manual when no report was fetched and nothing is awaiting", () => {
-    // `unreported` settles the run and skips the report read, so `awaiting` is
-    // false and there is no report — the two branches that used to carry a manual
-    // row. Before the guard it fell through to nothing and rendered no chip.
-    mockValidation = "unreported";
-    mockRun = run({
-      validation: { verdict: "unreported" },
-      cycles: [validationCycle],
-    });
-    mockCriteria.data = { content: CRITERIA };
-    mockLive = { "AC-001-a": "authoring" };
-    renderPage(undefined);
-
-    expect(screen.getByText("Manual")).toBeInTheDocument();
-    // Asserted negatively too: the method BADGE also carries the word "manual",
-    // so presence alone would still pass if the chip regressed to something else
-    // and only the badge matched. Neither of the two chips it could wrongly show
-    // here may appear on any row.
-    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
-    expect(screen.queryByText("Planned")).not.toBeInTheDocument();
-  });
 });
 
 // The run-wide narration a reader arrives with. Until now the tile had exactly

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -824,7 +824,7 @@ describe("ValidationPage lifecycle", () => {
   // The regression this replaced a default with: no state may FORCE a body, because
   // `?view=logs | absent` has no third value, so `onViewChange(undefined)` cannot
   // outrank a forced arm and the "View report" button silently does nothing.
-  // "Out of run" is a claim about a run that FINISHED without covering the row. A
+  // "No result" is a claim about a run that FINISHED without covering the row. A
   // repeat attempt in flight may still answer it, so while one is running the row
   // waits with everything else.
   it("says a drifted criterion is pending while a repeat attempt runs", () => {
@@ -844,7 +844,7 @@ describe("ValidationPage lifecycle", () => {
     renderPage(undefined);
 
     expect(screen.getByText("Pending")).toBeInTheDocument();
-    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+    expect(screen.queryByText("No result")).not.toBeInTheDocument();
     // The rows the pinned report DOES cover keep the last attempt's verdict, which
     // is what makes widening the pending signal safe.
     expect(screen.getByText("Passed")).toBeInTheDocument();
@@ -866,7 +866,7 @@ describe("ValidationPage lifecycle", () => {
     mockReport.data = { content: REPORT };
     renderPage(undefined);
 
-    expect(screen.getByText("Out of run")).toBeInTheDocument();
+    expect(screen.getByText("No result")).toBeInTheDocument();
     expect(screen.queryByText("Pending")).not.toBeInTheDocument();
   });
 

--- a/apps/console/src/features/validation/components/ValidationPage.test.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.test.tsx
@@ -1116,7 +1116,7 @@ describe("ValidationPage lifecycle", () => {
 // and nothing in the product expanded. The wire value cannot change (the runner,
 // the report generator and the tests/e2e/specs/<AC-ID>.spec.ts path all key on
 // it), so the display name is the thing under test here.
-describe("ValidationPage criterion method badges", () => {
+describe("ValidationPage criterion rows", () => {
   function renderWithCriteria() {
     mockValidation = "passed";
     mockRun = run({
@@ -1128,34 +1128,46 @@ describe("ValidationPage criterion method badges", () => {
     renderPage(undefined);
   }
 
-  it("says auto rather than the e2e wire value", () => {
+  // One signal per row, and it is the verdict. A manual criterion used to carry
+  // TWO marks saying the same thing at opposite margins — a purple `manual` method
+  // badge on the left and a neutral "Manual" status chip on the right. The status
+  // chip is sufficient here, so the method mark is gone and the chip has moved into
+  // the column the badge used to hold.
+  it("carries the verdict alone, with no method mark", () => {
     renderWithCriteria();
 
-    // Two e2e criteria in the fixture, plus the summary tally's own badge.
-    expect(screen.getAllByText("auto")).toHaveLength(2);
-    expect(screen.queryByText("e2e")).not.toBeInTheDocument();
-    expect(screen.getByText("auto 2")).toBeInTheDocument();
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    // Neither the wire value, nor the word it was spelled as, nor the glyph's
+    // hover phrase — a page with results has no need to say who would have checked.
+    for (const word of ["e2e", "auto", "manual"]) {
+      expect(screen.queryByText(word)).not.toBeInTheDocument();
+    }
+    expect(
+      screen.queryByText("Validated automatically by the agent."),
+    ).not.toBeInTheDocument();
   });
 
-  it("leaves the manual badge alone", () => {
+  // The tile above already prints "N passed · M manual" and its method line. The
+  // view's own tally repeated those numbers a few rows lower on the same screen.
+  it("drops the summary tally the tile above already prints", () => {
     renderWithCriteria();
 
-    expect(screen.getByText("manual")).toBeInTheDocument();
-    expect(screen.getByText("manual 1")).toBeInTheDocument();
+    expect(screen.queryByText("auto 2")).not.toBeInTheDocument();
+    expect(screen.queryByText("manual 1")).not.toBeInTheDocument();
+    expect(screen.queryByText(/requirements ·/)).not.toBeInTheDocument();
   });
 
-  it("explains each method on hover", async () => {
+  // Inside REQ-001's card the `AC-001-` half of every criterion id is already on
+  // the page, so the rows print only what distinguishes them. The full id stays
+  // reachable on hover, being the handle for spec filenames and for the agent.
+  it("shortens the ids to what the card does not already say", () => {
     renderWithCriteria();
 
-    fireEvent.mouseOver(screen.getAllByText("auto")[0]!);
-    expect(
-      await screen.findByText("Validated automatically by the agent."),
-    ).toBeInTheDocument();
-
-    fireEvent.mouseOver(screen.getByText("manual"));
-    expect(
-      await screen.findByText("Requires manual validation."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getAllByText("a").length).toBeGreaterThan(0);
+    expect(screen.queryByText("AC-001-a")).not.toBeInTheDocument();
+    expect(screen.queryByText("REQ-001")).not.toBeInTheDocument();
   });
 
   // The description explaining what criteria ARE belongs to the Spec view, where

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -629,7 +629,7 @@ export function ValidationPage({
         {headerWithCancelError}
         <EmptyState
           compact
-          description="Nothing validated yet. After a build, your software is checked against the validation criteria in your spec; results appear here."
+          description="Nothing validated yet. After a deployment, the deployed system is checked against the validation criteria in your spec. Results appear here."
         />
       </>
     );

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -333,15 +333,15 @@ export function ValidationPage({
   // it is worth showing, because it says what is being checked and what will never be
   // checked by an agent at all.
   //
-  // Deliberately not every `running` state. A repeat attempt has the previous
-  // attempt's verdict and report, which the page renders with its numbers marked as
-  // the last attempt's; replacing that with a page of Pending chips would throw away
-  // the only results anyone has.
+  // This gates the pending TILE and the reads behind it, NOT the criterion rows.
+  // Those take `validating`, because a row's fallback has to know whether ANY
+  // attempt is in flight: on a repeat attempt, a criterion the pinned report never
+  // covered is waiting on the run working right now, not left over from the one
+  // before it.
   //
-  // This gates the PENDING fallback only. A criterion the current attempt is
-  // actually working on gets a live status regardless (see `live` below), which is
-  // what un-freezes a repeat attempt without inventing a row that says nothing:
-  // "Pending" is a guess about every criterion, `Authoring…` is a fact about one.
+  // Widening the row signal costs the previous attempt's results nothing, because
+  // the report outranks the fallback (see CriterionChip) — a row the report covers
+  // keeps its verdict either way, and only the uncovered rows move.
   const awaitingFirstVerdict = state === "running" && rawVerdict === "";
   // `unreported` MEANS no report was committed at that commit, and the server
   // omits reportPath for it. Requesting the file anyway would 404 to rediscover
@@ -735,9 +735,11 @@ export function ValidationPage({
         noPadding
         fullWidth
         hideDescription
-        // A first attempt in flight has no report by definition, so every row says
-        // what is ABOUT to happen to it instead of nothing at all.
-        awaitingReport={awaitingFirstVerdict}
+        // `validating`, not `awaitingFirstVerdict`: a row with no result yet is
+        // waiting on whichever attempt is in flight, first or repeat. Narrowed to
+        // the first, it told the reader that a criterion authored since the last run
+        // was "out of run" while the current run was on its way to answering it.
+        awaitingReport={validating}
         criteria={criteria.data.content}
         {...(report.data ? { report: report.data.content } : {})}
         live={live.statuses}

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -333,15 +333,11 @@ export function ValidationPage({
   // it is worth showing, because it says what is being checked and what will never be
   // checked by an agent at all.
   //
-  // This gates the pending TILE and the reads behind it, NOT the criterion rows.
-  // Those take `validating`, because a row's fallback has to know whether ANY
-  // attempt is in flight: on a repeat attempt, a criterion the pinned report never
-  // covered is waiting on the run working right now, not left over from the one
-  // before it.
-  //
-  // Widening the row signal costs the previous attempt's results nothing, because
-  // the report outranks the fallback (see CriterionChip) — a row the report covers
-  // keeps its verdict either way, and only the uncovered rows move.
+  // Gates the pending TILE and the reads behind it, NOT the criterion rows: those
+  // take `validating`, because a row's fallback has to know whether ANY attempt is
+  // in flight. Safe for them, because the report outranks that fallback (see
+  // CriterionChip) — a row the report covers keeps its verdict either way, and only
+  // uncovered rows move.
   const awaitingFirstVerdict = state === "running" && rawVerdict === "";
   // `unreported` MEANS no report was committed at that commit, and the server
   // omits reportPath for it. Requesting the file anyway would 404 to rediscover
@@ -735,10 +731,10 @@ export function ValidationPage({
         noPadding
         fullWidth
         hideDescription
-        // `validating`, not `awaitingFirstVerdict`: a row with no result yet is
-        // waiting on whichever attempt is in flight, first or repeat. Narrowed to
-        // the first, it told the reader that a criterion authored since the last run
-        // was "out of run" while the current run was on its way to answering it.
+        // `validating`, not `awaitingFirstVerdict`: a row with no result yet waits
+        // on whichever attempt is in flight, first or repeat. Narrow it to the first
+        // and a criterion authored since the last run reads as out of that run while
+        // the current one is on its way to answering it.
         awaitingReport={validating}
         criteria={criteria.data.content}
         {...(report.data ? { report: report.data.content } : {})}

--- a/apps/console/src/features/validation/lib/liveLine.ts
+++ b/apps/console/src/features/validation/lib/liveLine.ts
@@ -49,10 +49,10 @@ const TERMINAL = new Set(["pass", "fail"]);
  * never move, so counting them would mean the line never reaches "all settled"
  * on any project that has one.
  *
- * The set comes from the shared vocabulary rather than a local `!== "manual"`,
- * because the criterion ROWS test the same thing to decide whether a live status
- * may speak for a row. Written twice, the two drifted — this line counted a
- * criterion as answerable that its own row was refusing to show progress for.
+ * From the shared vocabulary rather than a local `!== "manual"`: the criterion
+ * ROWS test the same thing to decide whether a live status may speak for a row, so
+ * a second copy here can count a criterion as answerable that its own row is
+ * refusing to show progress for.
  */
 function agentCriteriaIds(oracle: ValidationCriteria): string[] {
   return oracle.requirements.flatMap((r) =>

--- a/apps/console/src/features/validation/lib/liveLine.ts
+++ b/apps/console/src/features/validation/lib/liveLine.ts
@@ -38,6 +38,7 @@
 // it IS the rows, and it says something only in the two windows where they say
 // nothing.
 
+import { runWorksOn } from "@aep/ui-validation-view";
 import type { LiveStatuses, ValidationCriteria } from "@aep/ui-validation-view";
 
 /** report.json's terminal words, which the live feed also emits. */
@@ -47,10 +48,15 @@ const TERMINAL = new Set(["pass", "fail"]);
  * The criteria a RUN can act on. `manual` criteria are answered by a human and
  * never move, so counting them would mean the line never reaches "all settled"
  * on any project that has one.
+ *
+ * The set comes from the shared vocabulary rather than a local `!== "manual"`,
+ * because the criterion ROWS test the same thing to decide whether a live status
+ * may speak for a row. Written twice, the two drifted — this line counted a
+ * criterion as answerable that its own row was refusing to show progress for.
  */
 function agentCriteriaIds(oracle: ValidationCriteria): string[] {
   return oracle.requirements.flatMap((r) =>
-    r.criteria.filter((c) => c.method !== "manual").map((c) => c.id),
+    r.criteria.filter((c) => runWorksOn(c.method)).map((c) => c.id),
   );
 }
 

--- a/apps/console/src/mocks/fixtures/validation.ts
+++ b/apps/console/src/mocks/fixtures/validation.ts
@@ -26,7 +26,11 @@ type RunVerdict = NonNullable<
 // flight (see ValidationAttempt below) and whether the repo has an oracle at all:
 //   localStorage.setItem('aep:mock:validation-criteria', 'missing')
 // which drops validation-criteria.json from the file list, so the read 404s the way
-// it does for a version whose spec authored none (handlers/project.ts).
+// it does for a version whose spec authored none (handlers/project.ts). The same key
+// also takes:
+//   localStorage.setItem('aep:mock:validation-criteria', 'drifted')
+// which adds a criterion to the ORACLE that the report does not speak for — see
+// DRIFTED below.
 //
 // Setting it alone is enough: with no `aep:mock:project` chosen, the base scenario
 // becomes `deployed` rather than the usual `building`, because a verdict only
@@ -123,6 +127,49 @@ const CATALOGUE: CatalogueEntry[] = [
     method: "manual",
   },
 ];
+
+/**
+ * A criterion the oracle carries and the pinned report does not.
+ *
+ * Deliberately OUTSIDE the catalogue. build() derives both files from one outcome
+ * map, so every entry it can see lands in both — and drift is precisely the case
+ * where the two files disagree, which is why this is spliced into the oracle after
+ * the pair is built.
+ *
+ * Not a contrived state: the console reads the criteria at the branch tip and the
+ * report at the merge commit of the attempt that wrote it, so any criterion
+ * authored since that attempt looks exactly like this. Asking the agent for one
+ * more criterion after reading a failure is the ordinary way to get here.
+ */
+const DRIFTED: CatalogueEntry = {
+  req: "REQ-001",
+  statement: REQ_001,
+  id: "AC-001-c",
+  must: "A search with no matches explains that nothing was found",
+  method: "e2e",
+};
+
+/** The oracle with DRIFTED appended to its requirement; the report is left alone. */
+function withDrift(criteria: string): string {
+  const doc = JSON.parse(criteria) as {
+    requirements: {
+      id: string;
+      statement: string;
+      criteria: Record<string, unknown>[];
+    }[];
+  };
+  const entry = { id: DRIFTED.id, must: DRIFTED.must, method: DRIFTED.method };
+  const req = doc.requirements.find((r) => r.id === DRIFTED.req);
+  if (req) req.criteria.push(entry);
+  else {
+    doc.requirements.push({
+      id: DRIFTED.req,
+      statement: DRIFTED.statement,
+      criteria: [entry],
+    });
+  }
+  return JSON.stringify(doc, null, 2);
+}
 
 /** One criterion's outcome in a run report — the only thing a scenario varies. */
 interface Outcome {
@@ -372,14 +419,18 @@ const ARTIFACTS: Record<ValidationScenario, Artifacts> = {
 export function validationFiles(
   scenario: ValidationScenario,
   attempt: ValidationAttempt = "first",
+  drifted = false,
 ): { path: string; content: string }[] {
   // A repeat attempt is running OVER a failed one whose report is still committed —
   // which is what its copy counts. A first attempt has the oracle and nothing else.
   const { criteria, report } = isRepeat(scenario, attempt)
     ? FAILED
     : ARTIFACTS[scenario];
+  // Only the oracle moves: a report is written once and pinned, so drift can only
+  // ever come from the criteria side.
+  const oracle = criteria && drifted ? withDrift(criteria) : criteria;
   return [
-    ...(criteria ? [{ path: CRITERIA_PATH, content: criteria }] : []),
+    ...(oracle ? [{ path: CRITERIA_PATH, content: oracle }] : []),
     ...(report ? [{ path: REPORT_PATH, content: report }] : []),
   ];
 }

--- a/apps/console/src/mocks/handlers/project.ts
+++ b/apps/console/src/mocks/handlers/project.ts
@@ -119,6 +119,14 @@ function criteriaMissing(): boolean {
   return localStorage.getItem("aep:mock:validation-criteria") === "missing";
 }
 
+// Whether the oracle should carry a criterion the pinned report predates
+// (aep:mock:validation-criteria=drifted). Shares the key with `missing` because both
+// describe the criteria FILE rather than a run, and the two are mutually exclusive:
+// a file that is absent cannot also have drifted.
+function criteriaDrifted(): boolean {
+  return localStorage.getItem("aep:mock:validation-criteria") === "drifted";
+}
+
 // The project's files with the two validation artifacts swapped for the ones the
 // overridden verdict implies. Dropping them first is what makes `unreported` and
 // `skipped` reachable: those scenarios contribute FEWER files, not different ones.
@@ -127,7 +135,7 @@ function specFiles(s: Exclude<ProjectScenario, "error">) {
   if (!v) return projectSpecFiles[s];
   return [
     ...projectSpecFiles[s].filter((f) => !VALIDATION_FILE_PATHS.includes(f.path)),
-    ...validationFiles(v, validationAttempt()).filter(
+    ...validationFiles(v, validationAttempt(), criteriaDrifted()).filter(
       (f) => !(criteriaMissing() && f.path === CRITERIA_PATH),
     ),
   ];

--- a/packages/ui/validation-view/design/README.md
+++ b/packages/ui/validation-view/design/README.md
@@ -1,0 +1,137 @@
+# Design notes — `@aep/ui-validation-view`
+
+This package renders `specs/validation/validation-criteria.json` — the acceptance
+oracle — optionally joined against a run's `tests/validation/report.json`. Two
+consumers, one component:
+
+| Consumer | What it passes | What the reader is doing there |
+|---|---|---|
+| Spec view's file pane (`SpecView.tsx`) | `criteria` only | Reading the document, before any run exists |
+| Validations page (`ValidationPage.tsx`) | `criteria`, `report`, `live`, `awaitingReport` | Reading run results |
+
+## One gutter, one signal
+
+Every criterion row leads with a fixed-width column holding exactly one mark, and
+which mark depends on whether a run is attached:
+
+```text
+SPEC VIEW — no run                    VALIDATIONS — a run
+ ✦  a  A registered email …            [Passed]   a  A registered email …
+ ○  b  The reset copy reads …          [Manual]   b  The reset copy reads …
+                                       [Failed*]  c  A short password …
+```
+
+`✦` is `Sparkles` at `primary.main`, the glyph this console already means "the
+agent" by in nine other places; `○` is `User` at `text.secondary`. Both are
+icon-only, with the explanation on hover and repeated as visually-hidden text —
+`Tooltip` does add an `aria-label`, but its child is a bare span and an aria-label
+on a roleless element is ignored, the same trap `StatusChip` documents for a Chip
+with no `onClick`.
+
+Three things this replaced, each because it said something twice or said nothing:
+
+- **A summary line.** `N requirements · M criteria` over `AUTO 9` / `MANUAL 3`
+  badges. On the Validations page it sat directly beneath a tile already printing
+  both figures. Counts belong with the verdict that explains them, which the
+  consumer renders above this view.
+- **A method badge on every row.** A manual criterion carried a purple `MANUAL`
+  badge at the left margin *and* a neutral `Manual` status chip at the right — the
+  same fact at opposite ends of one row. Where there are results, the status chip
+  is sufficient; where there are none, the glyph is.
+- **Separate `flaky` / `healed` chips.** They qualify the verdict, so they now ride
+  it as a single `*` with the detail on hover. Both flags are independent in
+  `generate-report.mjs` (`flaky` only on a pass, `healed` set before the status is
+  decided), so `Failed*` is a real row and so is a pass that was both.
+
+Collapsing to one chip per row is what lets the gutter be one width for every row,
+which is what keeps the ids beside it aligned. `GUTTER_CHIP` / `GUTTER_ICON` /
+`ROW_GAP` are single constants and the failure block derives its indent from them;
+they were previously two unrelated magic numbers (`minWidth: 92`, `ml: "108px"`).
+
+`GUTTER_CHIP` has to fit the longest label the vocabulary can produce
+(`Not validated`), so a short chip like `Failed` leaves visible slack before the id.
+That is a deliberate trade, taken twice: the alternatives are right-aligning the
+chip in the column (constant gap, ragged chip left edges) or dropping the column
+(constant gap, ragged ids), and the aligned column won both times. It is also why
+the drift chip's label is kept terse — a descriptive one would widen every row.
+
+### Vertical alignment is a shared band, not a baseline
+
+`ROW_LINE` (24px, the MUI small Chip's own height) is the height of a row's first
+line. The gutter, the id mark and the requirement number are each given exactly
+that height and centre their own content in it, and the assertion takes it as its
+`line-height`. All three then sit in the middle of one band by construction, and it
+holds for an assertion that wraps because every later line is the same height.
+
+`align-items: baseline` was tried first and is the wrong tool. An MUI Chip is
+`inline-flex` with `align-items: center`, so it has no baseline-aligned flex item
+and therefore no in-flow line box — CSS synthesises its baseline from its bottom
+margin edge. Baseline alignment consequently sat the chip's *bottom* on the
+assertion's baseline rather than its label, and since the chip (24px) and the id
+mark (~18px) had different heights, the two did not even agree with each other. The
+glyph had the same defect for the same reason and needed its own workaround; under
+the shared band it needs none, because its parent centres it.
+
+The row itself is `align-items: flex-start`, which keeps the marks on the first
+line of a wrapping assertion. `center` would drift them into the middle of it.
+
+## `runAnswers` is the one predicate
+
+`e2e` is the only method a run answers. `generate-report.mjs` gives an e2e
+criterion its test's result and decides every other method from the method alone —
+`manual` for manual, `not_validated` for anything else.
+
+That single fact drives three decisions, so it lives in one predicate rather than
+three inlined method comparisons: which glyph a row shows, whether a live status
+may speak for a row, and whether `Pending` is a promise the run can keep. Splitting
+them is how the glyph came to claim a person checks a legacy `scenario` criterion
+while the awaiting branch still promised it an agent result.
+
+## Drift is a normal state, so it has a chip
+
+`ValidationPage` reads the criteria at the **branch tip** and the report at the
+**merge commit** of the attempt that wrote it (deliberately — reading the tip would
+show an older attempt the newest run's results). The join is by criterion id, so a
+criterion authored since that commit has no row in that report.
+
+That is the ordinary authoring loop: run validation, read a failure, ask the agent
+for another criterion. It gets a neutral `Out of run` chip. Neutral and not
+`warning`, because colouring the expected state teaches the reader to discount the
+colour; and locally worded, because `CRITERION_STATE_LABEL` is `report.json`'s
+vocabulary and this criterion is absent from `report.json`.
+
+The `hasRun` flag that chooses gutter contents is read from the **parsed**
+`statuses`, never from the `report` prop. The prop is raw text and parsing can
+fail; keying off it would hand every row the drift chip, announcing that all of
+them post-date the last run when the truth is that the file is unreadable. Read
+from `statuses`, such a view degrades to the plain oracle with the existing warning
+Alert above it.
+
+Reachable in the console's mock mode via
+`localStorage.setItem('aep:mock:validation-criteria', 'drifted')`.
+
+## Short ids (`shortId.ts`)
+
+`skills/validation-criteria/SKILL.md` fixes both shapes: `REQ-NNN` and
+`AC-<req-number>-<letter>`. Inside a requirement's own card the `AC-001-` half is
+already on the page, so rows print `a` and cards print `1`.
+
+Both sit on a soft `action.hover` ground rather than taking list punctuation
+(`1.`, `a)`), because they are names and not positions. Ids are stable by contract
+— a spec file is named `tests/e2e/specs/<AC-ID>.spec.ts`, so renumbering one would
+orphan it — which means a deleted requirement leaves a gap. `1, 3, 4` reads
+correctly as names and reads as a rendering fault as a list.
+
+Shortening is conditional, not cosmetic: `parse.ts` takes ids as arbitrary strings,
+and a criterion whose number names a *different* requirement keeps its full id,
+because that number is the only part of it that says it is filed in the wrong card.
+The full id stays one hover away — it is the handle for spec filenames,
+`report.json`, and telling the agent which criterion to change.
+
+## Tests
+
+`ValidationView.test.tsx` covers the rendering in-package (jsdom via a per-file
+`// @vitest-environment jsdom` pragma, matching `design-view`); `shortId.test.ts`
+covers the id fallbacks. `vitest.config.ts` scopes `include` to `src/` because
+`build` compiles the tests into `dist/` and the default glob would run those stale
+copies against whatever the source was at build time.

--- a/packages/ui/validation-view/design/README.md
+++ b/packages/ui/validation-view/design/README.md
@@ -28,32 +28,30 @@ icon-only, with the explanation on hover and repeated as visually-hidden text �
 on a roleless element is ignored, the same trap `StatusChip` documents for a Chip
 with no `onClick`.
 
-Three things this replaced, each because it said something twice or said nothing:
+Three rules hold the column to one mark:
 
-- **A summary line.** `N requirements · M criteria` over `AUTO 9` / `MANUAL 3`
-  badges. On the Validations page it sat directly beneath a tile already printing
-  both figures. Counts belong with the verdict that explains them, which the
-  consumer renders above this view.
-- **A method badge on every row.** A manual criterion carried a purple `MANUAL`
-  badge at the left margin *and* a neutral `Manual` status chip at the right — the
-  same fact at opposite ends of one row. Where there are results, the status chip
-  is sufficient; where there are none, the glyph is.
-- **Separate `flaky` / `healed` chips.** They qualify the verdict, so they now ride
-  it as a single `*` with the detail on hover. Both flags are independent in
-  `generate-report.mjs` (`flaky` only on a pass, `healed` set before the status is
-  decided), so `Failed*` is a real row and so is a pass that was both.
+- **No tally in this view.** Counts belong with the verdict that explains them,
+  which the consumer renders above; a second copy here says the same numbers twice.
+- **Never a method mark beside a status chip.** The chip already says `Manual`, so
+  a mark next to it states the same fact at the other margin of the row. Where
+  there are results the chip is sufficient; where there are none the glyph is.
+- **Qualifiers ride the verdict.** `flaky` and `healed` become a single `*` with
+  the detail on hover, rather than chips competing with the word they qualify. The
+  two flags are independent in `generate-report.mjs` (`flaky` only on a pass,
+  `healed` decided before the status), so `Failed*` is a real row and so is a pass
+  that was both.
 
-Collapsing to one chip per row is what lets the gutter be one width for every row,
-which is what keeps the ids beside it aligned. `GUTTER_CHIP` / `GUTTER_ICON` /
-`ROW_GAP` are single constants and the failure block derives its indent from them;
-they were previously two unrelated magic numbers (`minWidth: 92`, `ml: "108px"`).
+One mark per row is what lets the gutter be one width, which is what keeps the ids
+beside it aligned. `GUTTER_CHIP` / `GUTTER_ICON` / `ROW_GAP` are single constants
+and the failure block derives its indent from them, so the column and the indent
+cannot disagree.
 
 `GUTTER_CHIP` has to fit the longest label the vocabulary can produce
 (`Not validated`), so a short chip like `Failed` leaves visible slack before the id.
-That is a deliberate trade, taken twice: the alternatives are right-aligning the
-chip in the column (constant gap, ragged chip left edges) or dropping the column
-(constant gap, ragged ids), and the aligned column won both times. It is also why
-the drift chip's label is kept terse — a descriptive one would widen every row.
+That is a deliberate trade: the alternatives are right-aligning the chip in the
+column (constant gap, ragged chip left edges) or dropping the column (constant gap,
+ragged ids), and the aligned column is worth more than either. It is also why the
+drift chip's label is kept terse — a descriptive one would widen every row.
 
 ### Vertical alignment is a shared band, not a baseline
 
@@ -63,14 +61,14 @@ that height and centre their own content in it, and the assertion takes it as it
 `line-height`. All three then sit in the middle of one band by construction, and it
 holds for an assertion that wraps because every later line is the same height.
 
-`align-items: baseline` was tried first and is the wrong tool. An MUI Chip is
-`inline-flex` with `align-items: center`, so it has no baseline-aligned flex item
-and therefore no in-flow line box — CSS synthesises its baseline from its bottom
-margin edge. Baseline alignment consequently sat the chip's *bottom* on the
+`align-items: baseline` is the wrong tool here, and worth knowing why. An MUI Chip
+is `inline-flex` with `align-items: center`, so it has no baseline-aligned flex
+item and therefore no in-flow line box — CSS then synthesises its baseline from its
+bottom margin edge. Baseline alignment therefore sits the chip's *bottom* on the
 assertion's baseline rather than its label, and since the chip (24px) and the id
-mark (~18px) had different heights, the two did not even agree with each other. The
-glyph had the same defect for the same reason and needed its own workaround; under
-the shared band it needs none, because its parent centres it.
+mark (~18px) are different heights, the two do not even agree with each other. A
+bare glyph has the same defect for the same reason; under the shared band it needs
+no special handling, because its parent centres it.
 
 The row itself is `align-items: flex-start`, which keeps the marks on the first
 line of a wrapping assertion. `center` would drift them into the middle of it.
@@ -92,13 +90,13 @@ same answer:
   live-status guard, and by the console's run-wide progress line
   (`liveLine.ts`), which counts exactly this set.
 
-The gap between them is the whole point, and both mistakes have now been made.
-Inlining `method === "manual"` in three places let the glyph claim a person checks
-a `scenario` criterion while the `awaiting` branch still promised it an agent
-result. Collapsing all three onto `runAnswers` then fixed that and broke the other
-end: the row refused a live status that the progress line directly above it had
-already counted. `liveLine.ts` reads `runWorksOn` from this package rather than
-repeating the comparison, so the two cannot disagree again.
+The gap between them is the whole point, and there is a mistake waiting on each
+side of it. Inline the comparison per call site and the glyph can claim a person
+checks a `scenario` criterion while the `awaiting` branch promises it an agent
+result. Collapse all three onto `runAnswers` and a row refuses a live status that
+the progress line above it has already counted. `liveLine.ts` reads `runWorksOn`
+from this package rather than repeating the comparison, so the two cannot
+disagree.
 
 ## Drift is a normal state, so it has a chip
 

--- a/packages/ui/validation-view/design/README.md
+++ b/packages/ui/validation-view/design/README.md
@@ -75,17 +75,30 @@ the shared band it needs none, because its parent centres it.
 The row itself is `align-items: flex-start`, which keeps the marks on the first
 line of a wrapping assertion. `center` would drift them into the middle of it.
 
-## `runAnswers` is the one predicate
+## Two predicates, because a run gets asked two questions
 
-`e2e` is the only method a run answers. `generate-report.mjs` gives an e2e
-criterion its test's result and decides every other method from the method alone —
-`manual` for manual, `not_validated` for anything else.
+Both live in `counts.ts` (`runAnswers`, `runWorksOn`) so every caller reads the
+same answer:
 
-That single fact drives three decisions, so it lives in one predicate rather than
-three inlined method comparisons: which glyph a row shows, whether a live status
-may speak for a row, and whether `Pending` is a promise the run can keep. Splitting
-them is how the glyph came to claim a person checks a legacy `scenario` criterion
-while the awaiting branch still promised it an agent result.
+- **`runAnswers(method)`** — will the run produce a *verdict* for this row? `e2e`
+  only. `generate-report.mjs` gives an e2e criterion its test's result and decides
+  every other method from the method alone, `manual` for manual and
+  `not_validated` for anything else. Read by the glyph and by the `awaiting`
+  branch, which is why a criterion the run cannot answer gets its final word
+  instead of a `Pending` the report would contradict.
+- **`runWorksOn(method)`** — is the run *working on* this row, and so emitting live
+  progress naming it? Everything but `manual`. A run explores, authors and runs a
+  legacy `scenario` criterion and still reports `not_validated` for it. Read by the
+  live-status guard, and by the console's run-wide progress line
+  (`liveLine.ts`), which counts exactly this set.
+
+The gap between them is the whole point, and both mistakes have now been made.
+Inlining `method === "manual"` in three places let the glyph claim a person checks
+a `scenario` criterion while the `awaiting` branch still promised it an agent
+result. Collapsing all three onto `runAnswers` then fixed that and broke the other
+end: the row refused a live status that the progress line directly above it had
+already counted. `liveLine.ts` reads `runWorksOn` from this package rather than
+repeating the comparison, so the two cannot disagree again.
 
 ## Drift is a normal state, so it has a chip
 
@@ -99,6 +112,14 @@ for another criterion. It gets a neutral `Out of run` chip. Neutral and not
 `warning`, because colouring the expected state teaches the reader to discount the
 colour; and locally worded, because `CRITERION_STATE_LABEL` is `report.json`'s
 vocabulary and this criterion is absent from `report.json`.
+
+The chip is a claim about a run that FINISHED without covering the row, so it is
+gated on no attempt being in flight. `awaitingReport` therefore means "any attempt
+is in flight", not "this version's first" — narrowed to the first, the page told a
+reader that a criterion authored since the last run was out of that run while the
+current run was on its way to answering it. Widening it is safe because `report`
+outranks the pending fallback: a covered row keeps the previous attempt's verdict,
+and only uncovered rows read the flag.
 
 The `hasRun` flag that chooses gutter contents is read from the **parsed**
 `statuses`, never from the `report` prop. The prop is raw text and parsing can

--- a/packages/ui/validation-view/design/README.md
+++ b/packages/ui/validation-view/design/README.md
@@ -117,7 +117,7 @@ show an older attempt the newest run's results). The join is by criterion id, so
 criterion authored since that commit has no row in that report.
 
 That is the ordinary authoring loop: run validation, read a failure, ask the agent
-for another criterion. It gets a neutral `Out of run` chip. Neutral and not
+for another criterion. It gets a neutral `No result` chip. Neutral and not
 `warning`, because colouring the expected state teaches the reader to discount the
 colour; and locally worded, because `CRITERION_STATE_LABEL` is `report.json`'s
 vocabulary and this criterion is absent from `report.json`.

--- a/packages/ui/validation-view/design/README.md
+++ b/packages/ui/validation-view/design/README.md
@@ -9,16 +9,16 @@ consumers, one component:
 | Spec view's file pane (`SpecView.tsx`) | `criteria` only | Reading the document, before any run exists |
 | Validations page (`ValidationPage.tsx`) | `criteria`, `report`, `live`, `awaitingReport` | Reading run results |
 
-## One gutter, one signal
+## Two marks, at opposite ends of the row
 
-Every criterion row leads with a fixed-width column holding exactly one mark, and
-which mark depends on whether a run is attached:
+Every criterion row leads with a narrow fixed-width column holding the method
+glyph, and — where a run is attached — closes with that run's verdict:
 
 ```text
-SPEC VIEW — no run                    VALIDATIONS — a run
- ✦  a  A registered email …            [Passed]   a  A registered email …
- ○  b  The reset copy reads …          [Manual]   b  The reset copy reads …
-                                       [Failed*]  c  A short password …
+SPEC VIEW — no run              VALIDATIONS — a run
+ ✦  a  A registered email …      ✦  a  A registered email …   [✓ Passed]
+ ○  b  The reset copy reads …    ○  b  The reset copy reads …  [  Manual]
+                                 ✦  c  A short password …      [✗ Failed*]
 ```
 
 `✦` is `Sparkles` at `primary.main`, the glyph this console already means "the
@@ -28,38 +28,49 @@ icon-only, with the explanation on hover and repeated as visually-hidden text �
 on a roleless element is ignored, the same trap `StatusChip` documents for a Chip
 with no `onClick`.
 
-Three rules hold the column to one mark:
+The two marks answer two different questions, which is why both earn a place:
+
+- **The glyph says who CHECKS the criterion.** A standing property of the
+  criterion, so it is on every surface and in the same column whether or not a run
+  has happened. A reader scanning a page of results for their own work finds it
+  there instead of reading every verdict.
+- **The chip says what the run MADE of it.** Only where there is a run.
+- They coincide on a manual criterion, whose verdict is `Manual`. That is the
+  accepted cost of the first point.
+
+Two more rules hold the row to those two:
 
 - **No tally in this view.** Counts belong with the verdict that explains them,
   which the consumer renders above; a second copy here says the same numbers twice.
-- **Never a method mark beside a status chip.** The chip already says `Manual`, so
-  a mark next to it states the same fact at the other margin of the row. Where
-  there are results the chip is sufficient; where there are none the glyph is.
 - **Qualifiers ride the verdict.** `flaky` and `healed` become a single `*` with
   the detail on hover, rather than chips competing with the word they qualify. The
   two flags are independent in `generate-report.mjs` (`flaky` only on a pass,
   `healed` decided before the status), so `Failed*` is a real row and so is a pass
   that was both.
 
-One mark per row is what lets the gutter be one width, which is what keeps the ids
-beside it aligned. `GUTTER_CHIP` / `GUTTER_ICON` / `ROW_GAP` are single constants
-and the failure block derives its indent from them, so the column and the indent
-cannot disagree.
+Putting the verdict at the far end is what lets `GUTTER` be 22px rather than wide
+enough for the longest chip label: no label can widen the column, and none leaves
+slack in it. The ids therefore line up tightly against the glyphs, and the failure
+block derives its indent from the same constant, so column and indent cannot
+disagree. What is given up is the verdicts' left edge, which is ragged because it
+follows a variable-length assertion; their right edge is flush instead.
 
-`GUTTER_CHIP` has to fit the longest label the vocabulary can produce
-(`Not validated`), so a short chip like `Failed` leaves visible slack before the id.
-That is a deliberate trade: the alternatives are right-aligning the chip in the
-column (constant gap, ragged chip left edges) or dropping the column (constant gap,
-ragged ids), and the aligned column is worth more than either. It is also why the
-drift chip's label is kept terse — a descriptive one would widen every row.
+`STATE_ICON` marks the two TERMINAL verdicts and nothing else. `Passed` and
+`Failed` are the answers a run produces and the pair a reader must separate at a
+glance — as outlined chips they otherwise differ only in hue, which is nothing to
+a red/green colour-blind reader. Every other status is the ABSENCE of an answer,
+so marking one would spend the distinction where it is not needed.
 
 ### Vertical alignment is a shared band, not a baseline
 
 `ROW_LINE` (24px, the MUI small Chip's own height) is the height of a row's first
-line. The gutter, the id mark and the requirement number are each given exactly
-that height and centre their own content in it, and the assertion takes it as its
-`line-height`. All three then sit in the middle of one band by construction, and it
-holds for an assertion that wraps because every later line is the same height.
+line. The glyph gutter, the id mark, the requirement number and the verdict box at
+the far end are each given exactly that height and centre their own content in it,
+while the assertion takes it as its `line-height`. Everything on the row then sits
+in the middle of one band by construction, and it holds for an assertion that wraps
+because every later line is the same height. It is also what keeps the two ends of
+the row on the same line as each other, which matters more here than it would with
+a single mark.
 
 `align-items: baseline` is the wrong tool here, and worth knowing why. An MUI Chip
 is `inline-flex` with `align-items: center`, so it has no baseline-aligned flex

--- a/packages/ui/validation-view/package.json
+++ b/packages/ui/validation-view/package.json
@@ -17,8 +17,11 @@
     "@wso2/oxygen-ui-icons-react": ">=0.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "19.1.6",
     "@types/react-dom": "19.0.2",
+    "jsdom": "26.1.0",
     "typescript": "5.9.3",
     "vitest": "^4.1.10",
     "@wso2/oxygen-ui": "0.11.0",

--- a/packages/ui/validation-view/src/ValidationView.test.tsx
+++ b/packages/ui/validation-view/src/ValidationView.test.tsx
@@ -77,7 +77,7 @@ describe("ValidationView — the Spec view's pane (no run attached)", () => {
     expect(screen.getAllByText(AGENT)).toHaveLength(2);
     expect(screen.getAllByText(HUMAN)).toHaveLength(2);
     // Nothing here may name a run that does not exist.
-    for (const word of ["Passed", "Failed", "Pending", "Manual", "Out of run"]) {
+    for (const word of ["Passed", "Failed", "Pending", "Manual", "No result"]) {
       expect(screen.queryByText(word)).not.toBeInTheDocument();
     }
   });
@@ -162,7 +162,7 @@ describe("ValidationView — the Validations page (a report joined in)", () => {
         report={reportOf([{ id: "AC-001-a", status: "pass" }])}
       />,
     );
-    expect(screen.getAllByText("Out of run")).toHaveLength(3);
+    expect(screen.getAllByText("No result")).toHaveLength(3);
     expect(screen.getByText("Passed")).toBeInTheDocument();
   });
 
@@ -176,7 +176,7 @@ describe("ValidationView — the Validations page (a report joined in)", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText(AGENT)).toHaveLength(2);
     expect(screen.getAllByText(HUMAN)).toHaveLength(2);
-    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+    expect(screen.queryByText("No result")).not.toBeInTheDocument();
   });
 
   it("says what is about to happen while a first attempt is in flight", () => {
@@ -189,7 +189,7 @@ describe("ValidationView — the Validations page (a report joined in)", () => {
     expect(screen.getByText("Manual")).toBeInTheDocument();
     expect(screen.getByText("Not validated")).toBeInTheDocument();
     // Nothing has drifted — there is no report to have missed them.
-    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+    expect(screen.queryByText("No result")).not.toBeInTheDocument();
   });
 
   // The run works on a `scenario` criterion — explores it, authors a spec, runs

--- a/packages/ui/validation-view/src/ValidationView.test.tsx
+++ b/packages/ui/validation-view/src/ValidationView.test.tsx
@@ -223,6 +223,31 @@ describe("ValidationView — the Validations page (a report joined in)", () => {
   });
 });
 
+describe("ValidationView — the terminal verdicts carry an icon", () => {
+  /** The chip element wrapping a label, and whether it renders an icon. */
+  function hasIcon(label: string): boolean {
+    const chip = screen.getByText(label).closest(".MuiChip-root");
+    return chip?.querySelector("svg") != null;
+  }
+
+  it("separates pass from fail by more than colour", () => {
+    // Outlined chips in success/error differ only in hue without these, which is
+    // nothing to a red/green colour-blind reader — and pass/fail is the one pair
+    // that has to be told apart at a glance.
+    render(<ValidationView criteria={CRITERIA} report={FULL_REPORT} />);
+    expect(hasIcon("Passed")).toBe(true);
+    expect(hasIcon("Failed")).toBe(true);
+  });
+
+  it("leaves the non-answers unmarked", () => {
+    // Everything else is the ABSENCE of a verdict rather than one of them, so a
+    // mark would compete for the distinction the pair above needs.
+    render(<ValidationView criteria={CRITERIA} report={FULL_REPORT} />);
+    expect(hasIcon("Manual")).toBe(false);
+    expect(hasIcon("Not validated")).toBe(false);
+  });
+});
+
 describe("ValidationView — flaky and healed ride the verdict", () => {
   function noteFor(entry: Record<string, unknown>): string {
     render(

--- a/packages/ui/validation-view/src/ValidationView.test.tsx
+++ b/packages/ui/validation-view/src/ValidationView.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ValidationView } from "./ValidationView.js";
+
+const AGENT = "Validated automatically by the agent.";
+const HUMAN = "Requires manual validation.";
+
+// REQ-002 is absent on purpose: ids are stable by contract, so a deleted
+// requirement leaves a gap, and the numbers have to read as names rather than as
+// list positions.
+const CRITERIA = JSON.stringify({
+  requirements: [
+    {
+      id: "REQ-001",
+      statement: "A visitor can reset a forgotten password.",
+      criteria: [
+        {
+          id: "AC-001-a",
+          must: "A registered email receives a reset link",
+          method: "e2e",
+        },
+        {
+          id: "AC-001-b",
+          must: "The reset confirmation reads clearly",
+          method: "manual",
+        },
+      ],
+    },
+    {
+      id: "REQ-003",
+      statement: "Passwords meet the complexity policy.",
+      criteria: [
+        { id: "AC-003-a", must: "A short password is rejected", method: "e2e" },
+        { id: "AC-003-b", must: "The policy copy is accurate", method: "scenario" },
+      ],
+    },
+  ],
+});
+
+function reportOf(criteria: unknown[]): string {
+  return JSON.stringify({ schemaVersion: 1, criteria });
+}
+
+/** Every criterion answered, so no row drifts. */
+const FULL_REPORT = reportOf([
+  { id: "AC-001-a", status: "pass" },
+  { id: "AC-001-b", status: "manual" },
+  { id: "AC-003-a", status: "fail", failure: { message: "boom", location: "" } },
+  { id: "AC-003-b", status: "not_validated" },
+]);
+
+describe("ValidationView — the Spec view's pane (no run attached)", () => {
+  it("marks who checks each criterion, with no run signal anywhere", () => {
+    render(<ValidationView criteria={CRITERIA} />);
+    // Two e2e criteria take the agent glyph; manual AND the legacy `scenario`
+    // both fall to the person, because neither is ever automated.
+    expect(screen.getAllByText(AGENT)).toHaveLength(2);
+    expect(screen.getAllByText(HUMAN)).toHaveLength(2);
+    // Nothing here may name a run that does not exist.
+    for (const word of ["Passed", "Failed", "Pending", "Manual", "Out of run"]) {
+      expect(screen.queryByText(word)).not.toBeInTheDocument();
+    }
+  });
+
+  it("shortens both id levels to what the card does not already say", () => {
+    render(<ValidationView criteria={CRITERIA} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getAllByText("a")).toHaveLength(2);
+    expect(screen.getAllByText("b")).toHaveLength(2);
+    // The full id is the hover handle, so it is not on the page as text.
+    expect(screen.queryByText("AC-001-a")).not.toBeInTheDocument();
+    expect(screen.queryByText("REQ-001")).not.toBeInTheDocument();
+  });
+
+  it("drops the summary line, the method words and the criteria count", () => {
+    render(<ValidationView criteria={CRITERIA} />);
+    expect(screen.queryByText(/requirements ·/)).not.toBeInTheDocument();
+    expect(screen.queryByText("2 criteria")).not.toBeInTheDocument();
+    // The solid AUTO / MANUAL badges are gone with it.
+    expect(screen.queryByText("auto")).not.toBeInTheDocument();
+    expect(screen.queryByText("manual")).not.toBeInTheDocument();
+  });
+
+  it("explains a mark on hover", async () => {
+    render(<ValidationView criteria={CRITERIA} />);
+
+    // Tooltip listens on the glyph's wrapper — the hidden phrase's parent. Asserted
+    // through the tooltip's own role rather than a text count: the phrase is
+    // already on the page as hidden text, so findAllByText would resolve on that
+    // and never wait for the popper.
+    fireEvent.mouseOver(screen.getAllByText(AGENT)[0]!.parentElement!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(AGENT);
+  });
+
+  it("keeps the full id one hover away", async () => {
+    render(<ValidationView criteria={CRITERIA} />);
+
+    fireEvent.mouseOver(screen.getAllByText("a")[0]!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("AC-001-a");
+  });
+
+  it("renders an id that breaks the convention in full", () => {
+    render(
+      <ValidationView
+        criteria={JSON.stringify({
+          requirements: [
+            {
+              id: "legacy-req",
+              statement: "An older oracle, hand-edited.",
+              criteria: [{ id: "check-one", must: "It still renders", method: "e2e" }],
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("legacy-req")).toBeInTheDocument();
+    expect(screen.getByText("check-one")).toBeInTheDocument();
+  });
+});
+
+describe("ValidationView — the Validations page (a report joined in)", () => {
+  it("puts the verdict where the method mark was, and drops the mark", () => {
+    render(<ValidationView criteria={CRITERIA} report={FULL_REPORT} />);
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    expect(screen.getByText("Not validated")).toBeInTheDocument();
+    // The status chip is sufficient: a manual criterion says "Manual" once, not
+    // once as a method badge and again as a status.
+    expect(screen.queryByText(AGENT)).not.toBeInTheDocument();
+    expect(screen.queryByText(HUMAN)).not.toBeInTheDocument();
+  });
+
+  it("chips a criterion the pinned report predates", () => {
+    // The consumer reads criteria at the branch tip and the report at the merge
+    // commit that wrote it, so a criterion authored since has no row.
+    render(
+      <ValidationView
+        criteria={CRITERIA}
+        report={reportOf([{ id: "AC-001-a", status: "pass" }])}
+      />,
+    );
+    expect(screen.getAllByText("Out of run")).toHaveLength(3);
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+  });
+
+  it("falls back to method marks when the report will not parse", () => {
+    // hasRun is read from the PARSED statuses, not from the prop: keying off the
+    // prop would tell the reader all four criteria were authored after the last
+    // run, when the truth is that the file is unreadable.
+    render(<ValidationView criteria={CRITERIA} report="{ not json" />);
+    expect(
+      screen.getByText(/Couldn't parse the validation report/),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(AGENT)).toHaveLength(2);
+    expect(screen.getAllByText(HUMAN)).toHaveLength(2);
+    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+  });
+
+  it("says what is about to happen while a first attempt is in flight", () => {
+    render(<ValidationView criteria={CRITERIA} awaitingReport />);
+    // Only the two e2e criteria are the run's to answer, so only they are told to
+    // wait for it. The other two already have their final word — which is the
+    // point of routing both through runAnswers: a `scenario` criterion marked as
+    // a person's job on the Spec view cannot be promised an agent result here.
+    expect(screen.getAllByText("Pending")).toHaveLength(2);
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    expect(screen.getByText("Not validated")).toBeInTheDocument();
+    // Nothing has drifted — there is no report to have missed them.
+    expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
+  });
+
+  it("lets a live status outrank the previous attempt's verdict", () => {
+    render(
+      <ValidationView
+        criteria={CRITERIA}
+        report={FULL_REPORT}
+        live={{ "AC-001-a": "healing", "AC-001-b": "planned" }}
+      />,
+    );
+    expect(screen.getByText("Healing…")).toBeInTheDocument();
+    // A manual criterion never takes a live status: the run will never answer it.
+    expect(screen.queryByText("Planned")).not.toBeInTheDocument();
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+  });
+});
+
+describe("ValidationView — flaky and healed ride the verdict", () => {
+  function noteFor(entry: Record<string, unknown>): string {
+    render(
+      <ValidationView criteria={CRITERIA} report={reportOf([{ id: "AC-001-a", ...entry }])} />,
+    );
+    return screen.getByText(/the test/).textContent ?? "";
+  }
+
+  it("marks a flaky pass", () => {
+    expect(noteFor({ status: "pass", flaky: true })).toBe(
+      "Passed, but the test was flaky.",
+    );
+    expect(screen.getByText("Passed*")).toBeInTheDocument();
+  });
+
+  it("marks a healed pass", () => {
+    expect(noteFor({ status: "pass", healed: true })).toBe(
+      "Passed after the agent repaired the test.",
+    );
+    expect(screen.getByText("Passed*")).toBeInTheDocument();
+  });
+
+  it("marks a pass that was both", () => {
+    expect(noteFor({ status: "pass", flaky: true, healed: true })).toBe(
+      "Passed, but the test was flaky, and the agent repaired it.",
+    );
+    expect(screen.getByText("Passed*")).toBeInTheDocument();
+  });
+
+  it("marks a failure the agent tried to repair", () => {
+    // `healed` is set before the status is decided, so this row is real.
+    expect(noteFor({ status: "fail", healed: true })).toBe(
+      "Failed. The agent tried to repair the test.",
+    );
+    expect(screen.getByText("Failed*")).toBeInTheDocument();
+  });
+
+  it("leaves an unqualified verdict unmarked, and keeps no separate chips", () => {
+    render(<ValidationView criteria={CRITERIA} report={FULL_REPORT} />);
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+    expect(screen.queryByText("Passed*")).not.toBeInTheDocument();
+    expect(screen.queryByText("flaky")).not.toBeInTheDocument();
+    expect(screen.queryByText("healed")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/validation-view/src/ValidationView.test.tsx
+++ b/packages/ui/validation-view/src/ValidationView.test.tsx
@@ -191,6 +191,23 @@ describe("ValidationView — the Validations page (a report joined in)", () => {
     expect(screen.queryByText("Out of run")).not.toBeInTheDocument();
   });
 
+  // The run works on a `scenario` criterion — explores it, authors a spec, runs
+  // it — and still reports `not_validated` for it. So it emits progress for a row
+  // it will never answer, and the console's run-wide line counts that row. A row
+  // that refused the status would contradict the line directly above it.
+  it("shows live progress for a criterion the run works on but cannot answer", () => {
+    render(
+      <ValidationView
+        criteria={CRITERIA}
+        report={FULL_REPORT}
+        live={{ "AC-003-b": "running" }}
+      />,
+    );
+    expect(screen.getByText("Running…")).toBeInTheDocument();
+    // Not the pinned report's word for it, which the live status outranks.
+    expect(screen.queryByText("Not validated")).not.toBeInTheDocument();
+  });
+
   it("lets a live status outrank the previous attempt's verdict", () => {
     render(
       <ValidationView

--- a/packages/ui/validation-view/src/ValidationView.test.tsx
+++ b/packages/ui/validation-view/src/ValidationView.test.tsx
@@ -140,16 +140,17 @@ describe("ValidationView — the Spec view's pane (no run attached)", () => {
 });
 
 describe("ValidationView — the Validations page (a report joined in)", () => {
-  it("puts the verdict where the method mark was, and drops the mark", () => {
+  it("carries the verdict as well as the method, not instead of it", () => {
     render(<ValidationView criteria={CRITERIA} report={FULL_REPORT} />);
     expect(screen.getByText("Passed")).toBeInTheDocument();
     expect(screen.getByText("Failed")).toBeInTheDocument();
     expect(screen.getByText("Manual")).toBeInTheDocument();
     expect(screen.getByText("Not validated")).toBeInTheDocument();
-    // The status chip is sufficient: a manual criterion says "Manual" once, not
-    // once as a method badge and again as a status.
-    expect(screen.queryByText(AGENT)).not.toBeInTheDocument();
-    expect(screen.queryByText(HUMAN)).not.toBeInTheDocument();
+    // The glyphs survive a run: who CHECKS a criterion is a standing property of
+    // it, and a reader scanning a page of results for their own work needs it in
+    // the same fixed column it occupies with no run attached.
+    expect(screen.getAllByText(AGENT)).toHaveLength(2);
+    expect(screen.getAllByText(HUMAN)).toHaveLength(2);
   });
 
   it("chips a criterion the pinned report predates", () => {

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -51,14 +51,15 @@ const VISUALLY_HIDDEN = {
 const mono = { fontFamily: "monospace", fontSize: "0.875rem" } as const;
 
 /**
- * The row's first column, holding the one signal a row carries: the status chip
- * when a run is attached, the method glyph otherwise. One width for every row so
- * the ids line up, sized to the longest chip label ("Not validated") — which is
- * why DRIFT_LABEL stays terse, and why a short chip leaves slack. Raw px: a
- * word's width and a Chip's height are not spacing steps.
+ * The row's first column, which holds the method glyph and nothing else, on every
+ * surface. One narrow fixed width, so the ids beside it line up and the failure
+ * block has something to measure its indent from.
+ *
+ * Narrow is the point: the verdict sits at the row's far end instead, so no chip
+ * label can widen this column and none of them leaves slack in it. Raw px, because
+ * a glyph's box is not a spacing step.
  */
-const GUTTER_CHIP = 108;
-const GUTTER_ICON = 22;
+const GUTTER = 22;
 
 /**
  * The row's flex gap, as a theme spacing multiplier (`1` is 8px). A real spacing
@@ -403,13 +404,20 @@ function CriterionChip({
   );
 }
 
-// One acceptance criterion: its single signal in the gutter — the status chip when
-// a run is attached, otherwise who checks it — then its letter, the assertion, and
-// for a failure the spec path and message beneath.
+// One acceptance criterion: the method glyph, its letter, the assertion, the
+// verdict at the far end when a run is attached, and for a failure the spec path
+// and message beneath.
 //
-// One signal, never two: a status chip already says "Manual", so a method mark
-// beside it would say it twice, and a qualifier like flaky rides the verdict
-// instead of competing with it. That is what lets the gutter be a fixed width.
+// Two marks, because they answer two different questions. The glyph says who
+// CHECKS this criterion, which is a standing property of the criterion and true on
+// every surface; the chip says what the last run MADE of it, which exists only
+// where there is a run. They coincide on a manual criterion, whose verdict is
+// "Manual" — the price of keeping "whose job is this" scannable in a fixed column
+// on a page full of results, rather than making the reader read every verdict to
+// find their own work.
+//
+// A qualifier like flaky still rides the verdict rather than becoming a third
+// mark: it modifies that word and belongs beside it.
 function CriterionRow({
   criterion,
   requirementId,
@@ -443,20 +451,11 @@ function CriterionRow({
             display: "flex",
             alignItems: "center",
             height: ROW_LINE,
-            minWidth: hasRun ? GUTTER_CHIP : GUTTER_ICON,
+            minWidth: GUTTER,
             flexShrink: 0,
           }}
         >
-          {hasRun ? (
-            <CriterionChip
-              criterion={criterion}
-              report={report}
-              live={live}
-              awaiting={awaiting}
-            />
-          ) : (
-            <MethodIcon method={criterion.method} />
-          )}
+          <MethodIcon method={criterion.method} />
         </Box>
         <IdMark
           short={shortCriterionId(criterion.id, requirementId)}
@@ -468,15 +467,34 @@ function CriterionRow({
         >
           {criterion.must}
         </Typography>
+        {/* The assertion grows, so the verdict is pushed to the row's far end.
+            Boxed to the shared band for the same reason the gutter is, since a
+            24px chip beside a 24px line needs saying once at each end. */}
+        {hasRun && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: ROW_LINE,
+              flexShrink: 0,
+            }}
+          >
+            <CriterionChip
+              criterion={criterion}
+              report={report}
+              live={live}
+              awaiting={awaiting}
+            />
+          </Box>
+        )}
       </Box>
       {/* Full-width beneath the row, indented to where the letter starts, so a
-          long trace never crowds the assertion. A failure implies a report, so the
-          chip gutter is the one to measure from. */}
+          long trace never crowds the assertion. */}
       {failed && (report?.failureLocation || report?.spec || report?.failure) && (
         <Box
           sx={(theme) => ({
             mt: 0.75,
-            ml: `calc(${GUTTER_CHIP}px + ${theme.spacing(ROW_GAP)})`,
+            ml: `calc(${GUTTER}px + ${theme.spacing(ROW_GAP)})`,
           })}
         >
           {/* Prefer the reporter's `<file>:<line>`, which points at the failing

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -18,7 +18,7 @@
 
 import { useMemo } from "react";
 import { Alert, alpha, Box, Chip, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Check, Sparkles, User } from "@wso2/oxygen-ui-icons-react";
+import { Check, Sparkles, User, X } from "@wso2/oxygen-ui-icons-react";
 import {
   parseValidationCriteria,
   type Criterion,
@@ -126,6 +126,28 @@ type ChipColor =
 // (counts.ts), which the consumer's tally reads too, so a row and the verdict tile
 // above it cannot name the same status differently. Unknown statuses fall through
 // to a neutral chip labelled verbatim.
+// An icon for the two TERMINAL verdicts only. They are the answers a run produces
+// and the pair a reader has to tell apart at a glance — without one, `Failed` is
+// separated from `Passed` by hue alone, which is nothing to a red/green
+// colour-blind reader. Every other status is the ABSENCE of an answer rather than
+// one of them, so a mark there would compete for the distinction this pair needs.
+const STATE_ICON: Record<string, typeof Check> = { pass: Check, fail: X };
+
+/**
+ * Shared by every chip a row can carry. Hoisted rather than written inline for the
+ * reason GitHubRefChip records: an sx literal is a new object each render, which
+ * emotion has to re-serialise.
+ *
+ * MUI insets a small chip's icon by 4px while its label sits at 8px, so an icon
+ * crowds the border in a way no text does. Matching the label's inset makes a chip
+ * that carries an icon start its content exactly where one without an icon starts
+ * its text. Inert on the chips that never take an icon.
+ */
+const CHIP_SX = {
+  flexShrink: 0,
+  "& .MuiChip-icon": { ml: 1 },
+} as const;
+
 const STATE_COLOR: Record<string, ChipColor> = {
   pass: "success",
   fail: "error",
@@ -222,12 +244,13 @@ function verdictNote(
  */
 function StateChip({ status, note }: { status: string; note: string | undefined }) {
   const label = CRITERION_STATE_LABEL[status] ?? status;
+  const Icon = STATE_ICON[status];
   const chip = (
     <Chip
       size="small"
       variant="outlined"
       color={STATE_COLOR[status] ?? "default"}
-      {...(status === "pass" ? { icon: <Check size={14} /> } : {})}
+      {...(Icon ? { icon: <Icon size={14} /> } : {})}
       label={
         note === undefined ? (
           label
@@ -240,7 +263,7 @@ function StateChip({ status, note }: { status: string; note: string | undefined 
           </>
         )
       }
-      sx={{ flexShrink: 0 }}
+      sx={CHIP_SX}
     />
   );
   return note === undefined ? chip : <Tooltip title={note}>{chip}</Tooltip>;
@@ -288,7 +311,7 @@ function LiveChip({ status }: { status: string }) {
       variant="outlined"
       color={LIVE_COLOR[status] ?? "info"}
       label={LIVE_LABEL[status] ?? status}
-      sx={{ flexShrink: 0 }}
+      sx={CHIP_SX}
     />
   );
 }
@@ -358,7 +381,7 @@ function CriterionChip({
       );
     }
     return (
-      <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
+      <Chip size="small" variant="outlined" label="Pending" sx={CHIP_SX} />
     );
   }
 
@@ -374,7 +397,7 @@ function CriterionChip({
         size="small"
         variant="outlined"
         label={DRIFT_LABEL}
-        sx={{ flexShrink: 0 }}
+        sx={CHIP_SX}
       />
     </Tooltip>
   );

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -192,23 +192,18 @@ function LiveChip({ status }: { status: string }) {
 /**
  * The one chip a criterion's row carries, in precedence order.
  *
- * `manual` wins over everything. Such a criterion is answered by a person, so
- * the run will never answer it — that is what the method means — and any chip
- * promising a result is a claim the eventual report contradicts. It outranks a
- * live status as well as a report: a run legitimately reports progress for a
- * manual criterion (its test plan names every criterion, not only the ones an
- * agent will work), and rendering that as a run state left the row promising a
- * result beside a badge saying nobody would produce one.
+ * `manual` is the exception that shapes the order: such a criterion is answered
+ * by a person, so a run signal must not speak for it. It skips the live status
+ * and lands on the report's own `manual`, or on the same final word `awaiting`
+ * would otherwise have given it.
  *
- * Then live over report, and the ordering there is the whole point: a repeat
+ * Otherwise live beats report, and that ordering is the whole point: a repeat
  * attempt carries the PREVIOUS attempt's report, so ranking the report higher
  * would freeze a criterion on the last run's verdict for the entire time the
  * current run spends re-working it. The report wins again the moment the cycle
  * settles, because the consumer stops supplying live statuses then.
  *
- * `awaiting` last, and only it can yield nothing: the Spec view renders this
- * same pane with no run attached, where a chip would name a run that does not
- * exist.
+ * A view with no run attached yields no chip at all — see the `awaiting` guard.
  */
 function CriterionChip({
   criterion,
@@ -221,15 +216,35 @@ function CriterionChip({
   live: string | undefined;
   awaiting: boolean;
 }) {
-  if (criterion.method === "manual") return <StateChip status="manual" />;
-  // pass/fail arrive on the live feed too — report.json's own words, so its chip.
-  if (live) return LIVE_LABEL[live] ? <LiveChip status={live} /> : <StateChip status={live} />;
+  // A `manual` criterion never takes a live status. The run reports one — its
+  // test plan names every criterion, not only the ones an agent will work — but
+  // the run will never ANSWER this one, so a chip reading "Planned" promises a
+  // result nobody is going to produce, beside a badge saying as much. It is the
+  // only status such a row can receive, and nothing supersedes it: every later
+  // status needs a spec file it will never have.
+  if (live && criterion.method !== "manual") {
+    // pass/fail arrive on the live feed too — report.json's own words, so its chip.
+    return LIVE_LABEL[live] ? <LiveChip status={live} /> : <StateChip status={live} />;
+  }
   if (report) return <StateChip status={report.status} />;
-  // "Pending" is local rather than a sixth CRITERION_STATE_LABEL entry: that map
-  // is report.json's vocabulary, and a criterion with no report has no status to
-  // name.
-  if (awaiting) return <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />;
-  return null;
+
+  // Nothing awaited means no run is attached at all: the Spec view renders this
+  // same pane over the plain oracle, where any chip would name a run that does
+  // not exist. Checked HERE rather than first, because "this row has no signal"
+  // and "this view has no run" are different things — an `unreported` attempt
+  // has live statuses on other rows and none on this one.
+  if (!awaiting) return null;
+
+  // A manual criterion gets its final word rather than "Pending": the run will
+  // never answer it, so a chip promising a result is a claim the report
+  // contradicts. "Pending" is local rather than a sixth CRITERION_STATE_LABEL
+  // entry: that map is report.json's vocabulary, and a criterion with no report
+  // has no status to name.
+  return criterion.method === "manual" ? (
+    <StateChip status="manual" />
+  ) : (
+    <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
+  );
 }
 
 // One acceptance criterion: method badge, its id, the atomic assertion, its

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { forwardRef, useMemo, type ComponentPropsWithoutRef } from "react";
+import { useMemo } from "react";
 import { Alert, alpha, Box, Chip, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Check } from "@wso2/oxygen-ui-icons-react";
+import { Check, Sparkles, User } from "@wso2/oxygen-ui-icons-react";
 import {
   parseValidationCriteria,
   type Criterion,
@@ -30,29 +30,108 @@ import {
   type CriterionReport,
   type ValidationReport,
 } from "./report.js";
-import {
-  CRITERION_STATE_LABEL,
-  METHOD_COLOR,
-  METHOD_FALLBACK_COLOR,
-  METHOD_LABEL,
-  tallyCriterionMethods,
-} from "./counts.js";
+import { CRITERION_STATE_LABEL } from "./counts.js";
+import { shortCriterionId, shortRequirementId } from "./shortId.js";
 
-// The method colours are solid behind a badge here. Text color is computed for
-// contrast (getContrastText), so labels stay readable in both themes — the same
-// approach as the DesignView type badges and the OpenAPI viewer's method badges.
-// One line saying who does the checking, shown on hover. Only the two methods a
-// design turn can author carry one; anything else gets a bare badge rather than
-// an invented explanation.
-const METHOD_TOOLTIP: Record<string, string> = {
-  e2e: "Validated automatically by the agent.",
-  manual: "Requires manual validation.",
-};
-// Requirement ids are structural, so a muted slate keeps them from competing
-// with the colored method badges.
-const REQ_COLOR = "#546e7a";
+// Visually-hidden TEXT rather than an aria-label, for the reason StatusChip
+// records in the console: an aria-label on a roleless element is ignored by screen
+// readers, so an accessible name has to come from content. Mirrored here rather
+// than imported because this package does not depend on apps/console, and
+// @wso2/oxygen-ui does not re-export MUI's `visuallyHidden`.
+const VISUALLY_HIDDEN = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0 0 0 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+} as const;
 
 const mono = { fontFamily: "monospace", fontSize: "0.875rem" } as const;
+
+/**
+ * The row's first column, which holds whichever single signal the row carries:
+ * the status chip when a run is attached, the method icon when none is.
+ *
+ * One constant per mode, because the width has to be identical on every row for
+ * the ids beside it to line up — and the failure block derives its indent from it,
+ * so the two can no longer drift the way `minWidth: 92` and `ml: "108px"` did.
+ *
+ * Sized to the longest chip label the vocabulary can produce, which is now
+ * "Not validated"; a longer one would push its own row's id out of the column. A
+ * short chip therefore leaves slack after it — the price of the column, and the
+ * reason DRIFT_LABEL is kept terse rather than descriptive.
+ */
+const GUTTER_CHIP = 108;
+const GUTTER_ICON = 22;
+/** The row's own flex gap, in px — theme spacing(1). */
+const ROW_GAP = 8;
+
+/**
+ * The height of a row's FIRST line, shared by everything sitting on it.
+ *
+ * Baseline alignment cannot do this job. An MUI Chip is `inline-flex` with
+ * `align-items: center`, so it has no baseline-aligned flex item and therefore no
+ * in-flow line box — CSS then synthesises its baseline from its bottom margin
+ * edge. `align-items: baseline` consequently sat the chip's BOTTOM on the
+ * assertion's baseline instead of its label, and because the chip (24px) and the
+ * id mark (~18px) are different heights, the two did not even agree with each
+ * other.
+ *
+ * So every occupant is given this exact height and centres its own content in it,
+ * and the assertion takes it as its `line-height`. The first line of the row is
+ * then one band that all three sit in the middle of, by construction rather than
+ * by inference — and it survives an assertion that wraps, because every later line
+ * is the same height too.
+ *
+ * 24px is the MUI small Chip's own height, so the tallest occupant sets it and
+ * nothing has to be stretched.
+ */
+const ROW_LINE = 24;
+
+/**
+ * A requirement number or a criterion letter, on a soft neutral ground.
+ *
+ * A ground rather than list punctuation (`1.`, `a)`) because these are names, not
+ * positions: ids are stable by contract — a spec file is named after its criterion,
+ * so renumbering one would orphan it — which means deleting a requirement leaves a
+ * gap. `1, 3, 4` reads correctly as names and reads as a rendering fault as a list.
+ * Neutral rather than coloured: on these rows colour belongs to the status chip and
+ * to the agent glyph.
+ *
+ * `full` is the unabbreviated id, on hover, and only when it differs from what is
+ * shown. It is the handle the reader needs elsewhere — spec filenames, report.json,
+ * telling the agent which criterion to change — and the short form cannot be typed
+ * back into any of them.
+ */
+function IdMark({ short, full }: { short: string; full: string }) {
+  const mark = (
+    <Box
+      component="span"
+      sx={(theme) => ({
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        // The row's shared band rather than padding of its own, so the mark sits
+        // in the same line as the chip and the assertion — see ROW_LINE.
+        height: `${ROW_LINE}px`,
+        minWidth: 20,
+        px: 0.75,
+        borderRadius: 0.75,
+        flexShrink: 0,
+        bgcolor: theme.palette.action.hover,
+        color: "text.secondary",
+        ...mono,
+      })}
+    >
+      {short}
+    </Box>
+  );
+  return short === full ? mark : <Tooltip title={full}>{mark}</Tooltip>;
+}
 
 // The MUI/Oxygen Chip color union — kept local so the state map stays typed.
 type ChipColor =
@@ -66,9 +145,9 @@ type ChipColor =
 
 // report.json status → the chip colour shown on a criterion when a run report is
 // joined in. The LABEL comes from CRITERION_STATE_LABEL (counts.ts), which the
-// consumer's tally line reads too — so a criterion's chip and the summary above
-// it can never call the same status by two different names. Unknown statuses fall
-// through to a neutral chip labelled verbatim.
+// consumer's own tally line reads too — so a row's chip and the verdict tile above
+// this view can never call the same status by two different names. Unknown statuses
+// fall through to a neutral chip labelled verbatim.
 const STATE_COLOR: Record<string, ChipColor> = {
   pass: "success",
   fail: "error",
@@ -77,73 +156,146 @@ const STATE_COLOR: Record<string, ChipColor> = {
   manual: "default",
 };
 
-type SolidBadgeProps = { label: string; color: string } & ComponentPropsWithoutRef<"span">;
-
-// Forwards its ref and any remaining props onto the Box, because Tooltip hands
-// its child both a ref and the hover/focus handlers that open it. The console
-// wraps un-forwarding components in an inline-flex Box instead (see the kind chip
-// in SkillsSection), which works here too — but that comment calls itself out as
-// standing in for a ref the child could not hold, and this badge is local enough
-// to just hold one.
-const SolidBadge = forwardRef<HTMLSpanElement, SolidBadgeProps>(function SolidBadge(
-  { label, color, ...rest },
-  ref,
-) {
-  return (
-    <Box
-      component="span"
-      ref={ref}
-      {...rest}
-      sx={(theme) => ({
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        px: 1,
-        py: 0.5,
-        borderRadius: 1,
-        flexShrink: 0,
-        fontFamily: "monospace",
-        fontSize: "0.6875rem",
-        fontWeight: 700,
-        letterSpacing: "0.06em",
-        textTransform: "uppercase",
-        bgcolor: color,
-        color: theme.palette.getContrastText(color),
-      })}
-    >
-      {label}
-    </Box>
-  );
-});
-
-// Says who checks a criterion, with a tooltip carrying what the word means —
-// the badge alone cannot, and it is the reader's first encounter with the
-// distinction. `count` is passed only by the summary tally, which shows the same
-// badge with its total appended, so both surfaces stay in step by construction.
-function MethodBadge({ method, count }: { method: string; count?: number }) {
-  const label = METHOD_LABEL[method] ?? method;
-  const badge = (
-    <SolidBadge
-      label={count === undefined ? label : `${label} ${count}`}
-      color={METHOD_COLOR[method] ?? METHOD_FALLBACK_COLOR}
-    />
-  );
-  const tooltip = METHOD_TOOLTIP[method];
-  return tooltip ? <Tooltip title={tooltip}>{badge}</Tooltip> : badge;
+/**
+ * Whether a validation run answers this method at all.
+ *
+ * `e2e` is the only one it does. generate-report.mjs gives an e2e criterion the
+ * test's own result and decides every other method from the method alone —
+ * `manual` for a manual criterion, `not_validated` for anything else it cannot
+ * automate — so what will become of those rows is knowable before the run starts.
+ *
+ * One predicate, read by all three places that need it: which glyph the Spec view
+ * shows, whether a live status may speak for a row, and whether "Pending" is a
+ * promise the run can keep. Shared deliberately — with the glyph claiming a person
+ * checks a `scenario` criterion while the awaiting branch still promised "Pending"
+ * for it, the two surfaces contradicted each other about the same row.
+ */
+function runAnswers(method: string): boolean {
+  return method === "e2e";
 }
 
-// The per-criterion run-state chip (only rendered when a report is joined in).
-function StateChip({ status }: { status: string }) {
+/**
+ * Who checks a criterion — a mark, not a word.
+ *
+ * `e2e` is the only method an agent drives, so it takes the console's agent glyph:
+ * the same Sparkles at the same primary.main that the agent chat, the "ask the
+ * agent" action and the nav already carry, so the row inherits a meaning the
+ * reader arrives with instead of teaching a new one.
+ *
+ * Everything else falls to the person. `manual` by definition; the legacy
+ * `scenario` and the `"unknown"` parse.ts assigns a criterion with no method
+ * because neither is ever automated, which leaves them somebody's to check in
+ * practice. That is also why one sentence covers all three: the icon is already
+ * claiming a human does the work, so the tooltip says exactly that much.
+ */
+function methodMark(method: string): {
+  Icon: typeof Sparkles;
+  color: string;
+  title: string;
+} {
+  return runAnswers(method)
+    ? {
+        Icon: Sparkles,
+        color: "primary.main",
+        title: "Validated automatically by the agent.",
+      }
+    : {
+        Icon: User,
+        color: "text.secondary",
+        title: "Requires manual validation.",
+      };
+}
+
+/**
+ * The gutter's occupant when no run is attached — the Spec view's whole case, and
+ * a validation view whose report would not parse.
+ *
+ * Icon-only, so the sentence is repeated as hidden text. Tooltip does put its
+ * title on the child as an `aria-label`, but the child is a bare span: an
+ * aria-label on a roleless element is ignored, which is the same trap StatusChip
+ * documents for a Chip with no onClick. Content-based naming works whatever the
+ * role, so that is what this uses.
+ */
+function MethodIcon({ method }: { method: string }) {
+  const { Icon, color, title } = methodMark(method);
   return (
+    <Tooltip title={title}>
+      {/* No vertical handling here: the gutter centres this in the row's shared
+          band (ROW_LINE), which is the same thing that puts a status chip on the
+          line. `flex` so the svg is not an inline box with its own leading. */}
+      <Box component="span" sx={{ display: "flex", color, flexShrink: 0 }}>
+        <Icon size={16} aria-hidden />
+        <Box component="span" sx={VISUALLY_HIDDEN}>
+          {title}
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+}
+
+/**
+ * What the report says qualifies a verdict, as one sentence — or nothing.
+ *
+ * The two flags are independent in generate-report.mjs: `flaky` is only set on a
+ * pass, but `healed` is set before the status is decided. So a failure the agent
+ * tried to repair is a real row, and so is a pass that was both repaired and
+ * flaky — which is why all four readings are spelled out rather than concatenated
+ * from fragments that would read as a list of tags.
+ */
+function verdictNote(
+  status: string,
+  report: CriterionReport | undefined,
+): string | undefined {
+  const flaky = report?.flaky ?? false;
+  const healed = report?.healed ?? false;
+  if (!flaky && !healed) return undefined;
+  const verdict = CRITERION_STATE_LABEL[status] ?? status;
+  if (flaky && healed) {
+    return `${verdict}, but the test was flaky, and the agent repaired it.`;
+  }
+  if (flaky) return `${verdict}, but the test was flaky.`;
+  return status === "fail"
+    ? `${verdict}. The agent tried to repair the test.`
+    : `${verdict} after the agent repaired the test.`;
+}
+
+/**
+ * The per-criterion run-state chip (only rendered when a report is joined in).
+ *
+ * `note` is the report's qualifier on this verdict — flaky, healed, or both — and
+ * it rides the chip as a single `*` rather than as its own chips beside it. Those
+ * qualify THIS word, and as separate chips they read as independent facts and push
+ * the verdict out of the row's one aligned column. One mark covers every
+ * combination, because distinguishing them is all a second mark would buy and none
+ * of them changes what the reader does next.
+ *
+ * Declared `string | undefined` rather than optional: `exactOptionalPropertyTypes`
+ * is on, so a caller with nothing to say passes it explicitly.
+ */
+function StateChip({ status, note }: { status: string; note: string | undefined }) {
+  const label = CRITERION_STATE_LABEL[status] ?? status;
+  const chip = (
     <Chip
       size="small"
       variant="outlined"
       color={STATE_COLOR[status] ?? "default"}
       {...(status === "pass" ? { icon: <Check size={14} /> } : {})}
-      label={CRITERION_STATE_LABEL[status] ?? status}
+      label={
+        note === undefined ? (
+          label
+        ) : (
+          <>
+            <span aria-hidden>{`${label}*`}</span>
+            <Box component="span" sx={VISUALLY_HIDDEN}>
+              {note}
+            </Box>
+          </>
+        )
+      }
       sx={{ flexShrink: 0 }}
     />
   );
+  return note === undefined ? chip : <Tooltip title={note}>{chip}</Tooltip>;
 }
 
 /**
@@ -176,6 +328,11 @@ const LIVE_LABEL: Record<string, string> = {
 // and leave nothing to spend on this one.
 const LIVE_COLOR: Record<string, ChipColor> = { healing: "warning" };
 
+/** The chip for a criterion the pinned report predates — see CriterionChip. */
+const DRIFT_LABEL = "Out of run";
+const DRIFT_TOOLTIP =
+  "Authored after the last validation run, so it has no result yet.";
+
 // The per-criterion chip while the run is still working on it.
 function LiveChip({ status }: { status: string }) {
   return (
@@ -203,7 +360,9 @@ function LiveChip({ status }: { status: string }) {
  * current run spends re-working it. The report wins again the moment the cycle
  * settles, because the consumer stops supplying live statuses then.
  *
- * A view with no run attached yields no chip at all — see the `awaiting` guard.
+ * Only called when a run IS attached, so unlike its predecessor it always returns
+ * a chip. CriterionRow handles the no-run case, which shows who checks the
+ * criterion instead of what happened to it.
  */
 function CriterionChip({
   criterion,
@@ -216,50 +375,92 @@ function CriterionChip({
   live: string | undefined;
   awaiting: boolean;
 }) {
-  // A `manual` criterion never takes a live status. The run reports one — its
-  // test plan names every criterion, not only the ones an agent will work — but
-  // the run will never ANSWER this one, so a chip reading "Planned" promises a
-  // result nobody is going to produce, beside a badge saying as much. It is the
-  // only status such a row can receive, and nothing supersedes it: every later
-  // status needs a spec file it will never have.
-  if (live && criterion.method !== "manual") {
+  // A criterion the run does not answer never takes a live status. The run
+  // reports one — its test plan names every criterion, not only the ones an agent
+  // will work — but it will never ANSWER this row, so a chip reading "Planned"
+  // promises a result nobody is going to produce. It is the only status such a
+  // row can receive, and nothing supersedes it: every later status needs a spec
+  // file it will never have.
+  if (live && runAnswers(criterion.method)) {
     // pass/fail arrive on the live feed too — report.json's own words, so its chip.
-    return LIVE_LABEL[live] ? <LiveChip status={live} /> : <StateChip status={live} />;
+    return LIVE_LABEL[live] ? (
+      <LiveChip status={live} />
+    ) : (
+      <StateChip status={live} note={undefined} />
+    );
   }
-  if (report) return <StateChip status={report.status} />;
+  if (report) {
+    return (
+      <StateChip status={report.status} note={verdictNote(report.status, report)} />
+    );
+  }
 
-  // Nothing awaited means no run is attached at all: the Spec view renders this
-  // same pane over the plain oracle, where any chip would name a run that does
-  // not exist. Checked HERE rather than first, because "this row has no signal"
-  // and "this view has no run" are different things — an `unreported` attempt
-  // has live statuses on other rows and none on this one.
-  if (!awaiting) return null;
+  // A criterion the run does not answer gets its final word rather than
+  // "Pending": no result is coming, so a chip promising one is a claim the report
+  // will contradict. Which final word is decided by the method alone, which is
+  // why it can be said this early.
+  //
+  // "Pending" itself is local rather than a sixth CRITERION_STATE_LABEL entry:
+  // that map is report.json's vocabulary, and a criterion with no report has no
+  // status to name.
+  if (awaiting) {
+    if (!runAnswers(criterion.method)) {
+      return (
+        <StateChip
+          status={criterion.method === "manual" ? "manual" : "not_validated"}
+          note={undefined}
+        />
+      );
+    }
+    return (
+      <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
+    );
+  }
 
-  // A manual criterion gets its final word rather than "Pending": the run will
-  // never answer it, so a chip promising a result is a claim the report
-  // contradicts. "Pending" is local rather than a sixth CRITERION_STATE_LABEL
-  // entry: that map is report.json's vocabulary, and a criterion with no report
-  // has no status to name.
-  return criterion.method === "manual" ? (
-    <StateChip status="manual" />
-  ) : (
-    <Chip size="small" variant="outlined" label="Pending" sx={{ flexShrink: 0 }} />
+  // A settled run whose report has no row for this criterion. The consumer reads
+  // the criteria at the branch tip and the report at the merge commit of the
+  // attempt that wrote it, so a criterion authored since then cannot have a
+  // result — which is the ordinary authoring loop (run, read a failure, ask the
+  // agent for another criterion), not a fault. Hence a neutral chip and not a
+  // `warning`: colouring the expected state teaches the reader to discount the
+  // colour. Local wording for the same reason "Pending" above is local — this
+  // criterion is absent from report.json, so report.json has no word for it.
+  return (
+    <Tooltip title={DRIFT_TOOLTIP}>
+      <Chip
+        size="small"
+        variant="outlined"
+        label={DRIFT_LABEL}
+        sx={{ flexShrink: 0 }}
+      />
+    </Tooltip>
   );
 }
 
-// One acceptance criterion: method badge, its id, the atomic assertion, its
-// status chip (CriterionChip decides which one wins), healed/flaky markers, and
-// — for a failure — the spec path and message beneath.
+// One acceptance criterion: its single signal in the gutter — the status chip when
+// a run is attached, otherwise who checks it — then its letter, the atomic
+// assertion, and, for a failure, the spec path and message beneath.
+//
+// One signal and not two. A manual criterion used to carry a purple MANUAL badge
+// here AND a neutral "Manual" status chip at the far end of the row, saying the
+// same thing twice at opposite margins; and flaky/healed were two more chips
+// competing with the verdict they qualify. The gutter now holds exactly one thing,
+// which is what lets it be a fixed width and the letters beside it line up.
 function CriterionRow({
   criterion,
+  requirementId,
   report,
   live,
   awaiting,
+  hasRun,
 }: {
   criterion: Criterion;
+  /** The card this row sits in, so the letter can drop the prefix it repeats. */
+  requirementId: string;
   report: CriterionReport | undefined;
   live: string | undefined;
   awaiting: boolean;
+  hasRun: boolean;
 }) {
   const failed = report?.status === "fail";
   return (
@@ -267,33 +468,49 @@ function CriterionRow({
     // a failure block stays inside the criterion it belongs to instead of being cut
     // off from its own assertion.
     <Box sx={{ py: 1 }}>
-      <Box sx={{ display: "flex", gap: 1.5, alignItems: "flex-start" }}>
-        <Box sx={{ minWidth: 92, flexShrink: 0, pt: "1px" }}>
-          <MethodBadge method={criterion.method} />
+      {/* `flex-start`, so the marks stay on the FIRST line of an assertion that
+          wraps rather than drifting to the middle of it. Alignment within that
+          line is ROW_LINE's job, not this property's. */}
+      <Box
+        sx={{ display: "flex", gap: `${ROW_GAP}px`, alignItems: "flex-start" }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            height: `${ROW_LINE}px`,
+            minWidth: hasRun ? `${GUTTER_CHIP}px` : `${GUTTER_ICON}px`,
+            flexShrink: 0,
+          }}
+        >
+          {hasRun ? (
+            <CriterionChip
+              criterion={criterion}
+              report={report}
+              live={live}
+              awaiting={awaiting}
+            />
+          ) : (
+            <MethodIcon method={criterion.method} />
+          )}
         </Box>
-        <Typography component="span" sx={{ ...mono, flexShrink: 0 }}>
-          {criterion.id}
-        </Typography>
-        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+        <IdMark
+          short={shortCriterionId(criterion.id, requirementId)}
+          full={criterion.id}
+        />
+        <Typography
+          variant="body2"
+          sx={{ flexGrow: 1, lineHeight: `${ROW_LINE}px` }}
+        >
           {criterion.must}
         </Typography>
-        {report?.flaky && (
-          <Chip size="small" variant="outlined" color="warning" label="flaky" sx={{ flexShrink: 0 }} />
-        )}
-        {report?.healed && (
-          <Chip size="small" variant="outlined" label="healed" sx={{ flexShrink: 0 }} />
-        )}
-        <CriterionChip
-          criterion={criterion}
-          report={report}
-          live={live}
-          awaiting={awaiting}
-        />
       </Box>
-      {/* Failure detail sits full-width beneath the row (indented past the
-          method badge) so a long trace never crowds the assertion. */}
+      {/* Failure detail sits full-width beneath the row, indented to where the
+          criterion's letter starts, so a long trace never crowds the assertion. A
+          failure only exists with a report attached, so the chip gutter is the
+          right one to measure from. */}
       {failed && (report?.failureLocation || report?.spec || report?.failure) && (
-        <Box sx={{ mt: 0.75, ml: "108px" }}>
+        <Box sx={{ mt: 0.75, ml: `${GUTTER_CHIP + ROW_GAP}px` }}>
           {/* Prefer the reporter's `<file>:<line>`, which points at the failing
               assertion rather than merely the spec that contains it. The gate
               above admits it on its own: a reporter can hand back a location with
@@ -344,11 +561,13 @@ function RequirementCard({
   statuses,
   live,
   awaiting,
+  hasRun,
 }: {
   requirement: Requirement;
   statuses: ValidationReport | undefined;
   live: LiveStatuses | undefined;
   awaiting: boolean;
+  hasRun: boolean;
 }) {
   const count = requirement.criteria.length;
   return (
@@ -364,18 +583,31 @@ function RequirementCard({
         mb: 3,
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.75 }}>
-        <SolidBadge label={requirement.id} color={REQ_COLOR} />
-        <Typography variant="caption" color="text.secondary">
-          {count} {count === 1 ? "criterion" : "criteria"}
+      {/* The number leads the statement, echoing the rows below where the letter
+          leads the assertion — so the card reads the same way at both levels. The
+          "N criteria" caption that used to sit up here is gone: it counted a list
+          the reader is looking at. */}
+      {/* The same shared-band idiom as the rows below, so the number sits on the
+          statement's first line and stays there when the statement wraps. */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: `${ROW_GAP}px`,
+          mb: count > 0 ? 1.5 : 0,
+        }}
+      >
+        <IdMark
+          short={shortRequirementId(requirement.id)}
+          full={requirement.id}
+        />
+        <Typography
+          variant="body1"
+          sx={{ fontWeight: 500, lineHeight: `${ROW_LINE}px` }}
+        >
+          {requirement.statement}
         </Typography>
       </Box>
-      <Typography
-        variant="body1"
-        sx={{ fontWeight: 500, mb: count > 0 ? 1.5 : 0 }}
-      >
-        {requirement.statement}
-      </Typography>
       {count === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No criteria.
@@ -396,9 +628,11 @@ function RequirementCard({
             <CriterionRow
               key={c.id}
               criterion={c}
+              requirementId={requirement.id}
               report={statuses?.get(c.id)}
               live={live?.[c.id]}
               awaiting={awaiting}
+              hasRun={hasRun}
             />
           ))}
         </Box>
@@ -427,16 +661,18 @@ function ValidationBody({
   awaitingReport: boolean;
 }) {
   const { requirements } = criteria;
-  // Per-method tally for the summary header, from counts.ts so the consumer's own
-  // method line (the console's tile, while an attempt is still running) counts the
-  // same criteria in the same order. The per-run-state tally is deliberately NOT
-  // here: it belongs with the verdict it explains, which the consumer renders above
-  // this view (tallyCriterionStates), and duplicating it here would put the same
-  // numbers on the page twice.
-  const methods = useMemo(() => tallyCriterionMethods(criteria), [criteria]);
-  // Every criterion has exactly one method, so the tally is a partition of them.
-  const total = methods.reduce((n, m) => n + m.count, 0);
-
+  /**
+   * Whether a RUN is attached, which decides what every row's gutter holds: its
+   * status chip, or — with no run to report — who checks it.
+   *
+   * Read from `statuses`, NOT from the `report` prop. The prop is raw text and
+   * parsing it can fail, which leaves `statuses` undefined while a report WAS
+   * supplied; keying off the prop would then hand every row the drift chip,
+   * announcing that all of them were authored after the last run when the truth is
+   * that the file is unreadable. This way such a view degrades to the plain
+   * oracle, with the warning Alert above it naming the real problem.
+   */
+  const hasRun = statuses !== undefined || awaitingReport;
   const reqCount = requirements.length;
   return (
     // `height`/`overflow` are the file-pane contract and stay unconditional: on a
@@ -467,41 +703,32 @@ function ValidationBody({
           </Typography>
         )}
 
-        {/* Summary — totals plus a colored tally per verification method */}
-        <Box
-          sx={{
-            mt: 1,
-            mb: 3,
-            display: "flex",
-            alignItems: "center",
-            gap: 1.5,
-            flexWrap: "wrap",
-          }}
-        >
-          <Typography variant="body2" color="text.secondary">
-            {reqCount} {reqCount === 1 ? "requirement" : "requirements"} ·{" "}
-            {total} {total === 1 ? "criterion" : "criteria"}
-          </Typography>
-          {methods.map(({ method, count }) => (
-            <MethodBadge key={method} method={method} count={count} />
-          ))}
-        </Box>
+        {/* No summary line here. It read "N requirements · M criteria" over a
+            per-method tally, and on the Validations page it sat directly beneath a
+            tile already printing both — the same numbers twice, a screen apart.
+            The counts that a reader acts on belong with the verdict that explains
+            them, which the consumer renders above this view.
 
-        {reqCount === 0 ? (
-          <Typography variant="body2" color="text.secondary">
-            No validation criteria.
-          </Typography>
-        ) : (
-          requirements.map((r) => (
-            <RequirementCard
-              key={r.id}
-              requirement={r}
-              statuses={statuses}
-              live={live}
-              awaiting={awaitingReport}
-            />
-          ))
-        )}
+            The gap it used to leave below itself now belongs to the list, which is
+            what it was separating the heading from. */}
+        <Box sx={{ mt: 3 }}>
+          {reqCount === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No validation criteria.
+            </Typography>
+          ) : (
+            requirements.map((r) => (
+              <RequirementCard
+                key={r.id}
+                requirement={r}
+                statuses={statuses}
+                live={live}
+                awaiting={awaitingReport}
+                hasRun={hasRun}
+              />
+            ))
+          )}
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -459,7 +459,7 @@ function ValidationBody({
             Nothing else in the spec workspace says so, and the reader meets the
             criteria here before any run has produced a result to learn from. */}
         {!hideDescription && (
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, maxWidth: "72ch" }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
             Each criterion represents one thing your software must do, based on your
             requirements. After every deployment they are checked against the running
             software, and the results appear under Validations. To change one, ask the

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -33,11 +33,9 @@ import {
 import { CRITERION_STATE_LABEL, runAnswers, runWorksOn } from "./counts.js";
 import { shortCriterionId, shortRequirementId } from "./shortId.js";
 
-// Visually-hidden TEXT rather than an aria-label, for the reason StatusChip
-// records in the console: an aria-label on a roleless element is ignored by screen
-// readers, so an accessible name has to come from content. Mirrored here rather
-// than imported because this package does not depend on apps/console, and
-// @wso2/oxygen-ui does not re-export MUI's `visuallyHidden`.
+// An accessible name must come from CONTENT here: an aria-label on a roleless
+// element is ignored. Local because this package cannot reach the console's copy
+// and @wso2/oxygen-ui does not re-export MUI's `visuallyHidden`.
 const VISUALLY_HIDDEN = {
   position: "absolute",
   width: 1,
@@ -53,74 +51,41 @@ const VISUALLY_HIDDEN = {
 const mono = { fontFamily: "monospace", fontSize: "0.875rem" } as const;
 
 /**
- * The row's first column, which holds whichever single signal the row carries:
- * the status chip when a run is attached, the method icon when none is.
- *
- * One constant per mode, because the width has to be identical on every row for
- * the ids beside it to line up — and the failure block derives its indent from it,
- * so the two can no longer drift the way `minWidth: 92` and `ml: "108px"` did.
- *
- * Sized to the longest chip label the vocabulary can produce, which is now
- * "Not validated"; a longer one would push its own row's id out of the column. A
- * short chip therefore leaves slack after it — the price of the column, and the
- * reason DRIFT_LABEL is kept terse rather than descriptive.
- *
- * Raw px, unlike the gap below, because neither is a spacing step: one is the
- * width of a word and the other the height of a Chip. There is no theme token
- * that means either, and rounding them to one would only hide what sets them.
+ * The row's first column, holding the one signal a row carries: the status chip
+ * when a run is attached, the method glyph otherwise. One width for every row so
+ * the ids line up, sized to the longest chip label ("Not validated") — which is
+ * why DRIFT_LABEL stays terse, and why a short chip leaves slack. Raw px: a
+ * word's width and a Chip's height are not spacing steps.
  */
 const GUTTER_CHIP = 108;
 const GUTTER_ICON = 22;
 
 /**
- * The row's flex gap, as a theme spacing multiplier — `1` is 8px.
- *
- * A token and not a px literal: this one IS a spacing step, so the theme is
- * entitled to move it. The failure block's indent has to add it to a px width, so
- * it reads the same token back through `theme.spacing`.
+ * The row's flex gap, as a theme spacing multiplier (`1` is 8px). A real spacing
+ * step, so the theme owns it; the failure indent adds it to a px width by reading
+ * the same token back through `theme.spacing`.
  */
 const ROW_GAP = 1;
 
 /**
- * The height of a row's FIRST line, shared by everything sitting on it.
+ * The height of a row's first line. Every occupant takes this height and centres
+ * its content in it, and the assertion takes it as `line-height`, so all three sit
+ * in one band even when the assertion wraps. 24px is the small Chip's own height.
  *
- * Baseline alignment cannot do this job. An MUI Chip is `inline-flex` with
- * `align-items: center`, so it has no baseline-aligned flex item and therefore no
- * in-flow line box — CSS then synthesises its baseline from its bottom margin
- * edge. `align-items: baseline` consequently sat the chip's BOTTOM on the
- * assertion's baseline instead of its label, and because the chip (24px) and the
- * id mark (~18px) are different heights, the two did not even agree with each
- * other.
- *
- * So every occupant is given this exact height and centres its own content in it,
- * and the assertion takes it as its `line-height`. The first line of the row is
- * then one band that all three sit in the middle of, by construction rather than
- * by inference — and it survives an assertion that wraps, because every later line
- * is the same height too.
- *
- * 24px is the MUI small Chip's own height, so the tallest occupant sets it and
- * nothing has to be stretched.
- *
- * Passed to `height` as a bare number, which emotion renders as px, but to
- * `line-height` as an explicit `px` string — `line-height` is unitless in CSS, so
- * a bare 24 there would mean 24 TIMES the font size rather than 24 pixels.
+ * Not `align-items: baseline`: a Chip is `inline-flex`/`center`, so it has no
+ * in-flow line box and CSS synthesises its baseline from the bottom margin edge.
+ * `line-height` needs the explicit `px` — bare 24 means 24x the font size.
  */
 const ROW_LINE = 24;
 
 /**
- * A requirement number or a criterion letter, on a soft neutral ground.
+ * A requirement number or criterion letter on a soft neutral ground — a ground
+ * rather than `1.`/`a)` because these are names, not positions: ids are stable by
+ * contract (a spec file is named after its criterion), so a deleted requirement
+ * leaves a gap that reads fine as names and as a fault as a list.
  *
- * A ground rather than list punctuation (`1.`, `a)`) because these are names, not
- * positions: ids are stable by contract — a spec file is named after its criterion,
- * so renumbering one would orphan it — which means deleting a requirement leaves a
- * gap. `1, 3, 4` reads correctly as names and reads as a rendering fault as a list.
- * Neutral rather than coloured: on these rows colour belongs to the status chip and
- * to the agent glyph.
- *
- * `full` is the unabbreviated id, on hover, and only when it differs from what is
- * shown. It is the handle the reader needs elsewhere — spec filenames, report.json,
- * telling the agent which criterion to change — and the short form cannot be typed
- * back into any of them.
+ * `full` shows on hover when it differs — the handle for spec filenames,
+ * report.json and naming a criterion to the agent, none of which take `short`.
  */
 function IdMark({ short, full }: { short: string; full: string }) {
   const mark = (
@@ -130,8 +95,7 @@ function IdMark({ short, full }: { short: string; full: string }) {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        // The row's shared band rather than padding of its own, so the mark sits
-        // in the same line as the chip and the assertion — see ROW_LINE.
+        // The shared band, not padding of its own — see ROW_LINE.
         height: ROW_LINE,
         minWidth: 20,
         px: 0.75,
@@ -158,11 +122,10 @@ type ChipColor =
   | "success"
   | "warning";
 
-// report.json status → the chip colour shown on a criterion when a run report is
-// joined in. The LABEL comes from CRITERION_STATE_LABEL (counts.ts), which the
-// consumer's own tally line reads too — so a row's chip and the verdict tile above
-// this view can never call the same status by two different names. Unknown statuses
-// fall through to a neutral chip labelled verbatim.
+// report.json status → chip colour. The LABEL comes from CRITERION_STATE_LABEL
+// (counts.ts), which the consumer's tally reads too, so a row and the verdict tile
+// above it cannot name the same status differently. Unknown statuses fall through
+// to a neutral chip labelled verbatim.
 const STATE_COLOR: Record<string, ChipColor> = {
   pass: "success",
   fail: "error",
@@ -174,16 +137,11 @@ const STATE_COLOR: Record<string, ChipColor> = {
 /**
  * Who checks a criterion — a mark, not a word.
  *
- * `e2e` is the only method an agent drives, so it takes the console's agent glyph:
- * the same Sparkles at the same primary.main that the agent chat, the "ask the
- * agent" action and the nav already carry, so the row inherits a meaning the
- * reader arrives with instead of teaching a new one.
- *
- * Everything else falls to the person. `manual` by definition; the legacy
- * `scenario` and the `"unknown"` parse.ts assigns a criterion with no method
- * because neither is ever automated, which leaves them somebody's to check in
- * practice. That is also why one sentence covers all three: the icon is already
- * claiming a human does the work, so the tooltip says exactly that much.
+ * `e2e` takes the console's agent glyph (Sparkles at primary.main, as in the agent
+ * chat and the nav), so the row inherits a meaning the reader already has.
+ * Everything else falls to the person: neither `manual`, legacy `scenario`, nor
+ * the `"unknown"` parse.ts gives a method-less criterion is ever automated, which
+ * is why one sentence serves all three.
  */
 function methodMark(method: string): {
   Icon: typeof Sparkles;
@@ -207,19 +165,17 @@ function methodMark(method: string): {
  * The gutter's occupant when no run is attached — the Spec view's whole case, and
  * a validation view whose report would not parse.
  *
- * Icon-only, so the sentence is repeated as hidden text. Tooltip does put its
- * title on the child as an `aria-label`, but the child is a bare span: an
- * aria-label on a roleless element is ignored, which is the same trap StatusChip
- * documents for a Chip with no onClick. Content-based naming works whatever the
- * role, so that is what this uses.
+ * Icon-only, so the sentence is repeated as hidden text. Tooltip does set its
+ * title as an `aria-label`, but on a bare span that is ignored, so the name has to
+ * come from content.
  */
 function MethodIcon({ method }: { method: string }) {
   const { Icon, color, title } = methodMark(method);
   return (
     <Tooltip title={title}>
-      {/* No vertical handling here: the gutter centres this in the row's shared
-          band (ROW_LINE), which is the same thing that puts a status chip on the
-          line. `flex` so the svg is not an inline box with its own leading. */}
+      {/* The gutter centres this in the shared band, so there is nothing vertical
+          to do here. `flex` keeps the svg out of an inline box with its own
+          leading. */}
       <Box component="span" sx={{ display: "flex", color, flexShrink: 0 }}>
         <Icon size={16} aria-hidden />
         <Box component="span" sx={VISUALLY_HIDDEN}>
@@ -233,11 +189,10 @@ function MethodIcon({ method }: { method: string }) {
 /**
  * What the report says qualifies a verdict, as one sentence — or nothing.
  *
- * The two flags are independent in generate-report.mjs: `flaky` is only set on a
- * pass, but `healed` is set before the status is decided. So a failure the agent
- * tried to repair is a real row, and so is a pass that was both repaired and
- * flaky — which is why all four readings are spelled out rather than concatenated
- * from fragments that would read as a list of tags.
+ * The flags are independent in generate-report.mjs (`flaky` only on a pass,
+ * `healed` decided before the status), so a repaired failure and a pass that was
+ * both are each real. All four readings are written out rather than concatenated
+ * from fragments, which would read as a list of tags.
  */
 function verdictNote(
   status: string,
@@ -260,14 +215,10 @@ function verdictNote(
  * The per-criterion run-state chip (only rendered when a report is joined in).
  *
  * `note` is the report's qualifier on this verdict — flaky, healed, or both — and
- * it rides the chip as a single `*` rather than as its own chips beside it. Those
- * qualify THIS word, and as separate chips they read as independent facts and push
- * the verdict out of the row's one aligned column. One mark covers every
- * combination, because distinguishing them is all a second mark would buy and none
- * of them changes what the reader does next.
- *
- * Declared `string | undefined` rather than optional: `exactOptionalPropertyTypes`
- * is on, so a caller with nothing to say passes it explicitly.
+ * rides the chip as a single `*`. It qualifies THIS word, so a chip of its own
+ * would read as an independent fact and push the verdict out of the aligned
+ * column. `string | undefined` rather than optional, since
+ * `exactOptionalPropertyTypes` is on.
  */
 function StateChip({ status, note }: { status: string; note: string | undefined }) {
   const label = CRITERION_STATE_LABEL[status] ?? status;
@@ -305,12 +256,11 @@ function StateChip({ status, note }: { status: string; note: string | undefined 
  */
 export type LiveStatuses = Readonly<Record<string, string>>;
 
-// The in-flight vocabulary, LOCAL for the same reason "Pending" below is: these
-// words describe work happening, and report.json can only describe work in the
-// past tense, so none of them belongs in CRITERION_STATE_LABEL. Its two terminal
-// words (`pass`/`fail`) DO arrive on the live feed, and deliberately fall through
-// to StateChip — a criterion that has passed reads the same whether the news came
-// from the feed or from the report, because it is the same fact.
+// The in-flight vocabulary, local for the same reason "Pending" below is: these
+// words describe work happening, and report.json only speaks in the past tense, so
+// none of them belongs in CRITERION_STATE_LABEL. Its terminal words (`pass`/`fail`)
+// do arrive on this feed and fall through to StateChip on purpose — a criterion
+// that passed is the same fact whichever source said so.
 const LIVE_LABEL: Record<string, string> = {
   planned: "Planned",
   exploring: "Exploring…",
@@ -325,7 +275,7 @@ const LIVE_LABEL: Record<string, string> = {
 // and leave nothing to spend on this one.
 const LIVE_COLOR: Record<string, ChipColor> = { healing: "warning" };
 
-/** The chip for a criterion the pinned report predates — see CriterionChip. */
+/** For a criterion the pinned report has no row for — see CriterionChip. */
 const DRIFT_LABEL = "Out of run";
 const DRIFT_TOOLTIP =
   "Authored after the last validation run, so it has no result yet.";
@@ -357,9 +307,9 @@ function LiveChip({ status }: { status: string }) {
  * current run spends re-working it. The report wins again the moment the cycle
  * settles, because the consumer stops supplying live statuses then.
  *
- * Only called when a run IS attached, so unlike its predecessor it always returns
- * a chip. CriterionRow handles the no-run case, which shows who checks the
- * criterion instead of what happened to it.
+ * Only called when a run IS attached, so it always returns a chip. CriterionRow
+ * handles the no-run case, showing who checks the criterion instead of what
+ * happened to it.
  */
 function CriterionChip({
   criterion,
@@ -372,17 +322,11 @@ function CriterionChip({
   live: string | undefined;
   awaiting: boolean;
 }) {
-  // `runWorksOn`, not `runAnswers`: the question here is whether the run is
-  // WORKING on this row, which is wider than whether it will answer it. A run
-  // explores and runs a legacy `scenario` criterion and still reports
-  // `not_validated` for it, so it emits progress for a row it will never answer —
-  // and the console's run-wide progress line counts that row too. Asking the
-  // narrower question here made the row refuse a status the line beside it had
-  // already counted.
-  //
-  // Only `manual` is excluded, and unconditionally: the run names every criterion
-  // in its test plan, but a person answers this one, so a chip reading "Planned"
-  // promises a result nobody is going to produce.
+  // `runWorksOn`, not `runAnswers`: the question is whether the run is WORKING on
+  // this row, not whether it will answer it. The console's run-wide progress line
+  // counts the same set, so refusing a status here would contradict it. `manual`
+  // is excluded unconditionally — a person answers it, so "Planned" would promise
+  // a result nobody is going to produce.
   if (live && runWorksOn(criterion.method)) {
     // pass/fail arrive on the live feed too — report.json's own words, so its chip.
     return LIVE_LABEL[live] ? (
@@ -398,14 +342,12 @@ function CriterionChip({
   }
 
   // `runAnswers` here, the narrow question, because this branch is about the
-  // VERDICT: a criterion the run will not answer gets its final word rather than
-  // "Pending", since no result is coming and a chip promising one is a claim the
-  // report will contradict. Which final word is decided by the method alone,
-  // which is why it can be said before the run ends.
+  // VERDICT: a criterion the run will not answer gets its final word instead of
+  // "Pending", which would promise a result the report goes on to contradict. The
+  // method alone decides that word, which is why it can be said this early.
   //
-  // "Pending" itself is local rather than a sixth CRITERION_STATE_LABEL entry:
-  // that map is report.json's vocabulary, and a criterion with no report has no
-  // status to name.
+  // "Pending" is local rather than a sixth CRITERION_STATE_LABEL entry: that map
+  // is report.json's vocabulary, and this criterion has no report to name.
   if (awaiting) {
     if (!runAnswers(criterion.method)) {
       return (
@@ -423,15 +365,9 @@ function CriterionChip({
   // No attempt in flight, and the report has no row for this criterion. The
   // consumer reads the criteria at the branch tip and the report at the merge
   // commit of the attempt that wrote it, so a criterion authored since then cannot
-  // have a result — the ordinary authoring loop (run, read a failure, ask the agent
-  // for another criterion), not a fault. Hence a neutral chip and not a `warning`:
-  // colouring the expected state teaches the reader to discount the colour. Local
-  // wording for the same reason "Pending" above is local — this criterion is absent
-  // from report.json, so report.json has no word for it.
-  //
-  // Reached only after the `awaiting` branch above, which is what keeps this off a
-  // row the CURRENT run may still answer. Saying "out of run" while a run is
-  // working is the one thing this chip must never do.
+  // have a result — the ordinary authoring loop, not a fault, hence neutral rather
+  // than `warning`. Ranked below `awaiting` deliberately: claiming a row is out of
+  // the run while a run works on it is the one thing this chip must never do.
   return (
     <Tooltip title={DRIFT_TOOLTIP}>
       <Chip
@@ -445,14 +381,12 @@ function CriterionChip({
 }
 
 // One acceptance criterion: its single signal in the gutter — the status chip when
-// a run is attached, otherwise who checks it — then its letter, the atomic
-// assertion, and, for a failure, the spec path and message beneath.
+// a run is attached, otherwise who checks it — then its letter, the assertion, and
+// for a failure the spec path and message beneath.
 //
-// One signal and not two. A manual criterion used to carry a purple MANUAL badge
-// here AND a neutral "Manual" status chip at the far end of the row, saying the
-// same thing twice at opposite margins; and flaky/healed were two more chips
-// competing with the verdict they qualify. The gutter now holds exactly one thing,
-// which is what lets it be a fixed width and the letters beside it line up.
+// One signal, never two: a status chip already says "Manual", so a method mark
+// beside it would say it twice, and a qualifier like flaky rides the verdict
+// instead of competing with it. That is what lets the gutter be a fixed width.
 function CriterionRow({
   criterion,
   requirementId,
@@ -475,9 +409,9 @@ function CriterionRow({
     // a failure block stays inside the criterion it belongs to instead of being cut
     // off from its own assertion.
     <Box sx={{ py: 1 }}>
-      {/* `flex-start`, so the marks stay on the FIRST line of an assertion that
-          wraps rather than drifting to the middle of it. Alignment within that
-          line is ROW_LINE's job, not this property's. */}
+      {/* `flex-start` keeps the marks on the FIRST line of an assertion that wraps
+          rather than centring them in it. Alignment WITHIN that line is
+          ROW_LINE's job. */}
       <Box
         sx={{ display: "flex", gap: ROW_GAP, alignItems: "flex-start" }}
       >
@@ -512,10 +446,9 @@ function CriterionRow({
           {criterion.must}
         </Typography>
       </Box>
-      {/* Failure detail sits full-width beneath the row, indented to where the
-          criterion's letter starts, so a long trace never crowds the assertion. A
-          failure only exists with a report attached, so the chip gutter is the
-          right one to measure from. */}
+      {/* Full-width beneath the row, indented to where the letter starts, so a
+          long trace never crowds the assertion. A failure implies a report, so the
+          chip gutter is the one to measure from. */}
       {failed && (report?.failureLocation || report?.spec || report?.failure) && (
         <Box
           sx={(theme) => ({
@@ -524,10 +457,9 @@ function CriterionRow({
           })}
         >
           {/* Prefer the reporter's `<file>:<line>`, which points at the failing
-              assertion rather than merely the spec that contains it. The gate
-              above admits it on its own: a reporter can hand back a location with
-              an empty message, and dropping the block then would throw away the
-              only pointer to the failing assertion the run produced. */}
+              assertion rather than the spec containing it. Admitted on its own,
+              because a reporter can return a location with an empty message and
+              dropping the block would throw away the only pointer there is. */}
           {(report?.failureLocation || report?.spec) && (
             <Typography variant="caption" color="text.secondary" sx={mono}>
               {report.failureLocation || report.spec}
@@ -543,12 +475,10 @@ function CriterionRow({
                 mt: 0.5,
                 p: 1,
                 borderRadius: 1,
-                // A wash, not a saturated fill. The state chip on the row above
-                // already says "failed", so the surface's job is to be READABLE —
-                // a stack trace is the longest text on the page and it was set in
-                // monospace on solid error.main. The tint composites over
-                // whichever surface is beneath it, so it holds in both themes;
-                // same idiom as StatusChip's soft tones.
+                // A wash, not a saturated fill: the chip already says "failed",
+                // so this surface's only job is to keep the longest text on the
+                // page readable. The tint composites over whatever is beneath it,
+                // so it holds in both themes.
                 bgcolor: (theme) => alpha(theme.palette.error.main, 0.08),
                 color: "text.primary",
                 fontFamily: "monospace",
@@ -589,18 +519,14 @@ function RequirementCard({
         borderColor: "divider",
         borderRadius: 1,
         p: 2,
-        // Twice the gap between two criteria (16px). These were both 12px, so a
-        // requirement boundary carried the same weight as a row boundary and the
-        // nesting was invisible in the rhythm.
+        // Twice the gap between two criteria, so a requirement boundary outweighs
+        // a row boundary and the nesting shows in the rhythm.
         mb: 3,
       }}
     >
-      {/* The number leads the statement, echoing the rows below where the letter
-          leads the assertion — so the card reads the same way at both levels. The
-          "N criteria" caption that used to sit up here is gone: it counted a list
-          the reader is looking at. */}
-      {/* The same shared-band idiom as the rows below, so the number sits on the
-          statement's first line and stays there when the statement wraps. */}
+      {/* The number leads the statement, as the letter leads the assertion below,
+          so the card reads the same way at both levels. Same shared-band idiom, so
+          the number stays on the statement's first line when it wraps. */}
       <Box
         sx={{
           display: "flex",
@@ -625,16 +551,11 @@ function RequirementCard({
           No criteria.
         </Typography>
       ) : (
-        // A rule on the TOP of every row, not between rows. Bottom-of-all-but-last
-        // left the first criterion as the only one with no boundary above it, so it
-        // read as belonging to the statement in a way its siblings did not — and it
-        // made a one-criterion requirement render with no rule at all. This way the
-        // statement is the card's header, every criterion is bounded the same, and
-        // the card's own border closes the list at the bottom.
-        //
-        // Owned here rather than by CriterionRow because it is a property of the
-        // LIST; the rows get their own box because the badge row and the statement
-        // above are their siblings.
+        // A rule on the TOP of every row, so the statement reads as the card's
+        // header and the card's own border closes the list. Bounding
+        // all-but-the-last instead leaves the first criterion unbounded above and a
+        // one-criterion requirement with no rule at all. Owned here because it is a
+        // property of the LIST, not of a row.
         <Box sx={{ "& > *": { borderTop: 1, borderColor: "divider" } }}>
           {requirement.criteria.map((c) => (
             <CriterionRow
@@ -678,11 +599,11 @@ function ValidationBody({
    * status chip, or — with no run to report — who checks it.
    *
    * Read from `statuses`, NOT from the `report` prop. The prop is raw text and
-   * parsing it can fail, which leaves `statuses` undefined while a report WAS
-   * supplied; keying off the prop would then hand every row the drift chip,
-   * announcing that all of them were authored after the last run when the truth is
-   * that the file is unreadable. This way such a view degrades to the plain
-   * oracle, with the warning Alert above it naming the real problem.
+   * parsing it can fail, leaving `statuses` undefined while a report WAS supplied;
+   * keying off the prop would then hand every row the drift chip, announcing that
+   * all of them post-date the last run when the truth is that the file is
+   * unreadable. This way such a view degrades to the plain oracle, with the warning
+   * Alert above it naming the real problem.
    */
   const hasRun = statuses !== undefined || awaitingReport;
   const reqCount = requirements.length;
@@ -715,14 +636,10 @@ function ValidationBody({
           </Typography>
         )}
 
-        {/* No summary line here. It read "N requirements · M criteria" over a
-            per-method tally, and on the Validations page it sat directly beneath a
-            tile already printing both — the same numbers twice, a screen apart.
-            The counts that a reader acts on belong with the verdict that explains
-            them, which the consumer renders above this view.
-
-            The gap it used to leave below itself now belongs to the list, which is
-            what it was separating the heading from. */}
+        {/* No tally here. Counts belong with the verdict that explains them, which
+            the consumer renders above this view; a second copy a screen lower says
+            the same numbers twice. The margin separates the heading from the
+            list. */}
         <Box sx={{ mt: 3 }}>
           {reqCount === 0 ? (
             <Typography variant="body2" color="text.secondary">
@@ -792,12 +709,10 @@ export interface ValidationViewProps {
    * HAS a report — the Spec view's file preview shows the plain oracle with no run
    * attached to it, and chips there would name a run that does not exist.
    *
-   * "An attempt is in flight" means ANY attempt, not only a version's first. On a
-   * repeat attempt a criterion the pinned report never covered is waiting on the
-   * run working right now, so it is pending; passing this only for a first attempt
-   * left such a row saying it was out of the run while the run was on its way to
-   * answering it. Safe to widen because `report` outranks this — a covered row
-   * keeps the previous attempt's verdict, and only uncovered rows read it.
+   * ANY attempt, not only a version's first: on a repeat attempt a criterion the
+   * pinned report never covered is waiting on the run working right now. Safe,
+   * because `report` outranks this — a covered row keeps the previous attempt's
+   * verdict, and only uncovered rows read it.
    *
    * Named for the state rather than `pending`: a boolean prop by that name reads as
    * react-query's `isPending` — "still loading" — which is the opposite of what this

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -300,9 +300,9 @@ const LIVE_LABEL: Record<string, string> = {
 const LIVE_COLOR: Record<string, ChipColor> = { healing: "warning" };
 
 /** For a criterion the pinned report has no row for — see CriterionChip. */
-const DRIFT_LABEL = "Out of run";
+const DRIFT_LABEL = "No result";
 const DRIFT_TOOLTIP =
-  "Authored after the last validation run, so it has no result yet.";
+  "The last validation run produced no result for this criterion.";
 
 // The per-criterion chip while the run is still working on it.
 function LiveChip({ status }: { status: string }) {
@@ -670,9 +670,10 @@ function ValidationBody({
             criteria here before any run has produced a result to learn from. */}
         {!hideDescription && (
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            Each criterion represents one thing your software must do, based on your
-            requirements. After every deployment they are checked against the running
-            software, and the results appear under Validations. To change one, ask the
+            Each criterion represents one thing your system must do, based on your
+            requirements. After every deployment the ones that can be automated are
+            checked against the deployed system, and the results appear under
+            Validations. The rest you have to check yourself. To change one, ask the
             agent.
           </Typography>
         )}

--- a/packages/ui/validation-view/src/ValidationView.tsx
+++ b/packages/ui/validation-view/src/ValidationView.tsx
@@ -30,7 +30,7 @@ import {
   type CriterionReport,
   type ValidationReport,
 } from "./report.js";
-import { CRITERION_STATE_LABEL } from "./counts.js";
+import { CRITERION_STATE_LABEL, runAnswers, runWorksOn } from "./counts.js";
 import { shortCriterionId, shortRequirementId } from "./shortId.js";
 
 // Visually-hidden TEXT rather than an aria-label, for the reason StatusChip
@@ -64,11 +64,22 @@ const mono = { fontFamily: "monospace", fontSize: "0.875rem" } as const;
  * "Not validated"; a longer one would push its own row's id out of the column. A
  * short chip therefore leaves slack after it — the price of the column, and the
  * reason DRIFT_LABEL is kept terse rather than descriptive.
+ *
+ * Raw px, unlike the gap below, because neither is a spacing step: one is the
+ * width of a word and the other the height of a Chip. There is no theme token
+ * that means either, and rounding them to one would only hide what sets them.
  */
 const GUTTER_CHIP = 108;
 const GUTTER_ICON = 22;
-/** The row's own flex gap, in px — theme spacing(1). */
-const ROW_GAP = 8;
+
+/**
+ * The row's flex gap, as a theme spacing multiplier — `1` is 8px.
+ *
+ * A token and not a px literal: this one IS a spacing step, so the theme is
+ * entitled to move it. The failure block's indent has to add it to a px width, so
+ * it reads the same token back through `theme.spacing`.
+ */
+const ROW_GAP = 1;
 
 /**
  * The height of a row's FIRST line, shared by everything sitting on it.
@@ -89,6 +100,10 @@ const ROW_GAP = 8;
  *
  * 24px is the MUI small Chip's own height, so the tallest occupant sets it and
  * nothing has to be stretched.
+ *
+ * Passed to `height` as a bare number, which emotion renders as px, but to
+ * `line-height` as an explicit `px` string — `line-height` is unitless in CSS, so
+ * a bare 24 there would mean 24 TIMES the font size rather than 24 pixels.
  */
 const ROW_LINE = 24;
 
@@ -117,7 +132,7 @@ function IdMark({ short, full }: { short: string; full: string }) {
         justifyContent: "center",
         // The row's shared band rather than padding of its own, so the mark sits
         // in the same line as the chip and the assertion — see ROW_LINE.
-        height: `${ROW_LINE}px`,
+        height: ROW_LINE,
         minWidth: 20,
         px: 0.75,
         borderRadius: 0.75,
@@ -155,24 +170,6 @@ const STATE_COLOR: Record<string, ChipColor> = {
   not_validated: "warning",
   manual: "default",
 };
-
-/**
- * Whether a validation run answers this method at all.
- *
- * `e2e` is the only one it does. generate-report.mjs gives an e2e criterion the
- * test's own result and decides every other method from the method alone —
- * `manual` for a manual criterion, `not_validated` for anything else it cannot
- * automate — so what will become of those rows is knowable before the run starts.
- *
- * One predicate, read by all three places that need it: which glyph the Spec view
- * shows, whether a live status may speak for a row, and whether "Pending" is a
- * promise the run can keep. Shared deliberately — with the glyph claiming a person
- * checks a `scenario` criterion while the awaiting branch still promised "Pending"
- * for it, the two surfaces contradicted each other about the same row.
- */
-function runAnswers(method: string): boolean {
-  return method === "e2e";
-}
 
 /**
  * Who checks a criterion — a mark, not a word.
@@ -375,13 +372,18 @@ function CriterionChip({
   live: string | undefined;
   awaiting: boolean;
 }) {
-  // A criterion the run does not answer never takes a live status. The run
-  // reports one — its test plan names every criterion, not only the ones an agent
-  // will work — but it will never ANSWER this row, so a chip reading "Planned"
-  // promises a result nobody is going to produce. It is the only status such a
-  // row can receive, and nothing supersedes it: every later status needs a spec
-  // file it will never have.
-  if (live && runAnswers(criterion.method)) {
+  // `runWorksOn`, not `runAnswers`: the question here is whether the run is
+  // WORKING on this row, which is wider than whether it will answer it. A run
+  // explores and runs a legacy `scenario` criterion and still reports
+  // `not_validated` for it, so it emits progress for a row it will never answer —
+  // and the console's run-wide progress line counts that row too. Asking the
+  // narrower question here made the row refuse a status the line beside it had
+  // already counted.
+  //
+  // Only `manual` is excluded, and unconditionally: the run names every criterion
+  // in its test plan, but a person answers this one, so a chip reading "Planned"
+  // promises a result nobody is going to produce.
+  if (live && runWorksOn(criterion.method)) {
     // pass/fail arrive on the live feed too — report.json's own words, so its chip.
     return LIVE_LABEL[live] ? (
       <LiveChip status={live} />
@@ -395,10 +397,11 @@ function CriterionChip({
     );
   }
 
-  // A criterion the run does not answer gets its final word rather than
-  // "Pending": no result is coming, so a chip promising one is a claim the report
-  // will contradict. Which final word is decided by the method alone, which is
-  // why it can be said this early.
+  // `runAnswers` here, the narrow question, because this branch is about the
+  // VERDICT: a criterion the run will not answer gets its final word rather than
+  // "Pending", since no result is coming and a chip promising one is a claim the
+  // report will contradict. Which final word is decided by the method alone,
+  // which is why it can be said before the run ends.
   //
   // "Pending" itself is local rather than a sixth CRITERION_STATE_LABEL entry:
   // that map is report.json's vocabulary, and a criterion with no report has no
@@ -417,14 +420,18 @@ function CriterionChip({
     );
   }
 
-  // A settled run whose report has no row for this criterion. The consumer reads
-  // the criteria at the branch tip and the report at the merge commit of the
-  // attempt that wrote it, so a criterion authored since then cannot have a
-  // result — which is the ordinary authoring loop (run, read a failure, ask the
-  // agent for another criterion), not a fault. Hence a neutral chip and not a
-  // `warning`: colouring the expected state teaches the reader to discount the
-  // colour. Local wording for the same reason "Pending" above is local — this
-  // criterion is absent from report.json, so report.json has no word for it.
+  // No attempt in flight, and the report has no row for this criterion. The
+  // consumer reads the criteria at the branch tip and the report at the merge
+  // commit of the attempt that wrote it, so a criterion authored since then cannot
+  // have a result — the ordinary authoring loop (run, read a failure, ask the agent
+  // for another criterion), not a fault. Hence a neutral chip and not a `warning`:
+  // colouring the expected state teaches the reader to discount the colour. Local
+  // wording for the same reason "Pending" above is local — this criterion is absent
+  // from report.json, so report.json has no word for it.
+  //
+  // Reached only after the `awaiting` branch above, which is what keeps this off a
+  // row the CURRENT run may still answer. Saying "out of run" while a run is
+  // working is the one thing this chip must never do.
   return (
     <Tooltip title={DRIFT_TOOLTIP}>
       <Chip
@@ -472,14 +479,14 @@ function CriterionRow({
           wraps rather than drifting to the middle of it. Alignment within that
           line is ROW_LINE's job, not this property's. */}
       <Box
-        sx={{ display: "flex", gap: `${ROW_GAP}px`, alignItems: "flex-start" }}
+        sx={{ display: "flex", gap: ROW_GAP, alignItems: "flex-start" }}
       >
         <Box
           sx={{
             display: "flex",
             alignItems: "center",
-            height: `${ROW_LINE}px`,
-            minWidth: hasRun ? `${GUTTER_CHIP}px` : `${GUTTER_ICON}px`,
+            height: ROW_LINE,
+            minWidth: hasRun ? GUTTER_CHIP : GUTTER_ICON,
             flexShrink: 0,
           }}
         >
@@ -510,7 +517,12 @@ function CriterionRow({
           failure only exists with a report attached, so the chip gutter is the
           right one to measure from. */}
       {failed && (report?.failureLocation || report?.spec || report?.failure) && (
-        <Box sx={{ mt: 0.75, ml: `${GUTTER_CHIP + ROW_GAP}px` }}>
+        <Box
+          sx={(theme) => ({
+            mt: 0.75,
+            ml: `calc(${GUTTER_CHIP}px + ${theme.spacing(ROW_GAP)})`,
+          })}
+        >
           {/* Prefer the reporter's `<file>:<line>`, which points at the failing
               assertion rather than merely the spec that contains it. The gate
               above admits it on its own: a reporter can hand back a location with
@@ -593,7 +605,7 @@ function RequirementCard({
         sx={{
           display: "flex",
           alignItems: "flex-start",
-          gap: `${ROW_GAP}px`,
+          gap: ROW_GAP,
           mb: count > 0 ? 1.5 : 0,
         }}
       >
@@ -779,6 +791,13 @@ export interface ValidationViewProps {
    * Off by default, like its neighbours, and ignored for any criterion that
    * HAS a report — the Spec view's file preview shows the plain oracle with no run
    * attached to it, and chips there would name a run that does not exist.
+   *
+   * "An attempt is in flight" means ANY attempt, not only a version's first. On a
+   * repeat attempt a criterion the pinned report never covered is waiting on the
+   * run working right now, so it is pending; passing this only for a first attempt
+   * left such a row saying it was out of the run while the run was on its way to
+   * answering it. Safe to widen because `report` outranks this — a covered row
+   * keeps the previous attempt's verdict, and only uncovered rows read it.
    *
    * Named for the state rather than `pending`: a boolean prop by that name reads as
    * react-query's `isPending` — "still loading" — which is the opposite of what this

--- a/packages/ui/validation-view/src/counts.test.ts
+++ b/packages/ui/validation-view/src/counts.test.ts
@@ -21,6 +21,8 @@ import {
   countOf,
   CRITERION_STATE_LABEL,
   METHOD_LABEL,
+  runAnswers,
+  runWorksOn,
   tallyCriterionMethods,
   tallyCriterionStates,
   uncoveredCount,
@@ -253,5 +255,31 @@ describe("METHOD_LABEL", () => {
   it("expands the e2e wire value and leaves the rest alone", () => {
     expect(METHOD_LABEL["e2e"]).toBe("auto");
     expect(METHOD_LABEL["manual"]).toBeUndefined();
+  });
+});
+
+// The two questions a run gets asked about a method, and the gap between them.
+// Collapsing them into one predicate put the criterion rows out of step with the
+// console's run-wide progress line, which reads runWorksOn.
+describe("runAnswers / runWorksOn", () => {
+  it("answers only e2e", () => {
+    expect(runAnswers("e2e")).toBe(true);
+    for (const m of ["manual", "scenario", "unknown", ""]) {
+      expect(runAnswers(m)).toBe(false);
+    }
+  });
+
+  it("works on everything except manual", () => {
+    for (const m of ["e2e", "scenario", "unknown", ""]) {
+      expect(runWorksOn(m)).toBe(true);
+    }
+    expect(runWorksOn("manual")).toBe(false);
+  });
+
+  it("differ exactly where a run acts without answering", () => {
+    // `scenario` is the live case: worked on, never answered. If these two ever
+    // agree on it, one of the two callers is wrong.
+    expect(runWorksOn("scenario")).toBe(true);
+    expect(runAnswers("scenario")).toBe(false);
   });
 });

--- a/packages/ui/validation-view/src/counts.ts
+++ b/packages/ui/validation-view/src/counts.ts
@@ -80,6 +80,37 @@ export const METHOD_COLOR: Record<string, string> = {
 /** The colour for a method this vocabulary does not know. */
 export const METHOD_FALLBACK_COLOR = "#616161";
 
+/**
+ * Whether a validation run produces a VERDICT for this method.
+ *
+ * `e2e` only. generate-report.mjs gives an e2e criterion its test's own result and
+ * decides every other method from the method alone — `manual` for a manual
+ * criterion, `not_validated` for anything else it cannot automate — so what
+ * becomes of those rows is knowable before the run starts.
+ */
+export function runAnswers(method: string): boolean {
+  return method === "e2e";
+}
+
+/**
+ * Whether a run WORKS ON this criterion — explores it, authors a spec for it,
+ * runs it — and therefore emits live progress naming it.
+ *
+ * Deliberately wider than `runAnswers`, and the gap between them is not
+ * academic: a run works on a legacy `scenario` criterion and still reports
+ * `not_validated` for it, so it emits progress for a row it will never answer.
+ * Only `manual` is outside both, being a person's to judge, which is why a run
+ * never names it.
+ *
+ * The two were briefly one predicate, which put this package's rows out of step
+ * with the console's run-wide progress line — that line counts exactly this set,
+ * so a row refusing a status the line had already counted left the two
+ * contradicting each other about the same criterion. Both read this now.
+ */
+export function runWorksOn(method: string): boolean {
+  return method !== "manual";
+}
+
 /** Display order for the method tally; unknown methods sort after these. */
 export const METHOD_ORDER = ["e2e", "scenario", "manual"];
 

--- a/packages/ui/validation-view/src/counts.ts
+++ b/packages/ui/validation-view/src/counts.ts
@@ -48,19 +48,28 @@ export const CRITERION_STATE_LABEL: Record<string, string> = {
  * `e2e` is the contract shared with the runner, the report generator and the
  * spec-path convention, so it cannot be renamed — but it is an acronym the reader
  * has to expand, which the console lexicon forbids. The same split
- * CRITERION_STATE_LABEL draws for run statuses, and here for the same reason: the
- * badge on a criterion and the consumer's method tally must call a method by one
- * name. A method with no entry renders verbatim, so `manual` and anything
- * unrecognised are unaffected.
+ * CRITERION_STATE_LABEL draws for run statuses, and here for the same reason: two
+ * surfaces naming a method must name it the same way. A method with no entry
+ * renders verbatim, so `manual` and anything unrecognised are unaffected.
+ *
+ * The criterion rows no longer read this — they mark the method with a glyph
+ * rather than a word (ValidationView's methodMark) — so the remaining readers are
+ * the consumer's own prose and tally, which is why it still has to be one word in
+ * one place.
  */
 export const METHOD_LABEL: Record<string, string> = {
   e2e: "auto",
 };
 
 /**
- * criterion method → its identifying colour. Solid behind a badge, and a wash
- * behind the same word said in prose, so a consumer naming a method in a sentence
- * can mark it with the colour the reader will meet on every row.
+ * criterion method → its identifying colour, as a wash behind the method's word
+ * said in prose, so a consumer naming a method in a sentence can mark it as a term
+ * rather than leave it as ordinary text.
+ *
+ * It used to sit solid behind a badge on every criterion row as well. Those rows
+ * now carry a glyph on the console's own agent/person colours instead, so a
+ * consumer's sentence is the only reader left — nothing on screen has to match
+ * these hexes any more.
  */
 export const METHOD_COLOR: Record<string, string> = {
   e2e: "#1976d2",

--- a/packages/ui/validation-view/src/counts.ts
+++ b/packages/ui/validation-view/src/counts.ts
@@ -52,10 +52,8 @@ export const CRITERION_STATE_LABEL: Record<string, string> = {
  * surfaces naming a method must name it the same way. A method with no entry
  * renders verbatim, so `manual` and anything unrecognised are unaffected.
  *
- * The criterion rows no longer read this — they mark the method with a glyph
- * rather than a word (ValidationView's methodMark) — so the remaining readers are
- * the consumer's own prose and tally, which is why it still has to be one word in
- * one place.
+ * Read by a consumer's prose and its tally, not by the criterion rows — those mark
+ * the method with a glyph rather than a word (ValidationView's methodMark).
  */
 export const METHOD_LABEL: Record<string, string> = {
   e2e: "auto",
@@ -66,10 +64,8 @@ export const METHOD_LABEL: Record<string, string> = {
  * said in prose, so a consumer naming a method in a sentence can mark it as a term
  * rather than leave it as ordinary text.
  *
- * It used to sit solid behind a badge on every criterion row as well. Those rows
- * now carry a glyph on the console's own agent/person colours instead, so a
- * consumer's sentence is the only reader left — nothing on screen has to match
- * these hexes any more.
+ * A consumer's sentence is the only reader: the criterion rows carry a glyph on
+ * the console's own agent/person colours, so nothing else has to match these hexes.
  */
 export const METHOD_COLOR: Record<string, string> = {
   e2e: "#1976d2",
@@ -102,10 +98,10 @@ export function runAnswers(method: string): boolean {
  * Only `manual` is outside both, being a person's to judge, which is why a run
  * never names it.
  *
- * The two were briefly one predicate, which put this package's rows out of step
- * with the console's run-wide progress line — that line counts exactly this set,
- * so a row refusing a status the line had already counted left the two
- * contradicting each other about the same criterion. Both read this now.
+ * Do not collapse the two. The console's run-wide progress line counts exactly
+ * this set, so a criterion row that answers the narrower question refuses a status
+ * the line beside it has already counted, and the two then contradict each other
+ * about the same criterion.
  */
 export function runWorksOn(method: string): boolean {
   return method !== "manual";

--- a/packages/ui/validation-view/src/index.ts
+++ b/packages/ui/validation-view/src/index.ts
@@ -40,6 +40,8 @@ export {
   METHOD_COLOR,
   METHOD_FALLBACK_COLOR,
   METHOD_LABEL,
+  runAnswers,
+  runWorksOn,
   tallyCriterionMethods,
   tallyCriterionStates,
   uncoveredCount,

--- a/packages/ui/validation-view/src/shortId.test.ts
+++ b/packages/ui/validation-view/src/shortId.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { shortCriterionId, shortRequirementId } from "./shortId.js";
+
+describe("shortRequirementId", () => {
+  it("keeps only the number, past the padding", () => {
+    expect(shortRequirementId("REQ-001")).toBe("1");
+    expect(shortRequirementId("REQ-013")).toBe("13");
+    expect(shortRequirementId("REQ-100")).toBe("100");
+  });
+
+  it("does not renumber — a gap stays a gap", () => {
+    // Ids are stable by contract (a spec file is named after its criterion), so
+    // deleting REQ-002 leaves 1, 3, 4. These are names, not list positions.
+    expect(["REQ-001", "REQ-003", "REQ-004"].map(shortRequirementId)).toEqual([
+      "1",
+      "3",
+      "4",
+    ]);
+  });
+
+  it("shows an id that breaks the convention in full", () => {
+    expect(shortRequirementId("R-1")).toBe("R-1");
+    expect(shortRequirementId("REQ-1a")).toBe("REQ-1a");
+    expect(shortRequirementId("requirement one")).toBe("requirement one");
+    expect(shortRequirementId("")).toBe("");
+  });
+});
+
+describe("shortCriterionId", () => {
+  it("drops the prefix its own card already carries", () => {
+    expect(shortCriterionId("AC-001-a", "REQ-001")).toBe("a");
+    expect(shortCriterionId("AC-013-b", "REQ-013")).toBe("b");
+  });
+
+  it("matches on the number, not the padding", () => {
+    expect(shortCriterionId("AC-1-a", "REQ-001")).toBe("a");
+    expect(shortCriterionId("AC-001-a", "REQ-1")).toBe("a");
+  });
+
+  it("keeps the full id when the criterion names another requirement", () => {
+    // The number is the only part of the id that says it is filed in the wrong
+    // card, so shortening would render the mistake as a tidy "a".
+    expect(shortCriterionId("AC-001-a", "REQ-002")).toBe("AC-001-a");
+  });
+
+  it("keeps the full id when either side breaks the convention", () => {
+    expect(shortCriterionId("AC-001-a", "R-1")).toBe("AC-001-a");
+    expect(shortCriterionId("AC-001", "REQ-001")).toBe("AC-001");
+    expect(shortCriterionId("AC-001-", "REQ-001")).toBe("AC-001-");
+    expect(shortCriterionId("criterion one", "REQ-001")).toBe("criterion one");
+    expect(shortCriterionId("", "REQ-001")).toBe("");
+  });
+
+  it("keeps a multi-part suffix whole", () => {
+    expect(shortCriterionId("AC-001-a-2", "REQ-001")).toBe("a-2");
+  });
+});

--- a/packages/ui/validation-view/src/shortId.ts
+++ b/packages/ui/validation-view/src/shortId.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Short display forms for the two id levels.
+ *
+ * The authoring convention (skills/validation-criteria/SKILL.md) fixes both
+ * shapes: a requirement is `REQ-NNN`, and a criterion is
+ * `AC-<req-number>-<letter>`. Inside a requirement's own card the
+ * `AC-<req-number>-` half is already on the page, so a row that reprints it
+ * spends its most-scanned column on repetition.
+ *
+ * Kept as pure functions rather than done inline in the view, because the
+ * fallback below is the whole substance of them and it deserves its own tests.
+ */
+
+/**
+ * The requirement's number, normalised past leading zeros — the shared half of
+ * both ids, so both functions agree on what `REQ-001` and `AC-1-a` have in common.
+ */
+function requirementNumber(id: string): string | undefined {
+  return /^REQ-0*(\d+)$/.exec(id)?.[1];
+}
+
+/**
+ * `REQ-001` → `1`; anything else verbatim.
+ *
+ * The fallback is not defensive padding: `parse.ts` takes ids as arbitrary
+ * strings, oracles can be hand-edited, and older ones predate the convention. An
+ * id that does not match is shown in full rather than cut into a fragment that no
+ * longer identifies anything.
+ */
+export function shortRequirementId(id: string): string {
+  return requirementNumber(id) ?? id;
+}
+
+/**
+ * `AC-001-a` → `a`, but only inside the requirement whose number it names.
+ *
+ * The number match is the point. A criterion filed under the wrong requirement is
+ * a real thing an edited oracle can contain, and the number is the only part of
+ * the id that says so — dropping it would render `AC-001-a` as a tidy `a` under
+ * REQ-002 and hide the mismatch. So a criterion that does not belong keeps its
+ * full id, where the reader can see why.
+ */
+export function shortCriterionId(
+  criterionId: string,
+  requirementId: string,
+): string {
+  const number = requirementNumber(requirementId);
+  if (number === undefined) return criterionId;
+  const parts = /^AC-0*(\d+)-(.+)$/.exec(criterionId);
+  if (!parts || parts[1] !== number) return criterionId;
+  return parts[2] ?? criterionId;
+}

--- a/packages/ui/validation-view/src/test-setup.ts
+++ b/packages/ui/validation-view/src/test-setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "@testing-library/jest-dom/vitest";

--- a/packages/ui/validation-view/vitest.config.ts
+++ b/packages/ui/validation-view/vitest.config.ts
@@ -20,6 +20,32 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // parse/report/counts/shortId are pure logic and node is the fastest
+    // default; ValidationView.test.tsx opts into jsdom per-file via a
+    // `// @vitest-environment jsdom` pragma, mirroring design-view and
+    // apps/console.
     environment: "node",
+    // Source only. `build` compiles tests into dist/ alongside the library, and
+    // vitest's default glob collects those stale copies and runs them against
+    // whatever the source was at build time (matches design-view).
+    include: ["src/**/*.test.{ts,tsx}"],
+    // Needed so @testing-library/react's auto-cleanup-between-tests effect
+    // detects a global `afterEach` and actually registers — it silently no-ops
+    // without a global test-framework hook, and ValidationView.test.tsx renders
+    // many times in one file.
+    globals: true,
+    setupFiles: ["src/test-setup.ts"],
+    server: {
+      // oxygen-ui ships in a form that needs vite's transform pipeline rather
+      // than a plain node require (matches design-view and apps/console).
+      deps: {
+        inline: [
+          "@wso2/oxygen-ui",
+          "@mui/x-data-grid",
+          "@mui/x-date-pickers",
+          "@mui/x-tree-view",
+        ],
+      },
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.0.2(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: 19.1.6
         version: 19.1.6
@@ -553,12 +559,15 @@ importers:
       '@wso2/oxygen-ui-icons-react':
         specifier: 0.11.0
         version: 0.11.0(react@19.2.3)
+      jsdom:
+        specifier: 26.1.0
+        version: 26.1.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   playground:
     dependencies:
@@ -11624,36 +11633,6 @@ snapshots:
       '@types/node': 25.9.4
       '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(playwright@1.61.1)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 26.1.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.4
-      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@5.9.3))(playwright@1.61.1)(vite@7.3.6(@types/node@25.9.4)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
-      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Closes #738.

## What changed

A criterion row now carries two marks at opposite ends, and nothing twice.

- **The method is a glyph, never a word.** `Sparkles` at `primary.main` for a criterion an agent drives — the mark the agent chat, the "ask the agent" action and the nav already use — and `User` at `text.secondary` for everything else. Icon-only, explained on hover, with the same sentence as visually-hidden text.
- **The verdict ends the row**, and absorbs `flaky` / `healed` as a single `*` with the detail on hover.
- **`Passed` and `Failed` carry an icon**; nothing else does. As outlined chips they otherwise differ by hue alone.
- **Ids show only what the card does not already say** — `1`, `a` — on a soft neutral ground, full id on hover. A ground rather than `1.` / `a)` because ids are stable by contract, so a deleted requirement leaves a gap that reads fine as names and as a fault as a list.
- **`No result`** for a criterion the last run never covered, which is the ordinary authoring loop rather than a fault. It never appears while a run may still answer the row.
- **The tally, the `REQ-001` badge and the `N criteria` caption are gone.**
- **Copy**: the description now names both halves of what happens after a deployment, and the Validations empty state says *deployment* rather than *build* — settling the open note the lexicon carried. `lexicon.md` moves with all of it, per ADR-0019.

## The layout decision

Both arrangements were built and compared in mock mode. **The left-aligned one was rejected.**

### Chosen — verdict at the row's right end

<img width="1179" height="447" alt="image" src="https://github.com/user-attachments/assets/63746a3a-60d8-4a96-9195-90e7d2a2030c" />

The gutter holds only the glyph, so it is 22px and the ids sit tight against it. The method mark survives a run, which is what lets a reader scan one fixed column for their own work instead of reading every verdict to find it.

### Rejected — verdict in the left gutter

<img width="1301" height="514" alt="image" src="https://github.com/user-attachments/assets/c5649428-42ec-4ce1-b946-2788164ff8aa" />

Two problems the screenshot shows:

1. **The gutter has to fit the longest label.** `Not validated` is ~103px, so the column is sized to it and a short chip like `Failed` leaves roughly 50px of slack before the id. Every row pays for the widest word.
2. **The method mark disappears wherever there are results.** The verdict displaces it, so on the page where a reader most needs to know which criteria are theirs to check, nothing says so except reading each chip.

What the chosen layout gives up is the verdicts' left edge, which is ragged because it follows a variable-length assertion. Their right edge is flush instead.

## Verifying it

Mock mode, no backend needed:

```js
localStorage.setItem('aep:mock:settings', 'connected');
localStorage.setItem('aep:mock:validation', 'failed');
localStorage.setItem('aep:mock:validation-criteria', 'drifted');
location.reload();
```

That renders every chip in one screen: `Passed`, `Failed*`, `No result`, `Not run`, `Not validated`, `Manual`. Drop the third key to lose `No result`; `removeItem('aep:mock:validation')` for the Spec view's glyph-only pane. `aep:mock:validation-criteria=drifted` is new here — no scenario could previously produce a drifted criterion, because the fixture derives both files from one outcome map.

## Checks

| | |
|---|---|
| `@aep/ui-validation-view` | 69 tests |
| `@aep/console` | 1775 tests, 139 files |
| `make lint` | 29/29, 0 Go issues |
| `make typecheck` | clean |
| `make license-check` | clean |
| `make deadcode-ts-check` | clean |

`/code-review` was run against the branch. It raised two correctness findings and one standards finding; all three are fixed in `c8065e25` and `e957411a`, and the two behavioural fixes are mutation-checked — reinstating either defect fails exactly one new test.

## Reading the history

The branch argues with itself on purpose and the commits say why: `01a2c4a4` makes the case for one signal per row, and `426e7e2e` reverses it after the comparison above. Squash on merge if you would rather it read as one change.
