### PR TITLE
A named version reads back, and a Registered External brings its keys (#755)

### DIFF
--- a/services/aep-api/internal/dependencies/README.md
+++ b/services/aep-api/internal/dependencies/README.md
@@ -56,6 +56,7 @@ slices.
 | Port | Dir | Peer · contract |
 |---|---|---|
 | SecretWriter | needs | `platform/secrets` — SM-API vault writes for external-resource secret values |
+| `IsRegistered` · `RegisteredConfigKeys` | offers | `spec` — the design read asks whether a name is in the org catalog and, for one that is, what its config-key schema is. The second is not a convenience: a Registered External's project copy carries no keys, so the wiring derivation and the RT authoring both read the org record through this port |
 | OC `Resource`/`ResourceReleaseBinding` CRUD · `ClusterResourceType` discovery | needs | `openchoreo` client — OC is the store |
 | WorkloadDepSource | needs | `openchoreo` client — deployed Workload consumer refs (resource + endpoint) for Overview `list-workload-dependencies`; GetResource 404s are dangling and omitted |
 | ExecutionStore (admit/finish) | needs | `delivery` — a gate's provisioning run is the last remaining execution row, and this is its write surface |

--- a/services/aep-api/internal/dependencies/external_catalog.go
+++ b/services/aep-api/internal/dependencies/external_catalog.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/contracts"
 )
 
 // ExternalResourceCatalog is the org-level external-resource registry sourced
@@ -187,6 +188,33 @@ func (c *ExternalResourceCatalog) IsRegistered(ctx context.Context, orgID, name 
 		return false, err
 	}
 	return def != nil, nil
+}
+
+// RegisteredConfigKeys implements spec.ExternalResourceResolver: the org
+// record's config-key schema for a Registered External, nil for a name the
+// catalog does not hold.
+//
+// It is the same read IsRegistered makes; that one throws the definition away,
+// and the keys are exactly what a project's copy of a registered dependency
+// does not have.
+func (c *ExternalResourceCatalog) RegisteredConfigKeys(ctx context.Context, orgID, name string) ([]contracts.ConfigKey, error) {
+	if c == nil {
+		return nil, nil
+	}
+	def, err := c.Get(ctx, orgID, name)
+	if err != nil || def == nil {
+		return nil, err
+	}
+	keys := make([]contracts.ConfigKey, 0, len(def.Config))
+	for _, k := range def.Config {
+		keys = append(keys, contracts.ConfigKey{
+			Key:          k.Key,
+			Secret:       k.Secret,
+			Description:  k.Description,
+			DefaultValue: k.DefaultValue,
+		})
+	}
+	return keys, nil
 }
 
 // newerExternalRT reports whether rt should be preferred over cur as the

--- a/services/aep-api/internal/spec/README.md
+++ b/services/aep-api/internal/spec/README.md
@@ -158,6 +158,19 @@ the genai turn engine (runner/broker/sweeper), and the files / design / skills s
   number parsed out of a name. A supplied name is used verbatim: a collision is `ErrVersionNameTaken`
   (the build maps it to 409), never a quietly different tag. Only a name the platform itself suggested
   is recomputed past a racing pusher.
+- **Every read-at-tag asks whether the tag is a VERSION, never whether it is numbered**
+  (`requireVersionTag`). `GetDesignAtSpecTag`, `GetRequirementsAtTag` and `ValidateSpecAtTag` guard so
+  that a legacy `v<N>-<M>` design tag or a typo says so rather than surfacing as a missing tree — but
+  the check is membership in the project's version tags, resolved from the local mirror first. Asking
+  for a number instead is what made a version called `m1` cut cleanly and then fail its own build at
+  the roles gate.
+- **A Registered External arrives carrying the org record's config keys.** Its project definition
+  deliberately has none — the org `ResourceType` IS the registry (ADR-0009) — so the design read that
+  marks the dependency registered also fills its `Config` from the catalog
+  (`ExternalResourceResolver.RegisteredConfigKeys`). Everything downstream is built on those keys: the
+  wiring derivation turns them into the env-var names the coding agent binds, and provisioning authors
+  the resource type from them. Without them the build fails with "at least one config key required"
+  and the component's `design.json` carries no wiring at all.
 - **A name labels a snapshot; it does not make one.** `SaveSpec` still compares the whole `specs/` tree
   with the newest version's and reuses that version when they match — the requested name is ignored on
   that path, because cutting a second tag over an identical tree would spend a planning turn to change

