### PR TITLE
fix(scripts): mint a token that Thunder will actually accept for revalidation

### DIFF
--- a/scripts/project-revalidate.sh
+++ b/scripts/project-revalidate.sh
@@ -78,12 +78,16 @@ if [ -n "${CEILING:-}" ] && ! [[ "$CEILING" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 # The local plane keeps CLUSTER_CONTEXT in one place; source it rather than
-# restating "k3d-openchoreo" here. env.sh is pure assignments, no side effects.
+# restating "k3d-openchoreo" here. env.sh is pure assignments, no side effects —
+# but it assigns UNCONDITIONALLY, so an exported override has to be carried
+# across the source by hand or it is silently replaced by the default.
+CLUSTER_CONTEXT_OVERRIDE="${CLUSTER_CONTEXT:-}"
 if [ -f "${SCRIPT_DIR}/../deployments/scripts/env.sh" ]; then
     # shellcheck source=/dev/null
     . "${SCRIPT_DIR}/../deployments/scripts/env.sh"
 fi
-CLUSTER_CONTEXT="${CLUSTER_CONTEXT:-k3d-openchoreo}"
+CLUSTER_CONTEXT="${CLUSTER_CONTEXT_OVERRIDE:-${CLUSTER_CONTEXT:-k3d-openchoreo}}"
+# Not in env.sh — this one is restated from setup-local.sh, which creates it.
 AEP_NS="${AEP_NS:-wso2-aep}"
 
 # Read a key out of a cluster Secret; empty when kubectl, the cluster or the key
@@ -127,8 +131,11 @@ TOKEN=$(curl -sS -X POST "${THUNDER_URL%/}/oauth2/token" \
 if [ -z "$TOKEN" ]; then
     echo "❌ Thunder did not return an access_token for '${SEEDER_CLIENT_ID}'." >&2
     echo "   Tried the secret from ${SECRET_SOURCE}." >&2
-    echo "   The two paths that register this client disagree on its secret, so" >&2
-    echo "   read the live one and pass it explicitly:" >&2
+    echo "   Two paths register this client and they disagree on its secret:" >&2
+    echo "     deployments/scripts/setup-local.sh  — a random one, in the Secret" >&2
+    echo "     single-cluster/values-thunder.yaml  — the literal default" >&2
+    echo "   Whichever ran last is the one Thunder honours, so read the live one" >&2
+    echo "   and pass it explicitly:" >&2
     echo "     SEEDER_CLIENT_SECRET=\$(kubectl --context ${CLUSTER_CONTEXT} get secret \\" >&2
     echo "       aep-thunder-secrets -n ${AEP_NS} \\" >&2
     echo "       -o jsonpath='{.data.LOCAL_DEV_SEEDER_SECRET}' | base64 -d) \\" >&2

--- a/scripts/project-revalidate.sh
+++ b/scripts/project-revalidate.sh
@@ -22,36 +22,48 @@
 # whole interface, and the only friction in calling it is minting a token. This
 # is that curl with the Thunder client_credentials dance folded in.
 #
-# The loop it was written for: change the `aep-validation` skill, rebuild the
-# runner image (`make build-runner FORCE=1`), re-run this, watch the agent work
-# against the app already deployed. Nothing is rebuilt to answer the question.
+# The loop it was written for: change the `aep-validation` skill, rebuild and
+# deploy aep-api — the BFF carries the skills mirror a dispatched runner reads,
+# so `make build-runner` does NOT reach it — confirm the mirror landed, then run
+# this and watch the agent work against the app already deployed. Nothing is
+# rebuilt to answer the question: a validation run has no working set and skips
+# the build and deploy stages outright.
 #
-#   scripts/project-revalidate.sh                       # the defaults below
+#   scripts/project-revalidate.sh my-project            # tag v1, re-check only
 #   scripts/project-revalidate.sh my-project v2
-#   scripts/project-revalidate.sh my-project v2 2       # let it REPAIR — see below
+#   scripts/project-revalidate.sh my-project v2 3       # let it REPAIR — see below
 #
-# The third argument is the validation attempt budget. It defaults to 1, and that
-# default is the safe one: a single attempt is spent by the first fatal verdict,
-# which settles the run before the loop reaches the point where it would file
-# repair work — so the run reports and stops, touching neither the repo nor the
-# deployment. Raise it and a `failed` verdict becomes an issue per failed
-# criterion, an ordinary coding cycle, a build and a redeploy. That is a real
-# change to the project, so it is opt-in.
+# The third argument is the validation attempt budget, and since the delivery
+# loop split into three workflows it caps the VERSION's total validation runs
+# rather than this run's attempts: the workflow counts every `validation`-kind
+# run on the milestone, the one it is running in included. The default 1 is the
+# safe one — a fatal verdict settles the run before the repair mint, so the run
+# reports and stops, touching neither the repo nor the deployment.
+#
+# Raising it is opt-in because it changes the project, and it has to clear the
+# runs already spent: the reconcile sweep judges every version once by itself at
+# deployed-green, so a version judged N times needs at least N+2 here before a
+# `failed` verdict files an issue per failed criterion. The repair is then a
+# SEPARATE run — this one settles `failed` the moment it files — and the task run
+# that fixes those issues reopens the validation task, so a third run re-judges.
 #
 # Refusals are the endpoint's, and each is actionable: 409 while a run is already
-# working the version or while its milestone still has open work, 422 when the
-# version has no acceptance criteria to validate against.
+# working the version or while its milestone still has open dev work, 422 when the
+# version has no acceptance criteria to validate against, 404 when the tag never
+# ran here — a tag resolves through the platform's own run rows, never GitHub.
 set -e
 
-# The project this repo's author reaches for most; all three are positional.
-PROJECT="${1:-p18-bare-minimum-hello}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# A project that exists at the time of writing, for a bare invocation; all three
+# are positional. Project names rot as local stacks are rebuilt — pass your own.
+PROJECT="${1:-p47-hello-world}"
 TAG="${2:-v1}"
 ATTEMPTS="${3:-1}"
 
 BFF_URL="${BFF_URL:-http://localhost:9090}"
 THUNDER_URL="${THUNDER_URL:-http://thunder.openchoreo.localhost:8080}"
 SEEDER_CLIENT_ID="${SEEDER_CLIENT_ID:-aep-local-dev-seeder}"
-SEEDER_CLIENT_SECRET="${SEEDER_CLIENT_SECRET:-aep-local-dev-seeder-secret}"
 
 # Both budgets are interpolated into hand-built JSON below, so a non-numeric or
 # leading-zero value would ship a malformed body and come back as an opaque 400.
@@ -63,6 +75,40 @@ fi
 if [ -n "${CEILING:-}" ] && ! [[ "$CEILING" =~ ^[1-9][0-9]*$ ]]; then
     echo "❌ CEILING must be a positive integer (got '${CEILING}')." >&2
     exit 1
+fi
+
+# The local plane keeps CLUSTER_CONTEXT in one place; source it rather than
+# restating "k3d-openchoreo" here. env.sh is pure assignments, no side effects.
+if [ -f "${SCRIPT_DIR}/../deployments/scripts/env.sh" ]; then
+    # shellcheck source=/dev/null
+    . "${SCRIPT_DIR}/../deployments/scripts/env.sh"
+fi
+CLUSTER_CONTEXT="${CLUSTER_CONTEXT:-k3d-openchoreo}"
+AEP_NS="${AEP_NS:-wso2-aep}"
+
+# Read a key out of a cluster Secret; empty when kubectl, the cluster or the key
+# is missing. Same read as deployments/scripts/setup-local.sh's existing_secret,
+# because that script is what wrote the value.
+cluster_secret() {
+    kubectl --context "${CLUSTER_CONTEXT}" get secret "$1" \
+        -n "${AEP_NS}" -o jsonpath="{.data.$2}" 2>/dev/null \
+        | base64 -d 2>/dev/null || true
+}
+
+# TWO paths register this client and they disagree about its secret, so the
+# secret is resolved rather than assumed: setup-local.sh generates a random one
+# into the aep-thunder-secrets Secret and registers the app with it, while
+# Thunder's own bootstrap (single-cluster/values-thunder.yaml) registers the
+# literal below. Whichever ran last is the one Thunder will accept — hence the
+# cluster read first, and the literal only as the fallback that path needs.
+SECRET_SOURCE="the exported SEEDER_CLIENT_SECRET"
+if [ -z "${SEEDER_CLIENT_SECRET:-}" ]; then
+    SEEDER_CLIENT_SECRET="$(cluster_secret aep-thunder-secrets LOCAL_DEV_SEEDER_SECRET)"
+    SECRET_SOURCE="the aep-thunder-secrets Secret (${CLUSTER_CONTEXT}/${AEP_NS})"
+fi
+if [ -z "$SEEDER_CLIENT_SECRET" ]; then
+    SEEDER_CLIENT_SECRET="aep-local-dev-seeder-secret"
+    SECRET_SOURCE="the values-thunder.yaml bootstrap default"
 fi
 
 if ! curl -fsS --max-time 3 "$BFF_URL/healthz" > /dev/null 2>&1; then
@@ -79,8 +125,14 @@ TOKEN=$(curl -sS -X POST "${THUNDER_URL%/}/oauth2/token" \
     | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 if [ -z "$TOKEN" ]; then
-    echo "❌ Thunder did not return an access_token for '${SEEDER_CLIENT_ID}'."
-    echo "   The client is registered by deployments/scripts/setup-local.sh / start.sh."
+    echo "❌ Thunder did not return an access_token for '${SEEDER_CLIENT_ID}'." >&2
+    echo "   Tried the secret from ${SECRET_SOURCE}." >&2
+    echo "   The two paths that register this client disagree on its secret, so" >&2
+    echo "   read the live one and pass it explicitly:" >&2
+    echo "     SEEDER_CLIENT_SECRET=\$(kubectl --context ${CLUSTER_CONTEXT} get secret \\" >&2
+    echo "       aep-thunder-secrets -n ${AEP_NS} \\" >&2
+    echo "       -o jsonpath='{.data.LOCAL_DEV_SEEDER_SECRET}' | base64 -d) \\" >&2
+    echo "       bash scripts/project-revalidate.sh ${PROJECT} ${TAG}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## What

`scripts/project-revalidate.sh` — the local-dev trigger for
`POST /projects/{project}/builds/{tag}/revalidate` — had stopped working at its
first step, and its header comments had gone stale since #584 split the delivery
loop into three workflows. The endpoint itself is fine; this is the script.

## Why it was broken

Thunder answered `401 invalid_client` before the script ever reached the BFF.
Two paths register `aep-local-dev-seeder` and they disagree about its secret:

| path | secret it registers |
|---|---|
| Thunder's bootstrap (`single-cluster/values-thunder.yaml:146`) | the literal `aep-local-dev-seeder-secret` |
| `deployments/scripts/setup-local.sh:105-106,309` | a random `rand32`, kept only in the `aep-thunder-secrets` Secret |

Whichever ran last is the only secret Thunder honours, so the hardcoded literal
was a coin flip — and the value is never written to `deployments/.env`, so there
was nothing local to fall back on.

## Changes

- **Resolve the secret instead of assuming it.** Exported `SEEDER_CLIENT_SECRET`
  wins, then the cluster Secret (the `existing_secret` read from
  `setup-local.sh:67-72`, since that script is what wrote the value), then the
  literal so the bootstrap path still works. `CLUSTER_CONTEXT` is sourced from
  `deployments/scripts/env.sh` rather than restated.
- **Make the 401 actionable** — it now names which of the three sources was
  tried and prints the command that reads the live one. No secret value is ever
  echoed.
- **Correct the header comments for post-#584 behaviour**, which is the bulk of
  the diff:
  - `validationAttempts` caps the *version's* total validation runs, not this
    run's attempts (`run/activities.go` `ReadValidationHistory` counts every
    `validation`-kind run on the milestone, the asking one included). Since the
    reconcile sweep judges every version once by itself at deployed-green
    (`eventcore/sweep.go`), the old documented `2` no longer buys a repair — a
    version judged N times needs N+2.
  - A `failed` verdict now settles *that* run as soon as it files repair work;
    the fix is a separate task run, which reopens the validation task
    (`run/workflow_task.go` `reopenValidationTask`) so a third run re-judges.
  - A skill edit reaches a dispatched runner through the BFF's skills mirror, so
    it needs an aep-api deploy — `make build-runner` does not reach it.
  - Documents the 404 (a tag resolves through the platform's own run rows, never
    GitHub titles) and points the bare-invocation default at a project that
    exists.
- Argument validation moved ahead of the cluster read, so a typo'd budget fails
  without touching kubectl.
- An exported `CLUSTER_CONTEXT` now survives sourcing `env.sh` (second commit —
  see Code review below).

## Proof of real execution

Local stack, in order. The first three cost nothing:

```
$ bash scripts/project-revalidate.sh p31-bareminium-hello-world v999
🔁 Revalidating p31-bareminium-hello-world v999 (validationAttempts=1)
❌ HTTP 404
   {"code":"not_found","message":"no run for this version"}
```

404 rather than 401 — the token now mints and the request reaches tag
resolution. A read-only `GET /api/v1/projects` with the same token returns the
real project list, confirming the seeder token binds to the `default` org (a
mis-bound org would 404 identically, so this check is what separates them).

```
$ bash scripts/project-revalidate.sh p47-hello-world v1
🔁 Revalidating p47-hello-world v1 (validationAttempts=1)
✅ Started run 646634e7-8d0b-4ed3-b614-74d00255bb4e
```

That run, end to end in 2m10s:

```
 state     | validation_verdict | validation_issue
-----------+--------------------+------------------
 succeeded | passed             |                3

 kind       | attempts | open | pr_number | validation_verdict
------------+----------+------+-----------+--------------------
 validation |        1 | f    |         5 | passed
```

`kind=validation, origin=revalidate, validation_attempts=1` — a real
`ValidationRunWorkflow`, which dispatched agent component
`ca-79809bd548234b-4da74ae0`, opened its tests PR (#5) on the project repo and
recorded `passed`. `attempts=1` means it could only re-check and report, which
is what it did.

`make license-check` passes. `shellcheck` is not installed on this machine, so
the script is `bash -n` clean only.

## Code review

`/code-review` per AGENTS.md, both axes against `upstream/main`.

**Spec axis** verified every platform claim the new header ships against the Go
source — the attempt-ledger arithmetic including the `N+2`, the sweep's
automatic first judging run, the settle-then-separate-repair chain, all four
refusal codes, and the skills delivery path (ADR-0005 decision 3: one delivery
path, the project mirror, "no image fallback"). **No false statement shipped.**
No scope creep: no sibling script touched, no polling added, `openapi.yaml`
untouched.

**Standards axis** found one real bug, fixed in `03b3deba`: sourcing
`deployments/scripts/env.sh` silently discarded an exported `CLUSTER_CONTEXT`,
because `env.sh:26` assigns unconditionally — which also made the fallback below
the source dead whenever `env.sh` exists. Reproduced as
`before=my-override after=k3d-openchoreo`; all three paths now verified (export
wins, else `env.sh`, else the literal). The same commit names both provisioning
paths in the 401 hint, which previously named neither.

Two findings knowingly not actioned:

- **`scripts/AGENTS.md` charter** — "nothing that builds or runs the platform
  itself belongs here". Fair: this is the first script in `scripts/` to call
  `kubectl`. The clean answer is a shared `deployments/scripts/secrets.sh`, which
  only earns its keep once a second caller needs it.
- **`set -euo pipefail`** like the sibling `project-rebuild.sh`. `pipefail` would
  break the token error path — `curl | sed` failing would abort before the
  actionable 401 message prints — so this stays `set -e`.

## Not in scope

- `packages/contracts/api/v1/openapi.yaml:989-1010` still describes the
  pre-ADR-0020 design ("ENTERS THE LOOP AT VALIDATION rather than at the working
  set", and the post-verdict repair as "the run loop's ordinary behaviour").
  #584 never updated it and it regenerates into
  `apps/console/src/generated/aep-api.d.ts`, so fixing it is a contract change
  plus `make gen` — separate from getting the script working.
- `scripts/project-rebuild.sh`, `deployments/scripts/seed-dev.sh` and
  `deployments/scripts/setup-aep.sh` still hardcode the same dead literal and
  401 the same way. The resolution block here is copy-pasteable when one bites.
- The deeper fix is making `setup-local.sh` and `values-thunder.yaml` agree on
  this client's secret rather than having consumers resolve it. Reading the
  authoritative Secret is the right consumer-side behaviour meanwhile.
- The bare-invocation default project will rot again, as this one did. Requiring
  the argument instead is a one-line change if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
