### PR TITLE
fix(aep-api): a Ready binding is not serving until its URL answers

### DIFF
--- a/services/aep-api/internal/app/app.go
+++ b/services/aep-api/internal/app/app.go
@@ -418,6 +418,25 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	// index (one row read) + the org-scoped release-binding list —
 	// consumer-side ports wired here so projects imports neither.
 	projectService.SetStageSources(projectRunRows{runs: milestoneRunRepo, cycles: runCycleRepo, ledger: usageLedgerRepo}, componentClient)
+	// ONE endpoint gate, shared by the status poll here and the deploy-stage
+	// readiness poll below. Shared because the two used to hold different
+	// definitions of "up": the console counted a component live off the binding
+	// alone while the supervisor was dispatching validation at a URL that could
+	// not be reached. One gate makes the first probe serve both and makes the
+	// two answers impossible to diverge.
+	//
+	// Wired only when the data-plane gateway fronts TLS — the same stated fact
+	// that decides which advertised URL is the live one (PreferPlainHTTPEndpoints
+	// above). A plane without it has no per-host certificate to wait for, and its
+	// `*.openchoreoapis.localhost` names resolve to loopback from inside this
+	// process, so every probe would fail and hold every web component for ever.
+	var endpointGate *projects.EndpointGate
+	if cfg.PlatformAPI.DataPlaneGatewayTLS {
+		endpointGate = projects.NewEndpointGate(projects.NewHTTPEndpointProbe())
+	} else {
+		slog.Info("endpoint deploy-wait disabled — data-plane gateway does not front TLS, so there is no certificate window to wait for")
+	}
+	projectService.SetEndpointGate(endpointGate)
 	organizationService := organization.NewOrganizationService(orgRepo, namespaceClient)
 	// componentService takes repoSvc + buildCredSvc so TriggerBuild can
 	// pre-stage the per-WorkflowRun build Secret in workflows-<orgID>
@@ -1275,6 +1294,16 @@ func Assemble(cfg config.Config, in Infra, seam Seam) (*App, error) {
 	} else {
 		slog.Info("ThunderApplication CR reader disabled — no KUBERNETES_SERVICE_HOST/PORT or KUBE_API_BASE_URL; thunder deploy-wait skipped")
 	}
+	// Endpoint deploy-wait: after OC Ready, a component that advertises an
+	// external URL stays pending until that URL answers. OC reports Ready when
+	// the control plane is done, which on a cloud plane is minutes before a
+	// first-ever hostname has a certificate — and `serving` is what the
+	// validation sweep dispatches on.
+	//
+	// Gated on the SAME stated fact as PreferPlainHTTPEndpoints above, because
+	// both turn on what the data-plane gateway really is — see endpoint_wait.go
+	// for why the local plane must not wire it.
+	deploymentService.SetEndpointGate(endpointGate)
 	// The address a consumer reaches a protected sibling's managed API on. Config
 	// carries only an override; the default lives beside the context-path builder
 	// it has to agree with.

--- a/services/aep-api/internal/clients/openchoreo/component_chain_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_chain_client.go
@@ -233,7 +233,7 @@ func (c *componentClient) GetReleaseBindingStatus(ctx context.Context, orgName, 
 			JSON500: resp.JSON500,
 		})
 	}
-	summary := releaseBindingSummary(*resp.JSON200)
+	summary := c.releaseBindingSummary(*resp.JSON200)
 	return &summary, nil
 }
 