--- a/services/aep-api/internal/spec/artifact_service.go
+++ b/services/aep-api/internal/spec/artifact_service.go
@@ -290,12 +290,12 @@ func (s *artifactService) ListDesignFiles(ctx context.Context, orgID, projectID 
 }
 
 func (s *artifactService) GetRequirementsAtTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error) {
-	if _, ok := parseRequirementsTag(tag); !ok {
-		return nil, fmt.Errorf("%w: %q is not a v<N> tag", ErrInvalidVersionTag, tag)
-	}
 	_, ref, err := s.readyRef(ctx, orgID, projectID)
 	if err != nil {
 		return nil, err
+	}
+	if verr := s.requireVersionTag(ctx, ref, tag); verr != nil {
+		return nil, verr
 	}
 	return s.readBundleAtTag(ctx, ref, tag, requirementsPrefix, requirementsBundleFilter)
 }
@@ -322,7 +322,7 @@ func (s *artifactService) GetDesignAtTag(ctx context.Context, orgID, projectID, 
 	return s.readBundleAtTag(ctx, ref, tag, designPrefix, designBundleFilter)
 }
 
-// GetDesignAtSpecTag reads the design bundle at a `v<N>` spec tag.
+// GetDesignAtSpecTag reads the design bundle at a SPEC tag.
 //
 // It exists because GetDesignAtTag next door parses its argument as a
 // design-REVISION tag (`v<N>-<M>`, the legacy per-design sequence) and rejects
@@ -330,14 +330,39 @@ func (s *artifactService) GetDesignAtTag(ctx context.Context, orgID, projectID, 
 // consumer to the other method fails on every real build with "not a v<N>-<M>
 // tag" — which is exactly what happened to the roles ensure.
 func (s *artifactService) GetDesignAtSpecTag(ctx context.Context, orgID, projectID, tag string) (map[string]string, error) {
-	if _, ok := parseRequirementsTag(tag); !ok {
-		return nil, fmt.Errorf("%w: %q is not a v<N> spec tag", ErrInvalidVersionTag, tag)
-	}
 	_, ref, err := s.readyRef(ctx, orgID, projectID)
 	if err != nil {
 		return nil, err
 	}
+	if verr := s.requireVersionTag(ctx, ref, tag); verr != nil {
+		return nil, verr
+	}
 	return s.readBundleAtTag(ctx, ref, tag, designPrefix, designBundleFilter)
+}
+
+// requireVersionTag refuses a tag that is not one of this project's versions.
+//
+// The readers guard because handing them the legacy `v<N>-<M>` design tag, or a
+// typo, should say so rather than surface as a missing tree. What they may NOT
+// do is require a number: the name is the user's now (ADR-0030), and a version
+// called `m1` is as real as `v3`. The local mirror answers first — the tag was
+// cut by this platform, usually seconds earlier — and only an unknown name pays
+// for a fetch before being refused.
+func (s *artifactService) requireVersionTag(ctx context.Context, ref sourcecontrol.RepoRef, tag string) error {
+	if tag == "" {
+		return fmt.Errorf("%w: empty tag", ErrInvalidVersionTag)
+	}
+	if tags, err := s.listVersionTagsLocal(ctx, ref); err == nil && knownVersionTag(tags, tag) {
+		return nil
+	}
+	tags, err := s.listVersionTags(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("list tags: %w", err)
+	}
+	if !knownVersionTag(tags, tag) {
+		return fmt.Errorf("%w: %q is not a version of this project", ErrInvalidVersionTag, tag)
+	}
+	return nil
 }
 
 // ----- Versions -----

--- a/services/aep-api/internal/spec/artifact_store.go
+++ b/services/aep-api/internal/spec/artifact_store.go
@@ -92,6 +92,16 @@ func (s *ArtifactStore) SetOrgServiceResolver(r OrgServiceResolver) {
 // by the composition root via SetExternalResourceResolver.
 type ExternalResourceResolver interface {
 	IsRegistered(ctx context.Context, orgID, name string) (bool, error)
+	// RegisteredConfigKeys returns the org record's config-key schema for a
+	// registered name, nil for one it does not hold.
+	//
+	// A Registered External's project definition deliberately carries no
+	// `config`: the keys live on the org record, which IS the registry
+	// (ADR-0009). Everything downstream nonetheless needs them — the wiring
+	// derivation turns them into the env-var names the coding agent codes
+	// against, and provisioning authors the resource type from them — so the
+	// read that marks the dependency registered brings its schema along.
+	RegisteredConfigKeys(ctx context.Context, orgID, name string) ([]ConfigKey, error)
 }
 
 // SetExternalResourceResolver wires the org external-resource catalog used to
@@ -279,6 +289,7 @@ func (s *ArtifactStore) resolveExternalDependencies(ctx context.Context, orgID s
 		return
 	}
 	hits := map[string]bool{}
+	keyCache := map[string][]ConfigKey{}
 	for i := range d.Components {
 		for j := range d.Components[i].Dependencies {
 			dep := &d.Components[i].Dependencies[j]
@@ -299,10 +310,39 @@ func (s *ArtifactStore) resolveExternalDependencies(ctx context.Context, orgID s
 					}
 					hits[dep.Name] = registryHit
 				}
+				// A registered dependency's keys live on the org record, so the
+				// project's copy carries none. Bring them in: without them the
+				// wiring derivation stamps nothing (no env-var names for the
+				// coding agent) and provisioning cannot author the resource
+				// type at all.
+				if registryHit && len(dep.Config) == 0 {
+					if keys := s.registeredKeys(ctx, orgID, dep.Name, keyCache); len(keys) > 0 {
+						dep.Config = keys
+					}
+				}
 			}
 			ApplyDependencyStatus(dep, registryHit, OrgServiceHit{})
 		}
 	}
