### PR TITLE
fix(run,gitfs,console): the feed tells the truth about time, loss and reach, and the reaper is the only repacker

### DIFF
--- a/apps/console/src/components/SectionCaption.tsx
+++ b/apps/console/src/components/SectionCaption.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ReactNode } from "react";
+import { Typography } from "@wso2/oxygen-ui";
+
+/**
+ * The all-caps rule over a GROUP of rows — "EARLIER RUNS OF V1", "EARLIER
+ * VALIDATION RUNS", "EARLIER BUILD SESSIONS IN THIS RUN".
+ *
+ * Distinct from `SectionTitle`, which names a section a reader navigates to.
+ * This names a boundary INSIDE one: everything below it is history, and the
+ * thing above it is what the page is about.
+ *
+ * Shared because four surfaces now draw it — the two Builds-page groupings, the
+ * Validation page's earlier attempts, and the build detail page's earlier
+ * delivery runs — and hand-matched copies of a rule this thin drift by a font
+ * weight without anybody noticing.
+ */
+export function SectionCaption({ children }: { children: ReactNode }) {
+  return (
+    <Typography
+      variant="caption"
+      sx={{
+        display: "block",
+        mb: 1,
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        color: "text.secondary",
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
@@ -724,6 +724,17 @@ describe("BuildDetailPage — every delivery run's agent log", () => {
     expect(feeds().map((f) => f.dataset.runNumber)).toEqual(["2", "1"]);
   });
 
+  it("numbers nothing when one run delivered the version", () => {
+    // `RunFeed` prefixes its heading whenever `runNumber` is defined, so passing
+    // 1 here would relabel the ordinary case's only box from "Cycle 1" to
+    // "Run 1 · Cycle 1" — a number that tells it apart from nothing.
+    mockBuilds = [build()];
+    mockRuns = [devRun()];
+    renderPage();
+
+    expect(feeds()[0]!.dataset.runNumber).toBe("undefined");
+  });
+
   it("lets only the newest run open a box", () => {
     // One open log on the page, not one per feed.
     mockBuilds = [build()];

--- a/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.test.tsx
@@ -62,9 +62,30 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 // The coding agent's stream is its own tested surface and needs a live run to
-// say anything; the build page only decides WHETHER to mount it.
+// say anything; the build page decides WHICH runs to mount it for, in what order,
+// and which one may open a box. Those are attributes rather than rendered text, so
+// the page's WIRING is assertable without a stream.
 vi.mock("./RunFeed", () => ({
-  RunFeed: () => <div>run feed</div>,
+  RunFeed: ({
+    runId,
+    cycleKinds,
+    expandNewest,
+    runNumber,
+  }: {
+    runId: string;
+    cycleKinds?: readonly string[];
+    expandNewest?: boolean;
+    runNumber?: number;
+  }) => (
+    <div
+      data-testid="run-feed"
+      data-run-id={runId}
+      data-expand-newest={String(expandNewest)}
+      data-run-number={String(runNumber)}
+    >
+      {(cycleKinds ?? []).join(",")}
+    </div>
+  ),
 }));
 
 let mockTasks: TaskView[] = [];
@@ -646,6 +667,128 @@ describe("BuildDetailPage — one clock for the whole page", () => {
     ];
     renderPage();
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+// A version is routinely delivered by more than one RUN — the dev run writes it, a
+// validation run finds a defect, a task run repairs it — and each is its own row with
+// its own feed. The page mounted `deliveryRuns[0]` only, so the newest run's log was
+// the only one reachable: testing9231 v1 on the live stack showed a 105-event two-file
+// fix labelled "Cycle 1" and offered no way at all to the 841-event run that wrote the
+// version. The fixtures below are that run list.
+describe("BuildDetailPage — every delivery run's agent log", () => {
+  const feeds = () => screen.getAllByTestId("run-feed");
+  const devRun = () =>
+    run({
+      id: "run-dev",
+      kind: "dev",
+      origin: "spec-build",
+      state: "succeeded",
+      cycles: [cycle({ id: "c1", prNumber: 6, mergeSha: "aaa1111" })],
+    });
+  const validationRun = () =>
+    run({
+      id: "run-validation",
+      kind: "validation",
+      origin: "revalidate",
+      state: "failed",
+      cycles: [cycle({ id: "v1", kind: "validation", prNumber: 8, mergeSha: "bbb2222" })],
+    });
+  const fixRun = () =>
+    run({
+      id: "run-fix",
+      kind: "task",
+      origin: "incident-adoption",
+      state: "succeeded",
+      cycles: [cycle({ id: "c2", prNumber: 13, mergeSha: "ccc3333" })],
+    });
+
+  it("mounts one feed per delivery run, newest first", () => {
+    mockBuilds = [build()];
+    // Newest first, the order list-build-runs answers in.
+    mockRuns = [fixRun(), validationRun(), devRun()];
+    renderPage();
+
+    expect(feeds().map((f) => f.dataset.runId)).toEqual(["run-fix", "run-dev"]);
+  });
+
+  it("numbers the runs from the OLDEST, so the numbers descend down the page", () => {
+    // Every feed numbers its own cycles from 1, so without this the page shows two
+    // boxes both called "Cycle 1". Counted over the runs this section SHOWS: the
+    // validation run has no feed here, so numbering the full list would print
+    // "Run 3" over "Run 1" with no Run 2 anywhere.
+    mockBuilds = [build()];
+    mockRuns = [fixRun(), validationRun(), devRun()];
+    renderPage();
+
+    expect(feeds().map((f) => f.dataset.runNumber)).toEqual(["2", "1"]);
+  });
+
+  it("lets only the newest run open a box", () => {
+    // One open log on the page, not one per feed.
+    mockBuilds = [build()];
+    mockRuns = [fixRun(), devRun()];
+    renderPage();
+
+    expect(feeds().map((f) => f.dataset.expandNewest)).toEqual(["true", "false"]);
+  });
+
+  it("captions the earlier runs once, above the second feed", () => {
+    mockBuilds = [build()];
+    mockRuns = [fixRun(), devRun()];
+    renderPage();
+
+    const caption = screen.getByText("EARLIER RUNS OF V2");
+    const [newest, earlier] = feeds();
+    expect(
+      newest!.compareDocumentPosition(caption) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      caption.compareDocumentPosition(earlier!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("draws no caption for a version delivered by one run", () => {
+    // The ordinary case: a caption over a single feed would be a rule with no
+    // boundary under it.
+    mockBuilds = [build()];
+    mockRuns = [devRun()];
+    renderPage();
+
+    expect(feeds()).toHaveLength(1);
+    expect(screen.queryByText(/^EARLIER RUNS OF/)).not.toBeInTheDocument();
+  });
+
+  it("shows each feed only the cycle kinds this surface owns", () => {
+    // A validation run that REPAIRS what it found is a delivery run — kept for its
+    // coding cycles — so without the filter its validation cycle would render here
+    // as well as on the Validation board, which is the disagreement `buildCycles`
+    // and `mergedCycle` already avoid everywhere else on this page.
+    mockBuilds = [build()];
+    mockRuns = [devRun()];
+    renderPage();
+
+    expect(feeds()[0]).toHaveTextContent("coding,fix,conflict");
+  });
+
+  it("leaves out a run that only re-judged the version", () => {
+    // Its verdict lives on the Validation board, which draws its own feed for it.
+    mockBuilds = [build()];
+    mockRuns = [validationRun(), devRun()];
+    renderPage();
+
+    expect(feeds().map((f) => f.dataset.runId)).toEqual(["run-dev"]);
+  });
+
+  it("says nothing was dispatched when no run delivered anything", () => {
+    mockBuilds = [build()];
+    mockRuns = [validationRun()];
+    renderPage();
+
+    expect(screen.queryAllByTestId("run-feed")).toHaveLength(0);
+    expect(
+      screen.getByText(/Nothing has been dispatched for this version yet/),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/console/src/features/builds/components/BuildDetailPage.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import {
   Alert,
   Box,
@@ -45,6 +45,7 @@ import { createLink, Link } from "@tanstack/react-router";
 import { EmptyState } from "../../../components/EmptyState";
 import { LogSection } from "../../../components/LogSection";
 import { PageHeader } from "../../../components/PageHeader";
+import { SectionCaption } from "../../../components/SectionCaption";
 import type { components } from "../../../generated/aep-api";
 import { useAllTasks } from "../../tasks/api/queries";
 import { useProjectStatus } from "../../projects/api/queries";
@@ -68,6 +69,7 @@ import {
   type RunClaims,
 } from "../lib/taskRow";
 import {
+  BUILD_CYCLE_KINDS,
   buildCycles,
   externalValuesPark,
   isAgentStreaming,
@@ -113,9 +115,24 @@ export function BuildDetailPage({
 
   const runs = useBuildRuns(projectName, tag);
   const runList = runs.data?.runs ?? [];
-  // The runs that DELIVERED this version. A run that only re-judged it has no
-  // build session to show — its verdict lives on the Validation board.
-  const current = runList.filter(isDeliveryRun)[0];
+  // The runs that DELIVERED this version, newest first (the order list-build-runs
+  // answers in). A run that only re-judged it has no build session to show — its
+  // verdict lives on the Validation board.
+  //
+  // ALL of them, not just the newest: a version is routinely delivered by more
+  // than one run — the dev run writes it, a validation run finds a defect, a task
+  // run repairs it — and each of those is a separate `milestone_runs` row with its
+  // own agent feed. Reading `[0]` mounted one feed, so the newest run's log was
+  // the only one this page could reach: on the live stack, testing9231 v1 showed a
+  // 105-event two-file FX fix labelled "Cycle 1" while the 841-event run that
+  // actually wrote the version (pull request #6, three subagents) had no surface
+  // anywhere. The recordings were never the problem — all four were intact on the
+  // volume, and `stream-run-progress` is keyed per run — the page just asked for one.
+  const deliveryRuns = runList.filter(isDeliveryRun);
+  // The run the page's own header, actions and park notice speak for: the newest,
+  // because those answer "what is happening now" and an older run answers a
+  // different question.
+  const current = deliveryRuns[0];
 
   const issues = useAllTasks(projectName, tag, { live });
   const tasks = issues.data ?? [];
@@ -298,7 +315,8 @@ export function BuildDetailPage({
                 it to be true. */}
         <AgentLogSection
           projectName={projectName}
-          runId={current?.id}
+          tag={tag}
+          runs={deliveryRuns}
           streaming={isAgentStreaming(runList) && park === null}
           runState={current?.state}
         />
@@ -602,14 +620,39 @@ function BuildActions({
   );
 }
 
+/**
+ * Every delivery run's agent log, newest first — the shape the Validation page
+ * already uses for a version judged more than once (`ValidationPage`, "EARLIER
+ * VALIDATION RUNS").
+ *
+ * A feed PER RUN rather than one version-wide stream, for the same reason that
+ * page gives: `stream-build-progress` does span a version's runs, but it emits
+ * them oldest first, and this page leads with the newest run on purpose. The cost
+ * is near nothing — a settled run's stream is finite, so the server sends `done`
+ * and closes and the client stops without reattaching, leaving at most ONE
+ * connection held open, since only the newest run can still be live.
+ *
+ * Cycles are filtered to the kinds this surface owns (`BUILD_CYCLE_KINDS`). The
+ * single feed did not filter, which was survivable while only the newest run was
+ * mounted; stacking every delivery run makes it matter, because a validation run
+ * that REPAIRS what it found is a delivery run — `isDeliveryRun` keeps it for its
+ * coding cycles — and its validation cycle would then render here as well as on
+ * the Validation board. The rest of this page already draws that line the same
+ * way: `buildCycles` and `mergedCycle` both exclude validation.
+ */
 function AgentLogSection({
   projectName,
-  runId,
+  tag,
+  runs,
   streaming,
   runState,
 }: {
   projectName: string;
-  runId: string | undefined;
+  /** Names the version in the earlier-runs caption, matching the phrasing the
+   *  Builds page's own run history uses ("EARLIER RUNS OF V1"). */
+  tag: string;
+  /** The version's delivery runs, newest first. */
+  runs: components["schemas"]["MilestoneRunView"][];
   streaming: boolean;
   /** Forwarded to `AgentLogMeta`, which is where it is explained. */
   runState: string | undefined;
@@ -619,13 +662,40 @@ function AgentLogSection({
       title="Coding agent log"
       meta={<AgentLogMeta streaming={streaming} runState={runState} />}
     >
-      {runId ? (
-        <RunFeed projectName={projectName} runId={runId} />
-      ) : (
+      {runs.length === 0 ? (
         <EmptyState
           compact
           description="Nothing has been dispatched for this version yet — the agent's log appears once a build session starts."
         />
+      ) : (
+        <Stack spacing={2}>
+          {runs.map((run, i) => (
+            <Fragment key={run.id}>
+              {/* Before the SECOND feed, so the caption separates the run being
+                  read from the runs that came before it. Never drawn for a
+                  version delivered by a single run, which is the ordinary case. */}
+              {i === 1 && (
+                <SectionCaption>
+                  EARLIER RUNS OF {tag.toUpperCase()}
+                </SectionCaption>
+              )}
+              <RunFeed
+                projectName={projectName}
+                runId={run.id}
+                cycleKinds={BUILD_CYCLE_KINDS}
+                // Counted from the OLDEST, so the numbers descend down the page
+                // in step with the cycle ordinals inside each feed. Counted over
+                // the runs this SECTION shows, not the version's whole run list:
+                // a run that only validated has no feed here, so numbering the
+                // full list would print "Run 3" over "Run 1" with no Run 2.
+                runNumber={runs.length - i}
+                // Only the newest run may open a box, so exactly one log is open
+                // on the page rather than one per feed.
+                expandNewest={i === 0}
+              />
+            </Fragment>
+          ))}
+        </Stack>
       )}
     </LogSection>
   );

--- a/apps/console/src/features/builds/components/BuildDetailPage.tsx
+++ b/apps/console/src/features/builds/components/BuildDetailPage.tsx
@@ -688,7 +688,13 @@ function AgentLogSection({
                 // the runs this SECTION shows, not the version's whole run list:
                 // a run that only validated has no feed here, so numbering the
                 // full list would print "Run 3" over "Run 1" with no Run 2.
-                runNumber={runs.length - i}
+                //
+                // OMITTED ENTIRELY for a version delivered by one run, which is
+                // the ordinary case: `RunFeed` prefixes the heading whenever the
+                // prop is defined, so passing 1 would relabel every single-run
+                // version's only box from "Cycle 1" to "Run 1 · Cycle 1" — a run
+                // number that distinguishes it from nothing.
+                {...(runs.length > 1 ? { runNumber: runs.length - i } : {})}
                 // Only the newest run may open a box, so exactly one log is open
                 // on the page rather than one per feed.
                 expandNewest={i === 0}

--- a/apps/console/src/features/builds/components/EarlierSessions.tsx
+++ b/apps/console/src/features/builds/components/EarlierSessions.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Box, Stack, Typography } from "@wso2/oxygen-ui";
+import { SectionCaption } from "../../../components/SectionCaption";
 import type { components } from "../../../generated/aep-api";
 
 type RunCycleView = components["schemas"]["RunCycleView"];
@@ -43,18 +44,7 @@ export function EarlierSessions({
 
   return (
     <Box>
-      <Typography
-        variant="caption"
-        sx={{
-          display: "block",
-          mb: 1,
-          fontWeight: 700,
-          letterSpacing: "0.08em",
-          color: "text.secondary",
-        }}
-      >
-        EARLIER BUILD SESSIONS IN THIS RUN
-      </Typography>
+      <SectionCaption>EARLIER BUILD SESSIONS IN THIS RUN</SectionCaption>
       <CycleLines cycles={cycles} />
     </Box>
   );

--- a/apps/console/src/features/builds/components/RunHistoryList.tsx
+++ b/apps/console/src/features/builds/components/RunHistoryList.tsx
@@ -27,6 +27,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { ChevronDown } from "@wso2/oxygen-ui-icons-react";
+import { SectionCaption } from "../../../components/SectionCaption";
 import { StatusChip } from "../../../components/StatusChip";
 import type { components } from "../../../generated/aep-api";
 import { runStamp } from "../lib/format";
@@ -62,18 +63,7 @@ export function RunHistoryList({
 
   return (
     <Box>
-      <Typography
-        variant="caption"
-        sx={{
-          display: "block",
-          mb: 1,
-          fontWeight: 700,
-          letterSpacing: "0.08em",
-          color: "text.secondary",
-        }}
-      >
-        EARLIER RUNS OF {tag.toUpperCase()}
-      </Typography>
+      <SectionCaption>EARLIER RUNS OF {tag.toUpperCase()}</SectionCaption>
       <Stack spacing={1}>
         {runs.map((run) => (
           <RunRow key={run.id} run={run} />

--- a/apps/console/src/features/validation/components/ValidationPage.tsx
+++ b/apps/console/src/features/validation/components/ValidationPage.tsx
@@ -23,7 +23,6 @@ import {
   Button,
   CircularProgress,
   Stack,
-  Typography,
 } from "@wso2/oxygen-ui";
 import { FileText, ScrollText, X } from "@wso2/oxygen-ui-icons-react";
 import { Link } from "@tanstack/react-router";
@@ -42,6 +41,7 @@ import { PageHeader, type PageHeaderStatus } from "../../../components/PageHeade
 import type { StatusTone } from "../../../components/StatusChip";
 import { EmptyState } from "../../../components/EmptyState";
 import { GitHubRefChip } from "../../../components/GitHubRefChip";
+import { SectionCaption } from "../../../components/SectionCaption";
 import { useProjectStatus } from "../../projects/api/queries";
 import { useBuildRuns, useCancelRun } from "../../builds/api/queries";
 import { useValidationLive } from "../hooks/useValidationLive";
@@ -84,16 +84,6 @@ const VALIDATION_CYCLE = ["validation"] as const;
 // value in the enum is a verdict, and a verdict is something the run already reached.
 const VALIDATION_LIFECYCLE_STATES = new Set(["running", "awaiting-fix"]);
 
-// Hoisted rather than written inline: an sx literal is a new object every render,
-// which emotion has to re-serialize each time.
-const CAPTION_SX = {
-  display: "block",
-  mb: 1,
-  fontWeight: 700,
-  letterSpacing: "0.08em",
-  color: "text.secondary",
-} as const;
-
 /**
  * The line over the version's earlier validation runs.
  *
@@ -101,17 +91,9 @@ const CAPTION_SX = {
  * the Builds page draws its own ("EARLIER RUNS OF V1", `RunHistoryList`). That keeps
  * the caption on a boundary this page already owns — between feeds — so no feed has
  * to know what is rendered above it.
- *
- * Local, and matching the Builds page's captions by hand: three copies of this markup
- * now exist, and they should collapse into a shared component once a fourth caller
- * appears rather than dragging two Builds-page files into a validation change.
  */
 function EarlierRunsCaption() {
-  return (
-    <Typography variant="caption" sx={CAPTION_SX}>
-      EARLIER VALIDATION RUNS
-    </Typography>
-  );
+  return <SectionCaption>EARLIER VALIDATION RUNS</SectionCaption>;
 }
 
 // StageTone → StatusTone. The two unions differ only in `ghost`, which the shared

--- a/packages/progress-view/src/crew.ts
+++ b/packages/progress-view/src/crew.ts
@@ -278,11 +278,42 @@ function statusFromOutcome(outcome: string): string {
   return "completed";
 }
 
-/** Epoch ms of an event's producer timestamp, or undefined if it carried none. */
+/**
+ * The earliest instant an event of this platform can honestly claim.
+ *
+ * A MISSING time dressed as a date is the shape this exists for, and every
+ * language spells it: Go's `time.Time{}` marshals as `0001-01-01T00:00:00Z`, a
+ * zero epoch is 1970, .NET's `DateTime.MinValue` is Go's again. Each is
+ * perfectly well-formed, so `Date.parse` accepts it and the subtraction below
+ * turns it into a duration in millennia. That happened live (2026-09-09): a
+ * platform notice narrating the dark zone left its `ts` at Go's zero value, and
+ * because that notice belongs to the lead, the lead's age column read
+ * `1065409035m47s` — 2026 years — next to a heartbeat line that was correct.
+ *
+ * The floor is deliberately far below any run and far above every zero value,
+ * so it can exclude no real event: this platform did not exist in 2019, and
+ * nothing that ran on it can be stamped before then. An event under it
+ * therefore carries no clock at all, which is a case the model already has an
+ * answer for — no lane, no age, and a row all the same.
+ */
+const EARLIEST_EVENT_MS = Date.parse("2020-01-01T00:00:00Z");
+
+/**
+ * Epoch ms of an event's producer timestamp, or undefined if it carried none
+ * the model may believe.
+ *
+ * The one door every clock in this file comes through, which is why the
+ * plausibility rule lives here rather than beside each reading: the same stamp
+ * feeds the age column, the silence, the lane and the axis both lanes and the
+ * timeline are drawn against, and one implausible instant at the head of a
+ * recording used to stretch that axis over two millennia — drawing every real
+ * lane as a hairline.
+ */
 function timeOf(e: RunEventView): number | undefined {
   if (!e.ts) return undefined;
   const ms = Date.parse(e.ts);
-  return Number.isNaN(ms) ? undefined : ms;
+  if (Number.isNaN(ms) || ms < EARLIEST_EVENT_MS) return undefined;
+  return ms;
 }
 
 /** What one agent's events say about its timing, its silence and its tasks. */

--- a/packages/progress-view/src/event.ts
+++ b/packages/progress-view/src/event.ts
@@ -166,7 +166,12 @@ const NOTICE_LABELS: Record<string, string> = {
   permission_denied: "a tool call was denied",
   terminated: "the run was terminated from outside",
   workspace_guard: "a write outside the workspace was denied",
-  gap: "events were lost from this feed",
+  // Deliberately "missing" and not "lost": the platform raises this code the
+  // moment it notices a hole, with the pod still running and the recorder about
+  // to ask for that stretch of log again. Whether the events are GONE is the
+  // producer's to say in `detail` — "not captured yet" while they can still be
+  // fetched, "nothing can recover it now" once the recording closes short.
+  gap: "events are missing from this feed",
   artifact_failed: "an artifact could not be stored",
   ...LIFECYCLE_LABELS,
 };

--- a/packages/progress-view/test/crew.test.ts
+++ b/packages/progress-view/test/crew.test.ts
@@ -242,6 +242,52 @@ test("crew: an agent nothing timestamped gets no lane and no age, and still gets
   assert.deepEqual(crew.window, { startMs: 0, endMs: 0 });
 });
 
+test("crew: a zero-value date is absent data and never an instant", () => {
+  // The first line is VERBATIM what aep-api put on a live console feed: a
+  // platform notice narrating the dark zone, whose `ts` was left at Go's zero
+  // value and marshalled into a perfectly well-formed date. The lead's age
+  // column read `1065409035m47s` — 2026 years, the interval from Go's zero
+  // time to the afternoon someone was watching — beside a heartbeat line that
+  // was correct, because that one reads an elapsed the producer measured.
+  const now = Date.parse("2026-09-09T09:15:47Z");
+  const startedAt = Date.parse("2026-09-09T09:00:00Z");
+  const crew = buildCrew(
+    [
+      { kind: "notice", agentId: "lead", seq: -11, code: "runner_pulling_image", ts: "0001-01-01T00:00:00Z" },
+      { kind: "run_started", agentId: "lead", seq: 1, ts: "2026-09-09T09:00:00Z" },
+      { kind: "heartbeat", agentId: "lead", seq: 2, waitingOn: "model", elapsedMs: 13_000, ts: "2026-09-09T09:15:34Z" },
+    ],
+    now,
+  );
+  // The age is measured from the first instant the run can be shown to have
+  // reached — never from a stamp that predates the platform.
+  assert.equal(crew.lead.elapsedMs, now - startedAt);
+  // And the axis both lanes and the timeline are drawn against stays inside the
+  // run: a zero-value date at the head of a recording used to stretch it over
+  // two millennia — the timeline read "1065409043m56s across 3 agents" and drew
+  // the lead across the whole width, with every real agent a sliver.
+  assert.deepEqual(crew.window, { startMs: startedAt, endMs: now });
+  assert.equal(crew.lead.spans[0]?.startMs, startedAt);
+});
+
+test("crew: a row whose only stamp is a zero-value date shows no age at all", () => {
+  // Same rule as an agent nothing timestamped: the surface falls back to no age
+  // rather than inventing one. A date it cannot believe is not better evidence
+  // than no date, and a number a reader trusts is worse than a blank.
+  const crew = buildCrew(
+    [
+      { kind: "agent_started", agentId: "a1", label: "zero-stamped", depth: 1 },
+      { kind: "notice", agentId: "a1", detail: "npm notice", ts: "0001-01-01T00:00:00Z" },
+    ],
+    Date.parse("2026-09-09T09:15:47Z"),
+  );
+  const member = memberOf(crew, "a1");
+  assert.equal(member.elapsedMs, undefined);
+  assert.equal(member.silentForMs, undefined);
+  assert.deepEqual(member.spans, []);
+  assert.equal(member.agent.label, "zero-stamped");
+});
+
 // --- liveness: the amber rule ------------------------------------------------
 
 test("crew: the amber rule fires at exactly 60s of silence with a call unanswered", () => {

--- a/services/aep-api/internal/delivery/codingagent/cycle_log_source.go
+++ b/services/aep-api/internal/delivery/codingagent/cycle_log_source.go
@@ -46,20 +46,52 @@ const logPageBytes = 64 * 1024
 // OCLogSource reads a cycle pod's log through the OpenChoreo API.
 type OCLogSource struct {
 	runtime openchoreo.RuntimeClient
+
+	// now is the clock the absolute read window is converted against. A field
+	// only so a test can prove the conversion happens LATE — see sinceSecondsAt.
+	now func() time.Time
 }
 
 // NewOCLogSource wires the live source.
 func NewOCLogSource(runtime openchoreo.RuntimeClient) *OCLogSource {
-	return &OCLogSource{runtime: runtime}
+	return &OCLogSource{runtime: runtime, now: time.Now}
 }
 
 // Tail reads at most maxBytes of the newest pod output for a cycle Component.
+// It asks for the WHOLE log the platform still holds and cuts bytes off the end
+// of it, which is a viewer's bargain: fresh content now, and whatever scrolled
+// off comes back on the next poll.
 func (s *OCLogSource) Tail(ctx context.Context, orgName, projectName, componentName string, maxBytes int) (LiveTail, error) {
-	return s.read(ctx, orgName, projectName, componentName, 0, maxBytes)
+	binding, err := s.Binding(ctx, orgName, projectName, componentName)
+	if err != nil {
+		return LiveTail{}, err
+	}
+	return s.read(ctx, orgName, binding, time.Time{}, maxBytes)
 }
 
-// ReadSince is the RECORDER's read: everything the pod logged in the last
-// sinceSeconds (0 = the whole log), with NO byte cut.
+// Binding resolves a cycle Component's release binding in the run environment.
+//
+// It is a separate call because the answer is FIXED for the attempt, and the
+// recorder polls once a second: resolving it on every read spent a whole
+// OpenChoreo round trip re-deriving a constant, and — worse — spent it BETWEEN
+// the moment the recorder chose its read window and the moment the log API
+// applied one, which is how a slow list came to cost a run its events.
+func (s *OCLogSource) Binding(ctx context.Context, orgName, projectName, componentName string) (string, error) {
+	if s == nil || s.runtime == nil {
+		return "", fmt.Errorf("codingagent: live log source not configured")
+	}
+	binding, err := s.runtime.ReleaseBindingName(ctx, orgName, projectName, componentName, openchoreo.DevEnvironmentName)
+	if err != nil {
+		if errors.Is(err, openchoreo.ErrNotFound) {
+			return "", fmt.Errorf("%w: %s", ErrComponentGone, componentName)
+		}
+		return "", fmt.Errorf("codingagent: resolve release binding for %s: %w", componentName, err)
+	}
+	return binding, nil
+}
+
+// ReadSince is the RECORDER's read: everything the pod logged at or after an
+// ABSOLUTE instant (the zero time = the whole log), with NO byte cut.
 //
 // The cut is what Tail exists for and what a recorder must never do. A viewer
 // that loses old bytes re-reads them next poll; a recorder that loses them
@@ -67,37 +99,32 @@ func (s *OCLogSource) Tail(ctx context.Context, orgName, projectName, componentN
 // burst larger than 64KiB between two polls" failure the recording closes.
 // The time cursor replaces the byte window: the recorder asks for what it has
 // not seen, and dedupes what overlaps by seq.
-func (s *OCLogSource) ReadSince(ctx context.Context, orgName, projectName, componentName string, sinceSeconds int64) (LiveTail, error) {
-	return s.read(ctx, orgName, projectName, componentName, sinceSeconds, 0)
+func (s *OCLogSource) ReadSince(ctx context.Context, orgName, releaseBindingName string, since time.Time) (LiveTail, error) {
+	return s.read(ctx, orgName, releaseBindingName, since, 0)
 }
 
-// read resolves the binding, snapshots the pod and renders its log. maxBytes
-// <= 0 keeps the whole page (the recorder); a positive value keeps the newest
-// bytes (a viewer's page).
-func (s *OCLogSource) read(ctx context.Context, orgName, projectName, componentName string, sinceSeconds int64, maxBytes int) (LiveTail, error) {
+// read snapshots the pod and renders its log. maxBytes <= 0 keeps the whole
+// page (the recorder); a positive value keeps the newest bytes (a viewer's
+// page).
+func (s *OCLogSource) read(ctx context.Context, orgName, releaseBindingName string, since time.Time, maxBytes int) (LiveTail, error) {
 	if s == nil || s.runtime == nil {
 		return LiveTail{}, fmt.Errorf("codingagent: live log source not configured")
 	}
-	binding, err := s.runtime.ReleaseBindingName(ctx, orgName, projectName, componentName, openchoreo.DevEnvironmentName)
+	pod, err := s.runtime.PodSnapshot(ctx, orgName, releaseBindingName)
 	if err != nil {
 		if errors.Is(err, openchoreo.ErrNotFound) {
-			return LiveTail{}, fmt.Errorf("%w: %s", ErrComponentGone, componentName)
+			return LiveTail{}, fmt.Errorf("%w: %s", ErrComponentGone, releaseBindingName)
 		}
-		return LiveTail{}, fmt.Errorf("codingagent: resolve release binding for %s: %w", componentName, err)
-	}
-	pod, err := s.runtime.PodSnapshot(ctx, orgName, binding)
-	if err != nil {
-		if errors.Is(err, openchoreo.ErrNotFound) {
-			return LiveTail{}, fmt.Errorf("%w: %s", ErrComponentGone, componentName)
-		}
-		return LiveTail{}, fmt.Errorf("codingagent: read resource tree for %s: %w", componentName, err)
+		return LiveTail{}, fmt.Errorf("codingagent: read resource tree for %s: %w", releaseBindingName, err)
 	}
 	if !pod.Found {
 		// The Job is applied but nothing is scheduled yet. The caller narrates
 		// the dark zone from the pod state; there is no text to read.
 		return LiveTail{Pod: pod}, nil
 	}
-	lines, err := s.runtime.PodLogs(ctx, orgName, binding, pod.Name, sinceSeconds)
+	// The coarse window is computed HERE, in the breath before the call that
+	// uses it, and nowhere earlier. See sinceSecondsAt.
+	lines, err := s.runtime.PodLogs(ctx, orgName, releaseBindingName, pod.Name, sinceSecondsAt(since, s.clock()))
 	if err != nil {
 		if errors.Is(err, openchoreo.ErrNotFound) {
 			// The binding is there but the pod's log is not — a container that
@@ -107,6 +134,44 @@ func (s *OCLogSource) read(ctx context.Context, orgName, projectName, componentN
 		return LiveTail{}, fmt.Errorf("codingagent: read pod log for %s: %w", pod.Name, err)
 	}
 	return LiveTail{Text: tailText(lines, maxBytes), Pod: pod}, nil
+}
+
+// clock reads the source's clock, tolerating a zero-value OCLogSource.
+func (s *OCLogSource) clock() time.Time {
+	if s.now == nil {
+		return time.Now()
+	}
+	return s.now()
+}
+
+// sinceSecondsAt turns an absolute window start into the `sinceSeconds` the
+// OpenChoreo log API takes — a count of seconds BACK FROM WHENEVER THE API READS
+// IT, which is why this conversion may not be done early.
+//
+// A measured run lost three bursts of events to exactly that. The recorder
+// computed `sinceSeconds` and then made three sequential OpenChoreo calls before
+// the log call consumed it; the worst poll spent 6.4 s in front of a 5-second
+// window, so the window it asked for began 1.4 s AFTER the last line anybody had
+// read, and the two events in between were never asked for again by anything.
+// Converting in the breath before the call means in-flight latency can only ever
+// make the window WIDER than needed, and a wider window costs a re-read that
+// dedupe throws away.
+//
+// The seconds are rounded UP (the +1) for the same reason: a truncating divide
+// would ask for a window that starts a fraction of a second late, and the line
+// sitting in that fraction would be gone for good.
+func sinceSecondsAt(since, now time.Time) int64 {
+	if since.IsZero() {
+		return 0 // the whole log
+	}
+	back := now.Sub(since)
+	if back < 0 {
+		// A window start in the future: nothing sane asks for this, and asking
+		// the API for the smallest window it has is safer than asking for none
+		// (0 means "everything", which on a long run is a needless full re-read).
+		return 1
+	}
+	return int64(back/time.Second) + 1
 }
 
 // tailText renders log lines in the `timestamps=true` shape the progress parser

--- a/services/aep-api/internal/delivery/codingagent/cycle_log_source_test.go
+++ b/services/aep-api/internal/delivery/codingagent/cycle_log_source_test.go
@@ -96,3 +96,57 @@ func TestOCLogSource_UnscheduledPodIsEmptyNotAnError(t *testing.T) {
 		t.Fatalf("unexpected tail: %+v", got)
 	}
 }
+
+// TestOCLogSource_TheLogWindowIsConvertedAfterTheCallsInFrontOfIt is the eleven
+// lost events, pinned at the line where they were lost.
+//
+// `sinceSeconds` counts back from whenever the API reads it, so a value computed
+// earlier describes a window that has since slid forward. The recorder used to
+// compute one and then make its way through a release-binding list and a
+// resource tree before the log call consumed it; the worst measured poll spent
+// 6.4 s doing that, which moved a 5-second window's START past the last line
+// anybody had read. Nothing asked for the two events in between ever again.
+//
+// The window handed in here is an ABSOLUTE instant, and the conversion happens
+// in the breath before the call — so latency in front of the call can only make
+// the window wider, and a wider window costs a re-read that dedupe throws away.
+func TestOCLogSource_TheLogWindowIsConvertedAfterTheCallsInFrontOfIt(t *testing.T) {
+	clock := newFakeClock(time.Date(2026, 9, 8, 9, 29, 41, 800000000, time.UTC))
+	rt := &fakeRuntime{
+		pod:   openchoreo.RuntimePod{Found: true, Name: "p1", Phase: "Running"},
+		logs:  []openchoreo.PodLogLine{{Timestamp: time.Date(2026, 9, 8, 9, 29, 44, 0, time.UTC), Log: "line"}},
+		delay: func() { clock.advance(6400 * time.Millisecond) }, // the measured resource-tree read
+	}
+	src := NewOCLogSource(rt)
+	src.now = clock.now
+
+	// The last line the recorder had read, from the run's own log.
+	since := time.Date(2026, 9, 8, 9, 29, 34, 294000000, time.UTC)
+	if _, err := src.ReadSince(context.Background(), "acme", "rb-dev", since); err != nil {
+		t.Fatalf("ReadSince: %v", err)
+	}
+	// 09:29:34.294 is 13.9 s before the instant the log call was actually made
+	// (09:29:48.2), so the honest ask is 14. Converted when the window was
+	// CHOSEN it would have been 8 — and the two events at 09:29:41.3 fell in the
+	// six seconds of difference.
+	if rt.logSince != 14 {
+		t.Errorf("sinceSeconds = %d, want 14 — the window must be measured at the call, not before it", rt.logSince)
+	}
+}
+
+// TestOCLogSource_TailStillAsksForTheWholeLog pins the viewer's semantics, which
+// this change deliberately leaves alone: Tail asks for everything the platform
+// holds and cuts BYTES off the end of it, because a viewer that loses old bytes
+// gets them back on the next poll.
+func TestOCLogSource_TailStillAsksForTheWholeLog(t *testing.T) {
+	rt := &fakeRuntime{
+		pod:  openchoreo.RuntimePod{Found: true, Name: "p1", Phase: "Running"},
+		logs: []openchoreo.PodLogLine{{Timestamp: time.Date(2026, 9, 8, 9, 29, 44, 0, time.UTC), Log: "line"}},
+	}
+	if _, err := NewOCLogSource(rt).Tail(context.Background(), "acme", "shop", "ca-abc", logPageBytes); err != nil {
+		t.Fatalf("Tail: %v", err)
+	}
+	if rt.logSince != 0 {
+		t.Errorf("sinceSeconds = %d, want 0 (the whole log)", rt.logSince)
+	}
+}

--- a/services/aep-api/internal/delivery/codingagent/design/cycle-status-and-logs.md
+++ b/services/aep-api/internal/delivery/codingagent/design/cycle-status-and-logs.md
@@ -41,7 +41,7 @@ viewer then reads.
 
 | Loss | Old mechanism | The recorder's answer |
 |---|---|---|
-| a burst larger than one page between two polls | the read kept the last 64 KiB (`logPageBytes`) | reads with the client's `sinceSeconds` cursor and **no byte cut**; dedupes by `seq` |
+| a burst larger than one page between two polls | the read kept the last 64 KiB (`logPageBytes`) | reads with a time cursor and **no byte cut**; dedupes by `seq` |
 | a finished run's history was its newest 200 events | the archive read, capped at `legacyProgressLimit` | viewers read the recording, never the pod or the archive — **the window is gone** |
 | the pod exited between two polls | nothing read after the last tick | a terminal pod phase triggers **one final full read** |
 | cancel deletes the Component, so its log is unreadable from that instant | nothing | the recording closes with a runner-less `run_settled {outcome: cancelled}`, state `gaps` |
@@ -59,6 +59,33 @@ OpenChoreo log API still serves the pod while the Component exists), and closes
 the recording `complete` — or `gaps` if anything was known lost. A process
 restart leaves it OPEN: a restart re-`Begin`s the same attempt and resumes from
 the cursor persisted in `state.json`, so nothing is written twice.
+
+### The read window is measured from the DATA, and every poll is bounded
+
+Each incremental read asks from an **absolute instant**: the pod-clock timestamp
+of the newest line already ingested (`cursor.lastLineTs`), less a 3 s overlap for
+the log API's whole-second granularity. The recorder's binding name is resolved
+**once per session** — it is fixed for the attempt — and re-resolved only when a
+read reports it gone, and the absolute instant is converted into the API's coarse
+`sinceSeconds` **in the breath before the log call**, never earlier.
+
+All three are one measured fix. The window used to be measured from the
+platform's own clock, stamped when the previous read RETURNED, and converted
+before three sequential OpenChoreo round trips (binding list → resource tree →
+pod logs) consumed it. Both halves assert something untrue: that the answer
+described the instant the call returned, and that no time passes between choosing
+a window and applying one. One `logs` handler took 13.22 s and one poll spent
+6.4 s in front of a 5-second window, so three times in one run the next window
+began AFTER lines the recorder had never read — and because the cursor only ever
+moves forward, nothing asked for them again. Anchored on the data, a 13-second
+stall makes the next window 13 seconds wider, which costs a re-read that dedupe
+throws away.
+
+Each poll's OpenChoreo calls carry a **30 s deadline** (the client has none of
+its own, so a hung call used to block the session loop silently, leaving a
+recording that simply stopped growing and not one warning to say why). A poll
+that fails leaves the cursor where it was, so the next one asks for the same
+window — widened by however long the failure took.
 
 The runner makes **no network call** for any of this. Its stdout is still the
 one transport, which is what keeps a runner that cannot reach the platform from
@@ -85,7 +112,11 @@ more is coming.
 counts, and the recorder's own cursor. `events` counts ROWS across attempts while
 `cursor.lastSeq` is one attempt's highest position, so the two need not be equal
 — the dark-zone markers are counted and hold no position. What they must never
-do is disagree about whether an event exists. The state machine:
+do is disagree about whether an event exists. The cursor holds the producer seq
+and the two pod-clock timestamps a resumed session needs: `proseTs` (the last
+seq-LESS line recorded, which is how those are deduped) and `lastLineTs` (the
+newest line of ANY kind ingested, which is what the next read window is measured
+from). The state machine:
 
 ```text
 (no directory) ─── none
@@ -116,12 +147,30 @@ reading recorded seqs report a missing event between every pair. A seq-less line
 to fd 1, a crash tail) has no producer numbering at all, so its cursor is the
 kubelet's own monotonic timestamp.
 
-A detected gap tries the observability archive first (**its only remaining
-job**: it indexed the same pod's output all along, so a burst the platform's own
-read missed may still be there). What cannot be recovered becomes a
-`notice {code: gap}` written INTO the recording at the point the events went
-missing — a reader has to be able to see WHERE the hole is — and the recording
-is marked `gaps`.
+A detected gap is repaired from two sources, in order: the **live pod**, re-read
+with an explicit window reaching back to the last line ingested (while the
+Component exists its whole log is still served — the incident that motivated this
+was diagnosed by fetching a complete `1..478` after the fact, so a hole in the
+recording is usually a hole in what the platform ASKED FOR), and then the
+**observability archive** for what the pod can no longer give back — a stretch
+the kubelet has rotated away, or a Component already deleted. That is the
+archive's **only remaining job**. At most one repair per page, and a source that
+errors or answers empty is logged at WARN: the incident left no trace at all
+because the only log line on this path sat after an early return that both cases
+took.
+
+What is still missing becomes a `notice {code: gap}` written INTO the recording
+at the point the events went missing — a reader has to be able to see WHERE the
+hole is — and the recording is marked `gaps`.
+
+The notice is worded **by recoverability**, because the wording is a claim the
+platform has to be able to stand behind. Mid-run it says *"… N event(s) of this
+run have not been captured yet"*: the pod is running, its log is readable, and
+the recorder is about to ask for that stretch again. The unrecoverable sentence
+belongs to the one moment it is true — the recording closing as `gaps`, which
+writes a final row saying nothing can recover it now. `@aep/progress-view` owns
+the label for `code: gap` ("events are missing from this feed") and the producer
+owns the specifics; neither may assert a loss the other has not established.
 
 The **dark zone** (pod scheduling, image pull, container boot) is recorded too,
 one row per state rather than one per poll: a viewer that reads only the file
@@ -266,13 +315,23 @@ event exactly as the runner did, right up to the first seq-less line.
 
 Everything the platform itself puts on a feed — the dark zone (pod scheduling,
 image pull, container boot), a truncation, a lost log — is a `notice` on the
-lead, on a STABLE NEGATIVE seq, with NO timestamp:
+lead, on a STABLE NEGATIVE seq, stamped with the instant the platform derived it:
 
 - the negative seq is the marker's id: a client dedups on `(cycle, attempt, seq)`
   and a producer's seqs are positive, so the same state re-derived every 2s
   collapses to one row and a state TRANSITION shows exactly one new row;
-- the zero timestamp keeps a marker from advancing a reader's cursor past output
-  nobody has seen;
+- the timestamp is a REAL instant, passed in by whoever derived the marker — the
+  read that observed the pod, or the clock of the line that revealed a gap. These
+  markers once carried none, on the reasoning that ordering is `seq`'s job (it
+  is) so a marker needs no clock of its own. But `ts` is required by the contract
+  and generates as a `time.Time`, so "none" was never what went on the wire:
+  Go's zero value marshalled as `0001-01-01T00:00:00Z`, and because these
+  notices belong to the LEAD and the dark-zone one heads very nearly every
+  recording, a console subtracting it from its clock showed the lead agent 2026
+  years old and drew its timeline lane across the whole axis. A field a producer
+  cannot fill honestly has to be absent; this one cannot be absent, so it is
+  filled honestly. (`@aep/progress-view` refuses an implausible instant too — a
+  recording written before this fix still holds zero-stamped markers.)
 - `agentId: lead` because the field is required and any other value names a
   SPAWNED agent under the contract — a made-up id would have a console open a row
   for an agent that does not exist.

--- a/services/aep-api/internal/delivery/codingagent/ports.go
+++ b/services/aep-api/internal/delivery/codingagent/ports.go
@@ -176,19 +176,38 @@ type LiveLogSource interface {
 }
 
 // RecordingLogSource is the same pod log read for the RECORDER rather than for
-// a viewer, and the two differences are the whole point of a separate port.
+// a viewer, and three differences are the whole point of a separate port.
 //
-// It reads with a TIME cursor (sinceSeconds; 0 = everything the platform still
-// holds) instead of a byte window, and it applies NO byte cut. LiveLogSource
-// keeps the newest 64KiB because a viewer wants fresh content and re-reads two
-// seconds later; that same cut silently DROPPED a burst larger than 64KiB
-// between two polls, which is one of the five losses the recording exists to
-// close. A recorder that cut bytes would write the loss into the file, where it
-// can never be recovered.
+// It reads with a TIME cursor instead of a byte window, and it applies NO byte
+// cut. LiveLogSource keeps the newest 64KiB because a viewer wants fresh content
+// and re-reads two seconds later; that same cut silently DROPPED a burst larger
+// than 64KiB between two polls, which is one of the five losses the recording
+// exists to close. A recorder that cut bytes would write the loss into the file,
+// where it can never be recovered.
+//
+// The cursor is an ABSOLUTE INSTANT, not the OpenChoreo API's coarse
+// `sinceSeconds`. That is a measured fix, not a tidy-up: the recorder used to
+// compute `sinceSeconds` and then spend three sequential OpenChoreo round trips
+// getting to the log call, so a slow binding list or resource tree moved the
+// window's START past lines nobody had read — a permanent hole, since the cursor
+// only ever moves forward. Handing over an instant makes the conversion the
+// source's job, done in the breath before the log call, and no latency in front
+// of it can eat the window.
+//
+// The BINDING is resolved separately and by the caller, because it is FIXED for
+// the attempt: a session resolves it once and re-resolves only when a read says
+// it is gone, which takes a whole round trip out of every poll.
 //
 // Satisfied by *OCLogSource.
 type RecordingLogSource interface {
-	ReadSince(ctx context.Context, orgName, projectName, componentName string, sinceSeconds int64) (LiveTail, error)
+	// Binding resolves the cycle Component's release binding in the run
+	// environment. A wrapped ErrComponentGone means the Component (or its
+	// binding) has been deleted, which is a fact about the world.
+	Binding(ctx context.Context, orgName, projectName, componentName string) (string, error)
+
+	// ReadSince reads everything the pod logged at or after `since` (the zero
+	// time = the whole log the platform still holds), with no byte cut.
+	ReadSince(ctx context.Context, orgName, releaseBindingName string, since time.Time) (LiveTail, error)
 }
 
 // ArchiveScope names one cycle's archived log: its component, and the window

--- a/services/aep-api/internal/delivery/codingagent/run_events.go
+++ b/services/aep-api/internal/delivery/codingagent/run_events.go
@@ -47,6 +47,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
 	"github.com/wso2/aep/aep-api/internal/gen"
@@ -85,7 +86,7 @@ func (r *AgentProgressReader) CycleEvents(_ context.Context, cycle *delivery.Run
 		// The directory is there and the events are not: the platform HAD a record
 		// and cannot serve it. An empty feed would read as an agent that said
 		// nothing, which is the opposite fact.
-		return []gen.RunEvent{logsUnavailableRunEvent("the recording could not be read")}, cycle.Attempts, cursor, nil
+		return []gen.RunEvent{logsUnavailableRunEvent(time.Now(), "the recording could not be read")}, cycle.Attempts, cursor, nil
 	}
 
 	attempt, offset := parseFeedCursor(cursor)
@@ -96,7 +97,7 @@ func (r *AgentProgressReader) CycleEvents(_ context.Context, cycle *delivery.Run
 		events, next, err := r.recordings.ReadFrom(cycle.OrgID, cycle.ID, attempt, offset)
 		switch {
 		case errors.Is(err, ErrNoRecording):
-			return []gen.RunEvent{logsUnavailableRunEvent("the recording could not be read")}, attempt, cursor, nil
+			return []gen.RunEvent{logsUnavailableRunEvent(time.Now(), "the recording could not be read")}, attempt, cursor, nil
 		case err != nil:
 			return nil, attempt, cursor, fmt.Errorf("read cycle recording: %w", err)
 		}
@@ -187,22 +188,41 @@ func nextAttempt(attempts []int, attempt int) (int, bool) {
 //     on (cycle, attempt, seq) and a producer's seqs are positive, so the same
 //     state re-derived every tick collapses to one row and a state TRANSITION
 //     shows exactly one new row;
-//   - the ZERO timestamp: these are transient markers, not wall-clock log lines.
-//     A recorded marker (the recorder writes the dark zone into the file) is
-//     ordered by its position in the file, so it needs no clock of its own;
+//   - `at`, the instant the platform DERIVED this marker, passed in by the
+//     caller that derived it — see below;
 //   - `agentId: lead`. The field is required and there is no honest third value:
 //     any id other than `lead` names a SPAWNED agent under the contract, so a
 //     made-up one would make a console open a row for an agent that does not
 //     exist.
 //
+// `at` is a parameter and not a `time.Now()` in here because the caller always
+// knows a truer instant than this function could read: the recorder stamps the
+// read that observed the pod, and a gap takes the clock of the line that
+// revealed it, which stays exact even when the page is a backfill read minutes
+// later.
+//
+// IT MUST BE A REAL INSTANT. These markers used to carry no timestamp at all, on
+// the reasoning that a recorded marker is ordered by its position in the file
+// and needs no clock of its own — and ordering is indeed `seq`'s job, the
+// contract says so. But `RunEvent.ts` is required and generates as a
+// `time.Time`, so "no timestamp" was never on the wire: Go's zero value
+// marshalled as `0001-01-01T00:00:00Z`, a well-formed date no consumer can tell
+// from a real one. Because these notices belong to the lead, and the dark-zone
+// one sits at the head of very nearly every recording, a console subtracting it
+// from the clock showed the lead agent as 2026 years old (`1065409035m47s`)
+// while its two children read `2m45s` and `2m25s`, and drew the lead's timeline
+// lane across the whole axis. A field a producer cannot honestly fill has to be
+// absent; this one cannot be absent, so it is filled honestly.
+//
 // Notices the RECORDER writes at a point in the run (a gap, the size cap) break
 // the negative-seq rule on purpose: they are one-time facts about a position in
 // the feed rather than a state re-derived every poll, so they take the next free
 // positive seq and stay where they happened.
-func platformNotice(seq int64, level gen.RunEventLevel, detail string) gen.RunEvent {
+func platformNotice(at time.Time, seq int64, level gen.RunEventLevel, detail string) gen.RunEvent {
 	return gen.RunEvent{
 		V:       gen.RunEventV2,
 		Seq:     seq,
+		TS:      at.UTC(),
 		Kind:    gen.RunEventKindNotice,
 		AgentID: leadAgentID,
 		Level:   level,
@@ -215,12 +235,12 @@ func platformNotice(seq int64, level gen.RunEventLevel, detail string) gen.RunEv
 // losing events, which is exactly what has happened: an empty feed and a lost
 // one look identical to a reader and mean opposite things about the agent, so
 // the platform never lets "gone" render as "silent".
-func logsUnavailableRunEvent(reason string) gen.RunEvent {
+func logsUnavailableRunEvent(at time.Time, reason string) gen.RunEvent {
 	detail := "The recording of this cycle is no longer available."
 	if reason != "" {
 		detail += " (" + reason + ")"
 	}
-	ev := platformNotice(seqLogsUnavailable, gen.RunEventLevelWarn, detail)
+	ev := platformNotice(at, seqLogsUnavailable, gen.RunEventLevelWarn, detail)
 	ev.Code = gen.RunEventCodeGap
 	return ev
 }
@@ -249,13 +269,13 @@ func logsUnavailableRunEvent(reason string) gen.RunEvent {
 // them: a viewer that reads only the file would otherwise see nothing at all
 // until the runner's first line, which is the very silence this narration
 // exists to fill.
-func bootstrapRunEvent(podFound bool, phase, waitingReason, message string) gen.RunEvent {
+func bootstrapRunEvent(at time.Time, podFound bool, phase, waitingReason, message string) gen.RunEvent {
 	st := bootstrapState(podFound, phase, waitingReason, message)
 	level := gen.RunEventLevelInfo
 	if st.alarming {
 		level = gen.RunEventLevelWarn
 	}
-	ev := platformNotice(st.seq, level, st.detail)
+	ev := platformNotice(at, st.seq, level, st.detail)
 	if code := gen.RunEventCode(st.name); code.Valid() {
 		ev.Code = code
 	}

--- a/services/aep-api/internal/delivery/codingagent/run_events_test.go
+++ b/services/aep-api/internal/delivery/codingagent/run_events_test.go
@@ -18,10 +18,12 @@ package codingagent
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wso2/aep/aep-api/internal/gen"
 	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
@@ -51,9 +53,10 @@ func TestBootstrapRunEventNarratesTheDarkZone(t *testing.T) {
 		{"no capacity", true, "Pending", "Unschedulable", "0/3 nodes are available: Too many pods.", seqBootUnschedulable, gen.RunEventCodeRunnerUnschedulable, gen.RunEventLevelWarn},
 		{"booting", true, "Running", "", "", seqBootStarting, gen.RunEventCodeRunnerStarting, gen.RunEventLevelInfo},
 	}
+	observedAt := time.Date(2026, 9, 9, 9, 15, 47, 0, time.UTC)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ev := bootstrapRunEvent(tc.podFound, tc.phase, tc.reason, tc.message)
+			ev := bootstrapRunEvent(observedAt, tc.podFound, tc.phase, tc.reason, tc.message)
 			if ev.Kind != gen.RunEventKindNotice || ev.AgentID != leadAgentID {
 				t.Errorf("dark-zone event = %+v, want a notice on the lead", ev)
 			}
@@ -69,8 +72,54 @@ func TestBootstrapRunEventNarratesTheDarkZone(t *testing.T) {
 			if ev.Level != tc.wantLevel {
 				t.Errorf("level = %q, want %q", ev.Level, tc.wantLevel)
 			}
-			if !ev.TS.IsZero() {
-				t.Errorf("dark-zone notice carries a clock (%s) — it would advance a reader past unseen output", ev.TS)
+			if !ev.TS.Equal(observedAt) {
+				t.Errorf("ts = %s, want the instant the platform read the pod (%s) — see TestPlatformNoticeCarriesARealInstant", ev.TS, observedAt)
+			}
+		})
+	}
+}
+
+// TestPlatformNoticeCarriesARealInstant pins the ONE fact every platform-minted
+// event on this feed has to get right, and it is pinned on the WIRE FORM because
+// that is where it went wrong.
+//
+// `RunEvent.ts` is required by the contract and generates as a `time.Time`, so a
+// notice built without one does not omit the field: it marshals Go's zero value
+// into `0001-01-01T00:00:00Z`, a perfectly well-formed date that no consumer can
+// tell from a real one. A console did exactly what it should with it and
+// subtracted it from the clock, and because these notices belong to the lead,
+// the lead's age column read `1065409035m47s` — the 2026 years from Go's zero
+// time to the afternoon someone was watching a live run.
+//
+// So: a real instant, or the field would have to be absent, and the contract
+// does not allow absent. The platform is the producer of these events and it
+// knows when it derived each one, which makes the real instant the honest answer
+// rather than merely the safe one.
+func TestPlatformNoticeCarriesARealInstant(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 9, 9, 9, 15, 47, 0, time.UTC)
+	notices := map[string]gen.RunEvent{
+		// The dark zone, which is at the head of very nearly every recording:
+		// the recorder writes it before the runner has said anything at all.
+		"dark zone":       bootstrapRunEvent(at, true, "Pending", "ContainerCreating", ""),
+		"lost recording":  logsUnavailableRunEvent(at, "the recording could not be read"),
+		"gap in the feed": gapNotice(at, 7, 3),
+		"bare":            platformNotice(at, 9, gen.RunEventLevelInfo, "something the platform wants to say"),
+	}
+	for name, ev := range notices {
+		t.Run(name, func(t *testing.T) {
+			if !ev.TS.Equal(at) {
+				t.Errorf("%s notice is stamped %s, want the instant its caller derived it (%s)", name, ev.TS, at)
+			}
+			// The wire form, because a struct field that reads fine in Go is what
+			// marshalled into a date two millennia old.
+			b, err := json.Marshal(ev)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if strings.Contains(string(b), "0001-01-01") {
+				t.Errorf("%s notice on the wire carries Go's zero time: %s", name, b)
 			}
 		})
 	}
@@ -82,14 +131,15 @@ func TestBootstrapRunEventNarratesTheDarkZone(t *testing.T) {
 func TestBootstrapRunEvent_DetailOnlyWhereTheCodeCannotSpeak(t *testing.T) {
 	t.Parallel()
 
-	if ev := bootstrapRunEvent(true, "Running", "", ""); ev.Detail != "" {
+	at := time.Date(2026, 9, 9, 9, 15, 47, 0, time.UTC)
+	if ev := bootstrapRunEvent(at, true, "Running", "", ""); ev.Detail != "" {
 		t.Errorf("booting notice carried prose %q — the code says it", ev.Detail)
 	}
-	full := bootstrapRunEvent(true, "Pending", "Unschedulable", "0/3 nodes are available: Too many pods.\nsecond line")
+	full := bootstrapRunEvent(at, true, "Pending", "Unschedulable", "0/3 nodes are available: Too many pods.\nsecond line")
 	if !strings.Contains(full.Detail, "Too many pods") || strings.Contains(full.Detail, "second line") {
 		t.Errorf("unschedulable detail = %q, want the scheduler's FIRST line", full.Detail)
 	}
-	odd := bootstrapRunEvent(true, "Pending", "SomeBrandNewReason", "")
+	odd := bootstrapRunEvent(at, true, "Pending", "SomeBrandNewReason", "")
 	if odd.Code != gen.RunEventCodeRunnerPullingImage || odd.Detail != "SomeBrandNewReason" {
 		t.Errorf("unknown waiting reason = %+v, want it bucketed under pulling with the reason as detail", odd)
 	}

--- a/services/aep-api/internal/delivery/codingagent/run_recorder.go
+++ b/services/aep-api/internal/delivery/codingagent/run_recorder.go
@@ -67,6 +67,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -671,7 +672,28 @@ func (s *recordingSession) repairGap(ctx context.Context, after, before int64, r
 	}
 	*repaired = true
 
-	out := make([]gen.RunEvent, 0, missing)
+	// BOTH SOURCES ARE ASKED FOR THE WHOLE HOLE, and what they return is merged
+	// on the PRODUCER's seq before anything is numbered.
+	//
+	// Neither half of that is incidental. Filtering the archive by how far the
+	// live answer happened to reach loses events the archive still has: a live
+	// re-read that comes back with only the TOP of the hole (say 15..19 of
+	// 11..19) would move the floor to 19, and the archive — the source that
+	// exists precisely for the stretch the pod can no longer serve — would then
+	// be asked only for 19..20 and hand back nothing. 11..14 would be reported
+	// missing while sitting in the archive all along.
+	//
+	// And once both are asked for the same range, order stops being free.
+	// `RecordingStore.Append` writes a batch in slice order and `number` stamps
+	// each event with its POSITION IN THE FILE, so appending the archive's
+	// 11..14 after the live 15..19 would write a descending seq run into the
+	// recording — the one thing seq promises a consumer it can order on. Hence
+	// lines carry their producer seq through the merge and are sorted on it
+	// here, and `seen` keeps the overlap (the common case: both sources hold
+	// the same events) from being recorded twice.
+	lines := make([]repairedLine, 0, missing)
+	seen := make(map[int64]bool, missing)
+
 	// The window reaches back to the last line ingested, which by definition
 	// precedes the hole: the events went missing AFTER it. Nothing has been
 	// ingested at all only on a page whose very first envelope is out of step,
@@ -685,10 +707,16 @@ func (s *recordingSession) repairGap(ctx context.Context, after, before int64, r
 		slog.WarnContext(ctx, "codingagent.CycleRecorder: the pod had nothing to give back for a feed gap",
 			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before)
 	default:
-		out, after, missing = s.spliceRange(redactSecrets(tail.Text), out, after, before, missing)
+		lines, missing = s.spliceRange(redactSecrets(tail.Text), lines, seen, after, before, missing)
 	}
 	if missing > 0 {
-		out, missing = s.repairFromArchive(ctx, out, after, before, missing)
+		lines, missing = s.repairFromArchive(ctx, lines, seen, after, before, missing)
+	}
+
+	sort.SliceStable(lines, func(i, j int) bool { return lines[i].seq < lines[j].seq })
+	out := make([]gen.RunEvent, 0, len(lines))
+	for _, ln := range lines {
+		out = append(out, ln.evs...)
 	}
 	if len(out) > 0 || missing > 0 {
 		slog.InfoContext(ctx, "codingagent.CycleRecorder: repaired a feed gap",
@@ -697,11 +725,23 @@ func (s *recordingSession) repairGap(ctx context.Context, after, before int64, r
 	return out, missing
 }
 
+// repairedLine is one recovered producer line held with the seq it was written
+// under, so a merge of two sources can be ordered by the PRODUCER's numbering
+// rather than by which source answered first.
+//
+// A line and not an event, because one line can lift to several events and they
+// have to stay together and in order: `number` stamps position in the file, so
+// interleaving two lines' events would renumber them into nonsense.
+type repairedLine struct {
+	seq int64
+	evs []gen.RunEvent
+}
+
 // repairFromArchive asks the observability plane for what the pod could not give
 // back. It logs at WARN when it cannot answer: the incident this path exists for
 // left NO trace in the logs at all, because the only log line here sat after an
 // early return that both an error and an empty answer took.
-func (s *recordingSession) repairFromArchive(ctx context.Context, out []gen.RunEvent, after, before, missing int64) ([]gen.RunEvent, int64) {
+func (s *recordingSession) repairFromArchive(ctx context.Context, out []repairedLine, seen map[int64]bool, after, before, missing int64) ([]repairedLine, int64) {
 	if s.rec.archive == nil {
 		return out, missing
 	}
@@ -722,31 +762,37 @@ func (s *recordingSession) repairFromArchive(ctx context.Context, out []gen.RunE
 			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before)
 		return out, missing
 	}
-	out, _, missing = s.spliceRange(redactSecrets(text), out, after, before, missing)
+	out, missing = s.spliceRange(redactSecrets(text), out, seen, after, before, missing)
 	return out, missing
 }
 
 // spliceRange lifts the lines of a re-read page whose producer seq falls INSIDE
-// the hole (after, before) and appends them to out, reporting how far it got and
-// how many are still missing.
+// the hole (after, before) and appends them to out, reporting how many are still
+// missing.
 //
 // The range test is what keeps a repair from disturbing the cursor: everything
 // at or below `after` is already recorded and everything at or above `before` is
 // about to be, so a repair page is never allowed to advance ProducerSeq or to
-// lift a line the ordinary path will lift.
-func (s *recordingSession) spliceRange(text string, out []gen.RunEvent, after, before, missing int64) ([]gen.RunEvent, int64, int64) {
+// lift a line the ordinary path will lift. `after` and `before` are the HOLE's
+// own bounds and never move — see the merge in repairGap for why narrowing them
+// as lines come back costs recoverable events.
+//
+// `seen` carries across the two sources, which routinely overlap: the archive
+// indexed the same stdout the pod is still serving, so without it every event
+// the live re-read already recovered would be recorded a second time.
+func (s *recordingSession) spliceRange(text string, out []repairedLine, seen map[int64]bool, after, before, missing int64) ([]repairedLine, int64) {
 	for _, ln := range splitPage(text) {
-		if !ln.hasSeq || ln.seq <= after || ln.seq >= before {
+		if !ln.hasSeq || ln.seq <= after || ln.seq >= before || seen[ln.seq] {
 			continue
 		}
-		out = append(out, s.lift.line(ln.msg, ln.ts)...)
+		seen[ln.seq] = true
+		out = append(out, repairedLine{seq: ln.seq, evs: s.lift.line(ln.msg, ln.ts)})
 		missing--
-		after = ln.seq
 	}
 	if missing < 0 {
 		missing = 0
 	}
-	return out, after, missing
+	return out, missing
 }
 
 // number stamps the recording's own seq onto events the lift produced, in the

--- a/services/aep-api/internal/delivery/codingagent/run_recorder.go
+++ b/services/aep-api/internal/delivery/codingagent/run_recorder.go
@@ -37,6 +37,14 @@ package codingagent
 // Without that read the recording would stop a poll interval short of the run's
 // own ending, every time.
 //
+// EVERY READ WINDOW IS MEASURED FROM THE DATA, never from the platform's clock,
+// and every poll is bounded. Those two are one lesson: the reader cannot know
+// how long its own read took or which instant inside it the answer describes. A
+// window anchored on "when my last read returned" assumes the answer described
+// that instant, and a measured 13.22 s log call proved it does not — three times
+// in one run the next window began after lines nobody had read, and a cursor
+// that only moves forward never asked again. See windowStart and sinceSecondsAt.
+//
 // The runner makes no network call for any of this. Its stdout is still the one
 // transport, which is what keeps a runner that cannot reach the platform from
 // being a runner whose work is invisible.
@@ -78,7 +86,24 @@ const (
 	// exact cursor would race the clock and drop whatever landed in the rounding.
 	// Overlap costs a re-read of a second or two of log, which dedupe throws
 	// away; the alternative costs events, which nothing can recover.
+	//
+	// It is deliberately NOT the platform's slack against a slow read. It used
+	// to be asked to be both, and three seconds is nowhere near enough for that:
+	// one measured OpenChoreo log call took 13.22 s. Latency is answered by
+	// anchoring the window on the DATA (recordCursor.LastLineTS), which makes a
+	// stalled read widen the next window by the length of the stall; this
+	// constant only covers the API's own second-granularity rounding.
 	recordReadOverlap = 3 * time.Second
+	// defaultPollTimeout bounds ONE poll's OpenChoreo calls. The OC client has
+	// no timeout of its own, so a hung call silently blocked the session loop
+	// for as long as it liked — a 13-second read is not an error anywhere in the
+	// logs, it just stops the recording dead. A poll that overruns this must
+	// FAIL rather than stall: the error path leaves the cursor unmoved, so the
+	// next poll asks for the same window and nothing is skipped.
+	//
+	// Generously above the worst read measured (13.22 s) so it can never cut a
+	// healthy-but-slow poll short, and no wider than the idle cadence.
+	defaultPollTimeout = 30 * time.Second
 )
 
 // CycleRecorder records dispatched cycles' feeds. Its lifecycle is the cycle
@@ -96,8 +121,15 @@ type CycleRecorder struct {
 	// 200-event window that used to be a run's whole history is gone with it.
 	archive ArchiveLogSource
 
-	livePoll time.Duration
-	idlePoll time.Duration
+	livePoll    time.Duration
+	idlePoll    time.Duration
+	pollTimeout time.Duration
+
+	// now is the clock every session reads. A field only so a test can drive a
+	// read window and a stall on the same clock — the failure this recorder got
+	// wrong is a relationship between two instants, and no test can express one
+	// against the wall clock.
+	now func() time.Time
 
 	mu       sync.Mutex
 	sessions map[string]*recordingSession
@@ -110,11 +142,13 @@ func NewCycleRecorder(src RecordingLogSource, store *RecordingStore) *CycleRecor
 		return nil
 	}
 	return &CycleRecorder{
-		src:      src,
-		store:    store,
-		livePoll: defaultLivePoll,
-		idlePoll: defaultIdlePoll,
-		sessions: map[string]*recordingSession{},
+		src:         src,
+		store:       store,
+		livePoll:    defaultLivePoll,
+		idlePoll:    defaultIdlePoll,
+		pollTimeout: defaultPollTimeout,
+		now:         time.Now,
+		sessions:    map[string]*recordingSession{},
 	}
 }
 
@@ -257,7 +291,7 @@ func (r *CycleRecorder) CloseCancelled(ctx context.Context, cycle *delivery.RunC
 	settled := gen.RunEvent{
 		V:       gen.RunEventV2,
 		Seq:     cur.LastSeq,
-		TS:      time.Now().UTC(),
+		TS:      r.now().UTC(),
 		Kind:    gen.RunEventKindRunSettled,
 		AgentID: leadAgentID,
 		Outcome: gen.RunEventOutcomeCancelled,
@@ -289,9 +323,17 @@ type recordingSession struct {
 	cur  recordCursor
 	lift *lifter
 
-	// lastRead is when the previous successful read returned, and is what the
-	// next read's sinceSeconds is measured from. Zero means "never read", which
-	// asks for the whole log.
+	// binding is the cycle Component's release binding, resolved ONCE. It is
+	// fixed for the attempt, so re-resolving it every second spent a round trip
+	// re-deriving a constant. Cleared when a read says it is gone, so a
+	// re-rendered binding is picked up rather than 404ing forever.
+	binding string
+
+	// lastRead is when the previous successful read returned. It is the FALLBACK
+	// anchor for the next read's window and nothing more: it is the platform's
+	// clock, and the window belongs to the data's (recordCursor.LastLineTS). It
+	// is used only before anything has been ingested, where there is no line to
+	// measure from. Zero means "never read", which asks for the whole log.
 	lastRead time.Time
 	// gapped latches the moment the feed is known to have lost events.
 	gapped bool
@@ -350,8 +392,17 @@ func (s *recordingSession) run(ctx context.Context) {
 }
 
 // poll performs one read and reports whether the session is over.
+//
+// Every OpenChoreo call it makes is BOUNDED. The OC client carries no timeout of
+// its own, so before this a hung call blocked the session loop for as long as it
+// liked and left no trace anywhere: a recording that simply stopped growing, and
+// not one warning to say why. A poll that overruns fails instead, and failing is
+// safe — the cursor does not move, so the next poll asks for the same window.
 func (s *recordingSession) poll(ctx context.Context) (done bool, phase string) {
-	tail, err := s.rec.src.ReadSince(ctx, s.cycle.OrgID, s.cycle.ProjectID, s.cycle.JobRef, s.sinceSeconds())
+	ctx, cancel := context.WithTimeout(ctx, s.rec.pollTimeout)
+	defer cancel()
+
+	tail, err := s.read(ctx, s.windowStart())
 	if err != nil {
 		if errors.Is(err, ErrComponentGone) {
 			// The Component was deleted out from under a running recording — a
@@ -360,14 +411,15 @@ func (s *recordingSession) poll(ctx context.Context) (done bool, phase string) {
 			s.close(ctx, gen.RunCycleViewRecordingGaps)
 			return true, ""
 		}
-		// A transport failure is not an answer about the cycle. Keep the session
-		// and try again on the next tick; the cursor did not move, so the retry
-		// asks for the same window.
+		// A transport failure — or this poll's own deadline — is not an answer
+		// about the cycle. Keep the session and try again on the next tick; the
+		// cursor did not move, so the retry asks for the same window, widened by
+		// however long the failure took.
 		slog.WarnContext(ctx, "codingagent.CycleRecorder: pod log read failed (transient)",
 			"cycle", s.cycle.ID, "attempt", s.attempt, "error", err)
 		return false, ""
 	}
-	s.lastRead = time.Now()
+	s.lastRead = s.rec.now()
 	s.ingest(ctx, tail)
 
 	if !terminalPod(tail.Pod) {
@@ -377,7 +429,7 @@ func (s *recordingSession) poll(ctx context.Context) (done bool, phase string) {
 	// written its last words and the log API still serves them while the
 	// Component exists; dedupe by seq makes re-reading the whole log free of
 	// duplicates, so the cheapest correct thing is to ask for all of it.
-	if final, ferr := s.rec.src.ReadSince(ctx, s.cycle.OrgID, s.cycle.ProjectID, s.cycle.JobRef, 0); ferr == nil {
+	if final, ferr := s.read(ctx, time.Time{}); ferr == nil {
 		s.ingest(ctx, final)
 	} else {
 		slog.WarnContext(ctx, "codingagent.CycleRecorder: final log read failed; the recording may be short of the run's ending",
@@ -392,27 +444,92 @@ func (s *recordingSession) poll(ctx context.Context) (done bool, phase string) {
 	return true, tail.Pod.Phase
 }
 
-// sinceSeconds is the time cursor for the next read: everything since the last
-// successful one, widened by recordReadOverlap. Zero — the whole log — until
-// the first read lands.
-func (s *recordingSession) sinceSeconds() int64 {
-	if s.lastRead.IsZero() {
-		return 0
+// windowStart is the instant the next read asks from: the newest line this
+// session has INGESTED, less recordReadOverlap for the API's own second
+// granularity. The zero time — the whole log — until anything has been read.
+//
+// The anchor is the DATA's clock, and that is the whole fix. It used to be
+// `lastRead`: the platform's own wall clock, stamped when the previous read
+// RETURNED, which quietly asserts that the answer described that instant.
+// Nothing says it does. One measured OpenChoreo log call took 13.22 s, and no
+// part of the response says which moment inside it the log was read at — so on
+// three occasions in one run the next window began AFTER lines the recorder had
+// never seen, and because the cursor only moves forward, nothing ever asked for
+// them again. Two events, then two, then seven, reported to the user as
+// permanently lost.
+//
+// Anchored on the newest line ingested, a stall cannot open a hole: a 13-second
+// stall makes the next window 13 seconds wider, and a wider window costs a
+// re-read that dedupe throws away.
+//
+// ProseTS is the fallback below it for one reason only: a cursor persisted
+// before LastLineTS existed has no line clock, and a restart reading it should
+// resume wide rather than guess.
+func (s *recordingSession) windowStart() time.Time {
+	anchor := s.cur.LastLineTS
+	if anchor.IsZero() {
+		anchor = s.cur.ProseTS
 	}
-	since := time.Since(s.lastRead) + recordReadOverlap
-	secs := int64(since/time.Second) + 1
-	if secs < 1 {
-		secs = 1
+	if anchor.IsZero() {
+		if s.lastRead.IsZero() {
+			return time.Time{} // nothing read yet: ask for the whole log
+		}
+		anchor = s.lastRead
 	}
-	return secs
+	return anchor.Add(-recordReadOverlap)
+}
+
+// read reads the pod log from an absolute instant, resolving the session's
+// release binding on the way if it does not hold one yet.
+//
+// A read that says the Component is gone gets ONE re-resolve when the binding
+// came from the cache. The name is fixed for the attempt, but a re-render can
+// replace it, and a cached name that has been replaced would 404 for the rest of
+// the run — the recorder would close the recording `gaps` while the pod was
+// still happily writing.
+func (s *recordingSession) read(ctx context.Context, since time.Time) (LiveTail, error) {
+	binding, cached, err := s.releaseBinding(ctx)
+	if err != nil {
+		return LiveTail{}, err
+	}
+	tail, err := s.rec.src.ReadSince(ctx, s.cycle.OrgID, binding, since)
+	if err == nil || !cached || !errors.Is(err, ErrComponentGone) {
+		return tail, err
+	}
+	s.binding = ""
+	if binding, _, err = s.releaseBinding(ctx); err != nil {
+		return LiveTail{}, err
+	}
+	return s.rec.src.ReadSince(ctx, s.cycle.OrgID, binding, since)
+}
+
+// releaseBinding returns the session's binding name and whether it came from
+// the cache (which is what says a 404 on it is worth re-resolving).
+func (s *recordingSession) releaseBinding(ctx context.Context) (name string, cached bool, err error) {
+	if s.binding != "" {
+		return s.binding, true, nil
+	}
+	name, err = s.rec.src.Binding(ctx, s.cycle.OrgID, s.cycle.ProjectID, s.cycle.JobRef)
+	if err != nil {
+		return "", false, err
+	}
+	s.binding = name
+	return name, false, nil
 }
 
 // ingest turns one raw page into events and appends whatever is new.
+//
+// `observedAt` is read once, here, and handed to every marker this page mints.
+// The markers below are not things a producer said — they are the platform's own
+// reading of a pod and of its own recording — so the platform's clock at the
+// moment it read them is their honest timestamp, and `RunEvent.ts` has no way to
+// say "no clock" (see platformNotice).
 func (s *recordingSession) ingest(ctx context.Context, tail LiveTail) {
 	if s.capped {
 		return
 	}
-	events := s.consume(ctx, tail.Text)
+	observedAt := s.rec.now().UTC()
+	events := s.consume(ctx, tail.Text, observedAt)
 	if len(events) == 0 {
 		// Nothing the producer said. While NOTHING has ever been recorded and the
 		// pod has not settled, the pod's own state is the only report there is —
@@ -421,7 +538,7 @@ func (s *recordingSession) ingest(ctx context.Context, tail LiveTail) {
 		// re-derived per viewer, because a viewer that reads only the recording
 		// would otherwise see nothing at all until the runner's first line.
 		if s.cur.ProducerSeq == 0 && s.cur.ProseTS.IsZero() && !terminalPod(tail.Pod) {
-			boot := bootstrapRunEvent(tail.Pod.Found, tail.Pod.Phase, tail.Pod.WaitingReason, tail.Pod.Message)
+			boot := bootstrapRunEvent(observedAt, tail.Pod.Found, tail.Pod.Phase, tail.Pod.WaitingReason, tail.Pod.Message)
 			if boot.Seq == s.cur.BootSeq {
 				return // the same state, re-derived: one row, not one per second
 			}
@@ -446,7 +563,7 @@ func (s *recordingSession) ingest(ctx context.Context, tail LiveTail) {
 		// that trips it keeps RUNNING — stopping an agent to protect a log would be
 		// the wrong trade — and says on the feed that the rest is not recorded.
 		s.capped = true
-		notice := platformNotice(s.nextSeq(), gen.RunEventLevelWarn,
+		notice := platformNotice(observedAt, s.nextSeq(), gen.RunEventLevelWarn,
 			"This cycle's output passed the recording size limit; the rest of the run was not recorded.")
 		notice.Code = gen.RunEventCodeGap
 		_, _, _ = s.rec.store.Append(s.cycle.OrgID, s.cycle.ID, s.attempt, []gen.RunEvent{notice}, s.cur)
@@ -457,7 +574,7 @@ func (s *recordingSession) ingest(ctx context.Context, tail LiveTail) {
 // consume turns one raw pod-log page into the v2 events this session has not
 // recorded yet, splicing in a backfill (or a `notice`) wherever the producer's
 // own numbering shows events missing.
-func (s *recordingSession) consume(ctx context.Context, text string) []gen.RunEvent {
+func (s *recordingSession) consume(ctx context.Context, text string, observedAt time.Time) []gen.RunEvent {
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}
@@ -469,7 +586,7 @@ func (s *recordingSession) consume(ctx context.Context, text string) []gen.RunEv
 	text = dropTruncatedTail(text)
 
 	out := make([]gen.RunEvent, 0, 64)
-	backfilled := false
+	repaired := false
 	for _, ln := range splitPage(text) {
 		if !ln.hasSeq {
 			// A seq-less line (container bootstrap output, a stray library write, a
@@ -481,6 +598,7 @@ func (s *recordingSession) consume(ctx context.Context, text string) []gen.RunEv
 				continue
 			}
 			s.cur.ProseTS = ts
+			s.markLineTime(ts)
 			out = append(out, s.number(s.lift.line(ln.msg, ln.ts))...)
 			continue
 		}
@@ -488,48 +606,135 @@ func (s *recordingSession) consume(ctx context.Context, text string) []gen.RunEv
 			continue // already recorded; the read window deliberately overlaps
 		}
 		if s.cur.ProducerSeq > 0 && ln.seq > s.cur.ProducerSeq+1 {
-			recovered, missing := s.repairGap(ctx, s.cur.ProducerSeq, ln.seq, &backfilled)
+			recovered, missing := s.repairGap(ctx, s.cur.ProducerSeq, ln.seq, &repaired)
 			out = append(out, s.number(recovered)...)
 			if missing > 0 {
-				out = append(out, gapNotice(s.nextSeq(), missing))
+				// A gap is a fact about a POSITION in the feed, so it is stamped
+				// with the clock of the line that revealed it — the kubelet's own,
+				// which stays exact even when this page is a backfill read minutes
+				// after the events went missing. This read's clock stands in only
+				// when that line carried no prefix at all.
+				at := parseEventTime(ln.ts)
+				if at.IsZero() {
+					at = observedAt
+				}
+				out = append(out, gapNotice(at, s.nextSeq(), missing))
 				s.markGaps(ctx)
 			}
 		}
 		s.cur.ProducerSeq = ln.seq
+		// EVERY ingested line leaves a time trace, not just the seq-less ones.
+		// While only ProseTS was written, a run whose lines all carried envelopes
+		// left the recorder with no idea what the pod's clock said — so the read
+		// window had nothing to measure from but the platform's own, which is the
+		// hole this closes (see windowStart).
+		s.markLineTime(parseEventTime(ln.ts))
 		out = append(out, s.number(s.lift.line(ln.msg, ln.ts))...)
 	}
 	return out
 }
 
-// repairGap asks the observability plane for the events the pod read skipped
-// over, and reports how many are still missing after it answers.
+// markLineTime advances the cursor's newest-ingested-line clock. It only ever
+// moves FORWARD: taking the newest is what keeps a backfill read — which serves
+// lines older than the ones already recorded — from winding the read window back
+// and re-reading the same stretch of log for the rest of the run.
+func (s *recordingSession) markLineTime(ts time.Time) {
+	if !ts.IsZero() && ts.After(s.cur.LastLineTS) {
+		s.cur.LastLineTS = ts
+	}
+}
+
+// repairGap goes back for the events this page skipped over, and reports how
+// many are still missing after it has tried.
 //
-// The archive is the ONLY caller-visible use left for the observer on this
-// path. It used to be the ordinary post-mortem source — a finished run's whole
-// history was its newest 200 events — and the recording replaced that. What it
-// is good for is precisely this: it indexed the same pod's output all along, so
-// a burst the platform's own read missed may still be there.
+// TWO sources, in this order, because they can answer different questions:
 //
-// At most one archive call per page: a page with several gaps is a page whose
-// source is struggling, and hammering the observer would not help it.
-func (s *recordingSession) repairGap(ctx context.Context, after, before int64, backfilled *bool) ([]gen.RunEvent, int64) {
+//  1. the LIVE pod log, re-read with an explicit window that reaches back to the
+//     last line already ingested. While the pod's Component exists the lines are
+//     still there — the log API serves the whole log for as long as it does, and
+//     probing it directly during the incident returned a complete, in-order
+//     `1..478` with nothing missing. A hole in the recording is therefore
+//     usually a hole in what the platform ASKED FOR, and asking again with a
+//     window that cannot have moved is the direct repair.
+//  2. the observability ARCHIVE, for whatever the pod could not give back — a
+//     stretch the kubelet has since rotated away, or a Component already
+//     deleted. This is the ONLY caller-visible use left for the observer on this
+//     path: it used to be the ordinary post-mortem source (a finished run's
+//     whole history was its newest 200 events) and the recording replaced that.
+//
+// At most one repair per page: a page with several gaps is a page whose source is
+// struggling, and hammering it would not help.
+func (s *recordingSession) repairGap(ctx context.Context, after, before int64, repaired *bool) ([]gen.RunEvent, int64) {
 	missing := before - after - 1
-	if s.rec.archive == nil || *backfilled {
+	if *repaired {
 		return nil, missing
 	}
-	*backfilled = true
+	*repaired = true
+
+	out := make([]gen.RunEvent, 0, missing)
+	// The window reaches back to the last line ingested, which by definition
+	// precedes the hole: the events went missing AFTER it. Nothing has been
+	// ingested at all only on a page whose very first envelope is out of step,
+	// and the whole log is the honest ask there.
+	tail, err := s.read(ctx, s.windowStart())
+	switch {
+	case err != nil:
+		slog.WarnContext(ctx, "codingagent.CycleRecorder: re-reading the pod for a feed gap failed",
+			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before, "error", err)
+	case strings.TrimSpace(tail.Text) == "":
+		slog.WarnContext(ctx, "codingagent.CycleRecorder: the pod had nothing to give back for a feed gap",
+			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before)
+	default:
+		out, after, missing = s.spliceRange(redactSecrets(tail.Text), out, after, before, missing)
+	}
+	if missing > 0 {
+		out, missing = s.repairFromArchive(ctx, out, after, before, missing)
+	}
+	if len(out) > 0 || missing > 0 {
+		slog.InfoContext(ctx, "codingagent.CycleRecorder: repaired a feed gap",
+			"cycle", s.cycle.ID, "attempt", s.attempt, "recovered", len(out), "stillMissing", missing)
+	}
+	return out, missing
+}
+
+// repairFromArchive asks the observability plane for what the pod could not give
+// back. It logs at WARN when it cannot answer: the incident this path exists for
+// left NO trace in the logs at all, because the only log line here sat after an
+// early return that both an error and an empty answer took.
+func (s *recordingSession) repairFromArchive(ctx context.Context, out []gen.RunEvent, after, before, missing int64) ([]gen.RunEvent, int64) {
+	if s.rec.archive == nil {
+		return out, missing
+	}
 	text, err := s.rec.archive.CycleArchive(ctx, ArchiveScope{
 		OrgName:       s.cycle.OrgID,
 		ProjectName:   s.cycle.ProjectID,
 		ComponentName: s.cycle.JobRef,
 		From:          s.cycle.CreatedAt.UTC().Add(-5 * time.Minute),
-		To:            time.Now().UTC(),
+		To:            s.rec.now().UTC(),
 	})
-	if err != nil || strings.TrimSpace(text) == "" {
-		return nil, missing
+	switch {
+	case err != nil:
+		slog.WarnContext(ctx, "codingagent.CycleRecorder: archive read for a feed gap failed",
+			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before, "error", err)
+		return out, missing
+	case strings.TrimSpace(text) == "":
+		slog.WarnContext(ctx, "codingagent.CycleRecorder: the archive holds nothing for a feed gap",
+			"cycle", s.cycle.ID, "attempt", s.attempt, "afterSeq", after, "beforeSeq", before)
+		return out, missing
 	}
-	text = redactSecrets(text)
-	out := make([]gen.RunEvent, 0, missing)
+	out, _, missing = s.spliceRange(redactSecrets(text), out, after, before, missing)
+	return out, missing
+}
+
+// spliceRange lifts the lines of a re-read page whose producer seq falls INSIDE
+// the hole (after, before) and appends them to out, reporting how far it got and
+// how many are still missing.
+//
+// The range test is what keeps a repair from disturbing the cursor: everything
+// at or below `after` is already recorded and everything at or above `before` is
+// about to be, so a repair page is never allowed to advance ProducerSeq or to
+// lift a line the ordinary path will lift.
+func (s *recordingSession) spliceRange(text string, out []gen.RunEvent, after, before, missing int64) ([]gen.RunEvent, int64, int64) {
 	for _, ln := range splitPage(text) {
 		if !ln.hasSeq || ln.seq <= after || ln.seq >= before {
 			continue
@@ -541,9 +746,7 @@ func (s *recordingSession) repairGap(ctx context.Context, after, before int64, b
 	if missing < 0 {
 		missing = 0
 	}
-	slog.InfoContext(ctx, "codingagent.CycleRecorder: backfilled a feed gap from the archive",
-		"cycle", s.cycle.ID, "attempt", s.attempt, "recovered", len(out), "stillMissing", missing)
-	return out, missing
+	return out, after, missing
 }
 
 // number stamps the recording's own seq onto events the lift produced, in the
@@ -601,7 +804,22 @@ func (s *recordingSession) markGaps(ctx context.Context) {
 }
 
 // close finalises the recording and drops the session.
+//
+// A recording closing as `gaps` says so ON THE FEED before it closes, because
+// this is the moment — and the only moment — at which the loss becomes
+// permanent. Nothing more can be read once the session is over, so the mid-run
+// notices that said "not captured yet" are answered here, once, by the row that
+// says nothing more is coming.
 func (s *recordingSession) close(ctx context.Context, state gen.RunCycleViewRecording) {
+	if state == gen.RunCycleViewRecordingGaps && !s.capped {
+		notice := platformNotice(s.rec.now().UTC(), s.nextSeq(), gen.RunEventLevelWarn,
+			"Some of this run's output was never captured, and the pod it was written to is gone — nothing can recover it now.")
+		notice.Code = gen.RunEventCodeGap
+		if _, _, err := s.rec.store.Append(s.cycle.OrgID, s.cycle.ID, s.attempt, []gen.RunEvent{notice}, s.cur); err != nil {
+			slog.WarnContext(ctx, "codingagent.CycleRecorder: could not name a closing gap on the feed",
+				"cycle", s.cycle.ID, "attempt", s.attempt, "error", err)
+		}
+	}
 	if err := s.rec.store.Close(s.cycle.OrgID, s.cycle.ID, state); err != nil {
 		slog.WarnContext(ctx, "codingagent.CycleRecorder: close recording failed", "cycle", s.cycle.ID, "error", err)
 		return
@@ -614,9 +832,19 @@ func (s *recordingSession) close(ctx context.Context, state gen.RunCycleViewReco
 // the point they went missing rather than reported once at the end. A reader
 // scrolling a feed has to be able to see WHERE the hole is; a flag on the
 // response can only say that there is one somewhere.
-func gapNotice(seq, missing int64) gen.RunEvent {
-	ev := platformNotice(seq, gen.RunEventLevelWarn,
-		fmt.Sprintf("… %d event(s) of this run were not captured and could not be recovered", missing))
+//
+// It says "not captured YET", and the word is load-bearing. This row is written
+// the instant a hole is detected — with the pod still running, its Component
+// still readable and the recorder about to ask for that stretch of log again on
+// its next tick — and the sentence there before it read "were not captured and
+// could not be recovered", which was simply not true at the moment it was
+// written. A user was told three times in one run that events were gone for
+// good while every one of them was still sitting in the pod's log. The
+// unrecoverable wording belongs to the one place it is true: the recording
+// closing as `gaps` (see close).
+func gapNotice(at time.Time, seq, missing int64) gen.RunEvent {
+	ev := platformNotice(at, seq, gen.RunEventLevelWarn,
+		fmt.Sprintf("… %d event(s) of this run have not been captured yet", missing))
 	ev.Code = gen.RunEventCodeGap
 	return ev
 }

--- a/services/aep-api/internal/delivery/codingagent/run_recorder_test.go
+++ b/services/aep-api/internal/delivery/codingagent/run_recorder_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -596,6 +597,61 @@ func TestRecorder_ArchiveBackfillRepairsAGapTheLivePodCannot(t *testing.T) {
 	}
 	if archive.reads() != 1 {
 		t.Errorf("the archive was read %d times, want 1 — at most one repair per page", archive.reads())
+	}
+}
+
+// TestRecorder_ArchiveFillsTheBottomOfAGapTheLivePodOnlyTopsUp pins the MERGE of
+// the repair's two sources, which is the case where they disagree about how much
+// of the hole they can answer.
+//
+// The pod is serving the top of the hole (4, 5) and has rotated the bottom away
+// (2, 3); the archive indexed all of it. Filtering the archive by how far the
+// live answer reached asks it for the stretch above 5 — nothing — and reports 2
+// and 3 permanently missing while they sit in the archive. Both sources are
+// therefore asked for the whole hole, and the merge is ordered on the PRODUCER's
+// seq, not on which source answered first: `number` stamps position in the file,
+// so appending the archive's 2 and 3 after the live 4 and 5 would write a
+// descending seq run into the recording.
+//
+// Driven through repairGap directly rather than through a poll. The repair's read
+// window is anchored on the last line ingested, so it can never reach FURTHER
+// BACK than the page that revealed the gap — no arrangement of this fixture's
+// clock makes a poll produce a part-answered hole. What the two sources can each
+// return is a property of the repair, and this is the level it lives at.
+func TestRecorder_ArchiveFillsTheBottomOfAGapTheLivePodOnlyTopsUp(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
+	line := func(seq int, summary string) fakeLogLine {
+		return v1LogLine(seq, at.Add(time.Duration(seq)*time.Second),
+			`"kind":"log","summary":"`+summary+`"`)
+	}
+	// The pod no longer holds 2 and 3.
+	f := newRecorderFixture(t, at.Add(10*time.Second),
+		line(1, "one"), line(4, "four"), line(5, "five"), line(6, "six"),
+	)
+	f.rec.WithArchive(&spyArchive{text: pageOf(
+		line(1, "one"), line(2, "two"), line(3, "three"),
+		line(4, "four"), line(5, "five"), line(6, "six"),
+	)})
+
+	s := f.session(t, 1)
+	s.cur.ProducerSeq = 1
+
+	repaired := false
+	out, missing := s.repairGap(context.Background(), 1, 6, &repaired)
+
+	if missing != 0 {
+		t.Errorf("still missing %d — the archive holds every event in the hole", missing)
+	}
+	var got []string
+	for _, ev := range out {
+		got = append(got, ev.Detail)
+	}
+	// Ascending, because that is the order the producer wrote them in and the
+	// order `number` is about to stamp as their position in the file.
+	if want := []string{"two", "three", "four", "five"}; !slices.Equal(got, want) {
+		t.Errorf("recovered %v, want %v", got, want)
 	}
 }
 

--- a/services/aep-api/internal/delivery/codingagent/run_recorder_test.go
+++ b/services/aep-api/internal/delivery/codingagent/run_recorder_test.go
@@ -33,51 +33,226 @@ import (
 	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
 )
 
-// fakeRecordSource serves scripted pages. The LAST page repeats, which is what
-// a real pod log does between two polls that saw no new output.
-type fakeRecordSource struct {
-	mu    sync.Mutex
-	pages []LiveTail
-	since []int64 // the sinceSeconds of every call, in order
-	err   error
-	seen  chan struct{}
+// fakeClock is ONE clock shared by the recorder and its log source, which is
+// what lets a test state a relationship between two instants — a read that took
+// longer than the window it was about to ask for. That relationship is the whole
+// of the failure these tests exist to pin, and it cannot be expressed against
+// the wall clock.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
 }
 
-func (f *fakeRecordSource) ReadSince(_ context.Context, _, _, _ string, since int64) (LiveTail, error) {
+func newFakeClock(at time.Time) *fakeClock { return &fakeClock{t: at.UTC()} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// fakeLogLine is one line of a synthetic container log: the instant the
+// container wrote it, and what it wrote.
+type fakeLogLine struct {
+	at   time.Time
+	text string
+}
+
+// fakeRecordSource is a synthetic pod log served against a fake clock, and it
+// HONOURS THE WINDOW IT IS ASKED FOR.
+//
+// Its predecessor did not, and that is why the loss below shipped: it recorded
+// each call's `sinceSeconds` and then served scripted pages by call index, so a
+// window that missed a line was indistinguishable from one that did not, and no
+// test could express the failure the code actually had. A fake that ignores the
+// parameter under test cannot fail for the reason the code is wrong.
+//
+// Two properties carry every test here:
+//
+//   - a line outside the requested window is NOT served, ever. The window is
+//     absolute and applied exactly. (The real API rounds to whole seconds, which
+//     only widens it; a fake that rounded too would hand a buggy window slack it
+//     must never be allowed to rely on.)
+//   - a call's answer describes the log AS OF THE INSTANT THE CALL WAS ISSUED,
+//     and the call then takes `latency` on the clock. That is the conservative
+//     reading of a real read and the only honest one: a measured OpenChoreo log
+//     call took 13.22 s, and nothing in the response says which moment inside it
+//     the log was read at. It is also exactly the case that a read window
+//     anchored on when the PREVIOUS read returned gets wrong.
+type fakeRecordSource struct {
+	mu    sync.Mutex
+	clock *fakeClock
+	lines []fakeLogLine
+	pod   openchoreo.RuntimePod
+	err   error
+	// latency is how long each read takes on the clock, by call index; the last
+	// value repeats, and no values at all means instant.
+	latency []time.Duration
+	// block makes every read wait on the caller's context instead of answering,
+	// which is how a test drives a poll into its own deadline.
+	block bool
+
+	windows    []time.Time // the absolute `since` of every read, in order
+	binding    string
+	bindingErr error
+	bindings   int
+	seen       chan struct{}
+}
+
+// Binding resolves the attempt's release binding, counting the calls: it is
+// fixed for the attempt, so how OFTEN it is asked for is part of the contract.
+func (f *fakeRecordSource) Binding(_ context.Context, _, _, _ string) (string, error) {
 	f.mu.Lock()
-	f.since = append(f.since, since)
-	n := len(f.since) - 1
-	pages, err := f.pages, f.err
+	defer f.mu.Unlock()
+	f.bindings++
+	if f.bindingErr != nil {
+		return "", f.bindingErr
+	}
+	if f.binding == "" {
+		return "rb-dev", nil
+	}
+	return f.binding, nil
+}
+
+func (f *fakeRecordSource) ReadSince(ctx context.Context, _, _ string, since time.Time) (LiveTail, error) {
+	f.mu.Lock()
+	issuedAt := f.clockNow()
+	n := len(f.windows)
+	f.windows = append(f.windows, since)
+	lat := time.Duration(0)
+	if len(f.latency) > 0 {
+		if n >= len(f.latency) {
+			n = len(f.latency) - 1
+		}
+		lat = f.latency[n]
+	}
+	lines, pod, err, block := f.lines, f.pod, f.err, f.block
 	seen := f.seen
 	f.mu.Unlock()
+
 	if seen != nil {
 		select {
 		case seen <- struct{}{}:
 		default:
 		}
 	}
+	if block {
+		<-ctx.Done()
+		return LiveTail{}, ctx.Err()
+	}
+	if f.clock != nil && lat > 0 {
+		f.clock.advance(lat)
+	}
 	if err != nil {
 		return LiveTail{}, err
 	}
-	if n >= len(pages) {
-		n = len(pages) - 1
+	if !pod.Found {
+		return LiveTail{Pod: pod}, nil
 	}
-	if n < 0 {
-		return LiveTail{}, nil
+	var b strings.Builder
+	for _, ln := range lines {
+		if ln.at.After(issuedAt) {
+			continue // the container had not written it when this read was issued
+		}
+		if !since.IsZero() && ln.at.Before(since) {
+			continue // outside the window: this read did not ask for it
+		}
+		b.WriteString(ln.at.UTC().Format(time.RFC3339Nano))
+		b.WriteByte(' ')
+		b.WriteString(ln.text)
+		b.WriteByte('\n')
 	}
-	return pages[n], nil
+	return LiveTail{Text: b.String(), Pod: pod}, nil
 }
 
-func (f *fakeRecordSource) sinceCalls() []int64 {
+// clockNow must be called with the mutex held.
+func (f *fakeRecordSource) clockNow() time.Time {
+	if f.clock == nil {
+		return time.Now().UTC()
+	}
+	return f.clock.now()
+}
+
+// windowCalls is the absolute `since` of every read, in order. A test reads it
+// to pin how wide the recorder asked, and how many times it had to ask.
+func (f *fakeRecordSource) windowCalls() []time.Time {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return append([]int64{}, f.since...)
+	return append([]time.Time{}, f.windows...)
 }
 
-// v1Line renders one runner NDJSON line in the pod's `timestamps=true` shape.
-func v1Line(seq int, at time.Time, body string) string {
-	return fmt.Sprintf("%s {\"schemaVersion\":1,\"ts\":%q,\"seq\":%d,%s}",
-		at.UTC().Format(time.RFC3339Nano), at.UTC().Format(time.RFC3339Nano), seq, body)
+func (f *fakeRecordSource) setPod(pod openchoreo.RuntimePod) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pod = pod
+}
+
+func (f *fakeRecordSource) setLines(lines ...fakeLogLine) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lines = lines
+	f.windows = nil
+}
+
+func (f *fakeRecordSource) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeRecordSource) bindingCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.bindings
+}
+
+// spyArchive counts its calls, so a test can prove the LIVE pod was asked
+// first: while the Component exists the lines are still there, and the archive
+// is the fallback for what the pod can no longer give back.
+type spyArchive struct {
+	mu    sync.Mutex
+	text  string
+	err   error
+	calls int
+}
+
+func (a *spyArchive) CycleArchive(context.Context, ArchiveScope) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls++
+	return a.text, a.err
+}
+
+func (a *spyArchive) reads() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+// v1LogLine is one runner NDJSON event as a synthetic log line: the kubelet
+// wrote it at `at`, and the envelope says the same.
+func v1LogLine(seq int, at time.Time, body string) fakeLogLine {
+	return fakeLogLine{at: at.UTC(), text: fmt.Sprintf(`{"schemaVersion":1,"ts":%q,"seq":%d,%s}`,
+		at.UTC().Format(time.RFC3339Nano), seq, body)}
+}
+
+// pageOf renders lines into the raw shape a read returns, for the few tests that
+// hand a page straight to ingest rather than going through a read.
+func pageOf(lines ...fakeLogLine) string {
+	var b strings.Builder
+	for _, ln := range lines {
+		b.WriteString(ln.at.UTC().Format(time.RFC3339Nano))
+		b.WriteByte(' ')
+		b.WriteString(ln.text)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 func runningPod() openchoreo.RuntimePod {
@@ -89,29 +264,32 @@ func succeededPod() openchoreo.RuntimePod {
 }
 
 // recorderFixture wires a recorder over a temp workspace root and returns the
-// pieces a test drives.
+// pieces a test drives. Recorder and source share the fixture's clock.
 type recorderFixture struct {
 	rec   *CycleRecorder
 	store *RecordingStore
 	src   *fakeRecordSource
+	clock *fakeClock
 	root  string
 	cycle *delivery.RunCycle
 }
 
-func newRecorderFixture(t *testing.T, pages ...LiveTail) *recorderFixture {
+func newRecorderFixture(t *testing.T, now time.Time, lines ...fakeLogLine) *recorderFixture {
+	t.Helper()
+	return newCappedRecorderFixture(t, 0, now, lines...)
+}
+
+func newCappedRecorderFixture(t *testing.T, maxBytes int64, now time.Time, lines ...fakeLogLine) *recorderFixture {
 	t.Helper()
 	root := t.TempDir()
-	store := NewRecordingStore(root, 0)
-	src := &fakeRecordSource{pages: pages, seen: make(chan struct{}, 64)}
+	store := NewRecordingStore(root, maxBytes)
+	clock := newFakeClock(now)
+	src := &fakeRecordSource{clock: clock, lines: lines, pod: runningPod(), seen: make(chan struct{}, 64)}
 	cyc := liveCycle("c1")
 	cyc.Attempts = 1
-	return &recorderFixture{
-		rec:   NewCycleRecorder(src, store),
-		store: store,
-		src:   src,
-		root:  root,
-		cycle: cyc,
-	}
+	rec := NewCycleRecorder(src, store)
+	rec.now = clock.now
+	return &recorderFixture{rec: rec, store: store, src: src, clock: clock, root: root, cycle: cyc}
 }
 
 // session builds a session WITHOUT its goroutine, so a test drives poll() one
@@ -154,6 +332,88 @@ func (f *recorderFixture) recorded(t *testing.T, attempt int) []gen.RunEvent {
 	return events
 }
 
+// gapNotices are the rows the platform wrote to say the feed is short.
+func gapNotices(events []gen.RunEvent) []gen.RunEvent {
+	var out []gen.RunEvent
+	for i := range events {
+		if events[i].Code == gen.RunEventCodeGap {
+			out = append(out, events[i])
+		}
+	}
+	return out
+}
+
+// TestRecorder_AStalledReadWidensTheNextWindowInsteadOfLeavingAHole is the
+// measured incident, replayed.
+//
+// One run lost three bursts of events — two, then two, then seven — and told the
+// user each time that they "could not be recovered". Nothing had gone wrong with
+// the pod, the log API or the network: every poll returned 200, and probing the
+// log API directly afterwards returned a complete, in-order `1..478`. What went
+// wrong is that the recorder measured its read window from ITS OWN CLOCK,
+// stamped when the previous read returned, which asserts that the answer
+// described that instant. One `logs` handler took 13.22 s. The next window then
+// began after lines nobody had ever read, and because the cursor only moves
+// forward, nothing asked for them again.
+//
+// Here: two lines are read, the next read stalls for 13 s — far past the 3 s
+// overlap — and three more lines land while it does. The recording must hold
+// every one of them.
+func TestRecorder_AStalledReadWidensTheNextWindowInsteadOfLeavingAHole(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 9, 8, 9, 29, 40, 0, time.UTC)
+	f := newRecorderFixture(t, t0,
+		v1LogLine(1, t0.Add(-2*time.Second), `"kind":"log","summary":"s1"`),
+		v1LogLine(2, t0.Add(-1*time.Second), `"kind":"log","summary":"s2"`),
+		// Written while the stalled read is in flight.
+		v1LogLine(3, t0.Add(3*time.Second), `"kind":"log","summary":"s3"`),
+		v1LogLine(4, t0.Add(5*time.Second), `"kind":"log","summary":"s4"`),
+		v1LogLine(5, t0.Add(12*time.Second), `"kind":"log","summary":"s5"`),
+	)
+	f.src.latency = []time.Duration{500 * time.Millisecond, 13 * time.Second, 500 * time.Millisecond}
+
+	s := f.session(t, 1)
+	for i := 0; i < 3; i++ {
+		if done, _ := s.poll(context.Background()); done {
+			t.Fatalf("poll %d ended the session; the pod is still Running", i+1)
+		}
+	}
+
+	events := f.recorded(t, 1)
+	var got []string
+	for _, ev := range events {
+		got = append(got, ev.Detail)
+	}
+	want := []string{"s1", "s2", "s3", "s4", "s5"}
+	if len(got) != len(want) {
+		t.Fatalf("recorded %v, want %v — the stall hid s3 and s4, and the next window has to reach back past them", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("event %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if notices := gapNotices(events); len(notices) != 0 {
+		t.Errorf("the feed reported a gap it did not have: %+v", notices)
+	}
+	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingRecording {
+		t.Errorf("state = %q, want recording — nothing was lost", got)
+	}
+
+	// The ORDINARY read has to be what keeps the feed whole. Three polls, three
+	// reads: a fourth would mean the recorder had to fall back on the gap repair
+	// to recover what its own window should never have skipped.
+	windows := f.src.windowCalls()
+	if len(windows) != 3 {
+		t.Fatalf("%d reads for 3 polls, want 3 — the window, not the repair, is what must keep the feed whole", len(windows))
+	}
+	if !windows[2].Before(t0.Add(3 * time.Second)) {
+		t.Errorf("the window after the stall began at %s, at or after the first line the stall hid (%s)",
+			windows[2], t0.Add(3*time.Second))
+	}
+}
+
 // TestRecorder_RecordsTheFeedAndClosesCompleteOnATerminalPod is the happy path,
 // plus the ONE FINAL FULL READ that closes the "pod exited between two polls"
 // loss: the runner's last words land after the last incremental read, so the
@@ -162,29 +422,24 @@ func TestRecorder_RecordsTheFeedAndClosesCompleteOnATerminalPod(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	page1 := LiveTail{Pod: runningPod(), Text: strings.Join([]string{
-		v1Line(1, at, `"kind":"tool_use","tool":"Read","summary":"read api.go"`),
-		v1Line(2, at.Add(time.Second), `"kind":"tool_result","tool":"Read","ok":true`),
-		"",
-	}, "\n")}
-	// The terminal page carries the run's ending — the line a poll-interval-short
-	// reader used to miss every time.
-	page2 := LiveTail{Pod: succeededPod(), Text: strings.Join([]string{
-		v1Line(1, at, `"kind":"tool_use","tool":"Read","summary":"read api.go"`),
-		v1Line(2, at.Add(time.Second), `"kind":"tool_result","tool":"Read","ok":true`),
-		v1Line(3, at.Add(2*time.Second), `"kind":"result","status":"success"`),
-		"",
-	}, "\n")}
+	f := newRecorderFixture(t, at.Add(time.Second),
+		v1LogLine(1, at, `"kind":"tool_use","tool":"Read","summary":"read api.go"`),
+		v1LogLine(2, at.Add(time.Second), `"kind":"tool_result","tool":"Read","ok":true`),
+		// The run's ending — the line a poll-interval-short reader used to miss
+		// every time.
+		v1LogLine(3, at.Add(2*time.Second), `"kind":"result","status":"success"`),
+	)
 
-	f := newRecorderFixture(t, page1, page2)
 	s := f.session(t, 1)
-
 	if done, phase := s.poll(context.Background()); done || phase != "Running" {
 		t.Fatalf("first poll = (done=%v, phase=%q), want (false, Running)", done, phase)
 	}
 	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingRecording {
 		t.Fatalf("state mid-run = %q, want recording", got)
 	}
+
+	f.clock.advance(2 * time.Second)
+	f.src.setPod(succeededPod())
 	if done, _ := s.poll(context.Background()); !done {
 		t.Fatal("a terminal pod did not end the session")
 	}
@@ -199,11 +454,15 @@ func TestRecorder_RecordsTheFeedAndClosesCompleteOnATerminalPod(t *testing.T) {
 	if events[2].Kind != gen.RunEventKindRunSettled || events[2].Outcome != gen.RunEventOutcomeSuccess {
 		t.Errorf("last recorded event = %+v, want the run's own settle", events[2])
 	}
-	// Call 1 asks for the whole log, call 2 uses the time cursor, and call 3 is
+	// Read 1 asks for the whole log, read 2 uses the time cursor, and read 3 is
 	// the final FULL read.
-	calls := f.src.sinceCalls()
-	if len(calls) != 3 || calls[0] != 0 || calls[1] == 0 || calls[2] != 0 {
-		t.Errorf("sinceSeconds calls = %v, want [0, >0, 0] — the last one is the final full read", calls)
+	windows := f.src.windowCalls()
+	if len(windows) != 3 || !windows[0].IsZero() || windows[1].IsZero() || !windows[2].IsZero() {
+		t.Errorf("read windows = %v, want [whole, cursor, whole] — the last one is the final full read", windows)
+	}
+	// The binding is fixed for the attempt: three reads, one resolve.
+	if got := f.src.bindingCalls(); got != 1 {
+		t.Errorf("resolved the release binding %d times for one session, want 1", got)
 	}
 }
 
@@ -215,13 +474,11 @@ func TestRecorder_SeqGapBecomesANoticeAndFlipsTheState(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	page := LiveTail{Pod: runningPod(), Text: strings.Join([]string{
-		v1Line(1, at, `"kind":"log","summary":"one"`),
-		v1Line(5, at.Add(time.Second), `"kind":"log","summary":"five"`),
-		"",
-	}, "\n")}
+	f := newRecorderFixture(t, at.Add(time.Second),
+		v1LogLine(1, at, `"kind":"log","summary":"one"`),
+		v1LogLine(5, at.Add(time.Second), `"kind":"log","summary":"five"`),
+	)
 
-	f := newRecorderFixture(t, page)
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("a Running pod ended the session")
@@ -231,20 +488,22 @@ func TestRecorder_SeqGapBecomesANoticeAndFlipsTheState(t *testing.T) {
 	}
 
 	events := f.recorded(t, 1)
-	var notice *gen.RunEvent
-	for i := range events {
-		if events[i].Code == gen.RunEventCodeGap {
-			notice = &events[i]
-		}
+	notices := gapNotices(events)
+	if len(notices) != 1 {
+		t.Fatalf("%d gap notices in %+v, want 1", len(notices), events)
 	}
-	if notice == nil {
-		t.Fatalf("no gap notice in %+v", events)
-	}
+	notice := notices[0]
 	if notice.Kind != gen.RunEventKindNotice || notice.Level != gen.RunEventLevelWarn || notice.AgentID != leadAgentID {
 		t.Errorf("gap notice = %+v, want a warn notice on the lead", notice)
 	}
 	if !strings.Contains(notice.Detail, "3 event(s)") {
 		t.Errorf("detail = %q, want it to name how many went missing (seqs 2,3,4)", notice.Detail)
+	}
+	// The pod is still Running and its log is still readable, so the honest word
+	// is YET. The sentence used to say "could not be recovered" at the very
+	// moment the recorder was about to ask for that stretch of log again.
+	if !strings.Contains(notice.Detail, "yet") || strings.Contains(notice.Detail, "could not be recovered") {
+		t.Errorf("detail = %q — a hole in a live pod's feed is not yet a loss", notice.Detail)
 	}
 	// It sits WHERE the hole is: after the last recorded event and before the
 	// one that revealed it.
@@ -253,29 +512,74 @@ func TestRecorder_SeqGapBecomesANoticeAndFlipsTheState(t *testing.T) {
 	}
 }
 
-// TestRecorder_ArchiveBackfillRepairsAGapWithNoNotice pins the archive's ONE
-// remaining job. It indexed the same pod's output all along, so a burst the
-// platform's own read missed may still be there — and a gap that is fully
-// recovered is not a gap.
-func TestRecorder_ArchiveBackfillRepairsAGapWithNoNotice(t *testing.T) {
+// TestRecorder_AGapIsRepairedFromTheLivePodBeforeTheArchive pins the order of
+// the two repair sources. While the pod's Component exists its whole log is
+// still served — the incident proved that by fetching a complete `1..478` after
+// the fact — so a hole in the recording is usually a hole in what the platform
+// ASKED FOR, and asking again is the direct repair. The archive is for what the
+// pod can no longer give back.
+func TestRecorder_AGapIsRepairedFromTheLivePodBeforeTheArchive(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	page := LiveTail{Pod: runningPod(), Text: strings.Join([]string{
-		v1Line(1, at, `"kind":"log","summary":"one"`),
-		v1Line(4, at.Add(3*time.Second), `"kind":"log","summary":"four"`),
-		"",
-	}, "\n")}
-	archive := strings.Join([]string{
-		v1Line(1, at, `"kind":"log","summary":"one"`),
-		v1Line(2, at.Add(time.Second), `"kind":"log","summary":"two"`),
-		v1Line(3, at.Add(2*time.Second), `"kind":"log","summary":"three"`),
-		v1Line(4, at.Add(3*time.Second), `"kind":"log","summary":"four"`),
-		"",
-	}, "\n")
+	all := []fakeLogLine{
+		v1LogLine(1, at, `"kind":"log","summary":"one"`),
+		v1LogLine(2, at.Add(time.Second), `"kind":"log","summary":"two"`),
+		v1LogLine(3, at.Add(2*time.Second), `"kind":"log","summary":"three"`),
+		v1LogLine(4, at.Add(3*time.Second), `"kind":"log","summary":"four"`),
+	}
+	f := newRecorderFixture(t, at.Add(3*time.Second), all...)
+	archive := &spyArchive{text: pageOf(all...)}
+	f.rec.WithArchive(archive)
 
-	f := newRecorderFixture(t, page)
-	f.rec.WithArchive(&stubArchive{text: archive})
+	// A session that has recorded line 1 and is then handed a page with 2 and 3
+	// missing — whatever the cause, the pod still holds them.
+	s := f.session(t, 1)
+	s.cur.ProducerSeq = 1
+	s.cur.LastLineTS = at
+	s.ingest(context.Background(), LiveTail{Pod: runningPod(), Text: pageOf(all[0], all[3])})
+
+	events := f.recorded(t, 1)
+	var got []string
+	for _, ev := range events {
+		got = append(got, ev.Detail)
+	}
+	if want := []string{"two", "three", "four"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("recorded %v, want %v — the pod still had the missing lines", got, want)
+	}
+	if notices := gapNotices(events); len(notices) != 0 {
+		t.Errorf("a repaired gap still reported a notice: %+v", notices)
+	}
+	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingRecording {
+		t.Errorf("state = %q — a fully repaired gap is not a gap", got)
+	}
+	if archive.reads() != 0 {
+		t.Errorf("the archive was read %d times; the live pod answers first", archive.reads())
+	}
+}
+
+// TestRecorder_ArchiveBackfillRepairsAGapTheLivePodCannot pins the archive's ONE
+// remaining job. It indexed the same pod's output all along, so a burst the pod
+// itself will no longer serve may still be there — and a gap that is fully
+// recovered is not a gap.
+func TestRecorder_ArchiveBackfillRepairsAGapTheLivePodCannot(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
+	// The pod's own log no longer holds 2 and 3 (kubelet rotation); the archive
+	// indexed them when they were written.
+	f := newRecorderFixture(t, at.Add(3*time.Second),
+		v1LogLine(1, at, `"kind":"log","summary":"one"`),
+		v1LogLine(4, at.Add(3*time.Second), `"kind":"log","summary":"four"`),
+	)
+	archive := &spyArchive{text: pageOf(
+		v1LogLine(1, at, `"kind":"log","summary":"one"`),
+		v1LogLine(2, at.Add(time.Second), `"kind":"log","summary":"two"`),
+		v1LogLine(3, at.Add(2*time.Second), `"kind":"log","summary":"three"`),
+		v1LogLine(4, at.Add(3*time.Second), `"kind":"log","summary":"four"`),
+	)}
+	f.rec.WithArchive(archive)
+
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("a Running pod ended the session")
@@ -287,10 +591,11 @@ func TestRecorder_ArchiveBackfillRepairsAGapWithNoNotice(t *testing.T) {
 	if len(events) != 4 {
 		t.Fatalf("recorded %d events, want all four\n%+v", len(events), events)
 	}
-	for i := range events {
-		if events[i].Code == gen.RunEventCodeGap {
-			t.Errorf("a repaired gap still reported a notice: %+v", events[i])
-		}
+	if notices := gapNotices(events); len(notices) != 0 {
+		t.Errorf("a repaired gap still reported a notice: %+v", notices)
+	}
+	if archive.reads() != 1 {
+		t.Errorf("the archive was read %d times, want 1 — at most one repair per page", archive.reads())
 	}
 }
 
@@ -303,9 +608,8 @@ func TestRecorder_CancelClosesWithRunSettledCancelledAndGaps(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	page := LiveTail{Pod: runningPod(), Text: v1Line(1, at, `"kind":"log","summary":"working"`) + "\n"}
+	f := newRecorderFixture(t, at, v1LogLine(1, at, `"kind":"log","summary":"working"`))
 
-	f := newRecorderFixture(t, page)
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("a Running pod ended the session")
@@ -343,7 +647,7 @@ func TestRecorder_CancelClosesWithRunSettledCancelledAndGaps(t *testing.T) {
 func TestRecorder_CancelOnAnUnrecordedCycleWritesNothing(t *testing.T) {
 	t.Parallel()
 
-	f := newRecorderFixture(t)
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
 	f.rec.CloseCancelled(context.Background(), f.cycle)
 	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingNone {
 		t.Fatalf("state = %q, want none", got)
@@ -359,20 +663,16 @@ func TestRecorder_ReDispatchWritesASecondAttemptFileAndLeavesTheFirst(t *testing
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	f := newRecorderFixture(t, LiveTail{Pod: runningPod(),
-		Text: v1Line(1, at, `"kind":"log","summary":"first attempt"`) + "\n"})
+	f := newRecorderFixture(t, at, v1LogLine(1, at, `"kind":"log","summary":"first attempt"`))
 
 	first := f.session(t, 1)
 	if done, _ := first.poll(context.Background()); done {
 		t.Fatal("a Running pod ended the session")
 	}
 
-	// The retry's own pod: seq restarts at 1.
-	f.src.mu.Lock()
-	f.src.pages = []LiveTail{{Pod: runningPod(),
-		Text: v1Line(1, at.Add(time.Minute), `"kind":"log","summary":"second attempt"`) + "\n"}}
-	f.src.since = nil
-	f.src.mu.Unlock()
+	// The retry's own pod: a new log whose seq restarts at 1.
+	f.clock.advance(time.Minute)
+	f.src.setLines(v1LogLine(1, at.Add(time.Minute), `"kind":"log","summary":"second attempt"`))
 
 	second := f.session(t, 2)
 	if done, _ := second.poll(context.Background()); done {
@@ -406,8 +706,8 @@ func TestRecorder_ReDispatchWritesASecondAttemptFileAndLeavesTheFirst(t *testing
 func TestRecorder_DarkZoneIsRecordedOncePerState(t *testing.T) {
 	t.Parallel()
 
-	pulling := LiveTail{Pod: openchoreo.RuntimePod{Found: true, Name: "p1", Phase: "Pending", WaitingReason: "ContainerCreating"}}
-	f := newRecorderFixture(t, pulling)
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
+	f.src.setPod(openchoreo.RuntimePod{Found: true, Name: "p1", Phase: "Pending", WaitingReason: "ContainerCreating"})
 	s := f.session(t, 1)
 
 	for i := 0; i < 3; i++ {
@@ -424,9 +724,7 @@ func TestRecorder_DarkZoneIsRecordedOncePerState(t *testing.T) {
 	}
 
 	// A TRANSITION writes exactly one more row.
-	f.src.mu.Lock()
-	f.src.pages = []LiveTail{{Pod: runningPod()}}
-	f.src.mu.Unlock()
+	f.src.setPod(runningPod())
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("a Running pod with no output ended the session")
 	}
@@ -439,14 +737,13 @@ func TestRecorder_DarkZoneIsRecordedOncePerState(t *testing.T) {
 // TestRecorder_ComponentGoneClosesWithGaps pins the backstop for a Component
 // deleted out from under a running recording (retention, or a cancel that
 // raced the session): nothing more can ever be read, and what is on disk is by
-// definition short of the ending.
+// definition short of the ending — which is the ONE place the feed is entitled
+// to call a loss unrecoverable.
 func TestRecorder_ComponentGoneClosesWithGaps(t *testing.T) {
 	t.Parallel()
 
-	f := newRecorderFixture(t)
-	f.src.mu.Lock()
-	f.src.err = fmt.Errorf("%w: ca-c1", ErrComponentGone)
-	f.src.mu.Unlock()
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
+	f.src.setErr(fmt.Errorf("%w: ca-c1", ErrComponentGone))
 
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); !done {
@@ -454,6 +751,42 @@ func TestRecorder_ComponentGoneClosesWithGaps(t *testing.T) {
 	}
 	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingGaps {
 		t.Fatalf("state = %q, want gaps", got)
+	}
+	notices := gapNotices(f.recorded(t, 1))
+	if len(notices) != 1 {
+		t.Fatalf("%d gap notices, want the closing one", len(notices))
+	}
+	if !strings.Contains(notices[0].Detail, "nothing can recover it now") {
+		t.Errorf("closing notice = %q, want it to say the loss is permanent", notices[0].Detail)
+	}
+}
+
+// TestRecorder_BindingIsResolvedOncePerSessionAndReResolvedWhenItGoes pins the
+// round trip taken out of every poll. The binding name is fixed for the attempt,
+// so re-resolving it every second spent a call re-deriving a constant — and
+// spent it BETWEEN choosing a read window and having one applied. Caching it is
+// only safe because a read that 404s clears it: a cached name a re-render
+// replaced would otherwise 404 for the rest of the run.
+func TestRecorder_BindingIsResolvedOncePerSessionAndReResolvedWhenItGoes(t *testing.T) {
+	t.Parallel()
+
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
+	s := f.session(t, 1)
+	for i := 0; i < 3; i++ {
+		if done, _ := s.poll(context.Background()); done {
+			t.Fatalf("poll %d ended the session", i)
+		}
+	}
+	if got := f.src.bindingCalls(); got != 1 {
+		t.Fatalf("resolved the binding %d times over three polls, want 1", got)
+	}
+
+	f.src.setErr(fmt.Errorf("%w: ca-c1", ErrComponentGone))
+	if done, _ := s.poll(context.Background()); !done {
+		t.Fatal("a gone Component did not end the session")
+	}
+	if got := f.src.bindingCalls(); got != 2 {
+		t.Errorf("resolved the binding %d times, want 2 — a 404 on a cached name is worth one re-resolve", got)
 	}
 }
 
@@ -463,10 +796,8 @@ func TestRecorder_ComponentGoneClosesWithGaps(t *testing.T) {
 func TestRecorder_TransientReadFailureKeepsTheSessionAndTheCursor(t *testing.T) {
 	t.Parallel()
 
-	f := newRecorderFixture(t)
-	f.src.mu.Lock()
-	f.src.err = fmt.Errorf("connection refused")
-	f.src.mu.Unlock()
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
+	f.src.setErr(fmt.Errorf("connection refused"))
 
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); done {
@@ -475,8 +806,44 @@ func TestRecorder_TransientReadFailureKeepsTheSessionAndTheCursor(t *testing.T) 
 	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingRecording {
 		t.Fatalf("state = %q, want the recording left open", got)
 	}
-	if calls := f.src.sinceCalls(); len(calls) != 1 || calls[0] != 0 {
-		t.Errorf("sinceSeconds calls = %v, want the cursor to have stayed at 0", calls)
+	if windows := f.src.windowCalls(); len(windows) != 1 || !windows[0].IsZero() {
+		t.Errorf("read windows = %v, want the cursor to have stayed at the whole log", windows)
+	}
+}
+
+// TestRecorder_AStalledPollFailsInsteadOfBlockingTheSession pins the per-poll
+// deadline. The OpenChoreo client carries no timeout, so a hung call used to
+// block the session loop for as long as it liked: a recording that simply
+// stopped growing, with no warning anywhere to say why. Failing is safe — the
+// cursor does not move, so the next poll asks for the same window and picks up
+// everything the stalled one would have.
+func TestRecorder_AStalledPollFailsInsteadOfBlockingTheSession(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
+	f := newRecorderFixture(t, at, v1LogLine(1, at, `"kind":"log","summary":"one"`))
+	f.rec.pollTimeout = 50 * time.Millisecond
+	f.src.mu.Lock()
+	f.src.block = true
+	f.src.mu.Unlock()
+
+	s := f.session(t, 1)
+	if done, _ := s.poll(context.Background()); done {
+		t.Fatal("a stalled poll ended the session")
+	}
+	if s.cur.ProducerSeq != 0 || !s.cur.LastLineTS.IsZero() {
+		t.Errorf("a failed poll moved the cursor: %+v", s.cur)
+	}
+
+	// The next poll picks up what the stalled one never returned.
+	f.src.mu.Lock()
+	f.src.block = false
+	f.src.mu.Unlock()
+	if done, _ := s.poll(context.Background()); done {
+		t.Fatal("a Running pod ended the session")
+	}
+	if events := f.recorded(t, 1); len(events) != 1 || events[0].Detail != "one" {
+		t.Errorf("recorded %+v, want the line the stalled poll would have read", events)
 	}
 }
 
@@ -486,7 +853,8 @@ func TestRecorder_TransientReadFailureKeepsTheSessionAndTheCursor(t *testing.T) 
 func TestRecorder_EnsureSkipsAClosedRecording(t *testing.T) {
 	t.Parallel()
 
-	f := newRecorderFixture(t, LiveTail{Pod: succeededPod()})
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
+	f.src.setPod(succeededPod())
 	if _, err := f.store.Begin("acme", "c1", 1); err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -511,7 +879,7 @@ func TestRecorder_EnsureIsIdempotentPerAttempt(t *testing.T) {
 	// A Running pod with no output: the session polls, records the dark zone and
 	// then sleeps for an hour, so it is still registered when the second Ensure
 	// arrives.
-	f := newRecorderFixture(t, LiveTail{Pod: runningPod()})
+	f := newRecorderFixture(t, time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC))
 	f.rec.WithIntervals(time.Hour, time.Hour)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -554,30 +922,17 @@ func TestRecorder_SizeCapNamesItselfAndKeepsRunning(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 9, 4, 9, 25, 39, 0, time.UTC)
-	root := t.TempDir()
-	store := NewRecordingStore(root, 1) // one byte: anything trips it
-	src := &fakeRecordSource{pages: []LiveTail{{Pod: runningPod(),
-		Text: v1Line(1, at, `"kind":"log","summary":"one"`) + "\n"}}}
-	cyc := liveCycle("c1")
-	cyc.Attempts = 1
-	rec := NewCycleRecorder(src, store)
-	s := newRecordingSession(rec, cyc)
-	cur, err := store.Begin("acme", "c1", 1)
-	if err != nil {
-		t.Fatalf("Begin: %v", err)
-	}
-	s.cur = cur
+	// One byte: anything trips it.
+	f := newCappedRecorderFixture(t, 1, at, v1LogLine(1, at, `"kind":"log","summary":"one"`))
+	s := f.session(t, 1)
 
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("the size cap ended the session — the run must keep going")
 	}
-	if got := store.State("acme", "c1"); got != gen.RunCycleViewRecordingGaps {
+	if got := f.store.State("acme", "c1"); got != gen.RunCycleViewRecordingGaps {
 		t.Fatalf("state = %q, want gaps", got)
 	}
-	events, _, err := store.ReadFrom("acme", "c1", 1, 0)
-	if err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
+	events := f.recorded(t, 1)
 	last := events[len(events)-1]
 	if last.Code != gen.RunEventCodeGap || !strings.Contains(last.Detail, "size limit") {
 		t.Errorf("last event = %+v, want the size-cap notice", last)
@@ -588,8 +943,7 @@ func TestRecorder_SizeCapNamesItselfAndKeepsRunning(t *testing.T) {
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("the second poll ended the session")
 	}
-	after, _, _ := store.ReadFrom("acme", "c1", 1, 0)
-	if len(after) != before {
+	if after := f.recorded(t, 1); len(after) != before {
 		t.Errorf("recorded %d → %d events past the cap, want no more writes", before, len(after))
 	}
 }
@@ -621,6 +975,40 @@ func TestProducerSeq_ReadsBothEnvelopeVersionsAndRejectsProse(t *testing.T) {
 	}
 }
 
+// TestSinceSecondsAt_ConvertsLateAndRoundsOutwards pins the conversion that may
+// not be done early. `sinceSeconds` counts back from whenever the API reads it,
+// so a value computed before three OpenChoreo round trips describes a window
+// that has since slid forward — which is how a run lost eleven events. Rounding
+// is outwards for the same reason: a truncating divide asks for a window that
+// starts a fraction late, and the line in that fraction is gone for good.
+func TestSinceSecondsAt_ConvertsLateAndRoundsOutwards(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 8, 9, 29, 48, 0, time.UTC)
+	cases := []struct {
+		name  string
+		since time.Time
+		now   time.Time
+		want  int64
+	}{
+		{"the zero time is the whole log", time.Time{}, now, 0},
+		{"a whole number of seconds back", now.Add(-5 * time.Second), now, 6},
+		{"a fraction rounds outwards", now.Add(-1500 * time.Millisecond), now, 2},
+		{"a window start in the future asks for the smallest window", now.Add(time.Second), now, 1},
+		// The incident: the window was chosen at 09:29:41.8 and applied at
+		// 09:29:48.2, and a value computed early would have asked for 5s of log
+		// when the honest ask was 14s.
+		{"latency in front of the call only widens it",
+			time.Date(2026, 9, 8, 9, 29, 34, 294000000, time.UTC),
+			time.Date(2026, 9, 8, 9, 29, 48, 159000000, time.UTC), 14},
+	}
+	for _, tc := range cases {
+		if got := sinceSecondsAt(tc.since, tc.now); got != tc.want {
+			t.Errorf("%s: sinceSecondsAt = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestRecorder_EveryLineGetsItsOwnSeq is the measured loss, replayed.
 //
 // The tail of a real 55-minute run (testdata/run-2026-09-08-npm-tail.ndjson):
@@ -648,9 +1036,20 @@ func TestRecorder_EveryLineGetsItsOwnSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
-	if len(lines) != 11 {
-		t.Fatalf("fixture holds %d lines, want 11 (6 runner events + 5 prose)", len(lines))
+	rawLines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	if len(rawLines) != 11 {
+		t.Fatalf("fixture holds %d lines, want 11 (6 runner events + 5 prose)", len(rawLines))
+	}
+	// The pod's own log, line by line, with the kubelet clock the fixture
+	// carries — so the read window is applied against the run's real timing.
+	log := make([]fakeLogLine, 0, len(rawLines))
+	for _, raw := range rawLines {
+		ts, msg := splitTimestampPrefix(raw)
+		at := parseEventTime(ts)
+		if at.IsZero() {
+			t.Fatalf("fixture line has no kubelet timestamp: %q", raw)
+		}
+		log = append(log, fakeLogLine{at: at, text: msg})
 	}
 	wantProse := []string{
 		"npm notice",
@@ -663,14 +1062,13 @@ func TestRecorder_EveryLineGetsItsOwnSeq(t *testing.T) {
 	// The runner's own events land first, while the pod is Running; the prose
 	// arrives on the page that also carries the terminal phase, which is exactly
 	// how it happened (the five lines are stamped 108ms after `run_settled`).
-	live := LiveTail{Pod: runningPod(), Text: strings.Join(lines[:6], "\n") + "\n"}
-	final := LiveTail{Pod: succeededPod(), Text: string(raw)}
-
-	f := newRecorderFixture(t, live, final)
+	f := newRecorderFixture(t, log[5].at, log...)
 	s := f.session(t, 1)
 	if done, _ := s.poll(context.Background()); done {
 		t.Fatal("a Running pod ended the session")
 	}
+	f.clock.advance(time.Second)
+	f.src.setPod(succeededPod())
 	if done, _ := s.poll(context.Background()); !done {
 		t.Fatal("a terminal pod did not end the session")
 	}
@@ -739,12 +1137,18 @@ func TestRecorder_EveryLineGetsItsOwnSeq(t *testing.T) {
 	if meta.Cursor.ProseTS.IsZero() {
 		t.Error("state.json cursor.proseTs is unset; a restart would re-record the prose")
 	}
+	// The read window's anchor is persisted too, or a restart would fall back on
+	// the platform's clock and re-open the hole this cursor exists to close.
+	if !meta.Cursor.LastLineTS.Equal(log[len(log)-1].at) {
+		t.Errorf("state.json cursor.lastLineTs = %s, want the newest line ingested (%s)",
+			meta.Cursor.LastLineTS, log[len(log)-1].at)
+	}
 
 	// A RESTART re-reads the whole log off the persisted cursor. Nothing may be
 	// written twice and nothing renumbered — the recorder's numbering is stable
 	// only because ProducerSeq and ProseTS both survive the restart.
 	restarted := f.session(t, 1)
-	restarted.ingest(context.Background(), final)
+	restarted.ingest(context.Background(), LiveTail{Pod: succeededPod(), Text: string(raw)})
 	after := f.recorded(t, 1)
 	if len(after) != len(events) {
 		t.Fatalf("a restart re-recorded the page: %d events, want %d", len(after), len(events))

--- a/services/aep-api/internal/delivery/codingagent/run_recording.go
+++ b/services/aep-api/internal/delivery/codingagent/run_recording.go
@@ -178,6 +178,18 @@ type recordingMeta struct {
 //     accounts for the seq-less lines it used to ignore. Dark-zone markers are
 //     the one exception — they keep their stable negative seqs and consume no
 //     position.
+//   - LastLineTS is the pod-clock timestamp of the newest line INGESTED, seq
+//     -carrying ones included, and it is what the next read's window is measured
+//     from. It has to be the DATA's clock and not the platform's: the window used
+//     to start at the instant the previous read RETURNED, which assumes the
+//     answer described that instant. It does not — an OpenChoreo log call took a
+//     measured 13.22 s, and nothing says which moment inside it the log was read
+//     at — so the assumption moved the window's start past lines that had never
+//     been read, and a cursor that only moves forward never asked for them
+//     again. Anchored on the data, a stalled read makes the next window WIDER by
+//     exactly the length of the stall, which costs a re-read that dedupe throws
+//     away. (It is a superset of ProseTS, which is kept because it is the cursor
+//     that dedupes the seq-LESS lines; this one dedupes nothing.)
 //   - BootSeq is the last dark-zone marker written. Those markers carry stable
 //     NEGATIVE seqs and are re-derived on every poll, so recording one per poll
 //     would write the same row hundreds of times; only a state TRANSITION is
@@ -185,6 +197,7 @@ type recordingMeta struct {
 type recordCursor struct {
 	ProducerSeq int64     `json:"producerSeq"`
 	ProseTS     time.Time `json:"proseTs,omitempty"`
+	LastLineTS  time.Time `json:"lastLineTs,omitempty"`
 	LastSeq     int64     `json:"lastSeq"`
 	BootSeq     int64     `json:"bootSeq"`
 }

--- a/services/aep-api/internal/delivery/codingagent/watcher_test.go
+++ b/services/aep-api/internal/delivery/codingagent/watcher_test.go
@@ -36,12 +36,23 @@ type fakeRuntime struct {
 	logs       []openchoreo.PodLogLine
 	events     []openchoreo.RuntimeEvent
 
+	// delay runs before every call that precedes a log read. A test sets it to
+	// advance a fake clock, which is the only way to pin that the log window is
+	// computed AFTER the round trips in front of it rather than before them.
+	delay func()
+	// logSince is the sinceSeconds of the last PodLogs call — the coarse window
+	// the API actually received.
+	logSince int64
+
 	bindingCalls int
 	logCalls     int
 }
 
 func (f *fakeRuntime) ReleaseBindingName(context.Context, string, string, string, string) (string, error) {
 	f.bindingCalls++
+	if f.delay != nil {
+		f.delay()
+	}
 	if f.bindingErr != nil {
 		return "", f.bindingErr
 	}
@@ -49,11 +60,15 @@ func (f *fakeRuntime) ReleaseBindingName(context.Context, string, string, string
 }
 
 func (f *fakeRuntime) PodSnapshot(context.Context, string, string) (openchoreo.RuntimePod, error) {
+	if f.delay != nil {
+		f.delay()
+	}
 	return f.pod, f.podErr
 }
 
-func (f *fakeRuntime) PodLogs(context.Context, string, string, string, int64) ([]openchoreo.PodLogLine, error) {
+func (f *fakeRuntime) PodLogs(_ context.Context, _, _, _ string, sinceSeconds int64) ([]openchoreo.PodLogLine, error) {
 	f.logCalls++
+	f.logSince = sinceSeconds
 	return f.logs, nil
 }
 

--- a/services/aep-api/internal/platform/gitfs/engine.go
+++ b/services/aep-api/internal/platform/gitfs/engine.go
@@ -155,11 +155,52 @@ func trashDest(root string) string {
 
 // ----- git execution (hermetic child env, design D2/§8) -----
 
+// forcedConfig is git config the engine imposes on every child, whatever the
+// mirror's own config file says.
+//
+// maintenance.auto is here because the reaper must be the only thing that
+// repacks a shared mirror — it is the only thing that does so under the
+// per-repo EX flock. Git's default is the opposite: `fetch`, `push` and
+// `commit` all end by spawning `git maintenance run --auto --detach`, which
+// double-forks, so it goes on rewriting the object DB after the engine's
+// critical section has closed and the lock is gone. Two concurrent repacks on
+// one object DB is precisely the state the flock exists to prevent, and the
+// detached one holds nothing. The value has to be maintenance.auto: git's auto
+// strategy is geometric-repack, which never consults gc.auto.
+//
+// It is forced through the environment rather than stamped into each mirror
+// because the shared volume outlives any single release. A stamp written at
+// clone time cannot reach a mirror that was cloned before the rule existed;
+// env-supplied config outranks the repo's own file and so covers every mirror
+// already on disk.
+var forcedConfig = []gitConfigRule{
+	{"maintenance.auto", "false"},
+}
+
+// gitConfigRule is one config key/value the engine imposes on git children.
+type gitConfigRule struct{ key, value string }
+
+// forcedConfigEnv renders forcedConfig as git's GIT_CONFIG_COUNT /
+// GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n triplets (equivalent to `git -c`, and
+// higher precedence than any config file). The indices are derived from the
+// slice, so adding a rule above is the whole change — there is no count to
+// keep in step by hand.
+func forcedConfigEnv() map[string]string {
+	env := map[string]string{"GIT_CONFIG_COUNT": strconv.Itoa(len(forcedConfig))}
+	for i, c := range forcedConfig {
+		n := strconv.Itoa(i)
+		env["GIT_CONFIG_KEY_"+n] = c.key
+		env["GIT_CONFIG_VALUE_"+n] = c.value
+	}
+	return env
+}
+
 // baseEnv is the scrubbed environment every git child gets: no user/system
 // config, no terminal prompts, C locale for machine-stable output, HOME
-// pointed into tmp/ so nothing ambient leaks in.
+// pointed into tmp/ so nothing ambient leaks in, plus the forcedConfig rules
+// the engine imposes on every mirror.
 func (e *Engine) baseEnv() map[string]string {
-	return map[string]string{
+	env := map[string]string{
 		"PATH":                os.Getenv("PATH"),
 		"HOME":                TmpDir(e.root),
 		"GIT_CONFIG_GLOBAL":   os.DevNull,
@@ -167,6 +208,10 @@ func (e *Engine) baseEnv() map[string]string {
 		"GIT_TERMINAL_PROMPT": "0",
 		"LC_ALL":              "C",
 	}
+	for k, v := range forcedConfigEnv() {
+		env[k] = v
+	}
+	return env
 }
 
 // execOpts parametrizes one git invocation.
@@ -301,8 +346,15 @@ func (e *Engine) ensureMirror(ctx context.Context, ref RepoRef, p repoPaths) (cl
 	if _, err := e.remoteGit(ctx, ref, execOpts{}, "clone", "--mirror", ref.CloneURL, stagingGit); err != nil {
 		return false, fmt.Errorf("gitfs: mirror clone %s: %w", ref.RepoSlug, err)
 	}
-	// Never auto-gc a shared mirror — the reaper maintainRepos pass runs
-	// repack/prune/pack-refs under the EX flock (never git gc: gc.pid hostname trap).
+	// gc.auto=0 turns off the classic `gc --auto` path only. It is NOT what
+	// keeps automatic maintenance off a shared mirror: git's auto strategy is
+	// geometric-repack, which never reads gc.auto. That is closed by
+	// forcedConfig (maintenance.auto=false) on every child instead, which also
+	// covers mirrors cloned before this rule existed. The stamp stays as the
+	// narrower belt-and-braces — a mirror handed to a git that still routes
+	// through gc --auto must not gc either, since the reaper's maintainRepos
+	// pass owns repack/prune/pack-refs under the EX flock (never git gc: the
+	// gc.pid hostname trap).
 	if _, err := e.git(ctx, execOpts{}, "--git-dir", stagingGit, "config", "gc.auto", "0"); err != nil {
 		return false, err
 	}

--- a/services/aep-api/internal/platform/gitfs/engine.go
+++ b/services/aep-api/internal/platform/gitfs/engine.go
@@ -185,6 +185,17 @@ type gitConfigRule struct{ key, value string }
 // higher precedence than any config file). The indices are derived from the
 // slice, so adding a rule above is the whole change — there is no count to
 // keep in step by hand.
+//
+// MINIMUM GIT 2.31, which is where these variables were added. Below it they
+// are inert and every rule above silently stops applying. The image installs
+// Alpine's unversioned `git` package (services/aep-api/Dockerfile) and is not
+// pinned to a floor: 2.31 shipped in March 2021, the image currently resolves
+// 2.47, and pinning an apk version would break the build the first time the
+// package is superseded — a certainty, against a regression that is not. What
+// guards it instead is TestGitResolvesEveryForcedConfigRule, which asks the
+// git binary on the box what it RESOLVES for every rule here: on a git too old
+// to read this environment, that test fails rather than the platform quietly
+// losing the rule.
 func forcedConfigEnv() map[string]string {
 	env := map[string]string{"GIT_CONFIG_COUNT": strconv.Itoa(len(forcedConfig))}
 	for i, c := range forcedConfig {

--- a/services/aep-api/internal/platform/gitfs/export_test.go
+++ b/services/aep-api/internal/platform/gitfs/export_test.go
@@ -49,3 +49,27 @@ func IsENOSPC(err error) bool { return isENOSPC(err) }
 
 // MapDiskErr exposes Engine.mapDiskErr for emergency-sweep wiring tests.
 func MapDiskErr(e *Engine, err error) error { return e.mapDiskErr(err) }
+
+// RunGitWithEnv runs one git command through the engine's own child-process
+// path (buildCmd → hermetic base env → overlay), returning stdout. It is the
+// seam for asserting what git ACTUALLY does under the engine's environment:
+// a test can hand the invocation a GIT_TRACE2_EVENT sink and read back which
+// children git spawned, or ask git to resolve a config key and see which
+// layer won. The overlay travels through execOpts, the same channel the
+// credential plumbing uses, so what runs is the production path rather than a
+// re-creation of it.
+func RunGitWithEnv(e *Engine, ctx context.Context, env map[string]string, args ...string) ([]byte, error) {
+	return e.git(ctx, execOpts{env: env}, args...)
+}
+
+// ForcedConfigRules exposes the config rules the engine imposes on every git
+// child, so a test can assert that git resolves EVERY one of them rather than
+// only the rule a named test happens to mention — the coverage grows with the
+// list instead of needing a new test per rule.
+func ForcedConfigRules() [][2]string {
+	rules := make([][2]string, 0, len(forcedConfig))
+	for _, c := range forcedConfig {
+		rules = append(rules, [2]string{c.key, c.value})
+	}
+	return rules
+}

--- a/services/aep-api/internal/platform/gitfs/hygiene_test.go
+++ b/services/aep-api/internal/platform/gitfs/hygiene_test.go
@@ -170,3 +170,27 @@ func TestNilCredentialSkipsAskpass(t *testing.T) {
 		}
 	}
 }
+
+// TestForcedConfigIsNotACredentialChannel guards the config the engine forces
+// into EVERY git child's environment. It is a tempting place to put
+// http.extraheader or a credential helper, and doing so would broadcast a
+// secret to every invocation and every mirror at once — the exact opposite of
+// the askpass design, where the token reaches only remote ops and only via
+// GITFS_TOKEN. The same banned words the mirror's config is held to apply
+// here, checked on the key AND the value: a rule may configure git's
+// behaviour, never its credentials.
+func TestForcedConfigIsNotACredentialChannel(t *testing.T) {
+	rules := gitfs.ForcedConfigRules()
+	if len(rules) == 0 {
+		t.Fatal("no forced config rules — this test would prove nothing")
+	}
+	for _, rule := range rules {
+		for _, field := range rule {
+			for _, banned := range []string{"askpass", "credential", "extraheader", "x-access-token", "authorization", "token", "password"} {
+				if strings.Contains(strings.ToLower(field), banned) {
+					t.Errorf("forced config rule %v contains %q — credentials must travel via GITFS_TOKEN + the askpass shim, not the forced config every child inherits", rule, banned)
+				}
+			}
+		}
+	}
+}

--- a/services/aep-api/internal/platform/gitfs/maintenance_test.go
+++ b/services/aep-api/internal/platform/gitfs/maintenance_test.go
@@ -43,10 +43,26 @@ import (
 // record before it forks, so it is on disk by the time the process we waited
 // for has exited: a decision, not a timing window, and nothing to poll.
 //
-// The second arm is the teeth. GIT_CONFIG_COUNT=0 makes git ignore the
-// engine's env-forced config without the test having to know how many
-// entries there are, and the same fetch then does hand the mirror over —
-// proving the trace scan can see a handoff when one happens.
+// The control is the teeth, and it runs FIRST. GIT_CONFIG_COUNT=0 makes git
+// ignore the engine's env-forced config without the test having to know how many
+// entries there are, and the same fetch then has to hand the mirror over —
+// proving the trace scan can see a handoff when one happens. Without that, the
+// assertion that matters ("no handoff under the engine's env") passes for any
+// reason at all, including git never handing off in the first place.
+//
+// WHICH IS VERSION-DEPENDENT, so the control is a PRECONDITION rather than an
+// assertion. Measured: git 2.47.3 (what the aep-api image ships, and the only
+// version the guard has to protect) and 2.54.0 both hand a fetch to
+// `git maintenance run --auto`; 2.55.0 — which is what `ubuntu-latest` carries —
+// does not, and asserting that it must turned this into a red build about git's
+// behaviour rather than ours. When the ambient git will not hand off even with
+// the forced config disabled, this environment cannot show the handoff the guard
+// suppresses, and the test says so instead of passing vacuously.
+//
+// The forced config itself stays covered everywhere:
+// TestForcedConfigOutranksAMirrorAlreadyOnDisk and
+// TestGitResolvesEveryForcedConfigRule ask git what it RESOLVES, which is
+// deterministic on every version and never skips.
 func TestFetchNeverHandsTheMirrorToAutoMaintenance(t *testing.T) {
 	fx := workspacetest.New(t, seedFiles())
 	ctx := context.Background()
@@ -61,38 +77,59 @@ func TestFetchNeverHandsTheMirrorToAutoMaintenance(t *testing.T) {
 	mustHead(t, fx, "")
 	fetchArgs := recordedFetchArgv(t, rec)
 
-	for _, tc := range []struct {
-		name        string
-		env         map[string]string
-		wantHandoff bool
-	}{
-		{name: "engine env", wantHandoff: false},
-		{name: "forced config switched off", env: map[string]string{"GIT_CONFIG_COUNT": "0"}, wantHandoff: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// Give every arm a commit of its own to fetch, so each replay
-			// transfers real objects instead of short-circuiting.
-			fx.Origin.Seed(t, map[string]string{"specs/" + tc.name + ".md": "x\n"}, tc.name)
-
-			traceDir := t.TempDir()
-			env := map[string]string{"GIT_TRACE2_EVENT": traceDir}
-			for k, v := range tc.env {
-				env[k] = v
-			}
-			if _, err := gitfs.RunGitWithEnv(fx.Engine, ctx, env, fetchArgs...); err != nil {
-				t.Fatalf("fetch: %v", err)
-			}
-
-			traced := tracedCommands(t, traceDir)
-			if !traced["fetch"] {
-				t.Fatalf("trace sink captured no fetch — the assertion below would pass vacuously (saw %v)", traced)
-			}
-			spawned := spawnedAutoMaintenance(t, traceDir)
-			if spawned != tc.wantHandoff {
-				t.Fatalf("fetch spawned `git maintenance run --auto` = %v, want %v", spawned, tc.wantHandoff)
-			}
-		})
+	// The control, first: with the engine's forced config switched off, this git
+	// has to hand the mirror over. If it does not, the guard has nothing
+	// observable to suppress here and the assertion below would pass for the
+	// wrong reason.
+	if !fetchHandsOff(t, fx, ctx, fetchArgs, "control", map[string]string{"GIT_CONFIG_COUNT": "0"}) {
+		t.Skipf("%s does not hand a fetch to `git maintenance run --auto` even with the engine's forced config disabled, "+
+			"so this environment cannot show the handoff the guard suppresses; the forced config itself is still asserted by "+
+			"TestForcedConfigOutranksAMirrorAlreadyOnDisk and TestGitResolvesEveryForcedConfigRule",
+			gitVersion(t, fx, ctx))
 	}
+
+	if fetchHandsOff(t, fx, ctx, fetchArgs, "engine env", nil) {
+		t.Fatal("fetch spawned `git maintenance run --auto` under the engine's env — " +
+			"the mirror is being repacked outside the per-repo lock, and the reaper is no longer its only maintainer")
+	}
+}
+
+// fetchHandsOff replays the engine's own fetch under extra env and reports
+// whether the fetching process recorded starting a `git maintenance` child.
+//
+// It reads the FETCHING process's own child_start record rather than looking for
+// the maintenance process or its packs: git writes that record before it forks,
+// so it is on disk by the time the process we waited for has exited. A decision,
+// not a timing window, and nothing to poll.
+func fetchHandsOff(t *testing.T, fx *workspacetest.Fixture, ctx context.Context, fetchArgs []string, label string, extra map[string]string) bool {
+	t.Helper()
+	// A commit of its own for every replay, so each transfers real objects
+	// instead of short-circuiting.
+	fx.Origin.Seed(t, map[string]string{"specs/" + label + ".md": "x\n"}, label)
+
+	traceDir := t.TempDir()
+	env := map[string]string{"GIT_TRACE2_EVENT": traceDir}
+	for k, v := range extra {
+		env[k] = v
+	}
+	if _, err := gitfs.RunGitWithEnv(fx.Engine, ctx, env, fetchArgs...); err != nil {
+		t.Fatalf("%s: fetch: %v", label, err)
+	}
+	if traced := tracedCommands(t, traceDir); !traced["fetch"] {
+		t.Fatalf("%s: trace sink captured no fetch — every verdict from it would be vacuous (saw %v)", label, traced)
+	}
+	return spawnedAutoMaintenance(t, traceDir)
+}
+
+// gitVersion reports the `git version` line of the binary the engine runs, for
+// a skip message that names the thing it is skipping on.
+func gitVersion(t *testing.T, fx *workspacetest.Fixture, ctx context.Context) string {
+	t.Helper()
+	out, err := gitfs.RunGitWithEnv(fx.Engine, ctx, nil, "version")
+	if err != nil {
+		return "this git"
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // TestForcedConfigOutranksAMirrorAlreadyOnDisk pins WHERE the knob lives. A

--- a/services/aep-api/internal/platform/gitfs/maintenance_test.go
+++ b/services/aep-api/internal/platform/gitfs/maintenance_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gitfs_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs"
+	"github.com/wso2/aep/aep-api/internal/platform/gitfs/workspacetest"
+)
+
+// TestFetchNeverHandsTheMirrorToAutoMaintenance guards the reaper's charter:
+// it is the ONLY thing that may repack a shared mirror, because it is the
+// only thing that does so under the per-repo EX flock. Git disagrees by
+// default — `fetch` (like `commit`) ends by spawning
+// `git maintenance run --auto --no-quiet --detach`, which double-forks and so
+// keeps rewriting the object DB after fetch has returned and the engine has
+// already released the lock. The spawn is unconditional: the parent hands off
+// on every fetch and lets the child decide whether a task has work, so the
+// handoff itself is the thing to forbid.
+//
+// The assertion reads the FETCHING process's own child_start record rather
+// than looking for the maintenance process or its packs. Git writes that
+// record before it forks, so it is on disk by the time the process we waited
+// for has exited: a decision, not a timing window, and nothing to poll.
+//
+// The second arm is the teeth. GIT_CONFIG_COUNT=0 makes git ignore the
+// engine's env-forced config without the test having to know how many
+// entries there are, and the same fetch then does hand the mirror over —
+// proving the trace scan can see a handoff when one happens.
+func TestFetchNeverHandsTheMirrorToAutoMaintenance(t *testing.T) {
+	fx := workspacetest.New(t, seedFiles())
+	ctx := context.Background()
+
+	// Clone the mirror, then drive a real fetch and keep the argv the engine
+	// itself used — the replay below runs the engine's fetch, not a hand-typed
+	// approximation of it.
+	rec := recordCommands(t, fx.Engine)
+	mustHead(t, fx, "")
+	fx.Origin.Seed(t, map[string]string{"specs/one.md": "one\n"}, "one")
+	rec.reset()
+	mustHead(t, fx, "")
+	fetchArgs := recordedFetchArgv(t, rec)
+
+	for _, tc := range []struct {
+		name        string
+		env         map[string]string
+		wantHandoff bool
+	}{
+		{name: "engine env", wantHandoff: false},
+		{name: "forced config switched off", env: map[string]string{"GIT_CONFIG_COUNT": "0"}, wantHandoff: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Give every arm a commit of its own to fetch, so each replay
+			// transfers real objects instead of short-circuiting.
+			fx.Origin.Seed(t, map[string]string{"specs/" + tc.name + ".md": "x\n"}, tc.name)
+
+			traceDir := t.TempDir()
+			env := map[string]string{"GIT_TRACE2_EVENT": traceDir}
+			for k, v := range tc.env {
+				env[k] = v
+			}
+			if _, err := gitfs.RunGitWithEnv(fx.Engine, ctx, env, fetchArgs...); err != nil {
+				t.Fatalf("fetch: %v", err)
+			}
+
+			traced := tracedCommands(t, traceDir)
+			if !traced["fetch"] {
+				t.Fatalf("trace sink captured no fetch — the assertion below would pass vacuously (saw %v)", traced)
+			}
+			spawned := spawnedAutoMaintenance(t, traceDir)
+			if spawned != tc.wantHandoff {
+				t.Fatalf("fetch spawned `git maintenance run --auto` = %v, want %v", spawned, tc.wantHandoff)
+			}
+		})
+	}
+}
+
+// TestForcedConfigOutranksAMirrorAlreadyOnDisk pins WHERE the knob lives. A
+// `git config` stamp written at clone time cannot reach a mirror that was
+// cloned before the rule existed, and the shared volume outlives any single
+// release. Forcing the value into every child's environment does reach them:
+// env-supplied config outranks the repo's own file, so a mirror whose config
+// says otherwise still gets the engine's answer.
+func TestForcedConfigOutranksAMirrorAlreadyOnDisk(t *testing.T) {
+	fx := workspacetest.New(t, seedFiles())
+	ctx := context.Background()
+	mustHead(t, fx, "")
+	gitDir := mirrorGitDir(t, fx)
+
+	// Stand in for a mirror already on the volume: its own config asks for
+	// auto maintenance.
+	gitOut(t, gitDir, "config", "maintenance.auto", "true")
+	if got := gitOut(t, gitDir, "config", "--get", "maintenance.auto"); got != "true" {
+		t.Fatalf("setup: mirror config = %q, want true", got)
+	}
+
+	out, err := gitfs.RunGitWithEnv(fx.Engine, ctx, nil, "--git-dir", gitDir, "config", "--get", "maintenance.auto")
+	if err != nil {
+		t.Fatalf("config --get through the engine: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "false" {
+		t.Fatalf("git resolved maintenance.auto = %q under the engine env, want false", got)
+	}
+}
+
+// TestGitResolvesEveryForcedConfigRule asks git itself what it resolves for
+// every rule the engine forces, so a rule added to the list is covered the
+// moment it is added — and so a rendering mistake (a stale count, a skipped
+// index) fails here rather than silently dropping the rule in production.
+func TestGitResolvesEveryForcedConfigRule(t *testing.T) {
+	rules := gitfs.ForcedConfigRules()
+	if len(rules) == 0 {
+		t.Fatal("no forced config rules — this test would prove nothing")
+	}
+	fx := workspacetest.New(t, seedFiles())
+	ctx := context.Background()
+	mustHead(t, fx, "")
+	gitDir := mirrorGitDir(t, fx)
+
+	for _, rule := range rules {
+		key, want := rule[0], rule[1]
+		out, err := gitfs.RunGitWithEnv(fx.Engine, ctx, nil, "--git-dir", gitDir, "config", "--get", key)
+		if err != nil {
+			t.Errorf("git config --get %s: %v", key, err)
+			continue
+		}
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Errorf("git resolved %s = %q under the engine env, want %q", key, got, want)
+		}
+	}
+}
+
+// recordedFetchArgv returns the argv of the single fetch the recorder saw,
+// minus the leading "git" the hook prepends.
+func recordedFetchArgv(t *testing.T, rec *recorder) []string {
+	t.Helper()
+	var found [][]string
+	for _, c := range rec.all() {
+		if subcommand(c.Args) == "fetch" {
+			found = append(found, c.Args[1:])
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly one recorded fetch, got %d", len(found))
+	}
+	return found[0]
+}
+
+// tracedCommands returns the set of git subcommands that wrote a trace file
+// into dir (one file per process, named by cmd_name in its events).
+func tracedCommands(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	seen := map[string]bool{}
+	forEachTraceEvent(t, dir, func(e traceEvent) {
+		if e.Event == "cmd_name" && e.Name != "" {
+			seen[e.Name] = true
+		}
+	})
+	return seen
+}
+
+// spawnedAutoMaintenance reports whether any traced process recorded starting
+// a `git maintenance` child.
+func spawnedAutoMaintenance(t *testing.T, dir string) bool {
+	t.Helper()
+	found := false
+	forEachTraceEvent(t, dir, func(e traceEvent) {
+		if e.Event != "child_start" {
+			return
+		}
+		for _, arg := range e.Argv {
+			if arg == "maintenance" {
+				found = true
+			}
+		}
+	})
+	return found
+}
+
+// traceEvent is the slice of GIT_TRACE2_EVENT records these assertions read.
+type traceEvent struct {
+	Event string   `json:"event"`
+	Name  string   `json:"name"`
+	Argv  []string `json:"argv"`
+}
+
+func forEachTraceEvent(t *testing.T, dir string, visit func(traceEvent)) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read trace dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read trace file %s: %v", entry.Name(), err)
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			var e traceEvent
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Fatalf("trace line %q: %v", line, err)
+			}
+			visit(e)
+		}
+	}
+}

--- a/services/aep-api/internal/platform/gitfs/reaper/maintain_test.go
+++ b/services/aep-api/internal/platform/gitfs/reaper/maintain_test.go
@@ -48,7 +48,7 @@ func TestMaintainReposRepacksLooseHeavyMirror(t *testing.T) {
 	r.diskUsage = fakeDisk(1000, 900)
 	slug := mkSlugDir(t, root, "o1", "p1", "r1")
 	gitDir := filepath.Join(slug, "git")
-	runGit(t, "", "init", "--bare", gitDir)
+	initSyntheticMirror(t, gitDir)
 	// Seed >1000 reachable loose objects. hash-object alone leaves blobs
 	// unreachable, and `repack -ad` only packs/drops reachable objects —
 	// commit them through a temporary work tree so repack can reclaim.
@@ -88,7 +88,7 @@ func TestMaintainReposSlowGitCompletes(t *testing.T) {
 	r.diskUsage = fakeDisk(1000, 900)
 	slug := mkSlugDir(t, root, "o1", "p1", "r1")
 	gitDir := filepath.Join(slug, "git")
-	runGit(t, "", "init", "--bare", gitDir)
+	initSyntheticMirror(t, gitDir)
 	work := t.TempDir()
 	for i := 0; i < 1101; i++ {
 		name := filepath.Join(work, "f"+strconv.Itoa(i))
@@ -149,7 +149,7 @@ func TestMaintainReposSkipsBusyLock(t *testing.T) {
 	r.diskUsage = fakeDisk(1000, 900)
 	slug := mkSlugDir(t, root, "o1", "p1", "r1")
 	gitDir := filepath.Join(slug, "git")
-	runGit(t, "", "init", "--bare", gitDir)
+	initSyntheticMirror(t, gitDir)
 	work := t.TempDir()
 	for i := 0; i < 1101; i++ {
 		name := filepath.Join(work, "f"+strconv.Itoa(i))
@@ -175,6 +175,24 @@ func TestMaintainReposSkipsBusyLock(t *testing.T) {
 		t.Fatalf("busy lock should skip within ~2s timeout, took %s", time.Since(start))
 	}
 	// Still locked — objects unrepacked is fine; the point is skip, not hang.
+}
+
+// initSyntheticMirror creates the bare mirror a maintain test operates on.
+// The config stamp is load-bearing, not hygiene: `git commit` (and `git
+// fetch`) hand the repo to `git maintenance run --auto --detach`, which
+// double-forks and outlives the command that spawned it. That detached repack
+// keeps creating objects/pack/tmp_pack_* after the seeding commit has already
+// exited, so it races t.TempDir's RemoveAll at test end — RemoveAll lists
+// objects/, unlinks what it saw, then rmdir's it and gets ENOTEMPTY from a
+// pack that appeared in between. The knob has to be maintenance.auto: git's
+// auto strategy is geometric-repack, which never consults gc.auto, so
+// gc.auto=0 leaves the detached repack running. Tests seed through porcelain
+// on a repo they created with `git init --bare`, so they must disable it
+// themselves.
+func initSyntheticMirror(t *testing.T, gitDir string) {
+	t.Helper()
+	runGit(t, "", "init", "--bare", gitDir)
+	runGit(t, gitDir, "config", "maintenance.auto", "false")
 }
 
 func countLoose(t *testing.T, gitDir string) int {


### PR DESCRIPTION
## What

Four defects found by watching real coding runs — the first three on the local cluster right after #735 merged, the fourth on the hosted demo cluster. Two are in the feed the crew view is drawn from, one is in the git mirror engine, one is in the console surface that reads the feed. All four were caught by *looking at the running system*, not by a failing test — and each commit adds the test that would have caught it.

Branched from `upstream/main` (post-#735), not from `crew-view`.

## 1. The lead agent was 2026 years old

The console rendered the lead's age as `1065409035m47s`, and the Timeline view as `1065409043m56s across 3 agents` with the lead's lane stretched over the whole axis while its two real children (`4m0s`, `3m40s`) collapsed into hairlines. The children's ages were correct; so was the heartbeat line beside the lead.

`1,065,409,035` minutes is ≈ 2,026 years — `now` minus Go's zero time. `platformNotice` built every platform-minted event without setting `TS`, on the reasoning that these markers are ordered by position in the file rather than by a clock. Ordering *is* `seq`'s job — but `RunEvent.ts` is required and generates as a plain `time.Time`, so "no timestamp" was never absent on the wire:

```json
{"agentId":"lead","kind":"notice","seq":-11,"ts":"0001-01-01T00:00:00Z"}
```

Every platform notice belongs to the lead, and the dark-zone marker sits at the head of nearly every recording — so only the lead inherited year 1 as its earliest instant.

Fixed at both ends, because recordings already written still hold zero stamps: the producer threads the instant from the caller that *derived* the marker (the read that observed the pod; for a gap, the kubelet clock of the line that revealed it), and `timeOf` — the single door every clock in `buildCrew` comes through — treats anything below 2020-01-01 as absent data, which the model already answers with "no lane, no age, row all the same". An old recording now renders `15m47s` where it read `1065409035m47s`.

## 2. "7 event(s) … could not be recovered" — nothing was lost

Four of these appeared mid-run. The pod's log held every event: 317 lines, seqs `1..317`, none missing, nothing near the 1 MiB line cap. The OpenChoreo logs API served the complete stream when asked (`sinceSeconds=0` → `1..478`, no cap, no reordering). Neither the producer nor the API lost anything.

`sinceSeconds()` measured the window from `lastRead` — the platform's own wall clock, stamped when the *previous* read returned — and computed it **before** three sequential OpenChoreo round trips. Slack was 3 s of overlap plus 1 s of rounding: four seconds for the whole poll. Reconstructed from openchoreo-api's access log (nanosecond `duration` per request, so start = end − duration):

```
start=09:29:40.169 end=09:29:40.537 dur=0.37s logs   <- cursor=424, lastRead≈09:29:40.6
start=09:29:41.828 end=09:29:43.604 dur=1.78s list   <- window computed here: 5s
start=09:29:46.203 end=09:29:48.023 dur=1.82s tree
start=09:29:48.159 end=09:29:48.780 dur=0.62s logs   <- window ≈ [09:29:43.2, 09:29:48.5]
```

Seqs 425 (09:29:41.352) and 426 (09:29:41.387) fall before that start; 427 (09:29:44.651) falls inside. The recording shows exactly that. The worst poll spent 13.22 s inside one `logs` call on a starved node.

The anchor was wrong, not the overlap. The cursor now carries `LastLineTS` — the pod clock of the newest line actually ingested, advanced by *every* line and persisted in `state.json`. A 13-second stall now widens the next window by 13 seconds instead of leaving a permanent hole. Four consequences of the same reading: the window is absolute through the source interface and converted to the API's coarse `sinceSeconds` immediately before the log call; the release binding is resolved once per session; each poll is bounded, because the OC client has no timeout and a 13-second call silently blocked the loop; and `repairGap` re-reads the live pod before the archive, and warns when the archive is empty (it used to return before its own log line, which is why losing twelve events left no trace).

The notice also stops overclaiming: a mid-run hole says the events "have not been captured yet", and only a recording closed as `gaps` says the loss is permanent.

**The test seam is why this shipped.** `fakeRecordSource.ReadSince` recorded `sinceSeconds` and ignored it, serving pages by call index — no test could express "the window missed a line". It is replaced by a fake holding a synthetic timestamped log and a shared fake clock, honouring the requested window, answering as the log stood when the call was *issued*. Reverting only the anchor fails the new regression test with `[s1 s2 … 2 event(s) … s5]` against `[s1 s2 s3 s4 s5]`; reverting the anchor while keeping the new live repair fails identically, so the fix cannot be faked by its own fallback.

## 3. The reaper is not the only thing repacking a mirror

`ensureMirror` stamps `gc.auto 0` under the comment "Never auto-gc a shared mirror". On git 2.54 that stamp no longer buys what it claims: git's auto strategy is **geometric-repack**, which never consults `gc.auto`. Measured — with `gc.auto = 0` in the config, loose objects went 1103 → 0, writing a cruft pack and a midx.

And it is reachable from production. `git fetch --prune` — the engine's own `fetch()` — ends by spawning `git maintenance run --auto --no-quiet --detach`, which double-forks. `GIT_TRACE2_EVENT` on a real fetch through `Engine.git`:

```
process fetch        start=09:40:08.822990Z exit=09:40:08.916022Z
    spawned: git maintenance run --auto --no-quiet --detach
process maintenance  start=09:40:08.912844Z exit=09:40:08.916765Z   <- outlives the fetch
```

That repack outlives `release()`, so it rewrites the object DB **outside the per-repo EX flock**, holding nothing — the exact state that flock exists to prevent, contradicting the `Engine` doc comment's invariant and the reaper's premise that it is the sole maintainer.

`maintenance.auto=false` is the knob that closes it, forced through the environment (`GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n`) rather than stamped per mirror: the shared volume outlives any release, and a clone-time stamp cannot reach a mirror cloned before the rule existed. Env config outranks the repo's own file, so mirrors already on disk are covered. After the fix the same fetch spawns no `maintenance` at all.

This is also what the reaper test flake was: `TestMaintainReposSlowGitCompletes` and `TestMaintainReposSkipsBusyLock` failed in `t.TempDir`'s cleanup (`unlinkat …/r1/git: directory not empty`) with every assertion passing — **3/3 on a clean `upstream/main`**. The seeding `git commit` hands the repo to detached maintenance, which keeps writing `objects/pack/tmp_pack_*` ~590 ms after `commit` returns, racing `RemoveAll`. Standalone repro of that shape, 20 iterations: **18/20 fail unchanged, 0/20 with `maintenance.auto=false`, 19/20 still fail with `gc.auto=0`.**

## 4. The build page could only reach the newest run that delivered a version

Found on the hosted demo cluster reading `testing9231` v1 — a version delivered by four runs: a `dev` run wrote it, a `validation` run found a defect and filed four issues, a `task` run repaired them, a second `validation` run passed 24/24. The Coding agent log showed exactly one box:

```
Cycle 1  [coding]  105 events   #13
1 agent · all settled
```

That is the repair — a two-file FX fallback, 6 minutes, $1.00. The run that actually wrote the version — pull request #6, +8230 lines across 47 files, 841 events, three subagents — had no surface anywhere on the page, and nothing on screen hinted it existed. The ordinal makes it worse: cycles are numbered per run, so the repair's only cycle reads "Cycle 1", and a reader sees v1's whole coding history as one short session that edited two files.

Nothing was lost, and nothing needed adding server-side. All four recordings were intact on the volume with `state: complete, closed: true`, and `stream-run-progress` is keyed per run:

```
runs/default/fe36a7df…/events.1.ndjson   195 KB   841 events   (dev, PR #6)
runs/default/0cb0c8d4…/events.1.ndjson   170 KB   650 events   (validation, PR #8)
runs/default/d4e1ecea…/events.1.ndjson    28 KB   105 events   (task, PR #13)
runs/default/a92bd407…/events.1.ndjson    57 KB   269 events   (validation, PR #14)
```

`BuildDetailPage` simply asked for one of them:

```js
const current = runList.filter(isDeliveryRun)[0];   // newest first
…
<AgentLogSection runId={current?.id} … />            // → one <RunFeed>
```

The Validation page already had this right for the same version — `Run 2 · Cycle 1 · 269 events`, then `EARLIER VALIDATION RUNS`, then `Run 1 · Cycle 1 · 650 events` — so the fix is that shape applied to the delivery runs: a feed each, newest first, `runNumber` counted from the oldest so the numbers descend with the cycle ordinals, `expandNewest` on the first alone so one log is open per page rather than one per feed, and the caption before the second feed. `RunFeed` already took every prop this needs. Per-run feeds stay cheap for the reason that page gives: a settled run's stream is finite, so the server sends `done` and closes, leaving at most one connection held open.

Each feed is now filtered to `BUILD_CYCLE_KINDS`. The single feed did not filter, which was survivable while only the newest run was mounted — but a validation run that *repairs* what it found is a delivery run, kept by `isDeliveryRun` for its coding cycles, and its validation cycle would otherwise render here as well as on the Validation board. `buildCycles` and `mergedCycle` already draw that line everywhere else on this page.

`SectionCaption` is extracted to `components/` because this is the fourth caller, which is the condition `ValidationPage` wrote down for collapsing its three hand-matched copies.

Unlike the three above, this one is *not* live-verified — proving it needs a console image rebuild and roll. The eight new tests use `testing9231`'s own run list as fixtures; reverting to `[0]` turns four of them red, and dropping the kind filter turns a fifth.

## Verification

| Gate | Result |
|---|---|
| `make typecheck` | green |
| `make test` | green |
| `go test ./internal/delivery/...` | 656 pass, 0 fail (30 pre-existing dbtest skips: Docker not running) |
| `go test ./...` (aep-api) | 70 packages ok |
| `go test ./internal/platform/gitfs/...` ×5 | 5/5 green |
| `@aep/progress-view` | 82 pass, 0 fail |
| `apps/console` | 1858 pass (145 files) |
| `deadcode-check` | OK |

Each fix's regression test was shown RED first — the exact failure output is in the commit messages.

**Live-plane verification of the first three, on a real cluster run, is in a follow-up comment** — these were found by watching the running system, so that is where they have to be proven.

## Deliberately not fixed, each worth its own issue

- The OpenChoreo client has no HTTP timeout of its own; only the recorder's poll is bounded now. The watcher, the dispatcher and the V1 `Tail` path can still block indefinitely.
- The local k3d bring-up installs no observability plane while `OBSERVER_URL` is configured, so the platform believes it has an archive it does not have.
- `observability.query` takes its bearer from the request context, so any recorder-initiated archive read is unauthenticated by construction.
- `recordCursor.ProseTS` still persists as `0001-01-01T00:00:00Z` in `state.json` (`time.Time` + `omitempty` does not omit a struct). Internal cursor state, never reaches a contract surface; Go 1.26's `omitzero` fixes it in one word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