--- a/services/aep-api/internal/clients/openchoreo/component_client.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client.go
@@ -1052,7 +1052,7 @@ func (c *componentClient) ListProjectReleaseBindings(ctx context.Context, orgNam
 			if isInternalComponent(nil, lbls) {
 				continue
 			}
-			out = append(out, releaseBindingSummary(rb))
+			out = append(out, c.releaseBindingSummary(rb))
 		}
 		next := resp.JSON200.Pagination.NextCursor
 		if next == nil || *next == "" {
@@ -1069,9 +1069,15 @@ func (c *componentClient) ListProjectReleaseBindings(ctx context.Context, orgNam
 }
 
 // releaseBindingSummary extracts the deploy-stage facts: identity, undeploy
-// intent, and the aggregate Ready-typed condition (never the last-array-entry
-// heuristic — condition array order is not guaranteed).
-func releaseBindingSummary(rb ocgen.ReleaseBinding) ReleaseBindingSummary {
+// intent, the aggregate Ready-typed condition (never the last-array-entry
+// heuristic — condition array order is not guaranteed), and the public URL the
+// binding advertises.
+//
+// A METHOD for the URL alone: picking between the advertised http and https
+// forms needs the client's scheme preference, and a summary that chose
+// differently from the deployments read would hand two callers two answers
+// about one binding.
+func (c *componentClient) releaseBindingSummary(rb ocgen.ReleaseBinding) ReleaseBindingSummary {
 	s := ReleaseBindingSummary{}
 	var projectName, componentName string
 	if rb.Spec != nil {
@@ -1087,6 +1093,14 @@ func releaseBindingSummary(rb ocgen.ReleaseBinding) ReleaseBindingSummary {
 			if cond.Type == "Ready" {
 				s.ReadyStatus = string(cond.Status)
 				s.ReadyReason = cond.Reason
+				break
+			}
+		}
+	}
+	if rb.Status != nil && rb.Status.Endpoints != nil {
+		for _, ep := range *rb.Status.Endpoints {
+			if u := publicEndpointURL(ep.ExternalURLs, c.preferPlainHTTP); u != "" {
+				s.ExternalURL = u
 				break
 			}
 		}

--- a/services/aep-api/internal/clients/openchoreo/component_client_endpoint_url_test.go
+++ b/services/aep-api/internal/clients/openchoreo/component_client_endpoint_url_test.go
@@ -131,3 +131,36 @@ func TestDeploymentFromReleaseBinding_FallsBackWhenThePreferredSchemeIsAbsent(t 
 		t.Fatalf("EndpointURL = %q, want %q — the only scheme advertised", got.EndpointURL, want)
 	}
 }
+
+// The summary carries the SAME URL the deployments read does, off the same
+// object. It has to: the deploy-stage gate in `projects` decides whether a
+// component is reachable from the summary, and a person clicks the link the
+// deployments read produced. Two spellings of one binding's address would let
+// the platform hold a component the user can reach, or pass one they cannot.
+func TestReleaseBindingSummary_CarriesTheSamePublicURLAsTheDeploymentRead(t *testing.T) {
+	rb := bindingWithExternal(
+		httpsURL("web.apps.example.test", "/", 443),
+		httpURL("web.apps.example.test", "/", 80),
+	)
+	for _, preferPlainHTTP := range []bool{false, true} {
+		c := &componentClient{preferPlainHTTP: preferPlainHTTP}
+		summary := c.releaseBindingSummary(rb)
+		deployment := deploymentFromReleaseBinding(rb, preferPlainHTTP)
+		if summary.ExternalURL != deployment.EndpointURL {
+			t.Errorf("preferPlainHTTP=%v: summary %q != deployment %q",
+				preferPlainHTTP, summary.ExternalURL, deployment.EndpointURL)
+		}
+		if summary.ExternalURL == "" {
+			t.Errorf("preferPlainHTTP=%v: summary carries no URL", preferPlainHTTP)
+		}
+	}
+}
+
+// A component that exposes nothing — a worker, an internal-only service —
+// advertises no external URL, and the gate reads that as vacuously reachable.
+func TestReleaseBindingSummary_NoExternalURLWhenTheBindingAdvertisesNone(t *testing.T) {
+	c := &componentClient{}
+	if got := c.releaseBindingSummary(bindingWithExternal(nil, nil)); got.ExternalURL != "" {
+		t.Errorf("ExternalURL = %q, want empty", got.ExternalURL)
+	}
+}

--- a/services/aep-api/internal/clients/openchoreo/component_types.go
+++ b/services/aep-api/internal/clients/openchoreo/component_types.go
@@ -241,6 +241,17 @@ type ReleaseBindingSummary struct {
 	// and wrong. The run supervisor compares it against the release the
 	// component's newest succeeded build would cut (delivery.ReleaseNameFor).
 	ReleaseName string
+	// ExternalURL is the public URL this binding advertises, "" for a component
+	// that exposes none (a worker, an internal-only service).
+	//
+	// It rides the summary because it is a fact of the SAME object, read on the
+	// same call: `status.endpoints[].externalURLs`, picked by the same
+	// scheme preference as the deployments read (PreferPlainHTTPEndpoints).
+	// Carrying it is what lets a reader ask whether the binding's Ready claim is
+	// true at the EDGE without a second request — see the endpoint deploy-wait
+	// in `projects`, where Ready over an unanswerable URL is what dispatched
+	// validation against a system that could not be reached.
+	ExternalURL string
 }
 
 // -- ComponentOpenAPI (Test tab) ----------------------------------------------

--- a/services/aep-api/internal/projects/README.md
+++ b/services/aep-api/internal/projects/README.md
@@ -57,6 +57,7 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
 | `BindingConverger` (`Converge`) | offers | the config slice — an env-var edit pushes onto the live binding through the deploy path rather than patching a field of it, so the two can never write different desired states onto one object |
 | `ComponentEnvVarReader` · `RuntimeFileProvider` | needs | the config slice and `dependencies/runtimeconfig` — the two projections whose values ride the binding's workload overrides. Both are declared consumer-side and both distinguish "no values" from "cannot compute yet": an unready projection leaves its field UNMANAGED rather than writing an empty one over the user's values |
 | CRT catalog · binding patcher · `ThunderApplicationReader` | needs | after OC Ready, a web-app whose platform-resource CRT carries `ConsumerURLEnvConfig` stays pending until the ThunderApplication CR has the SPA callback. Wired via `SetResourceCatalog` / `SetResourceClient` / `SetThunderApplicationReader`. Any nil (or a nil store) skips the wait, so OC-only `DeploymentState` tests stay green. Service components never enter it. This domain consumes `ThunderApplicationView`; it does not GET Kubernetes |
+| `EndpointGate` | needs | after OC Ready, a component that advertises an external URL stays pending until that URL ANSWERS. ONE gate, wired via `SetEndpointGate` onto BOTH the deploy-stage read (`DeploymentState`) and the status poll (`holdUnreachable`), so the supervisor and the console cannot answer differently about one component and the first probe serves both. The URL rides `ReleaseBindingSummary.ExternalURL` — the same object, no second request. Nil skips the gate, and the composition root wires one only when the data-plane gateway fronts TLS: a plane without it has no certificate to wait for, and its `*.openchoreoapis.localhost` names resolve to loopback from this process. A component that advertises no URL passes untouched |
 | `OrgPublisher` | needs | `organization` — per-org Thunder publisher provisioning + the IDP profile a protected API's JWT validation is pinned to. Best-effort: a failure composes an unpinned trait rather than failing a version's deploy |
 | `ProjectLister` | needs | `sourcecontrol`, at the root — every project the platform tracks, for the converge sweep. The git-repository index rather than the executions table, because the run loop mints no execution rows and a sweep reading those saw nothing on that rail |
 | `Service` · `ComponentService` · `ConfigService` | offers | the edge (the 14 public ops) |
@@ -95,6 +96,25 @@ delivery's kernel: shared behaviour belongs in the root the slices import.
   The address rides the binding's env field and is overlaid ONLY when that field is already managed —
   merging into an unmanaged (nil) one would replace the user's whole config with the platform's variable.
 - **OpenChoreo Ready is not deployed for a Thunder SPA.** A web-application with a platform-resource whose CRT carries `ConsumerURLEnvConfig` stays pending until `ThunderApplication.spec.redirectUris` equals the SPA callback and that generation is ready (`status.ready` and `observedGeneration >= generation`). Failed and Undeploy skip the wait; a patch or CR GET error is returned for activity retry, not invented as Failed. `FilesForComponent` is a different seam — this wait does not grade the callback onto env-config.js.
+- **OpenChoreo Ready is not reachable.** OC reports a binding Ready when the control plane is done —
+  release rendered, workload rolled out. Every consumer reads it as a claim about the EDGE: the
+  validation sweep dispatches on it, the console counts components live by it, and a person clicks the
+  URL because of it. On a cloud plane a component that has never been deployed gets a hostname that has
+  never had a certificate, and cert-manager's ACME order has no happens-before edge to the binding, so
+  the two are minutes apart. A component that advertises an external URL is therefore not Ready here
+  until that URL answers — any HTTP response counts and only a transport failure does not, which is
+  [ADR-0006](../../../../runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md)'s
+  rule and the runner's preflight is its other implementation — narrowed to the ONE URL the binding
+  advertises, since the certificate is issued per host and that URL is the one a person clicks.
+  A held component is `converging`, which the deploy stage already waits on and its deadline
+  already fails. The first POSITIVE answer per
+  release is memoised for ever, so this is not health monitoring; a negative one is memoised for a
+  short retry window, because both readers are polled and a fresh connect per unreachable component
+  per poll is latency a person waiting on the project page would see. The console's counts run
+  through the SAME gate
+  (`holdUnreachable` downgrades a Ready binding whose URL does not answer, before `deployStageStatus`
+  and `countReady` see it), so the overview reads "Deploying · 1 of 2" for that window rather than
+  claiming a component is live at a moment clicking its link returns a TLS error.
 - **Deploy is DRIVEN, never inferred.** Components carry `autoDeploy: false`, so nothing promotes a release
   except a call to `Deploy`. That is what lets the run supervisor place validation after a version is
   genuinely serving — see [ADR-0017](../../../../docs/decisions/ADR-0017-the-platform-owns-deploy.md).

--- a/services/aep-api/internal/projects/deployment_service.go
+++ b/services/aep-api/internal/projects/deployment_service.go
@@ -68,6 +68,10 @@ type DeploymentService struct {
 	catalog        resourceMarkerCatalog
 	resourceClient bindingEnvironmentPatcher
 	thunder        ThunderApplicationReader
+	// endpoint gates a Ready binding on its public URL actually answering. Nil
+	// skips the gate, and the SAME gate is held by the status reader so the two
+	// cannot answer differently — see endpoint_wait.go.
+	endpoint *EndpointGate
 }
 
 // ComponentEnvVarReader is the user's component config, consumer-side.
@@ -291,6 +295,12 @@ func (s *DeploymentService) deployOne(ctx context.Context, orgID, projectID, com
 // CRT carries ConsumerURLEnvConfig is not Ready until the ThunderApplication
 // CR has the SPA callback (see applyThunderWait). Nil wait ports keep today's
 // OC-only verdict.
+//
+// Then a component that advertises an external URL is not Ready until that URL
+// ANSWERS (see applyEndpointWait). OpenChoreo reports the binding Ready when the
+// control plane is done, which on a cloud plane is minutes before a first-ever
+// hostname has a certificate — and `serving` is read by the validation sweep,
+// the console and a person clicking the link as a claim about the edge.
 func (s *DeploymentService) DeploymentState(ctx context.Context, orgID, projectID string, components []string) ([]delivery.ComponentDeploy, error) {
 	if s == nil || s.components == nil {
 		return nil, fmt.Errorf("deployment: not configured")
@@ -305,6 +315,7 @@ func (s *DeploymentService) DeploymentState(ctx context.Context, orgID, projectI
 		if err := s.applyThunderWait(ctx, orgID, projectID, name, summary, &st); err != nil {
 			return nil, err
 		}
+		s.applyEndpointWait(ctx, orgID, projectID, name, summary, &st)
 		out = append(out, st)
 	}
 	return out, nil

--- a/services/aep-api/internal/projects/endpoint_wait.go
+++ b/services/aep-api/internal/projects/endpoint_wait.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
 	"github.com/wso2/aep/aep-api/internal/delivery"
 )
@@ -120,6 +122,15 @@ type EndpointGate struct {
 	// arriving inside negativeRetryAfter answer from the memo rather than each
 	// paying probeTimeout. Negative answers expire; positive ones do not.
 	failed sync.Map
+	// inflight collapses CONCURRENT misses on one key into a single probe.
+	//
+	// The memos above are read-then-write, so without this two readers arriving
+	// together both miss and both probe — and the sentence above, that the two
+	// cannot disagree about whether a component is up, would only be true when
+	// their polls happen not to overlap. They are independent pollers on the
+	// same window, so overlapping is the normal case, not the rare one.
+	// Same pattern as organization's ensureInflight.
+	inflight singleflight.Group
 	// now is the clock, so the retry window is testable without sleeping.
 	now func() time.Time
 }
@@ -148,21 +159,68 @@ func (g *EndpointGate) Reachable(ctx context.Context, release, url string) bool 
 		return true
 	}
 	key := release + "\x00" + url
+	if g.memoised(key) {
+		return g.reachableByMemo(key)
+	}
+	// One probe per key, however many readers arrive at once; the others wait
+	// on it and read the same verdict. The func returns no error, so the value
+	// is the bool the shared call produced.
+	v, _, _ := g.inflight.Do(key, func() (any, error) {
+		// Re-checked INSIDE the flight: a caller that queued behind a probe
+		// which has just answered must read that answer, not launch another.
+		if g.memoised(key) {
+			return g.reachableByMemo(key), nil
+		}
+		if !g.probe.Answers(ctx, url) {
+			// A cancelled or timed-out CALLER is not evidence about the
+			// endpoint. Caching it would let one abandoned console request tell
+			// every other reader the component is down for the whole retry
+			// window — including the supervisor, which would hold the deploy.
+			//
+			// The verdict still comes back false for everyone sharing this
+			// flight, which is the safe direction: holding a component for one
+			// more poll costs a poll, and nothing was memoised, so the next
+			// caller probes afresh.
+			if ctx.Err() == nil {
+				g.failed.Store(key, g.clock())
+			}
+			return false, nil
+		}
+		g.seen.Store(key, struct{}{})
+		g.failed.Delete(key)
+		return true, nil
+	})
+	reachable, _ := v.(bool)
+	return reachable
+}
+
+// memoised reports whether this key already has an answer worth reusing — a
+// positive one, which is kept for ever, or a negative one still inside its
+// retry window.
+func (g *EndpointGate) memoised(key string) bool {
 	if _, ok := g.seen.Load(key); ok {
 		return true
 	}
-	if at, ok := g.failed.Load(key); ok {
-		if last, isTime := at.(time.Time); isTime && g.clock().Sub(last) < negativeRetryAfter {
-			return false
-		}
-	}
-	if !g.probe.Answers(ctx, url) {
-		g.failed.Store(key, g.clock())
+	return g.withinNegativeWindow(key)
+}
+
+// reachableByMemo reads the memoised verdict. Only meaningful when memoised
+// said yes: a positive answer wins over a stale negative one, since a URL that
+// has answered cannot go back to never having answered.
+func (g *EndpointGate) reachableByMemo(key string) bool {
+	_, ok := g.seen.Load(key)
+	return ok
+}
+
+// withinNegativeWindow reports whether the last negative answer for this key is
+// still fresh enough to reuse instead of re-probing.
+func (g *EndpointGate) withinNegativeWindow(key string) bool {
+	at, ok := g.failed.Load(key)
+	if !ok {
 		return false
 	}
-	g.seen.Store(key, struct{}{})
-	g.failed.Delete(key)
-	return true
+	last, isTime := at.(time.Time)
+	return isTime && g.clock().Sub(last) < negativeRetryAfter
 }
 
 // SetEndpointGate wires the reachability gate. A nil gate skips it, which is
@@ -208,6 +266,11 @@ func (s *DeploymentService) applyEndpointWait(ctx context.Context, orgID, projec
 	}
 
 	st.Ready = false
+	// Cleared with the verdict it described: componentDeployFrom copied
+	// OpenChoreo's Ready-TRUE reason onto st before this gate ran, and leaving
+	// it behind would caption a held component with the reason it was up. Same
+	// reason holdUnreachable clears ReadyReason on the status path.
+	st.Reason = ""
 	slog.InfoContext(ctx, "deployment: binding is Ready but the endpoint does not answer yet — holding at converging",
 		"org", orgID, "project", projectID, "component", componentName, "url", url, "release", st.Release)
 }

--- a/services/aep-api/internal/projects/endpoint_wait.go
+++ b/services/aep-api/internal/projects/endpoint_wait.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/delivery"
+)
+
+// Holds a component's deploy verdict at pending until its PUBLIC URL answers.
+//
+// OpenChoreo's binding Ready is a claim about the control plane: the release is
+// rendered and the workload rolled out. Everything downstream reads it as a
+// claim about the EDGE — the run supervisor dispatches validation against it,
+// the console counts components live by it, and a person clicks the URL because
+// of it. On a cloud plane those are minutes apart, because a component that has
+// never been deployed gets a hostname that has never had a certificate, and
+// cert-manager's ACME order is a second reconciler with its own timeline and no
+// happens-before edge to the binding. Validation dispatched into that gap dies
+// at its own preflight on a TLS alert, against a deployment where nothing is
+// misconfigured and nothing is slow.
+//
+// So the fix is not a retry in the consumer — that would leave the console and
+// the promote gate believing the same wrong claim. It is that `serving` means
+// what every consumer already reads it to mean. A component held here is
+// `converging`, which is ALREADY the state for "pinned, not ready yet": the
+// deploy stage waits on it and the stage deadline turns one that never resolves
+// into a deploy failure, so this adds a predicate rather than a mechanism.
+//
+// The local plane cannot see any of this — no per-host issuance step, so the
+// gap is zero — which is why it shipped. It is also where the gate must NOT
+// run: `*.openchoreoapis.localhost` resolves to loopback from inside the
+// compose aep-api container (Docker's embedded resolver answers ::1, so being
+// Go rather than curl does not help), and a probe that can never connect would
+// hold every local web component at converging for ever. The composition root
+// wires the probe only when the data-plane gateway fronts TLS, which is the
+// same stated fact that decides which advertised URL is the live one.
+
+const (
+	// probeTimeout bounds ONE probe. It is deliberately short: this runs on the
+	// console's status poll as well as the supervisor's, and a caller waiting on
+	// a page render must not wear a long connect. A false "not answering" costs
+	// one more retry window; the gateway answers in milliseconds once its
+	// certificate exists, and fails its handshake fast before that.
+	probeTimeout = 5 * time.Second
+	// negativeRetryAfter is how long a NEGATIVE answer is trusted before the
+	// gate probes again. Without it every poll through the issuance window pays
+	// a fresh connect per unreachable component, which on the console's poll is
+	// latency a person sees. A positive answer is kept for ever instead (see
+	// EndpointGate.seen); only the "not yet" needs re-asking.
+	negativeRetryAfter = 15 * time.Second
+)
+
+// endpointProbe answers whether a deployed endpoint responds at its public URL.
+//
+// ANY HTTP response means reachable; only a TRANSPORT failure does not. That is
+// ADR-0006's rule, and this is the second implementation of it (the runner's
+// `probeEndpoints` is the first, in TypeScript, so the rule is shared and the
+// code cannot be). Status is deliberately not evidence: an endpoint behind the
+// api-configuration trait legitimately answers 401, an API root legitimately
+// answers 404, and reading either as unreachable would hold a healthy component
+// out of `serving` for ever — manufacturing the deadlock this gate is supposed
+// to prevent.
+type endpointProbe interface {
+	Answers(ctx context.Context, url string) bool
+}
+
+// EndpointGate answers "does this release's URL answer yet", once per release.
+//
+// A VALUE rather than a method set, because two readers ask the same question
+// on the same window: the run supervisor's readiness poll (DeploymentState) and
+// the console's project status. Sharing one gate makes the first answer serve
+// both — whichever probes first pays — and, more importantly, stops the two
+// from disagreeing about whether a component is up, which is the split that put
+// "2 of 2 components live" on screen while validation was failing to reach one
+// of them.
+//
+// It probes the ONE URL the binding's summary carries, which is the same URL
+// the deployments read produces and the one a person clicks. That is a
+// deliberate narrowing of ADR-0006, whose runner probes every endpoint in the
+// validation context: the certificate this gate waits on is issued per HOST, a
+// component's endpoints share theirs, and the summary's stated contract is that
+// it carries exactly what the deployments read does.
+type EndpointGate struct {
+	probe endpointProbe
+	// seen memoises the FIRST positive answer per (release, url).
+	//
+	// The window this gate exists for is crossed exactly once per release.
+	// Re-probing afterwards would put an outbound request per component on
+	// every poll, for ever, to re-answer a question whose answer cannot go
+	// back. This is deliberately NOT health monitoring: a component whose
+	// endpoint breaks after it first served still reads reachable here, exactly
+	// as it does today on the binding alone. Watching for that is a different
+	// job with a different owner.
+	//
+	// Keyed on the release too, so promoting a new one re-opens the question —
+	// a rollout can move which pods serve the same URL.
+	seen sync.Map
+	// failed holds the time of the last NEGATIVE answer per key, so polls
+	// arriving inside negativeRetryAfter answer from the memo rather than each
+	// paying probeTimeout. Negative answers expire; positive ones do not.
+	failed sync.Map
+	// now is the clock, so the retry window is testable without sleeping.
+	now func() time.Time
+}
+
+// NewEndpointGate builds the gate. A nil probe makes every question answer
+// "reachable", which is the OC-only verdict this replaced — the off-switch that
+// keeps a plane with no certificate window, and every test that wires nothing,
+// behaving exactly as before.
+func NewEndpointGate(p endpointProbe) *EndpointGate {
+	return &EndpointGate{probe: p, now: time.Now}
+}
+
+func (g *EndpointGate) clock() time.Time {
+	if g.now == nil {
+		return time.Now()
+	}
+	return g.now()
+}
+
+// Reachable reports whether the release's URL has answered. A nil gate, a gate
+// with no probe, and an empty URL all answer true: none of them is evidence
+// that a component is DOWN, and holding on an absence would deadlock every
+// caller that has no probe wired.
+func (g *EndpointGate) Reachable(ctx context.Context, release, url string) bool {
+	if g == nil || g.probe == nil || url == "" {
+		return true
+	}
+	key := release + "\x00" + url
+	if _, ok := g.seen.Load(key); ok {
+		return true
+	}
+	if at, ok := g.failed.Load(key); ok {
+		if last, isTime := at.(time.Time); isTime && g.clock().Sub(last) < negativeRetryAfter {
+			return false
+		}
+	}
+	if !g.probe.Answers(ctx, url) {
+		g.failed.Store(key, g.clock())
+		return false
+	}
+	g.seen.Store(key, struct{}{})
+	g.failed.Delete(key)
+	return true
+}
+
+// SetEndpointGate wires the reachability gate. A nil gate skips it, which is
+// today's OC-only verdict — the same off-switch the thunder wait uses, so
+// existing DeploymentState tests stay green without new wiring.
+func (s *DeploymentService) SetEndpointGate(g *EndpointGate) {
+	if s != nil {
+		s.endpoint = g
+	}
+}
+
+// applyEndpointWait holds a component at pending until its external URL answers.
+//
+// Skipped for a component with NO external URL, and that is not a shortcut: a
+// worker or an internal-only service is vacuously exposed, and waiting for an
+// endpoint it will never advertise would hang the deploy stage's wave wait on
+// every project that has one. Undeploy, failed and already-pending verdicts are
+// left exactly as they were — a withdrawn component owes nothing, and a probe
+// cannot improve a verdict that is already not Ready.
+func (s *DeploymentService) applyEndpointWait(ctx context.Context, orgID, projectID, componentName string,
+	summary *openchoreo.ReleaseBindingSummary, st *delivery.ComponentDeploy) {
+	if s == nil || s.endpoint == nil {
+		return
+	}
+	// A nil summary is a binding OpenChoreo has not admitted yet — already
+	// pending, and the only shape that could reach the URL read below without
+	// one.
+	if summary == nil || summary.Undeploy {
+		return
+	}
+	if st == nil || !st.Ready || st.Failed {
+		return
+	}
+
+	// The URL off the SUMMARY, not a second read: GetReleaseBindingStatus
+	// already carried it back on the same object, picked by the same scheme
+	// preference the deployments read uses. Asking ListDeployments again would
+	// spend an OpenChoreo request per component per poll to re-learn a fact this
+	// call already has.
+	url := summary.ExternalURL
+	if s.endpoint.Reachable(ctx, st.Release, url) {
+		return
+	}
+
+	st.Ready = false
+	slog.InfoContext(ctx, "deployment: binding is Ready but the endpoint does not answer yet — holding at converging",
+		"org", orgID, "project", projectID, "component", componentName, "url", url, "release", st.Release)
+}
+
+// HTTPEndpointProbe is the default probe: one request, any answer counts.
+//
+// Redirects are NOT followed. A login redirect points at the IdP on the control
+// plane, which is a different hop with its own resolution story; chasing it
+// would turn an answered endpoint into a false negative. A 302 is an answer.
+//
+// TLS verification stays ON. A certificate that does not verify is precisely
+// the condition this gate exists to catch, so skipping verification would make
+// the probe pass in the window it was written for. A plane whose gateway does
+// not terminate TLS advertises the http URL instead
+// (openchoreo.Config.PreferPlainHTTPEndpoints), so nothing here needs to be
+// lenient about certificates to work locally.
+type HTTPEndpointProbe struct {
+	client *http.Client
+}
+
+// NewHTTPEndpointProbe builds the default probe, bounded by probeTimeout.
+func NewHTTPEndpointProbe() *HTTPEndpointProbe {
+	return &HTTPEndpointProbe{client: &http.Client{
+		Timeout: probeTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}}
+}
+
+func (p *HTTPEndpointProbe) Answers(ctx context.Context, url string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return false
+	}
+	// Nothing here reads the body; closing it returns the connection.
+	_ = resp.Body.Close()
+	return true
+}

--- a/services/aep-api/internal/projects/endpoint_wait_test.go
+++ b/services/aep-api/internal/projects/endpoint_wait_test.go
@@ -1,0 +1,425 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package projects
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo"
+	"github.com/wso2/aep/aep-api/internal/clients/openchoreo/mocks"
+)
+
+// UNIT tier for the endpoint deploy-wait: DeploymentState is not Ready for a
+// component whose advertised external URL does not answer yet, however happy
+// OpenChoreo is about the binding. Seam is DeploymentService.DeploymentState
+// and Service.holdUnreachable — the two readers that used to hold different
+// definitions of "up"; the OC status read and the probe are fakes.
+//
+// The downstream half needs no test here: Ready=false already classifies as
+// `converging` (delivery/run: policy_test.go), which is the state the deploy
+// stage waits on.
+
+const (
+	endpointWaitOrg     = "acme"
+	endpointWaitProject = "proj"
+	endpointWaitComp    = "web"
+	endpointWaitRelease = "proj-web-abc1234"
+	endpointWaitURL     = "https://web.example.test/"
+)
+
+// fakeEndpointProbe is a hand double of endpointProbe that counts calls, so a
+// test can assert the probe was NOT consulted as well as what it answered.
+type fakeEndpointProbe struct {
+	answers bool
+	calls   int
+	urls    []string
+}
+
+func (f *fakeEndpointProbe) Answers(_ context.Context, url string) bool {
+	f.calls++
+	f.urls = append(f.urls, url)
+	return f.answers
+}
+
+type endpointWaitOpts struct {
+	// summary is the binding read; nil means a Ready one.
+	summary *openchoreo.ReleaseBindingSummary
+	// url is what the binding advertises; empty means none, which is how a
+	// worker or an internal-only component reads.
+	url string
+	// probe is the gate; nil leaves it unwired, which is the OC-only verdict.
+	probe *fakeEndpointProbe
+}
+
+type endpointWaitHarness struct {
+	svc   *DeploymentService
+	probe *fakeEndpointProbe
+}
+
+func newEndpointWaitHarness(t *testing.T, opts endpointWaitOpts) *endpointWaitHarness {
+	t.Helper()
+	if opts.summary == nil {
+		opts.summary = &openchoreo.ReleaseBindingSummary{
+			ReadyStatus: "True",
+			ReleaseName: endpointWaitRelease,
+		}
+	}
+	// The URL rides the SUMMARY — the same object the readiness poll already
+	// read — so the fake sets it there rather than on a deployments list.
+	opts.summary.ExternalURL = opts.url
+	oc := &mocks.ComponentClientMock{
+		GetReleaseBindingStatusFunc: func(context.Context, string, string, string, string) (*openchoreo.ReleaseBindingSummary, error) {
+			return opts.summary, nil
+		},
+	}
+	svc := NewDeploymentService(oc, nil)
+	if opts.probe != nil {
+		svc.SetEndpointGate(NewEndpointGate(opts.probe))
+	}
+	return &endpointWaitHarness{svc: svc, probe: opts.probe}
+}
+
+func (h *endpointWaitHarness) ready(t *testing.T) bool {
+	t.Helper()
+	got, err := h.svc.DeploymentState(context.Background(), endpointWaitOrg, endpointWaitProject,
+		[]string{endpointWaitComp})
+	if err != nil {
+		t.Fatalf("DeploymentState: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 component, got %d", len(got))
+	}
+	return got[0].Ready
+}
+
+// The whole point: OpenChoreo says Ready, the edge does not answer, and the
+// component is held. This is the certificate-issuance window, in which
+// validation used to be dispatched against a system that could not be reached.
+func TestEndpointWaitHoldsAReadyBindingWhoseURLDoesNotAnswer(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	h := newEndpointWaitHarness(t, endpointWaitOpts{url: endpointWaitURL, probe: probe})
+
+	if h.ready(t) {
+		t.Fatal("component is Ready while its endpoint does not answer — validation would dispatch against an unreachable system")
+	}
+	if probe.calls != 1 {
+		t.Fatalf("probe calls = %d, want 1", probe.calls)
+	}
+	if probe.urls[0] != endpointWaitURL {
+		t.Errorf("probed %q, want the advertised URL %q", probe.urls[0], endpointWaitURL)
+	}
+}
+
+func TestEndpointWaitPassesAReadyBindingWhoseURLAnswers(t *testing.T) {
+	h := newEndpointWaitHarness(t, endpointWaitOpts{
+		url:   endpointWaitURL,
+		probe: &fakeEndpointProbe{answers: true},
+	})
+
+	if !h.ready(t) {
+		t.Fatal("component is not Ready though its endpoint answers")
+	}
+}
+
+// A worker or an internal-only service advertises no external URL. It is
+// vacuously exposed — holding it would hang the deploy stage's wave wait on
+// every project that has one.
+func TestEndpointWaitPassesAComponentWithNoExternalURL(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	h := newEndpointWaitHarness(t, endpointWaitOpts{url: "", probe: probe})
+
+	if !h.ready(t) {
+		t.Fatal("a component with no external URL was held — the wave wait would never finish")
+	}
+	if probe.calls != 0 {
+		t.Fatalf("probe calls = %d, want 0 — there is no URL to probe", probe.calls)
+	}
+}
+
+// Withdrawn on purpose: nothing is owed, so the gate does not ask.
+func TestEndpointWaitLeavesAnUndeployedComponentAlone(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	h := newEndpointWaitHarness(t, endpointWaitOpts{
+		summary: &openchoreo.ReleaseBindingSummary{Undeploy: true, ReleaseName: endpointWaitRelease},
+		url:     endpointWaitURL,
+		probe:   probe,
+	})
+
+	if !h.ready(t) {
+		t.Fatal("an undeployed component was held — nothing is owed there")
+	}
+	if probe.calls != 0 {
+		t.Fatalf("probe calls = %d, want 0", probe.calls)
+	}
+}
+
+// A binding that is not Ready yet is already pending. A probe cannot improve
+// that verdict, and spending a request per poll to re-learn it is waste.
+func TestEndpointWaitDoesNotProbeAPendingBinding(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: true}
+	h := newEndpointWaitHarness(t, endpointWaitOpts{
+		summary: &openchoreo.ReleaseBindingSummary{ReadyStatus: "False", ReleaseName: endpointWaitRelease},
+		url:     endpointWaitURL,
+		probe:   probe,
+	})
+
+	if h.ready(t) {
+		t.Fatal("a pending binding read as Ready")
+	}
+	if probe.calls != 0 {
+		t.Fatalf("probe calls = %d, want 0 — the binding is not Ready", probe.calls)
+	}
+}
+
+// A POSITIVE answer is kept for ever: the window is crossed once per release,
+// and re-probing would put an outbound request per component on every readiness
+// poll for the life of the run.
+func TestEndpointWaitProbesOncePerRelease(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: true}
+	h := newEndpointWaitHarness(t, endpointWaitOpts{url: endpointWaitURL, probe: probe})
+
+	for i := range 3 {
+		if !h.ready(t) {
+			t.Fatalf("poll %d: component is not Ready though its endpoint answered", i+1)
+		}
+	}
+	if probe.calls != 1 {
+		t.Fatalf("probe calls = %d over 3 polls, want 1", probe.calls)
+	}
+}
+
+// No probe wired is the OC-only verdict — the off-switch that keeps every
+// existing DeploymentState test green without new wiring.
+func TestEndpointWaitSkippedWithoutAProbe(t *testing.T) {
+	h := newEndpointWaitHarness(t, endpointWaitOpts{url: endpointWaitURL})
+
+	if !h.ready(t) {
+		t.Fatal("component was held with no probe wired")
+	}
+}
+
+// The default probe's rule, which has to match the runner's (ADR-0006): any
+// HTTP answer counts, and a status is never evidence. An endpoint behind the
+// api-configuration trait answers 401 and an API root answers 404, and reading
+// either as unreachable would hold a healthy component out of serving for ever.
+func TestHTTPEndpointProbeAcceptsAnyAnswer(t *testing.T) {
+	for _, code := range []int{http.StatusOK, http.StatusUnauthorized, http.StatusNotFound,
+		http.StatusFound, http.StatusInternalServerError} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+		}))
+		if !NewHTTPEndpointProbe().Answers(context.Background(), srv.URL) {
+			t.Errorf("status %d read as unreachable — only a transport failure may", code)
+		}
+		srv.Close()
+	}
+}
+
+// And the other half of the rule: a transport failure is the only thing that
+// means unreachable. Closing the server first is the closest stand-in for the
+// gateway that answered a TLS alert.
+func TestHTTPEndpointProbeRejectsATransportFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	if NewHTTPEndpointProbe().Answers(context.Background(), url) {
+		t.Error("a refused connection read as reachable")
+	}
+}
+
+// -- the console's half -------------------------------------------------------
+
+// reachableBinding is devBinding's (project_stages_test.go) sibling for this
+// concern: same dev-environment shape, but carrying the advertised URL the gate
+// keys on instead of a Ready reason.
+func reachableBinding(name, ready, url string) openchoreo.ReleaseBindingSummary {
+	return openchoreo.ReleaseBindingSummary{
+		ComponentName: name,
+		Environment:   openchoreo.DevEnvironmentName,
+		ReadyStatus:   ready,
+		ReleaseName:   endpointWaitRelease,
+		ExternalURL:   url,
+	}
+}
+
+// The console's count and chip come off the same gate now. Before this, the
+// overview read "Deployed · 2 of 2 components live" during the exact window in
+// which validation could not reach one of them.
+func TestHoldUnreachableDowngradesAReadyBindingThatDoesNotAnswer(t *testing.T) {
+	svc := &Service{}
+	svc.SetEndpointGate(NewEndpointGate(&fakeEndpointProbe{answers: false}))
+
+	dev := []openchoreo.ReleaseBindingSummary{
+		reachableBinding("api", "True", ""),
+		reachableBinding("web", "True", endpointWaitURL),
+	}
+	got := svc.holdUnreachable(context.Background(), dev)
+
+	if n := countReady(got); n != 1 {
+		t.Errorf("countReady = %d, want 1 — the web component cannot be reached", n)
+	}
+	if st := deployStageStatus(got); st != deployDeploying {
+		t.Errorf("deployStageStatus = %q, want %q", st, deployDeploying)
+	}
+	// A downgrade must read as PENDING, never as a failure: nothing is broken,
+	// the certificate has not been issued yet.
+	for _, b := range got {
+		if bindingFailed(b) {
+			t.Errorf("%s read as failed; want pending", b.ComponentName)
+		}
+	}
+}
+
+func TestHoldUnreachablePassesBindingsThatAnswer(t *testing.T) {
+	svc := &Service{}
+	svc.SetEndpointGate(NewEndpointGate(&fakeEndpointProbe{answers: true}))
+
+	dev := []openchoreo.ReleaseBindingSummary{reachableBinding("web", "True", endpointWaitURL)}
+	got := svc.holdUnreachable(context.Background(), dev)
+
+	if n := countReady(got); n != 1 {
+		t.Errorf("countReady = %d, want 1", n)
+	}
+	if st := deployStageStatus(got); st != deployDeployed {
+		t.Errorf("deployStageStatus = %q, want %q", st, deployDeployed)
+	}
+}
+
+// The caller's slice is the status poll's own read. Rewriting it in place would
+// leak a downgrade into whatever else that read feeds.
+func TestHoldUnreachableDoesNotMutateTheCallersSlice(t *testing.T) {
+	svc := &Service{}
+	svc.SetEndpointGate(NewEndpointGate(&fakeEndpointProbe{answers: false}))
+
+	dev := []openchoreo.ReleaseBindingSummary{reachableBinding("web", "True", endpointWaitURL)}
+	_ = svc.holdUnreachable(context.Background(), dev)
+
+	if dev[0].ReadyStatus != "True" {
+		t.Errorf("caller's slice was rewritten: ReadyStatus = %q", dev[0].ReadyStatus)
+	}
+}
+
+func TestHoldUnreachableWithoutAGateCountsAsBefore(t *testing.T) {
+	svc := &Service{}
+	dev := []openchoreo.ReleaseBindingSummary{reachableBinding("web", "True", endpointWaitURL)}
+
+	if n := countReady(svc.holdUnreachable(context.Background(), dev)); n != 1 {
+		t.Errorf("countReady = %d with no gate wired, want 1 — the binding-only count", n)
+	}
+}
+
+// The reason the gate is a shared VALUE: whichever reader probes first, the
+// other gets the answer without a second request — and, more importantly, the
+// two can never report different verdicts for one component.
+func TestEndpointGateIsSharedBetweenTheTwoReaders(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: true}
+	gate := NewEndpointGate(probe)
+
+	oc := &mocks.ComponentClientMock{
+		GetReleaseBindingStatusFunc: func(context.Context, string, string, string, string) (*openchoreo.ReleaseBindingSummary, error) {
+			return &openchoreo.ReleaseBindingSummary{
+				ReadyStatus: "True", ReleaseName: endpointWaitRelease, ExternalURL: endpointWaitURL,
+			}, nil
+		},
+	}
+	deploySvc := NewDeploymentService(oc, nil)
+	deploySvc.SetEndpointGate(gate)
+	statusSvc := &Service{}
+	statusSvc.SetEndpointGate(gate)
+
+	if _, err := deploySvc.DeploymentState(context.Background(), endpointWaitOrg, endpointWaitProject,
+		[]string{endpointWaitComp}); err != nil {
+		t.Fatalf("DeploymentState: %v", err)
+	}
+	got := statusSvc.holdUnreachable(context.Background(),
+		[]openchoreo.ReleaseBindingSummary{reachableBinding("web", "True", endpointWaitURL)})
+
+	if n := countReady(got); n != 1 {
+		t.Errorf("countReady = %d, want 1 — the supervisor already proved this URL answers", n)
+	}
+	if probe.calls != 1 {
+		t.Errorf("probe calls = %d across both readers, want 1", probe.calls)
+	}
+}
+
+// A NEGATIVE answer is memoised too, but only for negativeRetryAfter. Without
+// that window every console poll through the issuance gap pays a fresh connect
+// per unreachable component, which is latency a person waiting on the project
+// page sees.
+func TestEndpointGateDoesNotReprobeInsideTheNegativeWindow(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	gate := NewEndpointGate(probe)
+	now := time.Now()
+	gate.now = func() time.Time { return now }
+
+	for i := range 5 {
+		if gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL) {
+			t.Fatalf("poll %d: unreachable URL read as reachable", i+1)
+		}
+	}
+	if probe.calls != 1 {
+		t.Fatalf("probe calls = %d over 5 polls inside the window, want 1", probe.calls)
+	}
+}
+
+// And it does expire — a gate that never re-asked would hold a component whose
+// certificate has since been issued at converging until the stage deadline.
+func TestEndpointGateReprobesAfterTheNegativeWindow(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	gate := NewEndpointGate(probe)
+	now := time.Now()
+	gate.now = func() time.Time { return now }
+
+	if gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL) {
+		t.Fatal("unreachable URL read as reachable")
+	}
+	now = now.Add(negativeRetryAfter + time.Second)
+	probe.answers = true
+
+	if !gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL) {
+		t.Fatal("the URL answers now, but the gate never re-asked")
+	}
+	if probe.calls != 2 {
+		t.Fatalf("probe calls = %d, want 2 — one per side of the window", probe.calls)
+	}
+}
+
+// A downgrade carries no reason, so bindingFailed cannot read one. OpenChoreo's
+// Ready-True reason describes the verdict holdUnreachable has just withdrawn.
+func TestHoldUnreachableClearsTheWithdrawnReadyReason(t *testing.T) {
+	svc := &Service{}
+	svc.SetEndpointGate(NewEndpointGate(&fakeEndpointProbe{answers: false}))
+
+	dev := []openchoreo.ReleaseBindingSummary{{
+		ComponentName: "web",
+		Environment:   openchoreo.DevEnvironmentName,
+		ReadyStatus:   "True",
+		ReadyReason:   "ReleaseReady",
+		ReleaseName:   endpointWaitRelease,
+		ExternalURL:   endpointWaitURL,
+	}}
+	got := svc.holdUnreachable(context.Background(), dev)
+
+	if got[0].ReadyReason != "" {
+		t.Errorf("ReadyReason = %q, want empty — the Ready verdict was withdrawn", got[0].ReadyReason)
+	}
+}