+}
+
+// registeredKeys reads one registered name's config-key schema, memoised for
+// the design being assembled: a dependency several components share is one
+// catalog read, not one per edge. A failure is a warning and no keys — the
+// design still reads, and the shortfall surfaces where it matters (an absent
+// wiring is the coding agent's reportable fault) rather than as a failed read.
+func (s *ArtifactStore) registeredKeys(ctx context.Context, orgID, name string, cache map[string][]ConfigKey) []ConfigKey {
+	if cached, ok := cache[name]; ok {
+		return cached
+	}
+	keys, err := s.externals.RegisteredConfigKeys(ctx, orgID, name)
+	if err != nil {
+		slog.WarnContext(ctx, "external-resource resolver: registered config keys failed",
+			"org", orgID, "dependency", name, "error", err)
+		keys = nil
+	}
+	cache[name] = keys
+	return keys
 }
 
 // ---- Helpers ------------------------------------------------------------

--- a/services/aep-api/internal/spec/registered_external_keys_test.go
+++ b/services/aep-api/internal/spec/registered_external_keys_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+// A REGISTERED EXTERNAL BRINGS ITS SCHEMA WITH IT.
+//
+// The project's copy of a Registered External carries no `config`: the keys
+// live on the org record, which IS the registry (ADR-0009). Two things
+// downstream need them anyway — the wiring derivation turns them into the
+// env-var names the coding agent codes against, and provisioning authors the
+// resource type from them. Without them a build fails with "at least one config
+// key required" and the component's design.json carries no wiring at all.
+
+import (
+	"context"
+	"testing"
+)
+
+const registeredDesignJSON = `{
+  "name": "expense-api",
+  "type": "service",
+  "dependencies": [
+    {
+      "kind": "external",
+      "name": "currency-service",
+      "description": "Converts a foreign-currency amount to the household currency."
+    }
+  ]
+}`
+
+// The definition the platform stamps for a Registered External: provider and
+// contract, and deliberately no config.
+const registeredDefinitionJSON = `{
+  "name": "currency-service",
+  "source": "org",
+  "description": "Converts an amount into another currency.",
+  "provider": "Open Exchange Rates",
+  "style": "rest-api",
+  "contract": "openapi.yaml"
+}`
+
+func registeredDesignFiles() map[string]string {
+	return map[string]string{
+		DesignRootFile:                                  "cell {}\n",
+		"components/expense-api/design.json":            registeredDesignJSON,
+		"dependencies/currency-service/dependency.json": registeredDefinitionJSON,
+		"dependencies/currency-service/openapi.yaml":    "openapi: 3.0.3\n",
+	}
+}
+
+func orgKeys() []ConfigKey {
+	return []ConfigKey{{
+		Key:         "OPEN_EXCHANGE_RATES_APP_ID",
+		Secret:      true,
+		Description: "Your Open Exchange Rates App ID.",
+	}}
+}
+
+func TestRegisteredExternal_ArrivesCarryingTheOrgSchema(t *testing.T) {
+	store := NewArtifactStore(nil)
+	store.SetExternalResourceResolver(fakeExternalResourceResolver{
+		names: map[string]bool{"currency-service": true},
+		keys:  map[string][]ConfigKey{"currency-service": orgKeys()},
+	})
+
+	design, err := store.AssembleDesignFrom(context.Background(), "acme", registeredDesignFiles())
+	if err != nil {
+		t.Fatalf("AssembleDesignFrom: %v", err)
+	}
+	dep := design.Components[0].Dependencies[0]
+	if len(dep.Config) != 1 || dep.Config[0].Key != "OPEN_EXCHANGE_RATES_APP_ID" {
+		t.Fatalf("dependency config = %+v, want the org record's key — the project's copy carries none",
+			dep.Config)
+	}
+	if !dep.Config[0].Secret {
+		t.Errorf("key lost its secret flag: %+v", dep.Config[0])
+	}
+}
+
+// The keys are what the wiring is made of, so this is the coding agent's half:
+// without them the component's design.json carries no wiring and the agent has
+// no env-var names to write into workload.yaml.
+func TestRegisteredExternal_WiringIsDerivedFromTheOrgSchema(t *testing.T) {
+	store := NewArtifactStore(nil)
+	store.SetExternalResourceResolver(fakeExternalResourceResolver{
+		names: map[string]bool{"currency-service": true},
+		keys:  map[string][]ConfigKey{"currency-service": orgKeys()},
+	})
+	design, err := store.AssembleDesignFrom(context.Background(), "acme", registeredDesignFiles())
+	if err != nil {
+		t.Fatalf("AssembleDesignFrom: %v", err)
+	}
+
+	deriveDependencyWiring(design.Components, map[string]CRTType{}, "expenses")
+
+	wiring := design.Components[0].Dependencies[0].Wiring
+	if wiring == nil {
+		t.Fatal("no wiring derived for a registered external — the coding agent has nothing to bind")
+	}
+	if wiring.Ref == "" {
+		t.Errorf("wiring has no ref: %+v", wiring)
+	}
+	if got := wiring.EnvBindings["OPEN_EXCHANGE_RATES_APP_ID"]; got != "OPEN_EXCHANGE_RATES_APP_ID" {
+		t.Errorf("env bindings = %+v, want the org key bound to itself", wiring.EnvBindings)
+	}
+}
+
+// A dependency the org does not hold keeps the design's own answer: a Project
+// External's keys are its definition's, and an empty one stays empty.
+func TestRegisteredExternal_UnregisteredNameIsLeftAlone(t *testing.T) {
+	store := NewArtifactStore(nil)
+	store.SetExternalResourceResolver(fakeExternalResourceResolver{
+		names: map[string]bool{},
+		keys:  map[string][]ConfigKey{"currency-service": orgKeys()},
+	})
+
+	design, err := store.AssembleDesignFrom(context.Background(), "acme", registeredDesignFiles())
+	if err != nil {
+		t.Fatalf("AssembleDesignFrom: %v", err)
+	}
+	if got := design.Components[0].Dependencies[0].Config; len(got) != 0 {
+		t.Fatalf("config = %+v, want none — the catalog does not hold this name", got)
+	}
+}

