### PR TITLE
fix(aep-api): the Thunder token cache trusts the wall clock and recovers from a 401

### DIFF
--- a/services/aep-api/internal/clients/thundersvc/client.go
+++ b/services/aep-api/internal/clients/thundersvc/client.go
@@ -188,10 +188,17 @@ type client struct {
 	systemAud  string
 	httpClient *http.Client
 
-	mu          sync.RWMutex
-	cachedToken string
-	tokenExpiry time.Time
-	tokenSfg    singleflight.Group
+	// now is the clock the token cache reads. It is the WALL clock on purpose:
+	// the cache compares Unix seconds, never time.Time values, because Go's
+	// time.Before prefers the monotonic reading and a VM paused with a sleeping
+	// laptop stops that clock while the wall clock, and Thunder's `exp`, move
+	// on. Tests substitute it.
+	now func() time.Time
+
+	mu              sync.RWMutex
+	cachedToken     string
+	tokenExpiryUnix int64 // wall-clock second after which the cache stops trusting cachedToken
+	tokenSfg        singleflight.Group
 
 	// Default OU id, looked up once on first EnsurePublisherApp call
 	// and cached. Thunder's UI nests every org under a root OU
@@ -220,6 +227,7 @@ func New(cfg Config) Client {
 		systemSec:  cfg.ClientSecret,
 		systemAud:  cfg.SystemResourceIdentifier,
 		httpClient: hc,
+		now:        time.Now,
 	}
 }
 