--- a/services/aep-api/internal/projects/endpoint_wait_test.go
+++ b/services/aep-api/internal/projects/endpoint_wait_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,16 +49,41 @@ const (
 
 // fakeEndpointProbe is a hand double of endpointProbe that counts calls, so a
 // test can assert the probe was NOT consulted as well as what it answered.
+//
+// Guarded, because the concurrency tests below call it from several goroutines
+// at once — an unsynchronised counter there would race rather than fail.
 type fakeEndpointProbe struct {
+	mu      sync.Mutex
 	answers bool
 	calls   int
 	urls    []string
+	// block, when set, holds every probe until it is closed, so a test can be
+	// sure several callers are inside the gate at the same moment.
+	block chan struct{}
 }
 
 func (f *fakeEndpointProbe) Answers(_ context.Context, url string) bool {
+	f.mu.Lock()
 	f.calls++
 	f.urls = append(f.urls, url)
-	return f.answers
+	answers, block := f.answers, f.block
+	f.mu.Unlock()
+	if block != nil {
+		<-block
+	}
+	return answers
+}
+
+func (f *fakeEndpointProbe) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeEndpointProbe) probedURLs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.urls...)
 }
 
 type endpointWaitOpts struct {
@@ -120,11 +147,11 @@ func TestEndpointWaitHoldsAReadyBindingWhoseURLDoesNotAnswer(t *testing.T) {
 	if h.ready(t) {
 		t.Fatal("component is Ready while its endpoint does not answer — validation would dispatch against an unreachable system")
 	}
-	if probe.calls != 1 {
+	if probe.callCount() != 1 {
 		t.Fatalf("probe calls = %d, want 1", probe.calls)
 	}
-	if probe.urls[0] != endpointWaitURL {
-		t.Errorf("probed %q, want the advertised URL %q", probe.urls[0], endpointWaitURL)
+	if probe.probedURLs()[0] != endpointWaitURL {
+		t.Errorf("probed %q, want the advertised URL %q", probe.probedURLs()[0], endpointWaitURL)
 	}
 }
 
@@ -149,7 +176,7 @@ func TestEndpointWaitPassesAComponentWithNoExternalURL(t *testing.T) {
 	if !h.ready(t) {
 		t.Fatal("a component with no external URL was held — the wave wait would never finish")
 	}
-	if probe.calls != 0 {
+	if probe.callCount() != 0 {
 		t.Fatalf("probe calls = %d, want 0 — there is no URL to probe", probe.calls)
 	}
 }
@@ -166,7 +193,7 @@ func TestEndpointWaitLeavesAnUndeployedComponentAlone(t *testing.T) {
 	if !h.ready(t) {
 		t.Fatal("an undeployed component was held — nothing is owed there")
 	}
-	if probe.calls != 0 {
+	if probe.callCount() != 0 {
 		t.Fatalf("probe calls = %d, want 0", probe.calls)
 	}
 }
@@ -184,7 +211,7 @@ func TestEndpointWaitDoesNotProbeAPendingBinding(t *testing.T) {
 	if h.ready(t) {
 		t.Fatal("a pending binding read as Ready")
 	}
-	if probe.calls != 0 {
+	if probe.callCount() != 0 {
 		t.Fatalf("probe calls = %d, want 0 — the binding is not Ready", probe.calls)
 	}
 }
@@ -201,7 +228,7 @@ func TestEndpointWaitProbesOncePerRelease(t *testing.T) {
 			t.Fatalf("poll %d: component is not Ready though its endpoint answered", i+1)
 		}
 	}
-	if probe.calls != 1 {
+	if probe.callCount() != 1 {
 		t.Fatalf("probe calls = %d over 3 polls, want 1", probe.calls)
 	}
 }
@@ -356,7 +383,7 @@ func TestEndpointGateIsSharedBetweenTheTwoReaders(t *testing.T) {
 	if n := countReady(got); n != 1 {
 		t.Errorf("countReady = %d, want 1 — the supervisor already proved this URL answers", n)
 	}
-	if probe.calls != 1 {
+	if probe.callCount() != 1 {
 		t.Errorf("probe calls = %d across both readers, want 1", probe.calls)
 	}
 }
@@ -376,7 +403,7 @@ func TestEndpointGateDoesNotReprobeInsideTheNegativeWindow(t *testing.T) {
 			t.Fatalf("poll %d: unreachable URL read as reachable", i+1)
 		}
 	}
-	if probe.calls != 1 {
+	if probe.callCount() != 1 {
 		t.Fatalf("probe calls = %d over 5 polls inside the window, want 1", probe.calls)
 	}
 }
@@ -398,7 +425,7 @@ func TestEndpointGateReprobesAfterTheNegativeWindow(t *testing.T) {
 	if !gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL) {
 		t.Fatal("the URL answers now, but the gate never re-asked")
 	}
-	if probe.calls != 2 {
+	if probe.callCount() != 2 {
 		t.Fatalf("probe calls = %d, want 2 — one per side of the window", probe.calls)
 	}
 }
@@ -421,5 +448,95 @@ func TestHoldUnreachableClearsTheWithdrawnReadyReason(t *testing.T) {
 
 	if got[0].ReadyReason != "" {
 		t.Errorf("ReadyReason = %q, want empty — the Ready verdict was withdrawn", got[0].ReadyReason)
+	}
+}
+
+// -- concurrency and cancellation --------------------------------------------
+
+// The two readers poll independently, so they arrive together as a matter of
+// course. One probe must serve both: without single-flight each would miss the
+// memo and probe, and the claim that they cannot disagree about whether a
+// component is up would hold only when their polls happened not to overlap.
+func TestEndpointGateCollapsesConcurrentMissesIntoOneProbe(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: true, block: make(chan struct{})}
+	gate := NewEndpointGate(probe)
+
+	const readers = 8
+	verdicts := make([]bool, readers)
+	var wg sync.WaitGroup
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			verdicts[i] = gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL)
+		}()
+	}
+	// Let every reader reach the gate, then release the single probe.
+	for probe.callCount() == 0 {
+		runtime.Gosched()
+	}
+	close(probe.block)
+	wg.Wait()
+
+	if n := probe.callCount(); n != 1 {
+		t.Errorf("probe calls = %d across %d concurrent readers, want 1", n, readers)
+	}
+	for i, v := range verdicts {
+		if !v {
+			t.Errorf("reader %d read unreachable; every reader must share the one verdict", i)
+		}
+	}
+}
+
+// A caller giving up is not evidence about the endpoint. Caching it would let
+// one abandoned console request tell every other reader — the supervisor
+// included — that the component is down for the whole retry window.
+func TestEndpointGateDoesNotCacheCallerCancellation(t *testing.T) {
+	probe := &fakeEndpointProbe{answers: false}
+	gate := NewEndpointGate(probe)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if gate.Reachable(cancelled, endpointWaitRelease, endpointWaitURL) {
+		t.Fatal("a cancelled probe read as reachable")
+	}
+
+	// A live caller must get a fresh probe, not the cancelled caller's verdict.
+	probe.answers = true
+	if !gate.Reachable(context.Background(), endpointWaitRelease, endpointWaitURL) {
+		t.Error("the cancelled caller's failure was cached and held a reachable endpoint")
+	}
+	if n := probe.callCount(); n != 2 {
+		t.Errorf("probe calls = %d, want 2 — the live caller must probe afresh", n)
+	}
+}
+
+// The deploy path clears the withdrawn reason too, not just the status path.
+// componentDeployFrom copies OpenChoreo's Ready-True reason before the gate
+// runs, and a held component captioned with the reason it was up is a lie.
+func TestEndpointWaitClearsTheWithdrawnReasonOnTheDeployPath(t *testing.T) {
+	oc := &mocks.ComponentClientMock{
+		GetReleaseBindingStatusFunc: func(context.Context, string, string, string, string) (*openchoreo.ReleaseBindingSummary, error) {
+			return &openchoreo.ReleaseBindingSummary{
+				ReadyStatus: "True",
+				ReadyReason: "ReleaseReady",
+				ReleaseName: endpointWaitRelease,
+				ExternalURL: endpointWaitURL,
+			}, nil
+		},
+	}
+	svc := NewDeploymentService(oc, nil)
+	svc.SetEndpointGate(NewEndpointGate(&fakeEndpointProbe{answers: false}))
+
+	got, err := svc.DeploymentState(context.Background(), endpointWaitOrg, endpointWaitProject,
+		[]string{endpointWaitComp})
+	if err != nil {
+		t.Fatalf("DeploymentState: %v", err)
+	}
+	if got[0].Ready {
+		t.Fatal("component is Ready while its endpoint does not answer")
+	}
+	if got[0].Reason != "" {
+		t.Errorf("Reason = %q, want empty — the Ready verdict was withdrawn", got[0].Reason)
 	}
 }

--- a/services/aep-api/internal/projects/project_service.go
+++ b/services/aep-api/internal/projects/project_service.go
@@ -62,6 +62,18 @@ type Service struct {
 	specTurns      specTurnRows          // spec stage: newest agent turn (status_stages.go); may be nil
 	runAbandoner   runAbandoner          // run-supervisor teardown on delete; may be nil
 	kickoff        kickoffStarter        // fires `/start` on create (#562); may be nil
+	endpointGate   *EndpointGate         // deploy stage: is a Ready binding reachable (status_stages.go); may be nil
+}
+
+// SetEndpointGate wires the reachability gate the deploy stage's counts are
+// held on. The SAME gate as DeploymentService's, by construction at the
+// composition root: two gates would be two memos and, in the window before
+// either has an answer, two different verdicts about one component.
+// Nil skips the gate, which is the binding-only count this replaced.
+func (s *Service) SetEndpointGate(g *EndpointGate) {
+	if s != nil {
+		s.endpointGate = g
+	}
 }
 
 // runAbandoner is project_service's narrow consumer port for the run-supervisor

--- a/services/aep-api/internal/projects/status_stages.go
+++ b/services/aep-api/internal/projects/status_stages.go
@@ -376,6 +376,7 @@ func (s *Service) populateStages(ctx context.Context, orgName, projectName strin
 			dev = append(dev, b)
 		}
 	}