--- a/services/aep-api/internal/spec/resolve_external_dependencies_test.go
+++ b/services/aep-api/internal/spec/resolve_external_dependencies_test.go
@@ -26,7 +26,10 @@ import (
 // lists catalog hits; `err` forces a resolver error for fail-open tests.
 type fakeExternalResourceResolver struct {
 	names map[string]bool
-	err   error
+	// keys is the org record's schema per registered name — what a project's
+	// copy of a Registered External deliberately does not carry.
+	keys map[string][]ConfigKey
+	err  error
 }
 
 func (f fakeExternalResourceResolver) IsRegistered(_ context.Context, _, name string) (bool, error) {
@@ -34,6 +37,13 @@ func (f fakeExternalResourceResolver) IsRegistered(_ context.Context, _, name st
 		return false, f.err
 	}
 	return f.names[name], nil
+}
+
+func (f fakeExternalResourceResolver) RegisteredConfigKeys(_ context.Context, _, name string) ([]ConfigKey, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.keys[name], nil
 }
 
 // TestResolveExternalDependencies_AppliesStoredRules asserts that with no

--- a/services/aep-api/internal/spec/spec_save.go
+++ b/services/aep-api/internal/spec/spec_save.go
@@ -182,16 +182,16 @@ func (s *artifactService) SaveSpec(ctx context.Context, orgID, projectID string,
 	}, nil
 }
 
