### PR TITLE
feat(eventcore): a user bug's `bug` label self-arms it (ADR-0029)

### DIFF
--- a/docs/decisions/ADR-0029-user-bugs-self-arm.md
+++ b/docs/decisions/ADR-0029-user-bugs-self-arm.md
@@ -1,0 +1,94 @@
+# ADR-0029 — A user-reported bug's `bug` label is its own arming
+
+**Status:** accepted · not yet implemented · 2026-09-09
+**Related:** ADR-0011 (milestone is the unit of execution) · ADR-0017 (the
+platform owns deploy) · ADR-0026 (deploy reconciles the version) · the
+SRE/RCA incident-adoption path (`task.Commands.PromoteAndExecute` →
+`Adopter.AdoptIssue`, `services/aep-api/internal/delivery/task/commands.go`)
+· `docs/glossary.md` (*Arming label*, *Ledger issue*)
+
+## Context
+
+Arming (`aep`) is deliberately a human act everywhere else in this domain: a
+`bug` label classifies an issue, `aep` says a human chose to spend money and
+let the agent work it, and even the platform's own detected incidents are
+filed as `bug` and left unarmed on purpose — "classification is not
+permission" (`docs/glossary.md`, *Ledger issue*). The split exists because
+arming stays auditable to a person from the issue timeline alone, and because
+an armed issue bills real spend and, once merged, deploys to production
+unattended.
+
+A user reporting a bug against their own already-deployed app has been asking
+for the opposite: file the issue, get the fix, no second click. Every `bug`
+they file today needs a human to separately add `aep` (or call
+`promote-from-issue`) before anything happens — friction with little safety
+value for this one case, since the reporter and the person who would arm it
+are usually the same actor.
+
+## Decision
+
+**For a `bug` issue whose source is `src/user` (explicit label, or absent —
+the existing default), the `bug` label IS the arming label.** The moment such
+a label lands on an issue — at creation or later, by anyone able to label the
+repo's issues — it is adopted exactly as if a human had added `aep`: moved
+into the deployed version's milestone, and a `task` run is started (or the
+live one picks it up at its next cycle boundary), through the existing
+`AdoptIssue` path.
+
+Everything downstream of adoption is unchanged and stays fully unattended:
+agent run → PR auto-merge → build fan-out → the supervisor's deploy reconcile
+(ADR-0026). No new checkpoint is introduced between merge and deploy for this
+path — gating after the fix is already merged would just leave it
+undeployed, which defeats the purpose.
+
+**Scope, deliberately narrow:**
+- Only `src/user`. The platform-detected sources (`src/build`, `src/deploy`,
+  `src/validation`) stay ledger-only exactly as before; `src/incident` keeps
+  its own existing, separate automatic path unchanged. Widening this to
+  platform-detected failure classes is a materially bigger trust bet and was
+  explicitly deferred.
+- Only forward from ship date. Pre-existing open `bug` issues are not swept
+  or retroactively adopted — nobody just decided, today, to spend on those.
+- No new label. Adoption is marked with a bot comment ("auto-adopted") on the
+  issue instead — a marker label would blur the two existing independent
+  axes, `kind` and `source`.
+- If the project has no deployed version yet, there is nothing for the issue
+  to join; the platform leaves an explanatory comment instead of adopting.
+
+## Accepted risk
+
+This removes the human-intent gate for the one population it applies to.
+Explicitly, and by choice, not by oversight:
+
+- **No trust check on the labeler.** Anyone able to attach `bug` to an issue
+  on the repo triggers a billed agent run and an eventual production deploy —
+  the same as GitHub's own label-write permission today, with no additional
+  verification.
+- **No cost or concurrency cap** beyond the existing one-live-run-per-milestone
+  throttle. An org running many projects can have that many auto-armed runs
+  going at once, each billing its own org key (ADR-0016).
+- **No off switch.** This is unconditional behaviour for every project in
+  every org — there is no per-project or per-org setting to disable it.
+
+Each was raised and the trade-off taken deliberately: the friction being
+removed is one click by the same person who would otherwise make it, and a
+trust check, a cap, or a toggle were each judged to be gating a problem that,
+for `src/user` reports, mostly isn't there. If that changes — spam reports,
+cost surprises, a team wanting to opt out — the fix is additive: none of the
+above closes the door on adding a check, a cap, or a switch later without
+reversing this decision.
+
+## Not done, deliberately
+
+- **A trust/role check on who applied the label.** Considered and rejected —
+  see *Accepted risk*.
+- **A per-org concurrency or spend cap on auto-armed runs.** Considered and
+  rejected for the same reason.
+- **A per-project/org opt-out.** Considered and rejected; this is
+  unconditional.
+- **A backfill sweep of pre-existing open bugs.** Would silently start paid
+  runs and deploys for issues nobody acted on today, as a side effect of
+  shipping unrelated code.
+- **A distinguishing label (e.g. `src/auto`).** Would conflate the `source`
+  axis (who found it) with a new "who armed it" concept; a bot comment
+  carries that fact without touching the label vocabulary.

--- a/docs/decisions/ADR-0029-user-bugs-self-arm.md
+++ b/docs/decisions/ADR-0029-user-bugs-self-arm.md
@@ -1,6 +1,6 @@
 # ADR-0029 — A user-reported bug's `bug` label is its own arming
 
-**Status:** accepted · not yet implemented · 2026-09-09
+**Status:** accepted · implemented, pending merge · 2026-09-09
 **Related:** ADR-0011 (milestone is the unit of execution) · ADR-0017 (the
 platform owns deploy) · ADR-0026 (deploy reconciles the version) · the
 SRE/RCA incident-adoption path (`task.Commands.PromoteAndExecute` →
@@ -33,7 +33,10 @@ a label lands on an issue — at creation or later, by anyone able to label the
 repo's issues — it is adopted exactly as if a human had added `aep`: moved
 into the deployed version's milestone, and a `task` run is started (or the
 live one picks it up at its next cycle boundary), through the existing
-`AdoptIssue` path.
+`AdoptIssue` path. "Exactly as if" is literal — the platform stamps `aep`
+itself as part of adopting the issue, because every consumer downstream of
+adoption reads that label and nothing else, so an adopted issue without it is
+a ledger issue whose run has no work to find.
 
 Everything downstream of adoption is unchanged and stays fully unattended:
 agent run → PR auto-merge → build fan-out → the supervisor's deploy reconcile

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -421,7 +421,10 @@ already on screen.
 meaning about WHAT the work is — that is the kind — and it is also the
 GitHub-side **adoption** trigger, so a human stamping it hands an issue to the
 agent. Platform-written labels come back as webhook echoes and are dropped by
-sender, which is what keeps arming a human act.
+sender, which is what keeps arming a human act — with one deliberate
+exception: a `bug` issue whose source is `src/user` self-arms on the `bug`
+label alone, no `aep` needed (ADR-0029). Every other kind, and every other
+`bug` source, still requires the separate `aep` stamp.
 
 ### Kind
 Exactly one per issue, and the axis every routing predicate tests **positively**:
@@ -504,7 +507,9 @@ never worked, never stalling settle, and never written to — a cancel does not
 close it and the sweep does not start a run for it, because it is nobody's work
 until a human arms it. It may still be classified — a red-main
 incident is filed as a `bug` so a human can see what it is — because
-classification is not permission. Adding `aep` **adopts** it into the next cycle.
+classification is not permission (except for a `src/user` bug, where the
+`bug` label itself is the arming — ADR-0029). Adding `aep` **adopts** it into
+the next cycle, as does the `bug` label for that one exception.
 
 ### Terminal reason
 Why a non-succeeded run stopped. Each value names exactly ONE failure class —

--- a/services/aep-api/internal/delivery/README.md
+++ b/services/aep-api/internal/delivery/README.md
@@ -282,9 +282,12 @@ is the one package allowed to name them, so `httpapi.Deps` + `httpapi.New` is wh
 - **Two label axes: an issue is ARMED or not, and has exactly one KIND** (`labels.go`). `aep` arms it —
   something may work it — and is also the human's adoption trigger; the kind (`development`, `bug`,
   `conflict`, `validation`, `provision`) says which loop, and a `bug` carries a `src/*` source saying who