+	dev = s.holdUnreachable(ctx, dev)
 	status.Deploy.Status = deployStageStatus(dev)
 	status.Deploy.Components.Ready = int64(countReady(dev))
 
@@ -612,6 +613,49 @@ var bindingFailureReasons = map[string]bool{
 	"DataPlaneNotConfigured":      true,
 	"ComponentNotFound":           true,
 	"ProjectNotFound":             true,
+}
+
+// holdUnreachable downgrades a binding that claims Ready while its advertised
+// URL does not answer yet, BEFORE the two readers below see it.
+//
+// Done as a pass rather than inside bindingReady on purpose: deployStageStatus
+// and countReady are pure functions of a condition list and are tested as such,
+// and threading a context and a network call through them would make the
+// stage's arithmetic depend on the world. Here the impurity is one function
+// with one job, and both readers keep reading a plain slice.
+//
+// It changes what the console says during the window — "Deploying · 1 of 2"
+// rather than "Deployed · 2 of 2" — which is the point: the old count called a
+// component live at a moment a person clicking its link got a TLS error, and
+// the validation sweep dispatched against exactly that claim.
+//
+// A nil gate returns the slice untouched, so a plane with no probe wired counts
+// exactly as it did before.
+func (s *Service) holdUnreachable(ctx context.Context, dev []openchoreo.ReleaseBindingSummary) []openchoreo.ReleaseBindingSummary {
+	if s == nil || s.endpointGate == nil || len(dev) == 0 {
+		return dev
+	}
+	out := make([]openchoreo.ReleaseBindingSummary, len(dev))
+	copy(out, dev)
+	for i := range out {
+		if !bindingReady(out[i]) {
+			continue
+		}
+		if s.endpointGate.Reachable(ctx, out[i].ReleaseName, out[i].ExternalURL) {
+			continue
+		}
+		// "False" with no failure reason is PENDING to both readers below —
+		// deployStageStatus reads it as progressing, bindingFailed needs a
+		// terminal reason it does not have. Which is the honest reading: the
+		// deployment is still on its way up. The reason is cleared with the
+		// status so that stays true: OpenChoreo's Ready-True reason describes a
+		// verdict this pass has just withdrawn, and leaving it behind would let
+		// bindingFailed read a downgrade as a failure the day OC names a
+		// Ready-True reason that also appears in bindingFailureReasons.
+		out[i].ReadyStatus = "False"
+		out[i].ReadyReason = ""
+	}
+	return out
 }
 
 func bindingReady(b openchoreo.ReleaseBindingSummary) bool { return b.ReadyStatus == "True" }

