### PR TITLE
fix(console): a first validation attempt names the agent doing the work

### DIFF
--- a/apps/console/src/features/projects/components/DeploymentsPage.test.tsx
+++ b/apps/console/src/features/projects/components/DeploymentsPage.test.tsx
@@ -283,7 +283,7 @@ describe("DeploymentsPage — validation", () => {
 
   // Re-running validation on an already-PASSED version. The verdict lives on an
   // older run row — a revalidation is a fresh one — so reading the asking run made
-  // this say "Nothing reported yet", as if the version had never been judged.
+  // this say the agent had reported nothing, as if the version had never been judged.
   it("shows the last result while a revalidation re-asks a passed version", () => {
     mockDeploy = {
       version: "v1",
@@ -299,7 +299,7 @@ describe("DeploymentsPage — validation", () => {
     expect(
       screen.getByText("All 6 criteria passed in the last attempt. Validation is running again."),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Nothing reported yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/validation agent is running/)).not.toBeInTheDocument();
     // Nothing was fixed — that clause belongs to a repair, not a re-ask.
     expect(screen.queryByText(/fixed and deployed/)).not.toBeInTheDocument();
   });
@@ -319,7 +319,7 @@ describe("DeploymentsPage — validation", () => {
     render(<DeploymentsPage projectName="acme" />);
 
     expect(
-      screen.getByText("Nothing reported yet — the validation attempt is still running."),
+      screen.getByText("The validation agent is running."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/verdict: validating/)).not.toBeInTheDocument();
   });

--- a/apps/console/src/features/validation/lib/verdict.test.ts
+++ b/apps/console/src/features/validation/lib/verdict.test.ts
@@ -230,7 +230,7 @@ describe("verdictSentence", () => {
   // shared copy exists to stop.
   it("speaks for a first attempt, which has no verdict yet", () => {
     expect(verdictSentence("", undefined, "running")).toBe(
-      "Nothing reported yet — the validation attempt is still running.",
+      "The validation agent is running.",
     );
   });
 

--- a/apps/console/src/features/validation/lib/verdict.ts
+++ b/apps/console/src/features/validation/lib/verdict.ts
@@ -229,11 +229,12 @@ export function verdictSentence(
       // deployment's verdict: validating." — the very thing sharing this copy was
       // meant to stop. `awaiting-fix` cannot reach here; it requires a fatal verdict.
       //
-      // Says what there is to SEE rather than what is happening: the rail's stage
-      // note beside it already says the deployed system is being checked, and two
-      // adjacent elements saying that is a restatement.
+      // Names the ACTOR and nothing else. There is no evidence to summarise yet, so
+      // the sentence's only job is to say who the reader is waiting on; the stage
+      // note beside it carries the progress, and the counts line stays empty until
+      // an attempt reports.
       if (state === "running") {
-        return "Nothing reported yet — the validation attempt is still running.";
+        return "The validation agent is running.";
       }
       // `cancelled` is the other lifecycle value with no verdict, and it needs a
       // sentence for the same reason: it is the ABSENCE of one, so falling through


### PR DESCRIPTION
## What

The deployments verdict banner's sentence for a live **first** validation attempt read:

> Nothing reported yet — the validation attempt is still running.

It now reads:

> The validation agent is running.

Leading with an absence tells the reader something they did not ask about; what they want to know while a first attempt runs is who they are waiting on.

## Scope

Copy only — the condition is untouched. This is still the shared sentence in `verdictSentence`'s `default:` arm for `state === "running"` with no verdict on the run row, which reaches the screen through one surface: `VerdictBanner` on the Development environment card (`VerdictTile` is gated on `TILE_VERDICTS`, which has no entry for an empty verdict).

The rationale comment above the branch is updated with it: the old one argued for saying what there is to *see* rather than what is happening, which is no longer what the sentence does.

Three files: the string, and the two tests that assert it.

## Proof

Affected suites, on this branch:

```
$ pnpm vitest run src/features/validation/lib/verdict.test.ts \
                 src/features/projects/components/DeploymentsPage.test.tsx

 Test Files  2 passed (2)
      Tests  54 passed (54)
```

Both assertions that pin this copy are updated and green — `verdict.test.ts` "speaks for a first attempt, which has no verdict yet", and `DeploymentsPage.test.tsx` "does not call a first running attempt a verdict" (which also still proves a revalidation over a passed version does *not* fall to this sentence).

`eslint` clean on the three files. `tsc -b` in `apps/console` reports 16 errors in `features/spec`, `mocks/fixtures/build.ts` and `mocks/handlers/build.ts` — byte-identical before and after this change on a fresh `upstream/main` checkout, from a stale generated `@aep/contracts` dist rather than from this edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)