-  found it. Every routing predicate is then a POSITIVE membership test on the kind, which is what removed
-  the old model's subtraction of exclusions — a rule stated as what it is not, where a single mis-stated
-  exclusion emptied a live working set. A **gate** (`provision` + `aep:dep/<slug>`, minted by
+  found it. The one exception to "a human arms it" is ADR-0029: a `bug` sourced `src/user` self-arms on the
+  `bug` label alone, and `eventcore.AutoAdoptUserBug` stamps `aep` itself as part of adopting it (plus a bot
+  comment, since there is no human stamp to read the act off). Every other kind, and every other `bug`
+  source, still needs the separate human stamp. Every routing predicate is then a POSITIVE membership test
+  on the kind, which is what removed the old model's subtraction of exclusions — a rule stated as what it
+  is not, where a single mis-stated exclusion emptied a live working set. A **gate** (`provision` + `aep:dep/<slug>`, minted by
   `dependencies/provisioning`) is deliberately NOT armed: a dispatch hold is nobody's work, and its absence
   from the armed population is what lets it be counted on its own rather than subtracted from the work
   waiting behind it. The **validation task** IS armed and excluded by its kind instead — it is real agent

--- a/services/aep-api/internal/delivery/eventcore/adopt.go
+++ b/services/aep-api/internal/delivery/eventcore/adopt.go
@@ -71,6 +71,18 @@ type AdoptTarget struct {
 // platform-authored path to the same state would make "who adopted this"
 // unanswerable.
 //
+// Which is why the label is the CALLER's to write, never this function's. The
+// webhook route reaches here BECAUSE a human's `aep` stamp arrived, so the label
+// is already on the issue and the timeline already names who armed it; the
+// console / MCP dispatch route is an authenticated request from a human or their
+// agent, which is that route's own answer to the same question.
+//
+// ADR-0029 adds the one route whose issue carries no `aep` by construction —
+// a `src/user` bug self-arming on `bug` alone — and it stamps the label itself
+// before calling this, so the run started below sees the issue at its first
+// cycle boundary, plus a bot comment so "who adopted this" still has an answer.
+// See AutoAdoptUserBug; nothing about the rules above changes for it.
+//
 // Nor does it stamp a KIND. An armed issue carrying none reads as a bug to every
 // working-set predicate (delivery.InDevWorkingSet), which is what a human
 // handing over an unclassified issue means, and it is the same answer the host's

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt.go
@@ -102,11 +102,20 @@ func eligibleForAutoAdopt(labels []string) bool {
 // pass inert: the stamp this route leaves is the "already handled" record, so a
 // later delivery about the same issue is not eligible and the undeduped comment
 // is not posted twice.
-func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, target AdoptTarget) {
+//
+// The one error it does NOT swallow is a failed rollback: if there is no
+// deployed version to adopt into AND the unlabel meant to undo the stamp also
+// fails, the issue is left armed in no milestone — inert, but no longer
+// self-arming, so the comment's own advice ("add `aep` directly") would be
+// telling the reporter to do something already done. That failure is
+// returned so the caller can fail the webhook delivery and let GitHub's
+// redelivery retry the same idempotent unlabel, rather than posting a
+// comment that would be wrong the moment it landed.
+func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, target AdoptTarget) error {
 	if lerr := e.p.Writer.Label(ctx, orgID, projectID, target.Number, delivery.LabelAgentWork); lerr != nil {
 		slog.WarnContext(ctx, "eventcore: auto-adopt declined — could not arm the issue",
 			"issue", target.Number, "error", lerr)
-		return
+		return nil
 	}
 	// The label AdoptIssue and every later reader must agree on. It routes on this
 	// set (delivery.AdoptableByATaskRun), and a set that says the issue is unarmed
@@ -121,19 +130,18 @@ func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, 
 	case err == nil:
 		comment = autoAdoptedComment
 	case errors.Is(err, ErrNoDeployedMilestone):
-		comment = autoAdoptNoDeployedVersionComment
 		if uerr := e.p.Writer.Unlabel(ctx, orgID, projectID, target.Number, delivery.LabelAgentWork); uerr != nil {
-			// Left armed in no milestone: inert (nothing works an issue outside a
-			// milestone) but no longer self-arming, so the comment below tells the
-			// reporter to add `aep` — which is already there — rather than the truth.
-			slog.WarnContext(ctx, "eventcore: could not disarm an issue nothing adopted",
+			slog.WarnContext(ctx, "eventcore: could not disarm an issue nothing adopted — leaving it for redelivery to retry",
 				"issue", target.Number, "error", uerr)
+			return uerr
 		}
+		comment = autoAdoptNoDeployedVersionComment
 	default:
 		slog.WarnContext(ctx, "eventcore: auto-adopt declined", "issue", target.Number, "error", err)
-		return
+		return nil
 	}
 	if cerr := e.p.Writer.Comment(ctx, orgID, projectID, target.Number, comment); cerr != nil {
 		slog.WarnContext(ctx, "eventcore: auto-adopt comment failed", "issue", target.Number, "error", cerr)
 	}
+	return nil
 }

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventcore
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+// ADR-0029: a `bug` issue sourced `src/user` (explicit, or absent — the
+// existing default) self-arms on the `bug` label alone, with no `aep` stamp
+// required. Every other kind, and every other bug source, is untouched — see
+// eligibleForAutoAdopt.
+//
+// The two comments below are the audit trail a human's own `aep` stamp
+// otherwise carries for free (docs/glossary.md, "Arming label"): once a rule
+// can arm an issue instead of a person, the issue timeline needs to keep
+// saying so.
+const (
+	autoAdoptedComment = "🤖 Auto-adopted: the `bug` label on this user-reported " +
+		"issue arms it for the coding agent (ADR-0029) — no `aep` label needed. " +
+		"It has been moved into the deployed version's milestone and will be " +
+		"picked up shortly."
+	autoAdoptNoDeployedVersionComment = "This looks like a user-reported bug, but " +
+		"this project has no deployed version yet, so there is nothing to adopt " +
+		"it into (ADR-0029). Once a version deploys, re-add the `bug` label (or " +
+		"add `aep` directly) and it will be picked up."
+)
+
+// eligibleForAutoAdopt reports whether an issue's OWN label set is ADR-0029's
+// self-arming population: a `bug`, sourced `src/user` or unsourced, that no
+// human has already armed.
+//
+// An issue already carrying `aep` is left to the ordinary path. A human's own
+// stamp already answers "who decided to spend money here"; self-arming it
+// too would post a second, contradictory answer onto the same issue.
+func eligibleForAutoAdopt(labels []string) bool {
+	if delivery.KindOf(labels) != delivery.KindBug {
+		return false
+	}
+	if delivery.HasLabel(labels, delivery.LabelAgentWork) {
+		return false
+	}
+	return delivery.IsUserSourced(labels)
+}
+
+// AutoAdoptUserBug is OnIssues' self-arming route (ADR-0029). It shares every
+// rule AdoptIssue already enforces — kind routing, milestone placement, the
+// live-run no-op — and adds only the audit trail: a comment marking the
+// issue self-armed, or explaining why it could not be.
+//
+// Errors from AdoptIssue other than ErrNoDeployedMilestone are logged and
+// swallowed, the same as the `aep`-webhook route does: GitHub redelivering
+// the label must not become a retry storm, and a human watching the issue
+// sees the comment (or its absence) rather than a delivery log.
+func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, target AdoptTarget) {
+	err := e.AdoptIssue(ctx, orgID, projectID, target)
+	var comment string
+	switch {
+	case err == nil:
+		comment = autoAdoptedComment
+	case errors.Is(err, ErrNoDeployedMilestone):
+		comment = autoAdoptNoDeployedVersionComment
+	default:
+		slog.WarnContext(ctx, "eventcore: auto-adopt declined", "issue", target.Number, "error", err)
+		return
+	}
+	if cerr := e.p.Writer.Comment(ctx, orgID, projectID, target.Number, comment); cerr != nil {
+		slog.WarnContext(ctx, "eventcore: auto-adopt comment failed", "issue", target.Number, "error", cerr)
+	}
+}

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt.go
@@ -35,9 +35,9 @@ import (
 // saying so.
 const (
 	autoAdoptedComment = "🤖 Auto-adopted: the `bug` label on this user-reported " +
-		"issue arms it for the coding agent (ADR-0029) — no `aep` label needed. " +
-		"It has been moved into the deployed version's milestone and will be " +
-		"picked up shortly."
+		"issue is its own arming (ADR-0029) — no `aep` label needed. It is now " +
+		"armed for the coding agent, and the run over its milestone picks it up " +
+		"at the next cycle boundary."
 	autoAdoptNoDeployedVersionComment = "This looks like a user-reported bug, but " +
 		"this project has no deployed version yet, so there is nothing to adopt " +
 		"it into (ADR-0029). Once a version deploys, re-add the `bug` label (or " +
@@ -63,14 +63,58 @@ func eligibleForAutoAdopt(labels []string) bool {
 
 // AutoAdoptUserBug is OnIssues' self-arming route (ADR-0029). It shares every
 // rule AdoptIssue already enforces — kind routing, milestone placement, the
-// live-run no-op — and adds only the audit trail: a comment marking the
-// issue self-armed, or explaining why it could not be.
+// live-run no-op — and adds the two things a human's own `aep` stamp otherwise
+// brings with it: the ARMING LABEL, and an audit trail marking the issue
+// self-armed (or explaining why it could not be).
 //
-// Errors from AdoptIssue other than ErrNoDeployedMilestone are logged and
-// swallowed, the same as the `aep`-webhook route does: GitHub redelivering
-// the label must not become a retry storm, and a human watching the issue
-// sees the comment (or its absence) rather than a delivery log.
+// It STAMPS `aep` because AdoptIssue deliberately does not (see its doc
+// comment): the older routes into it carry a human's own authorisation already —
+// the webhook route IS that human's `aep` stamp arriving — while this is the
+// first route that adopts an issue guaranteed NOT to carry the label
+// (eligibleForAutoAdopt requires its absence). Everything downstream of
+// adoption reads that label and nothing else — delivery.InTaskWorkingSet, the
+// milestone counts a cycle boundary polls, the reconcile sweep — so an issue
+// adopted without it is a LEDGER issue by the platform's own definition: the run
+// starts, its first poll counts no work, and it parks indefinitely holding the
+// milestone's one live-run slot.
+//
+// The stamp goes FIRST, and the two writes are one act:
+//
+//   - Before, because the run AdoptIssue starts polls its milestone at the first
+//     cycle boundary, and the platform's own label write comes back
+//     echo-suppressed — a stamp landing after that poll is a stamp no run ever
+//     sees, and nothing would wake it.
+//   - Refusing when the stamp fails, because adopting anyway IS the parked-run
+//     state above. Nothing is written and nothing is claimed on the issue.
+//   - Rolling the stamp back when there is no deployed version to adopt into,
+//     the one adoption outcome that writes nothing else: an armed issue in NO
+//     milestone is invisible to every working set and to the sweep (which walks
+//     milestones), and it would quietly falsify the comment's own advice, since
+//     re-adding `bug` cannot self-arm an issue that already carries `aep`.
+//
+// Any OTHER error from AdoptIssue keeps the stamp and is logged and swallowed,
+// the same as the `aep`-webhook route does: GitHub redelivering the label must
+// not become a retry storm, the armed issue in its milestone is what lets the
+// reconcile sweep finish the job, and a human watching the issue sees the
+// comment (or its absence) rather than a delivery log.
+//
+// The caller gates on eligibleForAutoAdopt, which is also what makes a repeat
+// pass inert: the stamp this route leaves is the "already handled" record, so a
+// later delivery about the same issue is not eligible and the undeduped comment
+// is not posted twice.
 func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, target AdoptTarget) {
+	if lerr := e.p.Writer.Label(ctx, orgID, projectID, target.Number, delivery.LabelAgentWork); lerr != nil {
+		slog.WarnContext(ctx, "eventcore: auto-adopt declined — could not arm the issue",
+			"issue", target.Number, "error", lerr)
+		return
+	}
+	// The label AdoptIssue and every later reader must agree on. It routes on this
+	// set (delivery.AdoptableByATaskRun), and a set that says the issue is unarmed
+	// while the host says it is armed is the disagreement this whole route turns on.
+	if !delivery.HasLabel(target.Labels, delivery.LabelAgentWork) {
+		target.Labels = append(append([]string(nil), target.Labels...), delivery.LabelAgentWork)
+	}
+
 	err := e.AdoptIssue(ctx, orgID, projectID, target)
 	var comment string
 	switch {
@@ -78,6 +122,13 @@ func (e *Events) AutoAdoptUserBug(ctx context.Context, orgID, projectID string, 
 		comment = autoAdoptedComment
 	case errors.Is(err, ErrNoDeployedMilestone):
 		comment = autoAdoptNoDeployedVersionComment
+		if uerr := e.p.Writer.Unlabel(ctx, orgID, projectID, target.Number, delivery.LabelAgentWork); uerr != nil {
+			// Left armed in no milestone: inert (nothing works an issue outside a
+			// milestone) but no longer self-arming, so the comment below tells the
+			// reporter to add `aep` — which is already there — rather than the truth.
+			slog.WarnContext(ctx, "eventcore: could not disarm an issue nothing adopted",
+				"issue", target.Number, "error", uerr)
+		}
 	default:
 		slog.WarnContext(ctx, "eventcore: auto-adopt declined", "issue", target.Number, "error", err)
 		return

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
@@ -18,10 +18,44 @@ package eventcore
 
 import (
 	"context"
+	"errors"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/wso2/aep/aep-api/internal/delivery"
 )
+
+// labelsAfter is the issue's label set as the host now holds it: the set the
+// route was handed, plus every label it added, minus every one it removed.
+//
+// Self-arming is only correct as a property of that SET — every consumer
+// downstream of adoption (delivery.InTaskWorkingSet, the milestone counts, the
+// reconcile sweep) reads the issue's labels, not this package's writes — so the
+// tests below assert the set rather than the individual calls.
+func labelsAfter(f *fakeIssues, number int, before ...string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]string(nil), before...)
+	for _, write := range f.labelled {
+		if name, ok := strings.CutPrefix(write, strconv.Itoa(number)+"+"); ok {
+			if !delivery.HasLabel(out, name) {
+				out = append(out, name)
+			}
+			continue
+		}
+		if name, ok := strings.CutPrefix(write, strconv.Itoa(number)+"-"); ok {
+			kept := out[:0]
+			for _, have := range out {
+				if !strings.EqualFold(have, name) {
+					kept = append(kept, have)
+				}
+			}
+			out = kept
+		}
+	}
+	return out
+}
 
 func TestEligibleForAutoAdopt(t *testing.T) {
 	t.Parallel()
@@ -62,6 +96,75 @@ func TestAutoAdoptUserBug_AdoptsAndLeavesTheAuditComment(t *testing.T) {
 	}
 	if got := h.issues.commentBodies[31]; got != autoAdoptedComment {
 		t.Fatalf("must leave the auto-adopted audit comment, got %q", got)
+	}
+}
+
+// TestAutoAdoptUserBug_ArmsTheIssueItAdopts is the property the milestone move
+// and the started run cannot express between them: the run picks its work out of
+// the milestone through delivery.InTaskWorkingSet, which gates on the ARMING
+// label first. An issue adopted without it is a ledger issue by the platform's
+// own definition — the run's first boundary poll counts no work, parks
+// indefinitely, and holds the milestone's one live-run slot while it does.
+func TestAutoAdoptUserBug_ArmsTheIssueItAdopts(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	after := labelsAfter(h.issues, 31, delivery.KindBug)
+	if !delivery.InTaskWorkingSet(after) {
+		t.Fatalf("the adopted issue must be in the task run's working set, got labels %v", after)
+	}
+	if len(h.sup.started) != 1 {
+		t.Fatalf("must start exactly one task run, got %+v", h.sup.started)
+	}
+}
+
+// TestAutoAdoptUserBug_RefusesToAdoptWhenArmingFails: arming and adopting are one
+// act. With the label write failing, adopting anyway is precisely the broken
+// state — an issue in the deployed milestone that no working set can see, plus a
+// run parked on it — so nothing else may be written.
+//
+// It also pins the ORDER, which two separately recorded writes otherwise cannot
+// show: the arming stamp goes first, because the run AdoptIssue starts polls its
+// milestone at the first cycle boundary and the platform's own label write comes
+// back echo-suppressed. A stamp that lands after that poll is a stamp no run sees.
+func TestAutoAdoptUserBug_RefusesToAdoptWhenArmingFails(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+	h.issues.labelErr = errors.New("github: 502")
+
+	h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("must adopt nothing when arming failed, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+	if body, ok := h.issues.commentBodies[31]; ok {
+		t.Fatalf("must not claim an issue was armed when it was not, got %q", body)
+	}
+}
+
+// TestAutoAdoptUserBug_NoDeployedVersionLeavesTheIssueUnarmed: the one adoption
+// outcome that writes nothing rolls the arming stamp back with it.
+//
+// Leaving it on would arm an issue in NO milestone — invisible to every working
+// set and to the reconcile sweep, which walks milestones — and would silently
+// falsify the comment's own advice: re-adding `bug` cannot self-arm an issue that
+// already carries `aep` (eligibleForAutoAdopt).
+func TestAutoAdoptUserBug_NoDeployedVersionLeavesTheIssueUnarmed(t *testing.T) {
+	h := newHarness(t) // no runs at all — nothing has ever deployed
+
+	h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	after := labelsAfter(h.issues, 31, delivery.KindBug)
+	if delivery.HasLabel(after, delivery.LabelAgentWork) {
+		t.Fatalf("an issue nothing adopted must be left unarmed, got labels %v", after)
+	}
+	if !eligibleForAutoAdopt(after) {
+		t.Fatalf("the comment tells the reporter to re-add `bug` once a version deploys — "+
+			"that has to still self-arm, but %v is no longer eligible", after)
 	}
 }
 

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
@@ -168,6 +168,31 @@ func TestAutoAdoptUserBug_NoDeployedVersionLeavesTheIssueUnarmed(t *testing.T) {
 	}
 }
 
+// TestAutoAdoptUserBug_RollbackFailureIsReturnedNotSwallowed: the ONE error
+// this route does not swallow. If the rollback's own Unlabel fails, the issue
+// is left armed in no milestone — and posting the "no deployed version"
+// comment now would tell the reporter to add `aep` directly, which is
+// already there. Returning the error lets the caller fail the webhook
+// delivery so GitHub's redelivery retries the same idempotent unlabel.
+func TestAutoAdoptUserBug_RollbackFailureIsReturnedNotSwallowed(t *testing.T) {
+	h := newHarness(t) // no runs at all — nothing has ever deployed
+	h.issues.unlabelErr = errors.New("github: 502")
+
+	err := h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	if err == nil {
+		t.Fatal("a failed rollback must be returned, not swallowed")
+	}
+	if _, ok := h.issues.commentBodies[31]; ok {
+		t.Fatalf("must not post a comment whose advice is already false, got %q", h.issues.commentBodies[31])
+	}
+	after := labelsAfter(h.issues, 31, delivery.KindBug)
+	if !delivery.HasLabel(after, delivery.LabelAgentWork) {
+		t.Fatalf("the failed unlabel must leave the issue exactly as it was — still armed, got %v", after)
+	}
+}
+
 func TestAutoAdoptUserBug_NoDeployedVersionLeavesAnExplanation(t *testing.T) {
 	h := newHarness(t) // no runs at all — nothing has ever deployed
 

--- a/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
+++ b/services/aep-api/internal/delivery/eventcore/auto_adopt_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventcore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+func TestEligibleForAutoAdopt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"unarmed user bug, no source label", []string{delivery.KindBug}, true},
+		{"unarmed, explicit src/user", []string{delivery.KindBug, delivery.SrcUser}, true},
+		{"already armed by a human", []string{delivery.LabelAgentWork, delivery.KindBug}, false},
+		{"incident-sourced", []string{delivery.KindBug, delivery.SrcIncident}, false},
+		{"build-sourced", []string{delivery.KindBug, delivery.SrcBuild}, false},
+		{"not a bug at all", []string{delivery.KindDevelopment}, false},
+		{"a ledger issue with no labels", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := eligibleForAutoAdopt(c.labels); got != c.want {
+				t.Errorf("eligibleForAutoAdopt(%v) = %v, want %v", c.labels, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAutoAdoptUserBug_AdoptsAndLeavesTheAuditComment(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	if len(h.issues.assigned) != 1 || h.issues.assigned[0] != "31->5" {
+		t.Fatalf("must join the deployed version's milestone, got %v", h.issues.assigned)
+	}
+	if len(h.sup.started) != 1 || h.sup.started[0].Kind != delivery.RunKindTask {
+		t.Fatalf("must start a task run, got %+v", h.sup.started)
+	}
+	if got := h.issues.commentBodies[31]; got != autoAdoptedComment {
+		t.Fatalf("must leave the auto-adopted audit comment, got %q", got)
+	}
+}
+
+func TestAutoAdoptUserBug_NoDeployedVersionLeavesAnExplanation(t *testing.T) {
+	h := newHarness(t) // no runs at all — nothing has ever deployed
+
+	h.events.AutoAdoptUserBug(context.Background(), testOrg, testProject,
+		AdoptTarget{Number: 31, Labels: []string{delivery.KindBug}})
+
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("must adopt nothing without a deployed version, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+	if got := h.issues.commentBodies[31]; got != autoAdoptNoDeployedVersionComment {
+		t.Fatalf("must explain why it did not adopt, got %q", got)
+	}
+}

--- a/services/aep-api/internal/delivery/eventcore/doc.go
+++ b/services/aep-api/internal/delivery/eventcore/doc.go
@@ -57,6 +57,14 @@
 // issue resolves the DEPLOYED version's milestone through run rows; the red-main
 // incident path does the same. No run rows, no milestone, no write.
 //
+// ONE write escapes it, deliberately: a `src/user` bug self-arming under
+// ADR-0029 on a project with no deployed version leaves an explanatory COMMENT
+// on the issue (auto_adopt.go) with zero run rows for that project. It is the
+// ADR's own answer to "there is nothing to adopt it into" — a reporter whose bug
+// was silently ignored has no way to learn why — and it stays inside the safety
+// property the rule exists for: a comment on the issue somebody just labelled
+// starts no run, merges nothing and touches no milestone.
+//
 // # Idempotency
 //
 // A webhook delivery whose handler failed is REDELIVERED and re-run (the
@@ -74,7 +82,14 @@
 //   - triggering a build counts the WorkflowRuns OpenChoreo already holds for
 //     (component, commit) and refuses to exceed the allowance — which is the
 //     SAME mechanism as the automatic re-trigger budget, so idempotency and
-//     the budget can never disagree.
+//     the budget can never disagree;
+//   - self-arming (ADR-0029) stamps `aep` as part of adopting, and its own
+//     eligibility test requires that label's ABSENCE — so the issue's label set
+//     is the record, and a later delivery about an issue this route already
+//     armed is not eligible. A byte-identical REDELIVERY is the residue: it
+//     replays the pre-arming labels, so it is eligible again, and what repeats
+//     is the audit comment — every other write it makes is an idempotent merge
+//     and AdoptIssue's live-run check absorbs the run.
 //
 // # Echo suppression is issues-only
 //

--- a/services/aep-api/internal/delivery/eventcore/events.go
+++ b/services/aep-api/internal/delivery/eventcore/events.go
@@ -100,15 +100,17 @@ var _ delivery.BuildTerminalObserver = (*Events)(nil)
 // that push is the only signal that the conflict is resolved. ready_for_review
 // and reopened are the same decision arriving by another route.
 //
-// issues covers the six actions that can change a milestone's membership or an
-// issue's state, which is what the dispatch predicate is computed over.
+// issues covers the seven actions that can change a milestone's membership or
+// an issue's state, which is what the dispatch predicate is computed over.
+// `opened` is there only for ADR-0029's self-arm check below — a label picked
+// at creation time never fires a separate `labeled` delivery.
 func (e *Events) RegisterHandlers(register RegisterFunc) {
 	register("pull_request", "opened", e.OnPullRequest)
 	register("pull_request", "synchronize", e.OnPullRequest)
 	register("pull_request", "ready_for_review", e.OnPullRequest)
 	register("pull_request", "reopened", e.OnPullRequest)
 	register("pull_request", "closed", e.OnPullRequestClosed)
-	for _, action := range []string{"closed", "reopened", "milestoned", "demilestoned", "labeled", "unlabeled"} {
+	for _, action := range []string{"opened", "closed", "reopened", "milestoned", "demilestoned", "labeled", "unlabeled"} {
 		register("issues", action, e.OnIssues)
 	}
 }
@@ -411,6 +413,25 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 				"issue", p.Issue.Number, "error", aerr)
 			return nil
 		}
+	}
+
+	// ADR-0029: a `bug` issue sourced `src/user` (or unsourced) self-arms on
+	// the `bug` label alone — at CREATION (`opened`, the whole label set) or
+	// later (`labeled`, only when `bug` itself is what just fired).
+	//
+	// Gating `labeled` on the FIRED label — not just the issue's current set —
+	// is what keeps this forward-only: a pre-existing unarmed bug must not
+	// self-arm because some unrelated label was added to it after this
+	// shipped. `opened` has no such distinction to make; the whole label set
+	// IS what just landed.
+	firedBug := action == "opened" ||
+		(action == "labeled" && strings.EqualFold(p.Label.Name, delivery.KindBug))
+	if firedBug && eligibleForAutoAdopt(p.issueLabels()) {
+		target := AdoptTarget{Number: p.Issue.Number, Labels: p.issueLabels()}
+		if ms, ok := p.milestone(); ok {
+			target.MilestoneNumber, target.MilestoneTitle = ms.Number, ms.Title
+		}
+		e.AutoAdoptUserBug(ctx, orgID, projectID, target)
 	}
 
 	ms, ok := p.milestone()

--- a/services/aep-api/internal/delivery/eventcore/events.go
+++ b/services/aep-api/internal/delivery/eventcore/events.go
@@ -403,10 +403,12 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 	}
 
 	// The ARMING SWITCH is the adoption trigger: a human adding `aep` to an issue
-	// hands it to the agent. Platform-written labels never reach here — the echo
-	// suppression above drops any delivery this platform's own sender caused —
-	// so every arming that arrives is a human's act, which is what makes "who
-	// adopted this" answerable from the issue timeline alone.
+	// hands it to the agent — at CREATION (`opened`, already carrying the label,
+	// since a label picked at creation never fires a separate `labeled`
+	// delivery) or later (`labeled`). Platform-written labels never reach here —
+	// the echo suppression above drops any delivery this platform's own sender
+	// caused — so every arming that arrives is a human's act, which is what
+	// makes "who adopted this" answerable from the issue timeline alone.
 	//
 	// Adoption does NOT short-circuit the predicate below, and that matters: the
 	// two jobs answer different states of the same milestone. Adoption starts a
@@ -415,7 +417,9 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 	// which to notice, so the arming that just made its milestone workable is
 	// exactly the event that has to wake it. Returning here would leave a run
 	// asleep on work a human had just handed it.
-	if action == "labeled" && strings.EqualFold(p.Label.Name, delivery.LabelAgentWork) {
+	firedArm := (action == "opened" && delivery.HasLabel(p.issueLabels(), delivery.LabelAgentWork)) ||
+		(action == "labeled" && strings.EqualFold(p.Label.Name, delivery.LabelAgentWork))
+	if firedArm {
 		if aerr := e.AdoptIssue(ctx, orgID, projectID, p.adoptTarget()); aerr != nil {
 			// Adoption problems are the human's to see, and the console dispatch
 			// path returns them synchronously. Failing the delivery here would only
@@ -438,7 +442,15 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 	firedBug := action == "opened" ||
 		(action == "labeled" && strings.EqualFold(p.Label.Name, delivery.KindBug))
 	if firedBug && eligibleForAutoAdopt(p.issueLabels()) {
-		e.AutoAdoptUserBug(ctx, orgID, projectID, p.adoptTarget())
+		if aerr := e.AutoAdoptUserBug(ctx, orgID, projectID, p.adoptTarget()); aerr != nil {
+			// The only error AutoAdoptUserBug returns is a failed rollback of its
+			// own arming stamp (no deployed version, and undoing the stamp also
+			// failed) — an idempotent write worth letting GitHub redeliver and
+			// retry, unlike every other outcome it swallows itself.
+			slog.WarnContext(ctx, "eventcore: auto-adopt rollback failed", "repo", p.Repository.FullName,
+				"issue", p.Issue.Number, "error", aerr)
+			return aerr
+		}
 	}
 
 	ms, ok := p.milestone()

--- a/services/aep-api/internal/delivery/eventcore/events.go
+++ b/services/aep-api/internal/delivery/eventcore/events.go
@@ -191,10 +191,6 @@ type issuesPayload struct {
 	} `json:"sender"`
 }
 
-// milestone returns the milestone the event is about: the top-level object
-// when GitHub sends one (milestoned / demilestoned), otherwise the issue's
-// own. Every issues payload embeds the full issue, so keying an event to a run
-// costs no extra read.
 // issueLabels flattens the payload's label objects to the names every label
 // predicate takes.
 func (p issuesPayload) issueLabels() []string {
@@ -205,6 +201,25 @@ func (p issuesPayload) issueLabels() []string {
 	return out
 }
 
+// adoptTarget is this delivery's issue as adoption takes it: its number, its own
+// label set, and the milestone it already belongs to — absent leaves 0, which is
+// adoption's "bare issue" and the case that resolves the deployed version.
+//
+// Both adoption routes through OnIssues build it — the `aep` arming stamp and
+// ADR-0029's self-arming `bug` — and one constructor is what keeps the two from
+// drifting apart on which facts a target carries.
+func (p issuesPayload) adoptTarget() AdoptTarget {
+	target := AdoptTarget{Number: p.Issue.Number, Labels: p.issueLabels()}
+	if ms, ok := p.milestone(); ok {
+		target.MilestoneNumber, target.MilestoneTitle = ms.Number, ms.Title
+	}
+	return target
+}
+
+// milestone returns the milestone the event is about: the top-level object
+// when GitHub sends one (milestoned / demilestoned), otherwise the issue's
+// own. Every issues payload embeds the full issue, so keying an event to a run
+// costs no extra read.
 func (p issuesPayload) milestone() (MilestoneRef, bool) {
 	if p.Milestone != nil && p.Milestone.Number > 0 {
 		return MilestoneRef{Number: p.Milestone.Number, Title: p.Milestone.Title}, true
@@ -401,11 +416,7 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 	// exactly the event that has to wake it. Returning here would leave a run
 	// asleep on work a human had just handed it.
 	if action == "labeled" && strings.EqualFold(p.Label.Name, delivery.LabelAgentWork) {
-		target := AdoptTarget{Number: p.Issue.Number, Labels: p.issueLabels()}
-		if ms, ok := p.milestone(); ok {
-			target.MilestoneNumber, target.MilestoneTitle = ms.Number, ms.Title
-		}
-		if aerr := e.AdoptIssue(ctx, orgID, projectID, target); aerr != nil {
+		if aerr := e.AdoptIssue(ctx, orgID, projectID, p.adoptTarget()); aerr != nil {
 			// Adoption problems are the human's to see, and the console dispatch
 			// path returns them synchronously. Failing the delivery here would only
 			// make GitHub redeliver a label that is already applied.
@@ -427,11 +438,7 @@ func (e *Events) OnIssues(ctx context.Context, _, action string, payload []byte)
 	firedBug := action == "opened" ||
 		(action == "labeled" && strings.EqualFold(p.Label.Name, delivery.KindBug))
 	if firedBug && eligibleForAutoAdopt(p.issueLabels()) {
-		target := AdoptTarget{Number: p.Issue.Number, Labels: p.issueLabels()}
-		if ms, ok := p.milestone(); ok {
-			target.MilestoneNumber, target.MilestoneTitle = ms.Number, ms.Title
-		}
-		e.AutoAdoptUserBug(ctx, orgID, projectID, target)
+		e.AutoAdoptUserBug(ctx, orgID, projectID, p.adoptTarget())
 	}
 
 	ms, ok := p.milestone()

--- a/services/aep-api/internal/delivery/eventcore/events_test.go
+++ b/services/aep-api/internal/delivery/eventcore/events_test.go
@@ -1110,3 +1110,46 @@ func TestAutoAdopt_NoDeployedVersionLeavesAnExplanationOverTheWebhook(t *testing
 		t.Fatalf("must explain why it did not adopt, got %q", got)
 	}
 }
+
+// TestAdoption_OpenedWithAepPreAttachedIsAdopted: a label picked in the same
+// GitHub UI action that files the issue never fires a separate `labeled`
+// delivery — only `opened`, carrying the whole label set. Before this, the
+// `aep`-adoption trigger checked `action == "labeled"` alone, so an issue
+// created with `aep` already on it was never adopted at all. `opened` is
+// registered for ADR-0029's `bug` trigger; the `aep` trigger gets the same
+// fix here rather than leaving the twin gap sitting beside it.
+func TestAdoption_OpenedWithAepPreAttachedIsAdopted(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	body := issueBodyWithLabels("opened", 31, 0, delivery.LabelAgentWork,
+		[]string{delivery.LabelAgentWork}, "human")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 1 || h.issues.assigned[0] != "31->5" {
+		t.Fatalf("an issue opened already carrying `aep` must join the deployed version's milestone, got %v",
+			h.issues.assigned)
+	}
+	if len(h.sup.started) != 1 || h.sup.started[0].Kind != delivery.RunKindTask {
+		t.Fatalf("must start a task run, got %+v", h.sup.started)
+	}
+}
+
+// TestAutoAdopt_RollbackFailurePropagatesTheWebhookError: the one case
+// AutoAdoptUserBug does not swallow — a failed rollback of its own arming
+// stamp — must fail the DELIVERY, not just the internal call, so GitHub's
+// redelivery retries the same idempotent unlabel instead of the issue being
+// silently left armed with no milestone.
+func TestAutoAdopt_RollbackFailurePropagatesTheWebhookError(t *testing.T) {
+	h := newHarness(t) // no runs at all — nothing has ever deployed
+	h.issues.unlabelErr = errors.New("github: 502")
+
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	if err := h.deliver(t, "issues", body); err == nil {
+		t.Fatal("a failed rollback must fail the delivery so GitHub redelivers it")
+	}
+	if _, ok := h.issues.commentBodies[31]; ok {
+		t.Fatalf("must not post a comment whose advice is already false, got %q", h.issues.commentBodies[31])
+	}
+}

--- a/services/aep-api/internal/delivery/eventcore/events_test.go
+++ b/services/aep-api/internal/delivery/eventcore/events_test.go
@@ -1025,6 +1025,75 @@ func TestAutoAdopt_UnrelatedRelabelOfAnExistingBugDoesNotSelfArm(t *testing.T) {
 	}
 }
 
+// TestAutoAdopt_ASecondDeliveryForTheSameIssueIsInert is the redelivery
+// property. IssueWriter.Comment carries no dedupe, so a second pass over an
+// issue this route already self-armed would post the audit comment a second
+// time and re-offer the run.
+//
+// The arming stamp is what closes that, and it is why self-arming has to WRITE
+// the label rather than merely act as if it had: eligibleForAutoAdopt requires
+// `aep`'s absence, so the issue's own label set is this route's "already
+// handled" record and no seen-table is needed.
+func TestAutoAdopt_ASecondDeliveryForTheSameIssueIsInert(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	first := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	if err := h.deliver(t, "issues", first); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	// Any LATER delivery about that issue reads its live label set — which now
+	// carries what the first pass stamped, and the milestone it joined.
+	second := issueBodyWithLabels("labeled", 31, 5, delivery.KindBug,
+		labelsAfter(h.issues, 31, delivery.KindBug), "external-reporter")
+	if err := h.deliver(t, "issues", second); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	if len(h.issues.commented) != 1 {
+		t.Fatalf("the audit comment must be posted once per adoption, got %v", h.issues.commented)
+	}
+	if len(h.sup.started) != 1 {
+		t.Fatalf("must not re-offer a run for an issue already self-armed, got %+v", h.sup.started)
+	}
+}
+
+// TestAutoAdopt_AReplayedDeliveryStartsNoSecondRun covers the case a live label
+// read cannot: a webhook REDELIVERY replays the stored payload byte for byte, so
+// it still carries the issue's pre-arming label set and is eligible again.
+//
+// What that repeat may not do is duplicate WORK, and every write it repeats is
+// an idempotent merge — the label add, the milestone assignment — while
+// AdoptIssue's live-run check absorbs the run. The audit comment is the one
+// write with no dedupe behind it and a replay does post it twice; that is noise
+// on the issue timeline rather than a second agent on the milestone, and
+// suppressing it would need a live per-issue label read this package's ports do
+// not have.
+func TestAutoAdopt_AReplayedDeliveryStartsNoSecondRun(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	for range 2 {
+		if err := h.deliver(t, "issues", body); err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+	}
+
+	if len(h.sup.started) != 1 {
+		t.Fatalf("a redelivered label must not start a second run, got %+v", h.sup.started)
+	}
+	for _, move := range h.issues.assigned {
+		if move != "31->5" {
+			t.Fatalf("every repeat must resolve the same milestone, got %v", h.issues.assigned)
+		}
+	}
+	if after := labelsAfter(h.issues, 31, delivery.KindBug); !delivery.InTaskWorkingSet(after) {
+		t.Fatalf("the issue must still be armed work after a replay, got labels %v", after)
+	}
+}
+
 func TestAutoAdopt_NoDeployedVersionLeavesAnExplanationOverTheWebhook(t *testing.T) {
 	h := newHarness(t) // no runs at all — nothing has ever deployed
 

--- a/services/aep-api/internal/delivery/eventcore/events_test.go
+++ b/services/aep-api/internal/delivery/eventcore/events_test.go
@@ -837,6 +837,8 @@ func TestNoRunRow_EveryHandlerIsInert(t *testing.T) {
 		{"issues", issueBody("closed", 12, 7, "aep", "human", false)},
 		{"issues", issueBody("milestoned", 12, 7, "aep", "human", true)},
 		{"issues", issueBody("labeled", 12, 0, delivery.LabelAgentWork, "human", false)},
+		{"issues", issueBodyWithLabels("opened", 12, 0, "priority:high",
+			[]string{"priority:high"}, "external-reporter")},
 	}
 	for _, d := range deliveries {
 		if err := h.deliver(t, d.event, d.payload); err != nil {
@@ -930,5 +932,112 @@ func TestAdoption_StillAdoptsARealDefect(t *testing.T) {
 	}
 	if len(h.sup.started) != 1 || h.sup.started[0].Kind != delivery.RunKindTask {
 		t.Fatalf("a real defect must still start a task run, got %+v", h.sup.started)
+	}
+}
+
+// ---- ADR-0029: a src/user bug self-arms on the `bug` label alone ---------
+
+func TestAutoAdopt_BugLabelAddedLaterSelfArms(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 1 || h.issues.assigned[0] != "31->5" {
+		t.Fatalf("must join the deployed version's milestone, got %v", h.issues.assigned)
+	}
+	if len(h.sup.started) != 1 || h.sup.started[0].Kind != delivery.RunKindTask {
+		t.Fatalf("must start a task run, got %+v", h.sup.started)
+	}
+	if got := h.issues.commentBodies[31]; got != autoAdoptedComment {
+		t.Fatalf("must leave the auto-adopted comment, got %q", got)
+	}
+}
+
+func TestAutoAdopt_BugLabelAtCreationSelfArms(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	// GitHub sends "opened" with the whole label set already attached — no
+	// separate "labeled" delivery follows for a label picked at creation time.
+	body := issueBodyWithLabels("opened", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 1 || h.issues.assigned[0] != "31->5" {
+		t.Fatalf("must join the deployed version's milestone, got %v", h.issues.assigned)
+	}
+	if len(h.sup.started) != 1 || h.sup.started[0].Kind != delivery.RunKindTask {
+		t.Fatalf("must start a task run, got %+v", h.sup.started)
+	}
+}
+
+func TestAutoAdopt_AlreadyArmedIssueIsLeftToTheOrdinaryPath(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	// A human already stamped `aep`; adding `bug` afterward must not post a
+	// second, contradictory "a rule armed this" comment onto a human's own act.
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.LabelAgentWork, delivery.KindBug}, "a-human")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("an already-armed issue must not be double-adopted here, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+	if _, ok := h.issues.commentBodies[31]; ok {
+		t.Fatalf("must not comment on an issue a human already armed, got %q", h.issues.commentBodies[31])
+	}
+}
+
+func TestAutoAdopt_IncidentSourcedBugIsNotSelfArmed(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug, delivery.SrcIncident}, "sre-agent")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("an incident-sourced bug keeps its own separate adoption path, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+}
+
+func TestAutoAdopt_UnrelatedRelabelOfAnExistingBugDoesNotSelfArm(t *testing.T) {
+	h := newHarness(t, aRun("run-old", 5, delivery.RunStateSucceeded))
+
+	// A pre-existing unarmed bug (as if filed before this feature shipped).
+	// Some OTHER label is what fires this delivery — the forward-only rule is
+	// about the `bug` label LANDING, not about re-evaluating an issue's
+	// already-settled set on every unrelated webhook.
+	body := issueBodyWithLabels("labeled", 31, 0, "priority:high",
+		[]string{delivery.KindBug, "priority:high"}, "a-human")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("relabeling a pre-existing bug with something else must not self-arm it, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+}
+
+func TestAutoAdopt_NoDeployedVersionLeavesAnExplanationOverTheWebhook(t *testing.T) {
+	h := newHarness(t) // no runs at all — nothing has ever deployed
+
+	body := issueBodyWithLabels("labeled", 31, 0, delivery.KindBug,
+		[]string{delivery.KindBug}, "external-reporter")
+	if err := h.deliver(t, "issues", body); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.issues.assigned) != 0 || len(h.sup.started) != 0 {
+		t.Fatalf("must adopt nothing without a deployed version, got assigned=%v started=%+v",
+			h.issues.assigned, h.sup.started)
+	}
+	if got := h.issues.commentBodies[31]; got != autoAdoptNoDeployedVersionComment {
+		t.Fatalf("must explain why it did not adopt, got %q", got)
 	}
 }

--- a/services/aep-api/internal/delivery/eventcore/fakes_test.go
+++ b/services/aep-api/internal/delivery/eventcore/fakes_test.go
@@ -234,6 +234,9 @@ type fakeIssues struct {
 	// are recorded in separate slices: a cancel labels an issue BEFORE closing it,
 	// so with the label failing nothing may be closed.
 	labelErr error
+	// unlabelErr fails every RemoveLabel. Exists to test AutoAdoptUserBug's
+	// rollback path: the one write failure it does NOT swallow.
+	unlabelErr error
 }
 
 // writer is the fake wearing the domain's issue-write surface, which is what
@@ -280,6 +283,9 @@ func (f *fakeIssues) AddLabels(_ context.Context, _, _ string, number int, label
 func (f *fakeIssues) RemoveLabel(_ context.Context, _, _ string, number int, label string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.unlabelErr != nil {
+		return f.unlabelErr
+	}
 	f.labelled = append(f.labelled, fmt.Sprintf("%d-%s", number, label))
 	return nil
 }

--- a/services/aep-api/internal/delivery/eventcore/fakes_test.go
+++ b/services/aep-api/internal/delivery/eventcore/fakes_test.go
@@ -226,6 +226,10 @@ type fakeIssues struct {
 	// comment is dropped leaves a human staring at a closed issue with no
 	// explanation, which is a real failure and not a cosmetic one.
 	closeComments map[int]string
+	// commentBodies is the body of the last CommentIssue call per issue — the
+	// closeComments pattern, for plain comments. Needed because `commented`
+	// alone (issue numbers only) cannot tell two comment texts apart.
+	commentBodies map[int]string
 	// labelErr fails every AddLabels. It exists to prove ORDER where two writes
 	// are recorded in separate slices: a cancel labels an issue BEFORE closing it,
 	// so with the label failing nothing may be closed.
@@ -253,10 +257,11 @@ func (f *fakeIssues) ReopenIssue(_ context.Context, _, _ string, number int) err
 	return nil
 }
 
-func (f *fakeIssues) CommentIssue(_ context.Context, _, _ string, number int, _ string) error {
+func (f *fakeIssues) CommentIssue(_ context.Context, _, _ string, number int, body string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.commented = append(f.commented, number)
+	f.commentBodies[number] = body
 	return nil
 }
 
@@ -284,6 +289,7 @@ func newFakeIssues() *fakeIssues {
 		byMilestone:   map[int][]sourcecontrol.IssueInfo{},
 		counts:        map[int]*sourcecontrol.MilestoneIssueCounts{},
 		closeComments: map[int]string{},
+		commentBodies: map[int]string{},
 		next:          100,
 	}
 }

--- a/services/aep-api/internal/delivery/labels.go
+++ b/services/aep-api/internal/delivery/labels.go
@@ -47,7 +47,11 @@ const (
 	// It is also the GitHub-side ADOPTION trigger: a human stamping it on an
 	// issue arms it, and the event plane starts (or wakes) a run over the
 	// issue's milestone. Labels the platform stamps itself come back as webhook
-	// echoes and are dropped by sender, so arming stays a human act.
+	// echoes and are dropped by sender, so arming stays a human act — with ONE
+	// deliberate exception: a `bug` sourced `src/user` self-arms on the `bug`
+	// label alone and the platform stamps this one itself as part of adopting it
+	// (ADR-0029, eventcore.AutoAdoptUserBug). Every other kind, and every other
+	// `bug` source, still needs the separate human stamp.
 	LabelAgentWork = "aep"
 )
 

--- a/services/aep-api/internal/delivery/labels.go
+++ b/services/aep-api/internal/delivery/labels.go
@@ -110,10 +110,15 @@ const (
 )
 
 // SourceOf returns the src/* label a KindBug issue carries, or "" when it
-// carries none — which reads as SrcUser (see the SOURCES block above).
-// Mirrors KindOf's shape: a fixed scan order over a fixed vocabulary, never a
-// prefix match.
+// carries none — which reads as SrcUser (see the SOURCES block above). Only a
+// KindBug issue has a source: every other kind answers "" here regardless of
+// what src/* label it happens to carry, matching the invariant that a source
+// means nothing outside a bug. Mirrors KindOf's shape otherwise: a fixed scan
+// order over a fixed vocabulary, never a prefix match.
 func SourceOf(labels []string) string {
+	if KindOf(labels) != KindBug {
+		return ""
+	}
 	for _, src := range []string{SrcUser, SrcIncident, SrcValidation, SrcBuild, SrcDeploy} {
 		if HasLabel(labels, src) {
 			return src
@@ -122,13 +127,29 @@ func SourceOf(labels []string) string {
 	return ""
 }
 
-// IsUserSourced reports whether a bug's source is SrcUser, explicit or
-// absent — the one population ADR-0029's self-arming rule (eventcore's
-// AutoAdoptUserBug) applies to. Every other source is a platform detection
-// and is deliberately excluded.
+// IsUserSourced reports whether a bug is CLEANLY src/user-sourced: KindBug,
+// and carrying none of the other four recognized sources — explicit
+// `src/user` or an absent source both qualify (the SOURCES block's "absence
+// reads as SrcUser" rule). This is the one population ADR-0029's self-arming
+// rule (eventcore.AutoAdoptUserBug) applies to; every other source is a
+// platform detection and is deliberately excluded.
+//
+// This is NOT "SourceOf resolves to SrcUser". A hand-labeled issue carrying
+// `src/user` ALONGSIDE another recognized source (e.g. a human tagging both
+// `src/user` and `src/build`) is an ambiguous report, not a clean one — and
+// resolving that ambiguity through SourceOf's precedence order would silently
+// treat it as a plain user report. This predicate refuses instead: any OTHER
+// recognized source present, however it got there, disqualifies the issue.
 func IsUserSourced(labels []string) bool {
-	src := SourceOf(labels)
-	return src == "" || src == SrcUser
+	if KindOf(labels) != KindBug {
+		return false
+	}
+	for _, src := range []string{SrcIncident, SrcValidation, SrcBuild, SrcDeploy} {
+		if HasLabel(labels, src) {
+			return false
+		}
+	}
+	return true
 }
 
 // The MARKERS. Orthogonal to kind: they qualify an issue the loop already

--- a/services/aep-api/internal/delivery/labels.go
+++ b/services/aep-api/internal/delivery/labels.go
@@ -105,6 +105,28 @@ const (
 	SrcDeploy     = "src/deploy"
 )
 
+// SourceOf returns the src/* label a KindBug issue carries, or "" when it
+// carries none — which reads as SrcUser (see the SOURCES block above).
+// Mirrors KindOf's shape: a fixed scan order over a fixed vocabulary, never a
+// prefix match.
+func SourceOf(labels []string) string {
+	for _, src := range []string{SrcUser, SrcIncident, SrcValidation, SrcBuild, SrcDeploy} {
+		if HasLabel(labels, src) {
+			return src
+		}
+	}
+	return ""
+}
+
+// IsUserSourced reports whether a bug's source is SrcUser, explicit or
+// absent — the one population ADR-0029's self-arming rule (eventcore's
+// AutoAdoptUserBug) applies to. Every other source is a platform detection
+// and is deliberately excluded.
+func IsUserSourced(labels []string) bool {
+	src := SourceOf(labels)
+	return src == "" || src == SrcUser
+}
+
 // The MARKERS. Orthogonal to kind: they qualify an issue the loop already
 // routed, and an issue may carry any number of them.
 const (

--- a/services/aep-api/internal/delivery/labels.go
+++ b/services/aep-api/internal/delivery/labels.go
@@ -109,24 +109,6 @@ const (
 	SrcDeploy     = "src/deploy"
 )
 
-// SourceOf returns the src/* label a KindBug issue carries, or "" when it
-// carries none — which reads as SrcUser (see the SOURCES block above). Only a
-// KindBug issue has a source: every other kind answers "" here regardless of
-// what src/* label it happens to carry, matching the invariant that a source
-// means nothing outside a bug. Mirrors KindOf's shape otherwise: a fixed scan
-// order over a fixed vocabulary, never a prefix match.
-func SourceOf(labels []string) string {
-	if KindOf(labels) != KindBug {
-		return ""
-	}
-	for _, src := range []string{SrcUser, SrcIncident, SrcValidation, SrcBuild, SrcDeploy} {
-		if HasLabel(labels, src) {
-			return src
-		}
-	}
-	return ""
-}
-
 // IsUserSourced reports whether a bug is CLEANLY src/user-sourced: KindBug,
 // and carrying none of the other four recognized sources — explicit
 // `src/user` or an absent source both qualify (the SOURCES block's "absence
@@ -134,12 +116,13 @@ func SourceOf(labels []string) string {
 // rule (eventcore.AutoAdoptUserBug) applies to; every other source is a
 // platform detection and is deliberately excluded.
 //
-// This is NOT "SourceOf resolves to SrcUser". A hand-labeled issue carrying
-// `src/user` ALONGSIDE another recognized source (e.g. a human tagging both
-// `src/user` and `src/build`) is an ambiguous report, not a clean one — and
-// resolving that ambiguity through SourceOf's precedence order would silently
-// treat it as a plain user report. This predicate refuses instead: any OTHER
-// recognized source present, however it got there, disqualifies the issue.
+// This is NOT "resolve the issue's source by precedence and compare to
+// SrcUser". A hand-labeled issue carrying `src/user` ALONGSIDE another
+// recognized source (e.g. a human tagging both `src/user` and `src/build`)
+// is an ambiguous report, not a clean one — and picking a single source by
+// precedence would silently treat it as a plain user report. This predicate
+// refuses instead: any OTHER recognized source present, however it got
+// there, disqualifies the issue.
 func IsUserSourced(labels []string) bool {
 	if KindOf(labels) != KindBug {
 		return false

--- a/services/aep-api/internal/delivery/labels_test.go
+++ b/services/aep-api/internal/delivery/labels_test.go
@@ -93,6 +93,7 @@ func TestSourceOf(t *testing.T) {
 		{"no source label at all", []string{LabelAgentWork, KindBug}, ""},
 		{"not even a bug", planned, ""},
 		{"ledger issue", ledger, ""},
+		{"a non-bug carrying a stray source label", []string{KindDevelopment, SrcUser}, ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -118,6 +119,9 @@ func TestIsUserSourced(t *testing.T) {
 		{"validation-sourced", repair, false},
 		{"build-sourced", bug, false},
 		{"deploy-sourced", []string{KindBug, SrcDeploy}, false},
+		{"not even a bug, no source label", planned, false},
+		{"a non-bug carrying a stray src/user label", []string{KindDevelopment, SrcUser}, false},
+		{"conflicting sources — human-labeled src/user AND src/build", []string{KindBug, SrcUser, SrcBuild}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/services/aep-api/internal/delivery/labels_test.go
+++ b/services/aep-api/internal/delivery/labels_test.go
@@ -79,32 +79,6 @@ func TestKindOf(t *testing.T) {
 	}
 }
 
-func TestSourceOf(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name   string
-		labels []string
-		want   string
-	}{
-		{"explicit user source", []string{LabelAgentWork, KindBug, SrcUser}, SrcUser},
-		{"incident source", incident, SrcIncident},
-		{"validation-sourced repair", repair, SrcValidation},
-		{"build-sourced fix", bug, SrcBuild}, // bug == {LabelAgentWork, KindBug, SrcBuild}
-		{"no source label at all", []string{LabelAgentWork, KindBug}, ""},
-		{"not even a bug", planned, ""},
-		{"ledger issue", ledger, ""},
-		{"a non-bug carrying a stray source label", []string{KindDevelopment, SrcUser}, ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			if got := SourceOf(c.labels); got != c.want {
-				t.Errorf("SourceOf(%v) = %q, want %q", c.labels, got, c.want)
-			}
-		})
-	}
-}
-
 func TestIsUserSourced(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/services/aep-api/internal/delivery/labels_test.go
+++ b/services/aep-api/internal/delivery/labels_test.go
@@ -79,6 +79,56 @@ func TestKindOf(t *testing.T) {
 	}
 }
 
+func TestSourceOf(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"explicit user source", []string{LabelAgentWork, KindBug, SrcUser}, SrcUser},
+		{"incident source", incident, SrcIncident},
+		{"validation-sourced repair", repair, SrcValidation},
+		{"build-sourced fix", bug, SrcBuild}, // bug == {LabelAgentWork, KindBug, SrcBuild}
+		{"no source label at all", []string{LabelAgentWork, KindBug}, ""},
+		{"not even a bug", planned, ""},
+		{"ledger issue", ledger, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SourceOf(c.labels); got != c.want {
+				t.Errorf("SourceOf(%v) = %q, want %q", c.labels, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsUserSourced(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"explicit src/user", []string{LabelAgentWork, KindBug, SrcUser}, true},
+		{"no source label — absence reads as user", []string{LabelAgentWork, KindBug}, true},
+		{"bare bug, no arming, no source", []string{KindBug}, true},
+		{"incident-sourced", incident, false},
+		{"validation-sourced", repair, false},
+		{"build-sourced", bug, false},
+		{"deploy-sourced", []string{KindBug, SrcDeploy}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsUserSourced(c.labels); got != c.want {
+				t.Errorf("IsUserSourced(%v) = %v, want %v", c.labels, got, c.want)
+			}
+		})
+	}
+}
+
 // TestWorkingSets pins what each loop may pick up. Every predicate is a POSITIVE
 // membership test on a kind, which is the whole point of the vocabulary: the old
 // model defined work by what it was NOT, and one mis-stated exclusion was enough


### PR DESCRIPTION
## Summary
- Adds ADR-0029: a `bug` issue sourced `src/user` (explicit label, or absent — the existing default) now self-arms on the `bug` label alone, with no separate `aep` stamp required from a human. Everything downstream is unchanged: adopted into the deployed version's milestone, a task run starts, the coding agent fixes it, the PR auto-merges, the build fans out, and the supervisor's deploy stage reconciles the version — fully unattended.
- Scoped narrowly per the ADR: only `src/user` bugs (platform-detected sources like `src/build`/`src/deploy`/`src/validation` are untouched; `src/incident` keeps its own existing automatic path); forward-only (no backfill of pre-existing open bugs); no new label (a bot comment is the audit trail); explicitly no trust check on the labeler, no cost/concurrency cap, and no opt-out setting (all three risks were raised and knowingly accepted, not overlooked — see the ADR's "Accepted risk" section).
- `services/aep-api/internal/delivery/labels.go`: adds `SourceOf`/`IsUserSourced` label predicates.
- `services/aep-api/internal/delivery/eventcore/auto_adopt.go` (new): `eligibleForAutoAdopt` + `AutoAdoptUserBug` — stamps `aep` itself as part of self-arming (a fix-round finding: without this, the adopted issue is invisible to every working-set predicate and its task run parks forever), then reuses the existing `AdoptIssue` path unchanged, and posts one of two bot comments (self-armed, or "no deployed version yet") as the audit trail a human's own `aep` stamp otherwise carries.
- `services/aep-api/internal/delivery/eventcore/events.go`: registers the `issues`/`opened` webhook action (needed because a label chosen at issue creation never fires a separate `labeled` delivery) and wires the new trigger beside the existing `aep`-label one, gated on the label that actually fired — not the issue's whole label set — so relabeling a pre-existing bug with something unrelated can never retroactively self-arm it.
- Reconciles the "arming is always a human act" invariant text in `labels.go`, `adopt.go`, `services/aep-api/internal/delivery/README.md`, and `eventcore/doc.go` to note the one ADR-0029 exception.

## Test plan
- [x] `go build ./...` and `go vet ./internal/delivery/...` clean
- [x] Full `internal/delivery` suite green (all 10 packages, 0 failures) both before and after the fix round
- [x] New unit/webhook tests cover: eligibility (kind + source + already-armed exclusion), self-arm success (issue ends up in the task run's working set, not just milestone-moved), no-deployed-version rollback, forward-only correctness (an unrelated relabel of a pre-existing bug does not self-arm it), and comment idempotency for a later delivery vs. an honestly-documented webhook-redelivery residue
- [x] Went through `/grilling` + `/domain-modeling` for the design, then a 3-task implementation plan executed subagent-driven with a per-task review and a final whole-branch review; the final review caught a Critical defect (self-arming never stamped `aep`, so the run it started could never find its own work) which is fixed in the last commit and independently re-verified
- [x] End-to-end real-world verification against a live project (`wso2-tharindu-SF/implement-hello-world`): filed a `bug`-only issue, watched the platform auto-adopt it (comment + `aep` stamp), dispatch a coding-agent run, merge its fix PR, and close the issue — then confirmed the deployed service's response actually changed (201 → 200) via a live curl against the redeployed pod