--- a/skills/aep-validation/SKILL.md
+++ b/skills/aep-validation/SKILL.md
@@ -269,6 +269,10 @@ Then: write the test plan, author one spec per uncovered e2e criterion
 live app is the only trustworthy source), and remember the bar: a spec
 counts only after passing twice consecutively against the live app.
 
+- **One browser at a time.** Work the criteria in sequence, in this agent
+  — a live Chromium is the largest thing in the cycle's pod, and a second
+  session OOM-kills the run mid-phase. Splitting the criteria across
+  dispatched agents looks like parallel work and buys an OOM instead.
 - Plan artifact: `tests/validation/test-plan.md` — one section per
   criterion (id, must, target, numbered steps, expected assertion).
   Commit it before writing specs. On re-validation, append new sections;

--- a/skills/aep/references/component-contract.md
+++ b/skills/aep/references/component-contract.md
@@ -55,6 +55,8 @@ path or a payload shape, and never invent an operation.
 | `platform-resource` | its `wiring` outputs |
 | `external` | **a pinned contract wins when there is one**: `specs/design/dependencies/<name>/openapi.yaml` (or `schema.graphql`, or `sdk.json`), the slice of the provider's document the design committed to — or the interface it derived from the provider's reference; the vendor's docs fill what it does not cover. The procedure is `external-dependency-research.md` beside this file |
 