@@ -249,37 +257,24 @@ func SystemResourceIdentifier(issuer string) string {
 // Fast path: RLock + cache hit. Slow path: singleflight dedupe so
 // concurrent callers share one round-trip.
 func (c *client) getSystemToken(ctx context.Context) (string, error) {
-	c.mu.RLock()
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-		token := c.cachedToken
-		c.mu.RUnlock()
+	if token, ok := c.cachedSystemToken(); ok {
 		return token, nil
 	}
-	c.mu.RUnlock()
 
 	result, err, _ := c.tokenSfg.Do("system-token", func() (any, error) {
-		c.mu.RLock()
-		if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-			token := c.cachedToken
-			c.mu.RUnlock()
+		if token, ok := c.cachedSystemToken(); ok {
 			return token, nil
 		}
-		c.mu.RUnlock()
 
-		token, expiresIn, err := c.fetchSystemToken(ctx)
+		token, expiresAt, err := c.fetchSystemToken(ctx)
 		if err != nil {
 			return nil, err
 		}
 		c.mu.Lock()
 		c.cachedToken = token
-		const skew = 30
-		if expiresIn > skew {
-			c.tokenExpiry = time.Now().Add(time.Duration(expiresIn-skew) * time.Second)
-		} else if expiresIn > 0 {
-			c.tokenExpiry = time.Now().Add(time.Duration(expiresIn) * time.Second)
-		} else {
-			c.tokenExpiry = time.Now().Add(time.Minute)
-		}
+		// Refresh ahead of the issuer's deadline so a token is never presented
+		// in its final seconds; a token already inside the skew is not reused.
+		c.tokenExpiryUnix = expiresAt - tokenRefreshSkewSeconds
 		c.mu.Unlock()
 		return token, nil
 	})
@@ -289,7 +284,104 @@ func (c *client) getSystemToken(ctx context.Context) (string, error) {
 	return result.(string), nil
 }
 
-func (c *client) fetchSystemToken(ctx context.Context) (string, int, error) {
+// tokenRefreshSkewSeconds is how far ahead of a token's expiry the cache stops
+// handing it out.
+const tokenRefreshSkewSeconds = 30
+
+// cachedSystemToken returns the cached token when the wall clock says it is
+// still good.
+func (c *client) cachedSystemToken() (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.cachedToken == "" || c.now().Unix() >= c.tokenExpiryUnix {
+		return "", false
+	}
+	return c.cachedToken, true
+}
+
+// invalidateSystemToken drops stale from the cache if it is what the cache
+// holds. A token minted after stale was handed out is left alone: the caller
+// that got a 401 with the older token should now pick up the newer one rather
+// than force a third mint.
+func (c *client) invalidateSystemToken(stale string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cachedToken == stale {
+		c.cachedToken = ""
+		c.tokenExpiryUnix = 0
+	}
+}
+
+// do sends an admin request that carries the system token, and answers a 401
+// by evicting that token, minting once, and repeating the request. Thunder
+// says 401 for a token it no longer accepts and nothing else (an expired one
+// looks exactly like a forged one), so the only sensible reaction is to try
+// with a token it has just issued. One retry: if the fresh token is refused
+// too, the 401 is the answer and it is returned as such.
+//
+// The token endpoint itself must not go through here (its request carries no
+// bearer, and a 401 there means bad client credentials).
+func (c *client) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") || auth == "Bearer " {
+		return resp, nil // not a bearer request; nothing to refresh
+	}
+	stale := strings.TrimPrefix(auth, "Bearer ")
+	retry, rerr := c.retryWithFreshToken(req, stale)
+	if rerr != nil {
+		// The retry could not be attempted at all (no token, or a body that
+		// cannot be replayed). The original 401 is still the truthful answer.
+		slog.WarnContext(req.Context(), "thundersvc: admin call answered 401 and a retry with a fresh token was not possible",
+			"method", req.Method, "path", req.URL.Path, "error", rerr)
+		return resp, nil
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	return retry, nil
+}
+
+// retryWithFreshToken re-sends req once with a token minted after stale was
+// refused. Bodies are replayed through GetBody, which net/http sets for every
+// in-memory reader this client uses.
+func (c *client) retryWithFreshToken(req *http.Request, stale string) (*http.Response, error) {
+	c.invalidateSystemToken(stale)
+	fresh, err := c.getSystemToken(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	again := req.Clone(req.Context())
+	if req.Body != nil && req.Body != http.NoBody {
+		if req.GetBody == nil {
+			return nil, fmt.Errorf("request body cannot be replayed")
+		}
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("replay request body: %w", err)
+		}
+		again.Body = body
+	}
+	again.Header.Set("Authorization", "Bearer "+fresh)
+	resp, err := c.httpClient.Do(again)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Thunder refused a token it issued a moment ago: do not keep it.
+		c.invalidateSystemToken(fresh)
+	}
+	return resp, nil
+}
+
+// fetchSystemToken mints a system token and reports the wall-clock second the
+// issuer says it expires: the JWT's own `exp` claim when readable, else now
+// plus `expires_in`, else now plus a minute. The claim is preferred because it
+// is the issuer's statement rather than a copy that has to be re-anchored to
+// the receiver's clock.
+func (c *client) fetchSystemToken(ctx context.Context) (string, int64, error) {
 	// The system client is registered with
 	// `tokenEndpointAuthMethod: client_secret_post` (see
 	// single-cluster/thunder-resources/81-aep-system-client.yaml), so
@@ -337,7 +429,14 @@ func (c *client) fetchSystemToken(ctx context.Context) (string, int, error) {
 	if err := assertSystemScope(result.AccessToken, c.systemAud); err != nil {
 		return "", 0, err
 	}
-	return result.AccessToken, result.ExpiresIn, nil
+	if exp, ok := tokenExpiry(result.AccessToken); ok {
+		return result.AccessToken, exp, nil
+	}
+	now := c.now().Unix()
+	if result.ExpiresIn > 0 {
+		return result.AccessToken, now + int64(result.ExpiresIn), nil
+	}
+	return result.AccessToken, now + 60, nil
 }
 
 // assertSystemScope refuses a token that does not carry the `system` scope.
@@ -366,18 +465,10 @@ func assertSystemScope(token, resource string) error {
 // is false when the token is not a JWT or its payload is not JSON; an absent
 // claim is a readable answer (no scopes), not an unreadable token.
 func tokenScopes(token string) ([]string, bool) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, false
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
-	if err != nil {
-		return nil, false
-	}
 	var claims struct {
 		Scope any `json:"scope"`
 	}
-	if err := json.Unmarshal(payload, &claims); err != nil {
+	if !tokenClaims(token, &claims) {
 		return nil, false
 	}
 	switch v := claims.Scope.(type) {
@@ -397,6 +488,32 @@ func tokenScopes(token string) ([]string, bool) {
 	return nil, false
 }
 
+// tokenExpiry reads the `exp` claim of a JWT, unverified for the same reason
+// tokenScopes is. ok is false for an opaque token or an absent claim.
+func tokenExpiry(token string) (int64, bool) {
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if !tokenClaims(token, &claims) || claims.Exp <= 0 {
+		return 0, false
+	}
+	return claims.Exp, true
+}
+
+// tokenClaims decodes a JWT's payload into out without verifying it. false
+// when the token is not a three-part JWT or its payload is not JSON.
+func tokenClaims(token string, out any) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(payload, out) == nil
+}
+
 // -- OU resolution --------------------------------------------------------
 
 // getDefaultOUID returns Thunder's default organisation-unit id,
@@ -414,7 +531,7 @@ func (c *client) getDefaultOUID(ctx context.Context, token string) (string, erro
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return "", fmt.Errorf("thunder get default OU: %w", err)
 	}
@@ -459,7 +576,7 @@ func (c *client) ouExists(ctx context.Context, token, ouID string) (bool, error)
 		return false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return false, fmt.Errorf("thunder get OU %s: %w", ouID, err)
 	}
@@ -632,7 +749,7 @@ func (c *client) ensurePublisherTokenClaims(ctx context.Context, token, appID st
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return fmt.Errorf("thunder put app: %w", err)
 	}
@@ -742,7 +859,7 @@ func (c *client) getAppByID(ctx context.Context, token, appID string) (map[strin
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("thunder get app: %w", err)
 	}
@@ -795,7 +912,7 @@ func (c *client) listAppsPage(ctx context.Context, token string, offset, limit i
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("thunder list apps: %w", err)
 	}
@@ -831,7 +948,7 @@ func (c *client) deleteApp(ctx context.Context, token, appID string) (bool, erro
 		return false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return false, fmt.Errorf("thunder delete app: %w", err)
 	}
@@ -904,7 +1021,7 @@ func (c *client) createApp(ctx context.Context, token, appName, ouID string) (st
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("thunder create app: %w", err)
 	}
@@ -951,7 +1068,7 @@ func (c *client) regenerateSecret(ctx context.Context, token, appID string) (str
 		return "", err
 	}
 	getReq.Header.Set("Authorization", "Bearer "+token)
-	getResp, err := c.httpClient.Do(getReq)
+	getResp, err := c.do(getReq)
 	if err != nil {
 		return "", fmt.Errorf("thunder get app for secret regeneration: %w", err)
 	}
@@ -982,7 +1099,7 @@ func (c *client) regenerateSecret(ctx context.Context, token, appID string) (str
 	putReq.Header.Set("Authorization", "Bearer "+token)
 	putReq.Header.Set("Content-Type", "application/json")
 
-	putResp, err := c.httpClient.Do(putReq)
+	putResp, err := c.do(putReq)
 	if err != nil {
 		return "", fmt.Errorf("thunder put app for secret regeneration: %w", err)
 	}

--- a/services/aep-api/internal/clients/thundersvc/client_test.go
+++ b/services/aep-api/internal/clients/thundersvc/client_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // thunderMock is a minimal in-memory Thunder admin API for exercising
@@ -57,6 +59,16 @@ type thunderMock struct {
 	// resolves.
 	systemRS  string
 	tokenForm url.Values // the last token request's form body
+
+	// mints counts token-endpoint calls; issued holds every token handed out,
+	// oldest first. expIn, when non-zero, stamps an `exp` claim that many
+	// seconds from now (negative = already expired). revoked names tokens the
+	// admin endpoints refuse with 401, the way ThunderID refuses an expired one.
+	mints     int
+	issued    []string
+	expIn     int64
+	revoked   map[string]bool
+	revokeAll bool // every token is refused: a Thunder that will not accept this client at all
 }
 
 // unsignedJWT builds a three-part token with these claims and a fake signature.
@@ -76,16 +88,31 @@ func unsignedJWT(t *testing.T, claims map[string]any) string {
 func (m *thunderMock) server(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/oauth2/token":
+		if r.Method == http.MethodPost && r.URL.Path == "/oauth2/token" {
 			_ = r.ParseForm()
 			m.tokenForm = r.PostForm
-			claims := map[string]any{"iss": "mock", "aud": "urn:mock"}
+			m.mints++
+			claims := map[string]any{"iss": "mock", "aud": "urn:mock", "jti": fmt.Sprintf("t%d", m.mints)}
 			if m.systemRS == "" || r.PostForm.Get("resource") == m.systemRS {
 				claims["scope"] = "system"
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": unsignedJWT(t, claims), "expires_in": 3600})
-
+			if m.expIn != 0 {
+				claims["exp"] = time.Now().Unix() + m.expIn
+			}
+			tok := unsignedJWT(t, claims)
+			m.issued = append(m.issued, tok)
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": tok, "expires_in": 3600})
+			return
+		}
+		// Every admin endpoint below authenticates the bearer first. A revoked
+		// token is answered the way ThunderID answers an expired one: 401 with
+		// AUTH-4010, no hint of the cause.
+		if bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "); m.revokeAll || m.revoked[bearer] {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"code":"AUTH-4010","message":{"key":"error.auth.unauthorized","defaultValue":"Unauthorized"}}`))
+			return
+		}
+		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/applications":
 			var apps []map[string]any
 			if m.appID != "" {

--- a/services/aep-api/internal/clients/thundersvc/directory.go
+++ b/services/aep-api/internal/clients/thundersvc/directory.go
@@ -759,7 +759,7 @@ func (c *client) doRequest(ctx context.Context, token, method, path string, in, 
 	if in != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return fmt.Errorf("thunder %s %s: %w", method, redactPath(path), err)
 	}

--- a/services/aep-api/internal/clients/thundersvc/token_cache_test.go
+++ b/services/aep-api/internal/clients/thundersvc/token_cache_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package thundersvc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The system token is cached in-process, so these tests pin down the two
+// ways a cached token can outlive Thunder's acceptance of it: the clock the
+// cache trusts, and what happens when Thunder says 401 anyway.
+
+// The cache must judge expiry on the wall clock. Go's time.Now carries a
+// monotonic reading that time.Before prefers, and a VM paused with a sleeping
+// laptop stops that clock while the wall clock (and Thunder's view of `exp`)
+// moves on. After such a pause the cache believed a dead token had minutes
+// left, and every admin call answered 401 until the monotonic deadline came.
+func TestSystemToken_CacheExpiresOnTheWallClock(t *testing.T) {
+	m := &thunderMock{}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	if _, err := c.OUExists(context.Background(), "ou-1"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if m.mints != 1 {
+		t.Fatalf("mints after first call = %d, want 1", m.mints)
+	}
+
+	// The wall clock jumps past the token's life; the process's monotonic
+	// clock (which the test cannot move) has barely advanced.
+	c.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+
+	if _, err := c.OUExists(context.Background(), "ou-1"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if m.mints != 2 {
+		t.Errorf("mints after the wall clock passed expiry = %d, want 2 (a fresh token)", m.mints)
+	}
+}
+
+// Thunder's `exp` claim is the issuer's own statement of when the token dies;
+// `expires_in` is a courtesy copy. When the two disagree the claim wins.
+func TestSystemToken_CacheFollowsTheExpClaim(t *testing.T) {
+	m := &thunderMock{expIn: 10} // exp in 10 s, expires_in still says 3600
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	if _, err := c.OUExists(context.Background(), "ou-1"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// 10 s minus the refresh skew is already in the past: the next call must
+	// not reuse the token.
+	if _, err := c.OUExists(context.Background(), "ou-1"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if m.mints != 2 {
+		t.Errorf("mints = %d, want 2: a token whose exp claim is inside the skew must not be reused", m.mints)
+	}
+}
+
+// A 401 on an admin call means the token in hand is no good, whatever the
+// cache believed. The client drops it, mints once, and repeats the call, so
+// a token that died early costs one extra round-trip rather than a failed
+// build.
+func TestAdminCall_401_EvictsTheCachedTokenAndRetriesOnce(t *testing.T) {
+	m := &thunderMock{revoked: map[string]bool{}}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	if _, err := c.OUExists(context.Background(), "ou-1"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	m.revoked[m.issued[0]] = true // Thunder stops accepting the cached token
+
+	exists, err := c.OUExists(context.Background(), "ou-1")
+	if err != nil {
+		t.Fatalf("call with a revoked cached token should recover, got: %v", err)
+	}
+	if !exists {
+		t.Error("the retried call's answer was lost")
+	}
+	if m.mints != 2 {
+		t.Errorf("mints = %d, want 2 (one fresh token after the 401)", m.mints)
+	}
+	if c.cachedToken != m.issued[1] {
+		t.Error("the cache should now hold the fresh token")
+	}
+}
+
+// One retry, not a loop: when the fresh token is refused too, the 401 is the
+// answer and the caller hears it.
+func TestAdminCall_401_Persistent_RetriesExactlyOnce(t *testing.T) {
+	m := &thunderMock{revokeAll: true}
+	srv := m.server(t)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	_, err := c.OUExists(context.Background(), "ou-1")
+	if err == nil {
+		t.Fatal("expected the persistent 401 to surface")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should carry the status, got %q", err)
+	}
+	if m.mints != 2 {
+		t.Errorf("mints = %d, want exactly 2 (the original and one retry)", m.mints)
+	}
+	if c.cachedToken != "" {
+		t.Error("a token Thunder refused must not stay cached")
+	}
+}


### PR DESCRIPTION
## What broke

Clicking **Build** on a project answered **"publisher credentials unavailable"**. aep-api's log:

```
publisher provision for build failed: idp_service.EnsureOrgPublisher: findApp "aep-publisher-default":
thunder list apps returned 401: {"code":"AUTH-4010", ... "Authentication is required to access this resource"}
```

A token minted by hand from the same client (`aep-system-client`, `scope=system`, resource indicator set) listed applications with 200, so the credentials were fine. aep-api was presenting a token Thunder had already expired, and kept presenting it.

## Root cause

`thundersvc` cached the system token with `tokenExpiry = time.Now().Add(expires_in − 30s)` and checked `time.Now().Before(tokenExpiry)`. Go evaluates that comparison on the **monotonic** clock. The laptop slept on battery between 16:29 and 16:54 IST; the Colima VM was paused with it, its monotonic clock stopped, and the wall clock (which Thunder judges `exp` by) stepped forward on resume.

Measured on the running aep-api container after the wake:

| clock | age of the process |
|---|---|
| monotonic (`/proc/uptime − starttime`) | 2990 s |
| wall (`docker inspect StartedAt` → now) | 4198 s |

About twenty minutes lost. Thunder's access log shows the token minted at `10:48:33Z` (the 1030-byte response is the system client with the resource indicator; the org-unit lookup follows it), expiring at `11:48:33Z`. The failing `GET /applications` came at `11:49:47Z` with **no token mint before it**: the cache believed nineteen minutes remained. And because a 401 never touched the cache, every admin call would have failed until the monotonic deadline came round.

Two fingerprints that separate this from the earlier resource-indicator trap: Thunder answers **401** for an expired or invalid token and **403** for a token without the `system` scope. The existing mint-time scope assertion is untouched and still passes.

## The fix

In `services/aep-api/internal/clients/thundersvc`:

- **The cache trusts the wall clock.** Expiry is kept as a Unix second taken from the JWT's own `exp` claim (falling back to `expires_in`, then a minute) and compared through an injectable `now`. The 30 s refresh skew stays; a token already inside the skew is not reused.
- **A 401 evicts and retries once.** Every admin request (client.go and directory.go) goes through one send helper. On 401 it drops that token from the cache if it is still the cached one, mints once, replays the request with the fresh token (bodies via `GetBody`), and returns that response. A second 401 is returned as the answer and the fresh token is not kept. The token endpoint itself stays outside the helper.

## Tests

New `token_cache_test.go`, against the existing Thunder mock (which gained mint counting, an `exp` claim and token revocation):

- the wall clock jumps two hours past expiry → a fresh token is minted
- `exp` ten seconds out while `expires_in` says 3600 → the token is not reused
- Thunder revokes the cached token → the call recovers with exactly one extra mint and the cache holds the fresh token
- Thunder refuses every token → exactly one retry, the 401 surfaces, nothing stays cached

All four fail against the previous code. `go test` for the package and for every consumer package (`organization`, `identity`, `app`, `clients/...`) is green; build, vet, golangci-lint (0 issues) and the Go dead-code gate are clean.

## Proof from the live environment

The diagnosis above is from the local converged cluster on 2026-09-11 (Thunder access log, aep-api log, the container clock measurement, and the hand-minted token that succeeded). The fixed image has **not** been deployed yet; the running stack recovered on its own once its monotonic deadline passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