-// ValidateSpecAtTag re-runs the whole-spec hard gate on the tree a `v<N>` tag
+// ValidateSpecAtTag re-runs the whole-spec hard gate on the tree a version tag
 // names — the dev workflow's defensive re-check that what it is about to plan
 // from is buildable.
 func (s *artifactService) ValidateSpecAtTag(ctx context.Context, orgID, projectID, tag string) error {
-	if _, ok := parseRequirementsTag(tag); !ok {
-		return fmt.Errorf("%w: %q is not a v<N> tag", ErrInvalidVersionTag, tag)
-	}
 	_, ref, err := s.readyRef(ctx, orgID, projectID)
 	if err != nil {
 		return err
+	}
+	if verr := s.requireVersionTag(ctx, ref, tag); verr != nil {
+		return verr
 	}
 	reqFiles, err := s.readBundleAtTag(ctx, ref, tag, requirementsPrefix, requirementsBundleFilter)
 	if err != nil {

--- a/services/aep-api/internal/spec/version_naming.go
+++ b/services/aep-api/internal/spec/version_naming.go
@@ -127,6 +127,22 @@ func versionTags(tags []sourcecontrol.TagInfo) []sourcecontrol.TagInfo {
 	return out
 }
 
+// knownVersionTag reports whether `tag` names one of the project's versions.
+//
+// It is what the read-at-tag paths ask now. They used to ask whether the name
+// parsed as `v<N>`, which was the same question while the platform chose the
+// name — and became the wrong one the moment the user could: a version called
+// `m1` cut cleanly and then could not be read back, so its build failed at the
+// roles gate with "not a v<N> spec tag".
+func knownVersionTag(tags []sourcecontrol.TagInfo, tag string) bool {
+	for _, t := range tags {
+		if t.Name == tag && isVersionTag(t) {
+			return true
+		}
+	}
+	return false
+}
+
 // latestVersionTag returns the newest version, or ok=false when the project has
 // never been built.
 func latestVersionTag(tags []sourcecontrol.TagInfo) (sourcecontrol.TagInfo, bool) {

--- a/services/aep-api/internal/spec/version_reads_test.go
+++ b/services/aep-api/internal/spec/version_reads_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package spec
+
+// READING BACK A VERSION THE USER NAMED.
+//
+// Cutting `m1` always worked; every read-at-tag then refused it, because the
+// readers asked whether the NAME parsed as `v<N>` rather than whether the tag
+// was one of the project's versions. The build died at the roles gate with
+// `read design at m1: "m1" is not a v<N> spec tag`, so a named version was
+// unbuildable — a whole feature that could be used but not used twice.
+//
+// These run over the real-git harness: a real annotated tag, read back through
+// the real store.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func seedForRead() map[string]string {
+	return map[string]string{
+		"specs/requirements/prd.md": "# PRD\n\nfirst\n",
+		"specs/design/design.cell":  "cell {}\n",
+		"specs/design/components/orders-api/design.json": `{
+  "name": "orders-api",
+  "type": "service",
+  "dependencies": []
+}`,
+	}
+}
+
+func TestReadAtTag_AcceptsAVersionTheUserNamed(t *testing.T) {
+	ctx := context.Background()
+	r := newRig(t, seedForRead())
+	tagAt(t, r, "m1", specTagSubject+"m1", "2026-01-01T10:00:00+00:00")
+
+	design, err := r.svc.GetDesignAtSpecTag(ctx, r.org, r.proj, "m1")
+	if err != nil {
+		t.Fatalf("GetDesignAtSpecTag(m1): %v — a named version must read back", err)
+	}
+	if len(design) == 0 {
+		t.Fatalf("design at m1 is empty, want the seeded bundle")
+	}
+
+	reqs, err := r.svc.GetRequirementsAtTag(ctx, r.org, r.proj, "m1")
+	if err != nil {
+		t.Fatalf("GetRequirementsAtTag(m1): %v", err)
+	}
+	if len(reqs) == 0 {
+		t.Fatalf("requirements at m1 are empty, want prd.md")
+	}
+}
+
+// The dev workflow re-checks the tag it is about to plan from. It has to accept
+// the same names the cut does, or the run fails one step later than the gate.
+func TestValidateSpecAtTag_AcceptsAVersionTheUserNamed(t *testing.T) {
+	ctx := context.Background()
+	r := newRig(t, seedForRead())
+	tagAt(t, r, "payments-v2", specTagSubject+"payments-v2", "2026-01-01T10:00:00+00:00")
+
+	if err := r.svc.ValidateSpecAtTag(ctx, r.org, r.proj, "payments-v2"); err != nil {
+		// The gate itself may refuse the seeded spec on its own merits; what
+		// must never happen is a refusal about the NAME.
+		if errors.Is(err, ErrInvalidVersionTag) {
+			t.Fatalf("ValidateSpecAtTag(payments-v2) refused the name: %v", err)
+		}
+	}
+}
+
+// The guard still earns its place: a tag this project does not have is refused
+// by name, rather than surfacing later as an empty tree.
+func TestReadAtTag_RefusesATagThatIsNotAVersion(t *testing.T) {
+	ctx := context.Background()
+	r := newRig(t, seedForRead())
+	tagAt(t, r, "m1", specTagSubject+"m1", "2026-01-01T10:00:00+00:00")
+	// A release tag somebody pushed — a real ref, and not a version.
+	tagAt(t, r, "release-2026-01", "ship it", "2026-01-02T10:00:00+00:00")
+
+	for _, tag := range []string{"release-2026-01", "nope", ""} {
+		_, err := r.svc.GetDesignAtSpecTag(ctx, r.org, r.proj, tag)
+		if err == nil {
+			t.Errorf("GetDesignAtSpecTag(%q) = nil error, want a refusal", tag)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidVersionTag) {
+			t.Errorf("GetDesignAtSpecTag(%q) = %v, want ErrInvalidVersionTag", tag, err)
+		}
+		if tag != "" && !strings.Contains(err.Error(), tag) {
+			t.Errorf("refusal for %q does not name it: %v", tag, err)
+		}
+	}
+}


### PR DESCRIPTION
## What happened

`track-family-expenses` cut a version called **`m1`** and the build failed a minute later:

```
plan-failed · ProvisionGates ×3
  roles:     read design at m1: invalid version tag: "m1" is not a v<N> spec tag
  user-auth: provisioning: read security.json: … same
  currency-service: external resourcetype "currency-service": at least one config key required
```

Two independent faults, both of which make a real project unbuildable.

## 1. A version the user names cannot be read back (regression, #749/#750)

#750 made the version's name the user's — free text, cut as the tag. Three READ paths were left asking whether the name parses as `^v(\d+)$`:

- `GetDesignAtSpecTag` — the roles gate, and `ReadSecurityJSON` routes through it
- `GetRequirementsAtTag`
- `ValidateSpecAtTag` — the dev workflow's own re-check, so the run would have failed one step later regardless

So any version not named `v<number>` cuts cleanly and then fails its own build. The tests shipped with #750 covered cutting, ordering and listing named versions; none read one back.

**Fix:** the guards ask what they were always meant to ask — is this tag one of the project's versions — resolved from the local mirror first, falling back to a fetch before refusing. A legacy `v<N>-<M>` design tag and a typo are still refused by name.

## 2. A Registered External can never be provisioned

Independent of naming, and older. `authorExternalPrepared` builds the resource type from the design's union config schema:

```go
keys, _ := spec.UnionExternalConfigFor(comps, in.Dependency)
er := &dependencies.ExternalResource{…, ConfigKeys: keys}
if cells := s.registeredEnvCells(ctx, orgID, in.Dependency); len(cells) > 0 { … }  // VALUES only
```

A Registered External's project definition deliberately carries no `config` — the keys live on the org record, which IS the registry (ADR-0009). The org lookup supplies the values and never the keys, so `keys` is empty and `BuildExternalResourceType` refuses with *"at least one config key required"*.

Here `currency-service` is registered org-wide with one key (`OPEN_EXCHANGE_RATES_APP_ID`) and lists `track-family-expenses/expense-api` among its consumers, so the record was right there.

The same shortfall has a second, quieter effect: the wiring derivation builds an external dependency's `envBindings` out of those keys, so the component's `design.json` carried **no wiring at all** for `currency-service` — the coding agent had no env-var names to bind and no `resources:` entry to write into `workload.yaml`.

**Fix:** one seam serves both. The design read already marks an external dependency registered against the org catalog; it now brings the schema along (`ExternalResourceResolver.RegisteredConfigKeys`), so a Registered External arrives carrying its keys. Provisioning and the wiring derivation are unchanged — they were always reading the dependency's `Config`.

## Tests

- Reading back a version named `m1` / `payments-v2` — design, requirements and the workflow re-check — over the real-git harness; and a release tag still refused by name.
- A Registered External whose project definition has no `config`: it arrives carrying the org keys, its wiring derives from them, and an unregistered name is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VNg9Gdpd7SMv6c4VD6PLn