+**Generate the client from an OpenAPI contract with your stack's generator instead of hand-writing one.**
+
 **An endpoint dependency's env var is always `<DEP_NAME>_URL`**, upper-snake-cased
 (`todo-api` → `TODO_API_URL`). With no published contract at all, implement a
 minimal client against the injected address plus its `basePath`, and nothing more.

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -55,10 +55,20 @@ Two rules are this skill's, because they are the gateway's contract:
   header only when its claim is present; when it is absent the client's own value
   for that header is forwarded. `groups` is the one that matters: a token issued
   without it (a `client_credentials` token, or a user in no groups) leaves
-  `X-User-Groups` caller-controlled. Treat a role decision as trustworthy only
-  for a caller whose token actually carries the claim. A service that owns its
-  own people records sidesteps this: its role comes from the record it stored,
-  keyed on `X-User-Id`, which no caller can set (`thunder-authentication`).
+  `X-User-Groups` caller-controlled.
+
+  That is a **gap in the gateway's contract**, and a service cannot close it from
+  the inside: the header arrives populated with whatever the caller chose, and
+  nothing in the request distinguishes it from one the gateway asserted. What it
+  is NOT is a reason to invent a second role authority — roles reach a service
+  only through that header (`thunder-authentication`), so a service that resolves
+  them from its own table instead sees none of the roles the platform granted and
+  is broken for every real user. Contain it where it can be contained: the
+  bullet above is the rule — a lane with no gateway on it lets a caller set these
+  freely — so keep `client_credentials` clients off externally-reachable
+  role-gated routes, and treat an absent or empty `X-User-Groups` as no role
+  (**403**), never as a reason to fall back to a source the caller can influence.
+  Raise the residual risk rather than designing around it.
 - **An authenticated caller who has no role → 403, never 401.** A 401 tells the
   SPA its token expired, so it restarts sign-in and loops forever. The role
   resolution itself is in `thunder-authentication`.

--- a/skills/api-management/SKILL.md
+++ b/skills/api-management/SKILL.md
@@ -55,23 +55,20 @@ Two rules are this skill's, because they are the gateway's contract:
   header only when its claim is present; when it is absent the client's own value
   for that header is forwarded. `groups` is the one that matters: a token issued
   without it (a `client_credentials` token, or a user in no groups) leaves
-  `X-User-Groups` caller-controlled.
+  `X-User-Groups` caller-controlled. That is a **gap in the gateway's contract**
+  which a service cannot close from the inside, since nothing in the request
+  tells an asserted header from a supplied one: keep `client_credentials` clients
+  off externally-reachable role-gated routes, and raise the residual risk rather
+  than designing around it.
 
-  That is a **gap in the gateway's contract**, and a service cannot close it from
-  the inside: the header arrives populated with whatever the caller chose, and
-  nothing in the request distinguishes it from one the gateway asserted. What it
-  is NOT is a reason to invent a second role authority — roles reach a service
-  only through that header (`thunder-authentication`), so a service that resolves
-  them from its own table instead sees none of the roles the platform granted and
-  is broken for every real user. Contain it where it can be contained: the
-  bullet above is the rule — a lane with no gateway on it lets a caller set these
-  freely — so keep `client_credentials` clients off externally-reachable
-  role-gated routes, and treat an absent or empty `X-User-Groups` as no role
-  (**403**), never as a reason to fall back to a source the caller can influence.
-  Raise the residual risk rather than designing around it.
-- **An authenticated caller who has no role → 403, never 401.** A 401 tells the
-  SPA its token expired, so it restarts sign-in and loops forever. The role
-  resolution itself is in `thunder-authentication`.
+  What it is NOT is a reason to invent a second role authority. Roles reach a
+  service only through that header, so one resolved from the service's own table
+  sees none the platform granted. **`thunder-authentication` owns the role
+  decision**, the cold start included — this skill owns only the header.
+- **An authenticated caller the resolver grants no role → 403, never 401.** A 401
+  tells the SPA its token expired, so it restarts sign-in and loops forever. When
+  that happens — and the `coldStartRole` that usually prevents it — is
+  `thunder-authentication`.
 
 **Own your rows by `X-User-Id`.** It is the only stable per-caller key the
 gateway gives you: stamp it on every row this service creates, and gate every

--- a/skills/ballerina/SKILL.md
+++ b/skills/ballerina/SKILL.md
@@ -27,7 +27,9 @@ Write tests only when the user asks — then load [tests.md](references/tests.md
 
 ### Working with OpenAPI Specifications
 
-- Prioritize generating services and clients from OAS specifications as instructed in [openapi.md](references/openapi.md) 
+**Load [openapi.md](references/openapi.md) before writing a service or a client that has
+an OpenAPI document** — one this component implements, or one it calls. It carries the
+`bal openapi` invocation for each, and where the generated module has to land.
 
 ### bal library
 

--- a/skills/ballerina/references/code-rules.md
+++ b/skills/ballerina/references/code-rules.md
@@ -57,7 +57,7 @@ For tests, see [tests.md](tests.md) — write them only when the user asks.
 - Import only packages your code actually references — `bal build` errors on unused imports. Don't pre-import a connector's dependency module (e.g. `ballerina/sql` behind a database client) unless your code names a type from it.
 - Do not import a langlib whose name is a basic type — the type keyword itself puts the prefix in scope, so the import is an error. That is `lang.boolean`, `lang.decimal`, `lang.error`, `lang.float`, `lang.function`, `lang.future`, `lang.int`, `lang.map`, `lang.object`, `lang.stream`, `lang.string`, `lang.table`, `lang.typedesc` and `lang.xml`. The rule is the keyword, not the `lang.` prefix: **`lang.value`, `lang.array` and `lang.regexp` DO need importing** — `import ballerina/lang.value;`, and `undefined module` if you leave it out. Measured against the compiler, one module per line. For `lang.regexp` that means when you name a `regexp:` symbol; the bare `re` literal needs nothing — see Regular Expressions.
 - Packages with dots in names use aliases: `import org/package.one as one;`
-- Submodules in `generated/<moduleName>/`: import as `import <packageName>.<moduleName>;` — the import should contain only the package name and submodule name, no path components.
+- Submodules live in `modules/<moduleName>/` and import as `import <packageName>.<moduleName>;` — only the package name (`Ballerina.toml`'s `name`, which is not the hyphenated component directory) and the submodule name, no path components.
 - For SQL databases, import the matching `.driver` package alongside the client so the JDBC driver is on the runtime classpath (also required for GraalVM native builds):
   ```ballerina
   import ballerinax/postgresql;

--- a/skills/ballerina/references/openapi.md
+++ b/skills/ballerina/references/openapi.md
@@ -6,12 +6,24 @@ belong is [project-structure.md](project-structure.md)'s rule.
 
 ```bash
 bal tool pull openapi                          # once per environment
-bal openapi -i oas.yaml --mode service         # generate service from openapi spec
-bal openapi -i oas.yaml --mode client          # generate client from openapi spec
+bal openapi -i ./path/openapi.yaml --mode service --single-file                 # the spec this component implements
+mkdir -p modules/weather && bal openapi -i ./path/weather_oas.yaml --mode client --single-file -o modules/weather   # each spec it calls
 ```
+
+`--single-file` keeps each generated artefact in one file — types and utilities included.
 
 After `--mode service`:
 
 - The stub is the starting point: fill every empty resource body with Edit — an unfilled body is a compile error.
 - Change the generated `new (9090, config = {host: "localhost"})` to `new (9090)` — localhost binding leaves the deployed container unreachable while it looks healthy.
 - Delete the `bal new` scaffold's `main.bal` once the service exists.
+
+After `--mode client`:
+
+- **One client, one module**: `modules/weather` is reached as `import <package>.weather;`
+  and `weather:Client`. `<package>` is `Ballerina.toml`'s `name`.
+- The generated client and its types ARE the integration: call it, and do not re-declare
+  its request or response records by hand.
+- Handle the error responses the spec declares. A non-2xx the spec names is a case to
+  answer, not an error to pass on to your own caller unchanged.
+- Regenerate when the spec changes rather than editing generated files.

--- a/skills/security-design/SKILL.md
+++ b/skills/security-design/SKILL.md
@@ -107,12 +107,12 @@ one is rejected.
 | Field | Rule |
 |---|---|
 | `version` | Always `1`. |
-| `coldStartRole` | The role a caller holds before anyone grants them one, or `null` when a caller with no role reaches nothing. Must name a declared role. See **the cold start** below. |
+| `coldStartRole` | The role a caller holds when their identity-provider groups match no declared role — before anyone grants them one — or `null` when such a caller reaches nothing. Must name a declared role. See **the cold start** below. |
 | `publicComponents` | Components that serve unauthenticated traffic. Absence of sign-in is a decision, so write it down rather than leaving it to be inferred from silence. |
 | `roles[].name` | Verbatim — it becomes the identity-provider group name and reaches the app as a `groups` claim. Reuse a catalog name where one fits. |
 | `roles[].description` | What the role is for. A **create-time seed only**: a shared role may already have been described by somebody else, and the platform never overwrites that. |
 | `roles[].stories` | The PRD story numbers this role serves. At least one. |
-| `roles[].grantedBy` | How a person comes to hold it: the name of the role that can grant it, or `first sign-in` for the cold-start role. |
+| `roles[].grantedBy` | How a person comes to hold it: the name of the role that can grant it, or `first sign-in` for the cold-start role — the one a caller holds with no matching group, granted by nobody. |
 | `roles[].permissions[]` | Per component: `actions` for a service, `screens` for a web application. At least one entry, and each entry grants at least one of the two. |
 | `testUsers[].username` | Lowercase letters, digits, `.`, `_`, `-`. Username and role only. |
 | `testUsers[].role` | Must match a declared `roles[].name`. |
@@ -126,7 +126,9 @@ redirect URIs, and grants.
 ## Answer the cold start
 
 A matrix whose every role is granted by somebody else describes a system nobody
-can enter. `coldStartRole` names the role a first-time caller holds. The default:
+can enter. `coldStartRole` names the role a caller holds while their
+identity-provider groups match no declared role — which is where a first-time
+caller starts, and where anyone the org never enrolled stays. The default:
 the PRD's least-privileged actor, so a fresh deployment is usable by whoever
 signs in, and every role above it is granted by someone who already holds one —
 `grantedBy` names who. Say so explicitly where the system needs a different

--- a/skills/security-design/SKILL.md
+++ b/skills/security-design/SKILL.md
@@ -107,7 +107,7 @@ one is rejected.
 | Field | Rule |
 |---|---|
 | `version` | Always `1`. |
-| `coldStartRole` | The role a caller holds when their identity-provider groups match no declared role — before anyone grants them one — or `null` when such a caller reaches nothing. Must name a declared role. See **the cold start** below. |
+| `coldStartRole` | The role a caller holds when their identity-provider groups match no declared role — a real person's first sign-in — or `null` when such a caller reaches nothing. When non-null, it must name a declared role. See **the cold start** below. |
 | `publicComponents` | Components that serve unauthenticated traffic. Absence of sign-in is a decision, so write it down rather than leaving it to be inferred from silence. |
 | `roles[].name` | Verbatim — it becomes the identity-provider group name and reaches the app as a `groups` claim. Reuse a catalog name where one fits. |
 | `roles[].description` | What the role is for. A **create-time seed only**: a shared role may already have been described by somebody else, and the platform never overwrites that. |
@@ -127,14 +127,21 @@ redirect URIs, and grants.
 
 A matrix whose every role is granted by somebody else describes a system nobody
 can enter. `coldStartRole` names the role a caller holds while their
-identity-provider groups match no declared role — which is where a first-time
-caller starts, and where anyone the org never enrolled stays. The default:
-the PRD's least-privileged actor, so a fresh deployment is usable by whoever
-signs in, and every role above it is granted by someone who already holds one —
-`grantedBy` names who. Say so explicitly where the system needs a different
-origin: an admin admits people, an import loads them, the first user becomes the
-admin. `null` is a real answer, but only for a system where a caller with no role
-genuinely reaches nothing.
+identity-provider groups match no declared role.
+
+**It is for real people, not the test accounts.** The platform enrols every test
+account in its role's group, so those always match; this is the first sign-in of
+somebody the org never enrolled. The default is the PRD's least-privileged
+actor, so a fresh deployment is usable by whoever arrives, and every role above
+it is granted by someone who already holds one — `grantedBy` names who. Say so
+explicitly where the system needs a different origin: an admin admits people, an
+import loads them, the first user becomes the admin. `null` is a real answer,
+but only for a system where such a caller genuinely reaches nothing — the app
+then answers them 403, which nobody can clear from inside the app.
+
+It has a second effect worth knowing when you choose it: the test account for
+this role is the one the platform serves when a caller asks for credentials
+without naming a role.
 
 ---
 

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -194,19 +194,22 @@ The gateway hands your service the caller's verified identity as headers
 (`api-management` covers the mechanism and the 401-on-missing-`X-User-Id` rule).
 What follows is what that identity *means*. Which roles exist, and what each may
 do in this project, is `specs/design/security.json` — read role names,
-permissions, `coldStartRole`, and `publicComponents` from it before writing a
-resolver, and match its `roles[].name` values.
+permissions and `coldStartRole` from it before writing a resolver, and match its
+`roles[].name` values. `publicComponents` names the components that serve
+unauthenticated traffic; it says nothing about where a role comes from.
 
 ## Identity is not authorization
 
 `X-User-Id` is an **opaque IdP subject** — not a record key in any other service,
 so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
-- **Role** (what may they do) comes from ONE authority, and which one depends on
-  whether the org publishes a directory: `X-User-Groups` when it does, the
-  service's own people record when it does not (**Implementation** below). Either
-  way, an authenticated caller with no role is a **403, never a 401**: a 401 tells
-  the SPA its token expired, so it restarts sign-in and loops forever.
+- **Role** (what may they do) comes from `X-User-Groups`, always: the platform
+  makes an identity-provider group out of every `security.json` role — enrolling
+  the design's test users in the ones it owns — so the groups claim IS the role
+  (**Implementation** below). A group the platform found rather than created
+  reaches your service the same way; only its membership is somebody else's. A caller whose groups match no declared role holds the design's
+  `coldStartRole`, and where that is `null` they are a **403, never a 401**: a
+  401 tells the SPA its token expired, so it restarts sign-in and loops forever.
 - **Directory attributes** (which unit is theirs, their own id in the directory)
   come from the caller's **directory record**, resolved by `X-User-Name` — the
   username, which the directory keys on. A group name is a role, not an identity,
@@ -217,18 +220,17 @@ so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
 ## Implementation
 
-**One authority decides a caller's role, and the design picks which.** A published
-directory owns roles through `X-User-Groups`; with none published, the service
-owns them in its own people records. The two are alternatives, never a fallback
-chain — a resolver that tries one and falls through to the other grants whatever
-the weaker source says.
+**`X-User-Groups` is the role authority, and there is no fork to pick.** Every
+`roles[].name` in `security.json` becomes an identity-provider group at Build
+(`security-design`), so a role reaches you only through that header. A service that reads the role from
+anywhere else — a role column in its own table, a roster in config — sees none of
+them: the seeded admin arrives as whatever that service defaults to, and no
+endpoint exists to correct it. Your own records hold per-user DATA, never the
+role.
 
-One resolver, called by every protected handler, whichever authority it reads.
-**403**, never 401, when it yields no role: return the empty/absent case
-explicitly rather than defaulting to the least-privileged real role, which is a
-silent authorization grant.
+One resolver, called by every protected handler.
 
-### A directory is published — the role is in `X-User-Groups`
+### The role is in `X-User-Groups`
 
 Resolve from the header, never by looking `X-User-Id` up anywhere. It arrives as
 a JSON array (e.g. `["Compliance Admin"]`) — the SAME groups claim the SPA reads
@@ -236,6 +238,13 @@ from `user.profile.groups`; accept a comma-separated string as a fallback. Match
 each group case-insensitively against the spec's role names: a substring match on
 the keyword (`admin`, `auditor`) survives the org renaming its groups, an
 equality check does not.
+
+**No group matches a declared role → the design's `coldStartRole`**, read from
+`specs/design/security.json` and not from prose, so a first-time caller in no
+group reaches the app's base experience rather than a 403 nobody can clear.
+`null` there means such a caller reaches nothing: answer **403**. Where the
+design said `null`, defaulting to the least-privileged real role is a silent
+grant.
 
 When roles scope by the caller's own directory attributes — their unit, their own
 id — resolve the caller's **directory record** by `X-User-Name` and filter on
@@ -246,25 +255,14 @@ that record's fields:
   of the resolved record — never on `X-User-Id` (opaque) and never on a group
   name.
 
-### No directory is published — the service owns its people records
+### The service's own per-caller rows
 
-Key them on `X-User-Id` — the one case where that is right, because the service
-stored the subject itself rather than matching it against ids another system
-minted — and fill display fields from `X-User-Name`.
-
-**The stored record's role IS the role**, resolved by `X-User-Id`. Read
-`X-User-Groups` for nothing on this path: no directory published those groups, so
-they carry no authority here, and a token issued without a `groups` claim leaves
-that header caller-controlled (`api-management`) — reading a role out of it lets
-a caller name their own.
-
-**A caller with no record yet gets one, at the cold-start role.**
-`specs/design/security.json`'s `coldStartRole` says which role a first-time caller
-holds — read it from that file, not from prose. `null` there means a caller with
-no role reaches nothing, and there is no record to create. Otherwise create the
-record on first sign-in at that role, so a new user reaches the app's base
-experience rather than a 403 nobody can clear. A roster in config is a demo
-fixture, not the mechanism: it goes stale the moment somebody new signs in.
+Rows this service creates for a caller — their draft, their preferences, the
+record that makes "their own" well-defined — are keyed on `X-User-Id`, the one
+case where that is right, because the service stored the subject itself rather
+than matching it against ids another system minted. Fill display fields from
+`X-User-Name`. Store no role column: the header already answered that, and a
+second copy is a second authority that drifts.
 
 Express this in your stack's own idiom — where the resolver lives, its
 signature, and how a handler returns 403 — following the conventions that skill
@@ -278,10 +276,11 @@ hardcode a roster.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Return **403**. Resolve the role from the service's one authority — `X-User-Groups` with a directory, the stored people record without one — and never key a *directory* lookup on `X-User-Id`. |
+| Signed-in user loops back to the login page forever | A protected handler answers no-role (or a failed directory lookup keyed on `X-User-Id`) with **401**; the SPA reads 401 as "token expired" and restarts sign-in | Return **403**. Resolve the role from `X-User-Groups`, and never key a *directory* lookup on `X-User-Id`. |
 | A role-scoped caller signs in but sees no rows | Scope derived the attribute from a group NAME (empty for a generic role group), or matched `X-User-Id` (an opaque subject) against a stored directory id (never equal) | Resolve the caller's directory record via `X-User-Name`, read the attribute from it, filter on that. |
 | Every user shows no role / `groups` is empty | Roles read from the access token or a hand-decoded JWT | SPA: `user.profile.groups`. API: `X-User-Groups`. |
-| Every signed-in user gets 403 and the app is unusable from a fresh deploy | The service requires a people record it has no way to create, or it creates one and then still resolves the role from `X-User-Groups` | Create the caller's record on first sign-in at the cold-start role, and resolve the role FROM that record — `specs/design/security.json`'s `coldStartRole` names it. |
+| The SPA shows a role's screens but every call it makes 403s, naming a role the caller does not hold | Two authorities: the SPA read `user.profile.groups`, the service read a role off its own record instead of `X-User-Groups`, so every seeded user is stuck at the service's default | One authority. Match `X-User-Groups` against `roles[].name`, and fall to `coldStartRole` only when no group matches. |
+| A design with no directory dependency is read as "no roles are published" | `publicComponents` is about unauthenticated traffic; the platform publishes role groups for every project with a `security.json` | Resolve from `X-User-Groups` regardless of what the design depends on. |
 | Sign-in loops at the right path, or the user is sent to login on every visit / new tab | No persistent `WebStorageStateStore` (the in-memory default loses the PKCE verifier across the redirect), session in `sessionStorage`, or the load path calls `signIn()` on a merely-expired token | `WebStorageStateStore({ store: localStorage })` + `automaticSilentRenew`; renew via `signinSilent()` and only `signIn()` when there is no session. |
 | After login, "invalid redirect URI" | `redirect_uri` doesn't match the `<origin>/callback` the platform registered | Compute `window.location.origin + '/callback'`. |
 | Logout button does nothing | `signOut()` calls only `signoutRedirect()`, which rejects (no `end_session_endpoint`), and the handler swallows it | Wrap it in the try/catch fallback to `removeUser()` + reload. |

--- a/skills/thunder-authentication/SKILL.md
+++ b/skills/thunder-authentication/SKILL.md
@@ -205,9 +205,10 @@ so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
 - **Role** (what may they do) comes from `X-User-Groups`, always: the platform
   makes an identity-provider group out of every `security.json` role — enrolling
-  the design's test users in the ones it owns — so the groups claim IS the role
-  (**Implementation** below). A group the platform found rather than created
-  reaches your service the same way; only its membership is somebody else's. A caller whose groups match no declared role holds the design's
+  the project's test accounts in the ones it owns — so the groups claim IS the
+  role (**Implementation** below). A group the platform found rather than created
+  reaches your service the same way; only its membership is somebody else's.
+  A caller whose groups match no declared role holds the design's
   `coldStartRole`, and where that is `null` they are a **403, never a 401**: a
   401 tells the SPA its token expired, so it restarts sign-in and loops forever.
 - **Directory attributes** (which unit is theirs, their own id in the directory)
@@ -222,11 +223,11 @@ so a directory lookup keyed on it 404s. Split the two questions a caller raises:
 
 **`X-User-Groups` is the role authority, and there is no fork to pick.** Every
 `roles[].name` in `security.json` becomes an identity-provider group at Build
-(`security-design`), so a role reaches you only through that header. A service that reads the role from
-anywhere else — a role column in its own table, a roster in config — sees none of
-them: the seeded admin arrives as whatever that service defaults to, and no
-endpoint exists to correct it. Your own records hold per-user DATA, never the
-role.
+(`security-design`), so a role reaches you only through that header. A service
+that reads the role from anywhere else — a role column in its own table, a
+roster in config — sees none of them: the seeded admin arrives as whatever that
+service defaults to, and no endpoint exists to correct it. Your own records hold
+per-user DATA, never the role.
 
 One resolver, called by every protected handler.
 
@@ -240,11 +241,12 @@ the keyword (`admin`, `auditor`) survives the org renaming its groups, an
 equality check does not.
 
 **No group matches a declared role → the design's `coldStartRole`**, read from
-`specs/design/security.json` and not from prose, so a first-time caller in no
-group reaches the app's base experience rather than a 403 nobody can clear.
-`null` there means such a caller reaches nothing: answer **403**. Where the
-design said `null`, defaulting to the least-privileged real role is a silent
-grant.
+`specs/design/security.json` and not from prose. The platform enrols every test
+account in its role's group, so those never arrive here: this is the path a
+**real person** takes on first sign-in, and it is what lets them reach the app's
+base experience instead of a 403 nobody can clear. `coldStartRole: null` means
+such a caller reaches nothing — answer **403**, and never substitute the
+least-privileged real role, which is a silent grant.
 
 When roles scope by the caller's own directory attributes — their unit, their own
 id — resolve the caller's **directory record** by `X-User-Name` and filter on

--- a/skills/wireframes/references/implementing.md
+++ b/skills/wireframes/references/implementing.md
@@ -39,8 +39,10 @@ over the issue text when the two differ.
   Read the role in the SPA from the sign-in identity the auth
   dependency provides (`user.profile.groups`; see `thunder-authentication`),
   and treat it as **presentation only** — the backend enforces permission and
-  answers 403. A component with no auth dependency has no roles: build the
-  screen as drawn.
+  answers 403. Groups matching no declared role fall to the design's
+  `coldStartRole`, the same rule the backend applies, so a first-time person
+  sees the base experience rather than an empty shell. A component with no auth
+  dependency has no roles: build the screen as drawn.
 
 ## Element for element
 


### PR DESCRIPTION
One bug fix and three skill corrections, all found the same way: by watching a
real run do the wrong thing.

## `serving` now means reachable (`aep-api`)

OpenChoreo reports a ReleaseBinding Ready when the **control plane** is done.
Every consumer reads it as a claim about the **edge** — the validation sweep
dispatches on it, the console counts components live by it, and a person clicks
the URL because of it.

On a cloud plane those are minutes apart. A component that has never been
deployed gets a hostname that has never had a certificate, and cert-manager's
ACME order is a second reconciler with no happens-before edge to the binding.

**Measured on allocation-app v2, 2026-09-10:**

| Event | Time |
|---|---|
| Binding reports Ready | `10:40:46Z` |
| **Validation dispatched** | **`10:42:01Z`** |
| First certificate issued | `10:44:01Z` |

Validation died at its own preflight on `ERR_SSL_TLSV1_ALERT_INTERNAL_ERROR` —
the gateway answering a TLS alert for an SNI it held no certificate for.
Nothing was misconfigured and nothing was slow; the ordering was decided by
wall clock.

### The fix

A component that advertises an external URL is held at `converging` until that
URL answers. `converging` is *already* the state for "pinned, not ready yet",
so this adds a **predicate, not a mechanism**: the deploy stage already waits
on it and the stage deadline already turns one that never resolves into a
deploy failure.

Any HTTP response counts; only a transport failure does not. That is
[ADR-0006](runners/remote-worker/design/decisions/ADR-0006-the-runner-proves-endpoint-reachability.md)'s
rule, and the runner's preflight is its other implementation — a 401 behind the
`api-configuration` trait and a 404 at an API root are answers.

**One gate, both readers.** The supervisor's readiness poll and the console's
status poll used to hold different definitions of "up" — which is what put
"2 of 2 components live" on screen during the exact window validation could not
reach one of them. They now share one `EndpointGate`, so they cannot diverge
and the first probe serves both.

**It costs no extra OpenChoreo request.** The URL rides
`ReleaseBindingSummary.ExternalURL` off the same object the readiness poll
already read, picked by the same scheme preference as the deployments read. A
test pins the two to the same string so a person cannot click a link the gate
never checked.

**Off on the local plane.** Wired only when the data-plane gateway fronts TLS —
the same stated fact that decides which advertised URL is live. Locally there is
no certificate window, and `*.openchoreoapis.localhost` resolves to loopback
from inside this process's container, so a probe would hold every web component
at `converging` for ever.

A component that advertises no URL — a worker, an internal-only service —
passes untouched.

## Skill corrections

**`X-User-Groups` is the one role authority.** `thunder-authentication` offered
two and told the agent to choose: the header "when the org publishes a
directory", the service's own people records when it does not. That fork does
not exist — the platform makes an IdP group out of every `security.json` role,
so a role reaches a service only through that header. An agent taking the wrong
arm ships an app that cannot be used: the SPA reads `user.profile.groups` and
shows a role's screens while the service reads a role off its own table and sees
the default it invented, so every call 403s with no endpoint to correct it.
`coldStartRole` moves onto the one path it belongs to (groups match no declared
role — not "no record yet"), and `security-design` now says that in its field
table, its `grantedBy` row and its prose.

**A client for an OpenAPI contract is generated.** "Prioritize generating" read
as a preference, and agents hand-wrote clients that re-declared the records the
generator produces. It is now a load instruction, and `openapi.md` — which had
nothing at all after `--mode client` — covers the module layout, `--single-file`,
the declared error responses, and regeneration.

**Validation works one browser at a time.** A live Chromium is the largest thing
in a cycle's pod; splitting criteria across dispatched agents buys an OOM kill
mid-phase.

## Proof

**The bug fix** — 15 new unit tests over the two readers that used to disagree,
with the OC read and the probe faked:

```
$ go test -count=1 -run 'Endpoint|HoldUnreachable|ReleaseBindingSummary' ./internal/projects/... ./internal/clients/openchoreo/...
ok  github.com/wso2/aep/aep-api/internal/projects
ok  github.com/wso2/aep/aep-api/internal/clients/openchoreo
```

They pin the behaviour that matters: a Ready binding whose URL does not answer
is held; any HTTP status is an answer and only a transport failure is not; a
component with no URL is never probed; a pending or undeployed one is never
probed; the two readers share one probe; the console's slice is not mutated;
and with no probe wired the counts are exactly the old binding-only ones.

**The Ballerina claims** — verified against `bal` 2201.13.2 and a real
playground run. Run `2026-09-11T05-01-01-521Z-code` executed the new commands
verbatim and produced exactly one file per module. The 2026-09-10 run of the
same project, without `--single-file`, produced three client files and needed a
hand `mv`, and had to retry `-o` after failing without `mkdir -p`. The
package-name caveat is real in this repo: directory `expense-api`, package
`expense_api`, and the one real submodule import is
`import wso2/expense_api.exchangerate;`.

**Gates** — full `aep-api` suite (70 packages), `license-check`, and the Go
`deadcode` gate all green.

## Reviewed

`/code-review` ran both axes before this was opened, and CodeRabbit reviewed the
first push. Findings are folded into commits rather than left for a follow-up.

### The gate

- **One probe per key.** The memos are read-then-write, so two readers arriving
  together both missed and both probed — the claim that the two cannot disagree
  held only when their polls happened not to overlap, and they are independent
  pollers on the same window. `singleflight.Group` now collapses concurrent
  misses, matching `organization`'s `ensureInflight`. Proven: **3 probes across
  8 concurrent readers without it, 1 with.**
- **A cancelled caller is not a verdict.** The negative memo cached a probe that
  failed because the *caller* went away, so one abandoned console request could
  tell every other reader — the supervisor included — that a healthy component
  was down for the whole retry window.
- **Polled-path latency.** `holdUnreachable` sits on the console's status read,
  so a 10s probe per unreachable component per poll was latency a person would
  see. Positive answers memoised for ever, negatives for a short retry window,
  one probe bounded at 5s.
- **The withdrawn reason** is cleared on both paths, so a held component is not
  captioned with the reason it was up.

### The identity chain

The first push left three skills disagreeing about the most security-sensitive
decision an agent makes: `api-management` said absent/empty `X-User-Groups` is
no role and a 403, while `thunder-authentication` and `security-design` said no
matching group takes `coldStartRole`. An absent header *is* "no group matches".

`coldStartRole` wins — it is the rule that describes the platform, and the 403
clause bought nothing anyway, since the vector it was written for sets the
header to a **real** role name. Read along the path an agent takes, each skill
now states its own half once: `api-management` the header and the 403-never-401
status rule, `thunder-authentication` the role decision, `security-design` the
field. `wireframes` had the SPA read groups with no cold-start rule at all, so a
first-time person saw an empty shell while the backend granted them the base
role.

The cold start is **for real people, not the seeded accounts** — the platform
enrols every test account in its role's group, so those always match. That is
now written down where it was previously implied.

### Known gap, not closed here

A token carrying no `groups` claim leaves `X-User-Groups` caller-controlled, and
a service cannot tell an asserted header from a supplied one. The skills carry
containment and say to raise the residual risk. **The fix belongs in the gateway
(strip or overwrite inbound `X-User-*` unconditionally) and is not in this PR.**

### Deliberately not changed

- The gate probes the **one** URL the binding advertises, where ADR-0006's
  runner probes every endpoint. The certificate is issued per host, a
  component's endpoints share theirs, and the summary's contract is that it
  carries exactly what the deployments read does. Documented at the type.
- `--status-code-binding` on the generated Ballerina client was suggested and
  declined; the flag exists in 2201.13.2, but adopting it is a separate call
  about generated-client shape, not part of this fix.

## Not verified live

The endpoint gate has not been exercised against a real cloud deploy — it is
off on the local plane by construction, so the certificate window it exists to
close cannot be reproduced there. The evidence above is the incident it was
written from plus unit coverage of both readers. Worth watching the first cloud
deploy after this lands: a component stuck at `converging` past its stage
deadline would mean the probe is failing for a reason other than issuance.

Related open issues, neither blocking: **#538** (web-applications get no public
hostname, so `externalURLs` is empty — the gate reads that as vacuously
reachable and passes them through, then starts protecting them once #538 lands)
and **#618** (the same Ready-lies-about-the-edge class, for `thunder-app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
